### PR TITLE
Use `-contains`

### DIFF
--- a/kvm.ps1
+++ b/kvm.ps1
@@ -378,7 +378,7 @@ filter List-Parts {
   $delim=""
 
   foreach($alias in $aliases){
-    if($_.Name.Split('\', 2).Contains($alias.Name)){
+    if($_.Name.Split('\', 2) -contains $alias.Name){
         $fullAlias += $delim + $alias.Alias
         $delim = ", "
     }


### PR DESCRIPTION
PowerShell 2 errors with "Method invocation failed because [System.String[]] doesn't contain a method named 'IndexOf'."
