### PR TITLE
canged the references to kvm and kre to align with the latest renaming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ASP.NET vNext Home
+# ASP.NET 5 Home
 Latest dev version: [![dev version](http://img.shields.io/myget/aspnetvnext/v/kre-clr-win-x86.svg?style=flat)](https://www.myget.org/gallery/aspnetvnext)<br>
 Latest master version: [![master version](http://img.shields.io/myget/aspnetmaster/v/kre-clr-win-x86.svg?style=flat)](https://www.myget.org/gallery/aspnetmaster)
 
-The Home repository is the starting point for people to learn about ASP.NET vNext. This repo contains samples and [documentation](https://github.com/aspnet/Home/wiki) to help folks get started and learn more about what's coming in ASP.NET vNext.
+The Home repository is the starting point for people to learn about ASP.NET 5. This repo contains samples and [documentation](https://github.com/aspnet/Home/wiki) to help folks get started and learn more about what's coming in ASP.NET 5.
 
-ASP.NET vNext is being actively developed by the ASP.NET team assigned to the Microsoft Open Tech Hub and in collaboration with a community of open source developers. Together we are dedicated to creating the best possible platform for web development.
+ASP.NET 5 is being actively developed by the ASP.NET team assigned to the Microsoft Open Tech Hub and in collaboration with a community of open source developers. Together we are dedicated to creating the best possible platform for web development.
 
 The samples provided in this repo are designed to show some of the features of the new framework and to provide a starting point for further exploration. All the component packages are available on NuGet. To try out the latest bits under development switch to the dev branch of the Home repo and use the dev feed in NuGet.config (https://www.myget.org/F/aspnetvnext).
 
@@ -35,56 +35,55 @@ The easiest way to get started with ASP.NET vNext is to try out the latest previ
 
 That said, you can also try out ASP.NET vNext with just a command-prompt and a text editor. The following instructions will walk you through getting your dev environment setup.
 
-### Install the K Version Manager (KVM)
+### Install the .NET Version Manager (DNVM)
 
-The first thing we need to do is setup the tools required to build and run an application. We will start out by getting the [K Version Manager (KVM)](https://github.com/aspnet/Home/wiki/version-manager). We use the K Version Manager to install different versions of the ASP.NET vNext runtime and switch between them.
+The first thing we need to do is setup the tools required to build and run an application. We will start out by getting the [.NET Version Manager (DNVM)](https://github.com/aspnet/Home/wiki/version-manager). We use the .NET Version Manager to install different versions of the ASP.NET vNext runtime and switch between them.
 
 #### Windows
-To install KVM on Windows run the following command, which will download and run a script that installs KVM for the current user (requires admin privileges for Powershell). This will use the currently released version of `kvm` (from the `release` branch of this repo).
+To install DNVM on Windows run the following command, which will download and run a script that installs DNVM for the current user (requires admin privileges for Powershell). This will use the currently in-development version of `dnvm` (from the `dev` branch of this repo).
 
 ```
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/release/kvminstall.ps1'))"
-
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.ps1'))"
 ```
 
-If you want to run on the bleeding edge and install the latest development version of KVM, run the following command:
+If you want to run on the bleeding edge and install the latest development version of DNVM, run the following command:
 
 ```
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "&{$Branch='dev';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/release/kvminstall.ps1'))}"
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "&{$Branch='dev';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/release/dnvminstall.ps1'))}"
 ```
 
-After the script has run open a new command prompt to start using KVM.
+After the script has run open a new command prompt to start using DNVM.
 
 #### OS X:
 
-To install KVM and the correct version of Mono on OS X using [Homebrew](http://brew.sh) follow the following steps: 
+To install DNVM and the correct version of Mono on OS X using [Homebrew](http://brew.sh) follow the following steps: 
 
  * Install [Homebrew](http://brew.sh) if it is not already installed.
- * Run command `brew tap aspnet/k` to tap the ASP.NET vNext related git repositories. If you had already tapped the repo for previous releases, run `brew untap aspnet/k` to delete the old commands and tap again to get the updated brew scripts.
- * Run command `brew install kvm` to install KVM. This also automatically install the latest KRE package from https://www.nuget.org/api/v2 feed.
+ * Run command `brew tap aspnet/k` to tap the ASP.NET 5 related git repositories. If you had already tapped the repo for previous releases, run `brew untap aspnet/k` to delete the old commands and tap again to get the updated brew scripts.
+ * Run command `brew install kvm` to install DNVM. This also automatically install the latest KRE package from https://www.nuget.org/api/v2 feed.
  * Run command `source kvm.sh` on your terminal if your terminal cannot understand kvm. 
 
 #### Linux:
 
-Installing KVM requires `curl`. Do verify if that is installed on the machine. Next install KVM on Linux run the following command:
+Installing DNVM requires `curl`. Do verify if that is installed on the machine. Next install DNVM on Linux run the following command:
 
 ```
-curl -sSL https://raw.githubusercontent.com/aspnet/Home/release/kvminstall.sh | sh && source ~/.k/kvm/kvm.sh
+curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | sh && source ~/.k/dnvm/dnvm.sh
 ```
 
-If you want to run on the bleeding edge and install the latest development version of KVM, use this command:
+If you want to run on the bleeding edge and install the latest development version of DNVM, use this command:
 
 ```
-curl -sSL https://raw.githubusercontent.com/aspnet/Home/release/kvminstall.sh | KVM_BRANCH=dev sh && source ~/.k/kvm/kvm.sh
+curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | KVM_BRANCH=dev sh && source ~/.k/dnvm/dnvm.sh
 ```
 
 Note that on Linux you need to also install [Mono](http://mono-project.com) 3.4.1 or later.
 
-### Install the K Runtime Environment (KRE)
+### Install the .NET Execution Environment (DNX)
 
-Now that you have KVM setup you can install the latest version of the runtime by running the following command: ```kvm upgrade```
+Now that you have DNVM setup you can install the latest version of the runtime by running the following command: ```dnvm upgrade```
  
-This command will download the specified version of the K Runtime Environment (KRE), and put it on your user profile ready to use. You are now ready to start using ASP.NET vNext!
+This command will download the specified version of the .NET Execution Environment (KRE), and put it on your user profile ready to use. You are now ready to start using ASP.NET 5!
 
 ## Samples
 
@@ -93,7 +92,7 @@ The samples in this repo are basic starting points for you to experiment with.
 + [ConsoleApp](https://github.com/aspnet/Home/tree/release/samples/ConsoleApp). This is just basic console app if you want to use it as a starting point.
 + [HelloWeb](https://github.com/aspnet/Home/tree/release/samples/HelloWeb). This is a minimal startup class that shows welcome page and static file middleware. This is mostly for you to run through the steps in the readme and make sure you have everything setup and working correctly.
 + [HelloMvc](https://github.com/aspnet/Home/tree/release/samples/HelloMvc). This sample is a basic MVC app. It is not designed to show all the functionality of the new web stack, but to give you a starting point to play with features.
-+ [MVC Music Store](https://github.com/aspnet/MusicStore) and [BugTracker](https://github.com/aspnet/BugTracker) are application samples that are both being ported to ASP.NET vNext. Each of these samples have their own separate repositories that you can look at.
++ [MVC Music Store](https://github.com/aspnet/MusicStore) and [BugTracker](https://github.com/aspnet/BugTracker) are application samples that are both being ported to ASP.NET 5. Each of these samples have their own separate repositories that you can look at.
 
 ### Running the samples
 
@@ -109,9 +108,9 @@ The samples in this repo are basic starting points for you to experiment with.
 
 ### Switching to Core CLR
 
-By default when running ASP.NET vNext applications on the Windows platform you are running on the full .NET Framework. You can switch to use the new Cloud Optimized runtime, or Core CLR, using the KVM command.
+By default when running ASP.NET 5 applications on the Windows platform you are running on the full .NET Framework. You can switch to use the new Cloud Optimized runtime, or Core CLR, using the DNVM command.
 
-1. Run ```kvm upgrade -runtime CoreCLR``` This command gets the latest Core CLR version of the k runtime and sets it as your default. The `-runtime CoreCLR` switch tells it to use Core CLR. You can use `-r CLR` to target desktop again.
+1. Run ```dnvm upgrade -runtime CoreCLR``` This command gets the latest Core CLR version of the k runtime and sets it as your default. The `-runtime CoreCLR` switch tells it to use Core CLR. You can use `-r CLR` to target desktop again.
 2. Run ```k web``` to run on WebListener. 
 3. The first line of your output should say "Loaded Module: klr.core45.dll" instead of "Loaded Module: klr.net45.dll"
 4. The HelloWeb app should work the same as when running on the full desktop .NET Framework but now as a fully self-contained app with true side-by-side versioning support.


### PR DESCRIPTION
Not sure how much of this is actually correct but it seemed better than wrong info :smile: 
- kvm > dnvm
- kre > dnx
- ASP.NET vNext > ASP.NET 5
- K Version Manager > .NET Version Manager
- K Runtime Environment (KRE) > .NET Execution Environment (DNX)

NOTE: left the Homebrew stuff as is because I don't know if it is changed.
