### PR TITLE
Update MVC version in HelloMvc from 1140 to 1146

### DIFF
--- a/samples/HelloMvc/project.json
+++ b/samples/HelloMvc/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.AspNet.Diagnostics": "0.1-alpha-build-0623",
     "Microsoft.AspNet.Hosting": "0.1-alpha-build-0519",
-    "Microsoft.AspNet.Mvc": "0.1-alpha-build-1140",
+    "Microsoft.AspNet.Mvc": "0.1-alpha-build-1146",
     "Microsoft.AspNet.Server.WebListener": "0.1-alpha-build-0469"
   },
   "commands": {


### PR DESCRIPTION
The version pulled down when I run `kpm restore` is 1146, then `k web` crashes looking for 1140. Updating the version here fixes the issue.

(Fixes Issue #31)
