### PR TITLE
Add badges to show latest KRE versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # ASP.NET vNext Home
+Latest dev version: ![dev version](http://img.shields.io/myget/aspnetvnext/v/KRE-svr50-x64.svg?style=flat)  
+Latest master version: ![master version](http://img.shields.io/myget/aspnetmaster/v/KRE-svr50-x64.svg?style=flat)  
 
 The Home repository is the starting point for people to learn about ASP.NET vNext. This repo contains samples and [documentation](https://github.com/aspnet/Home/wiki) to help folks get started and learn more about what's coming in ASP..NET vNext.
 


### PR DESCRIPTION
Due to an update in shields.io, it's now possible to create badges for myget packages. Showing the latest available KRE version on the home repo is a good idea I think. This should also be added to Mvc, EF etc, but with their respective badges ofc. To get the version of any package, the use the following url:

```
http://img.shields.io/myget/<myget feed name>/v/<package id>.svg?style=flat
```
