### PR TITLE
lowercase mono-complete package name

### DIFF
--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -25,7 +25,7 @@ To get these builds you need to run:
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get update
-sudo apt-get install Mono-Complete
+sudo apt-get install mono-complete
 ```
 
 ### Get libuv


### PR DESCRIPTION
### Wrong casing of "Mono-Complete" package in GettingStartedDeb.md

In order to install mono in Debian Wheezy, we have to lowercase the package name

FROM 
`sudo apt-get install Mono-Complete`
TO 
`sudo apt-get install mono-complete`

Currently the script doesn't work
### Expected result

**mono-complete** package installed successfully.   
### Actual result

```
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package Mono-Complete
```
### Operating system

Debian Wheezy 7.7
(32 bits)
