### PR TITLE
Fix list command when there are no alias

### DIFF
--- a/kvm.sh
+++ b/kvm.sh
@@ -354,10 +354,12 @@ kvm()
             local arr=()            
             local i=0
             local format="%-20s %s\n"
-            for _kvm_file in $(find "$KRE_USER_HOME/alias" -name *.alias); do
-                arr[$i]="$(basename $_kvm_file | sed 's/.alias//')/$(cat $_kvm_file)"
-                let i+=1
-            done
+            if [ -d "$KRE_USER_HOME/alias" ]; then
+                for _kvm_file in $(find "$KRE_USER_HOME/alias" -name *.alias); do
+                    arr[$i]="$(basename $_kvm_file | sed 's/.alias//')/$(cat $_kvm_file)"
+                    let i+=1
+                done
+            fi
     
             local formatString="%-6s %-20s %-7s %-20s %s\n"
             printf "$formatString" "Active" "Version" "Runtime" "Location" "Alias"


### PR DESCRIPTION
We need to check if the alias directory exist when we use the list command, becase the alias directory is created only when the alias command is called for the first time.

This is the error message without the check

```
root@afd642140b5a:~# kvm list

find: `/root/.kre/alias': No such file or directory
Active Version              Runtime Location             Alias
------ -------              ------- --------             -----
       1.0.0-alpha4         Mono    ~/.kre/packages
```
