### PR TITLE
Fix samples to run with latest kestrel

### DIFF
--- a/samples/HelloMvc/Startup.cs
+++ b/samples/HelloMvc/Startup.cs
@@ -15,7 +15,13 @@ namespace HelloMvc
                 services.AddMvc();
             });
 
-            app.UseMvc();
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller}/{action}/{id?}",
+                    defaults: new { controller = "Home", action = "Index" });
+            }); 
 
             app.UseWelcomePage();
         }       

--- a/samples/HelloMvc/project.json
+++ b/samples/HelloMvc/project.json
@@ -1,17 +1,17 @@
 {
     "dependencies": {
-        "Kestrel": "1.0.0-beta1",
-        "Microsoft.AspNet.Diagnostics": "1.0.0-beta1",
-        "Microsoft.AspNet.Hosting": "1.0.0-beta1",
-        "Microsoft.AspNet.Mvc": "6.0.0-beta1",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta1"
+        "Kestrel": "1.0.0-*",
+        "Microsoft.AspNet.Diagnostics": "1.0.0-*",
+        "Microsoft.AspNet.Hosting": "1.0.0-*",
+        "Microsoft.AspNet.Mvc": "6.0.0-*",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-*"
     },
     "commands": {
         "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5001",
         "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:5004"
     },
-	 "frameworks": {
+	"frameworks": {
         "aspnet50": {},
         "aspnetcore50": {}
-  }
+    }
 }

--- a/samples/HelloWeb/project.json
+++ b/samples/HelloWeb/project.json
@@ -1,10 +1,10 @@
 {
     "dependencies": {
-        "Kestrel": "1.0.0-beta1",
-        "Microsoft.AspNet.Diagnostics": "1.0.0-beta1",
-        "Microsoft.AspNet.Hosting": "1.0.0-beta1",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta1",
-        "Microsoft.AspNet.StaticFiles": "1.0.0-beta1"
+        "Kestrel": "1.0.0-*",
+        "Microsoft.AspNet.Diagnostics": "1.0.0-*",
+        "Microsoft.AspNet.Hosting": "1.0.0-*",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
+        "Microsoft.AspNet.StaticFiles": "1.0.0-*"
     },
     "commands": {
         "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5001",


### PR DESCRIPTION
Replaced beta1 with \* in project.json and added routing configuration in MVC sample.
