### PR TITLE
Add proxy support in kvm

### DIFF
--- a/kvm.ps1
+++ b/kvm.ps1
@@ -1,7 +1,7 @@
 param(
   [parameter(Position=0)]
   [string] $command,
-  [string] $proxy = "",
+  [string] $proxy,
   [switch] $verbosity = $false,
   [alias("g")][switch] $global = $false,
   [alias("p")][switch] $persistent = $false,
@@ -130,13 +130,13 @@ function Add-Proxy-If-Specified {
 param(
     [System.Net.WebClient] $wc
 )
-    if ([string]::IsNullOrEmpty($proxy)) {
-        $proxy = [Environment]::GetEnvironmentVariable("http_proxy")
+    if (!$proxy) {
+        $proxy = $env:http_proxy
     }
-    if (-NOT [string]::IsNullOrEmpty($proxy)) {
+    if ($proxy) {
         $wp = New-Object System.Net.WebProxy($proxy)
         $pb = New-Object UriBuilder($proxy)
-        if ([string]::IsNullOrEmpty($pb.UserName)) {
+        if (!$pb.UserName) {
             $wp.Credentials = [System.Net.CredentialCache]::DefaultCredentials
         } else {
             $wp.Credentials = New-Object System.Net.NetworkCredential($pb.UserName, $pb.Password)

--- a/kvm.ps1
+++ b/kvm.ps1
@@ -156,7 +156,7 @@ param(
 
     $wc = New-Object System.Net.WebClient
     $wc.Credentials = new-object System.Net.NetworkCredential("aspnetreadonly", "4d8a2d9c-7b80-4162-9978-47e918c9658c")
-    Add-Proxy-If-Specified([ref]$wc)
+    Add-Proxy-If-Specified($wc)
     [xml]$xml = $wc.DownloadString($url)
 
     $version = Select-Xml "//d:Version" -Namespace @{d='http://schemas.microsoft.com/ado/2007/08/dataservices'} $xml 
@@ -203,7 +203,7 @@ param(
 
     $wc = New-Object System.Net.WebClient
     $wc.Credentials = new-object System.Net.NetworkCredential("aspnetreadonly", "4d8a2d9c-7b80-4162-9978-47e918c9658c")
-    Add-Proxy-If-Specified([ref]$wc)
+    Add-Proxy-If-Specified($wc)
     $wc.DownloadFile($url, $tempKreFile)
 
     Do-Kvm-Unpack $tempKreFile $kreTempDownload


### PR DESCRIPTION
- Add proxy option to "kvm upgrade"
- "kvm upgrade" uses global proxy (http_proxy env var) by default
- Support authenticated proxies

parent aspnet/KRuntime#215
