### PR TITLE
readme update for osx kvm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ To install KVM and the correct version of Mono on OS X using [Homebrew](http://b
 
  * Install [Homebrew](http://brew.sh) if it is not already installed.
  * Run command `brew tap aspnet/k` to tap the ASP.NET vNext related git repositories. If you had already tapped the repo for previous releases, run `brew untap aspnet/k` to delete the old commands and tap again to get the updated brew scripts.
+ * For the kvm install, please note that zsh is not supported. If you switch your shell to /bin/bash all should be well.
  * Run command `brew install kvm` to install KVM. This also automatically install the latest KRE package from https://www.nuget.org/api/v2 feed.
- * Run command `source kvm.sh` on your terminal if your terminal cannot understand kvm. 
+ * Run command `source kvm.sh` on your terminal if your terminal cannot understand kvm.
 
 #### Linux:
 


### PR DESCRIPTION
update to readme file to note that kvm install and the zsh shell are not compatible.
