### PR TITLE
Fixed dnu restore on HelloMvc sample application

### DIFF
--- a/samples/1.0.0-beta4/HelloMvc/project.json
+++ b/samples/1.0.0-beta4/HelloMvc/project.json
@@ -14,7 +14,7 @@
         "Microsoft.AspNet.Diagnostics": "1.0.0-beta4-*",
         "Microsoft.AspNet.Mvc": "6.0.0-beta4-*",
         "Microsoft.AspNet.Server.IIS": "1.0.0-beta4-*",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4*"
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4-*"
     },
     "commands": {
         "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5001",


### PR DESCRIPTION
When I try to do a `dnu restore` on the sample application I get the error `Unable to locate Microsoft.AspNet.Server.WebListener >= 1.0.0-beta4*`
