### PR TITLE
Corrected paths to DNX repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Please log a new issue in the appropriate GitHub repo. Here are some of the most
 * [DependencyInjection](https://github.com/aspnet/DependencyInjection)
 * [EntityFramework](https://github.com/aspnet/EntityFramework)
 * [Identity](https://github.com/aspnet/Identity)
-* [KRuntime](https://github.com/aspnet/KRuntime)
+* [DNX](https://github.com/aspnet/dnx)
 * [MVC](https://github.com/aspnet/Mvc)
 * [SignalR-Server](https://github.com/aspnet/SignalR-Server)
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ These are some of the most common repos:
 * [DependencyInjection](https://github.com/aspnet/DependencyInjection) - basic dependency injection infrastructure and default implementation
 * [EntityFramework](https://github.com/aspnet/EntityFramework) - data access technology
 * [Identity](https://github.com/aspnet/Identity) - users and membership system
-* [KRuntime](https://github.com/aspnet/KRuntime) - core runtime, project system, loader
+* [DNX](https://github.com/aspnet/dnx) - core runtime, project system, loader
 * [MVC](https://github.com/aspnet/Mvc) - MVC framework for web apps and services
 * [SignalR-Server](https://github.com/aspnet/SignalR-Server) - real-time 
 


### PR DESCRIPTION
Renamed KRuntime to DNX and corrected repository paths in CONTRIBUTING.md and README.md.
