### PR TITLE
Added instructions on how to source dnvm.sh on OsX

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ brew install dnvm
 ```
 Note that on Windows the .NET Framework is already installed, whereas on OS X the brew formula uses a particular version of [Mono](http://www.mono-project.com/) that we know works with ASP.NET 5.
 
-Execute ```dnvm``` to verify that everything works. Should that fail with ```-bash: dnvm: command not found``` run the command ```source dnvm.sh```. This means that ```dnvm``` will be available in this session. To make it sure for every session, add it to your ```~/.bashrc``` with the following command ```echo "source dnvm.sh" >> ~/.bashrc```.  
+Execute `dnvm` to verify that everything works. Should that fail with `-bash: dnvm: command not found` run the command `source dnvm.sh`. This means that `dnvm` will be available in this session. To make sure `dnvm` is available for *every* session, add the command to your `~/.bashrc` with the following command `echo "source dnvm.sh" >> ~/.bashrc`.  
 
 ## Linux
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ brew install dnvm
 ```
 Note that on Windows the .NET Framework is already installed, whereas on OS X the brew formula uses a particular version of [Mono](http://www.mono-project.com/) that we know works with ASP.NET 5.
 
+Execute `dnvm` to verify that everything works. Should that fail with `-bash: dnvm: command not found` run the command `source dnvm.sh`. This means that `dnvm` will be available in this session. To make sure `dnvm` is available for *every* session, add the command to your `~/.bashrc` with the following command `echo "source dnvm.sh" >> ~/.bashrc`.  
+
 ## Linux
 
 * [Debian, Ubuntu and derivatives see here](GettingStartedDeb.md)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ brew install dnvm
 ```
 Note that on Windows the .NET Framework is already installed, whereas on OS X the brew formula uses a particular version of [Mono](http://www.mono-project.com/) that we know works with ASP.NET 5.
 
+Execute ```dnvm``` to verify that everything works. Should that fail with ```-bash: dnvm: command not found``` run the command ```source dnvm.sh```. This means that ```dnvm``` will be available in this session. To make it sure for every session, add it to your ```~/.bashrc``` with the following command ```echo "source dnvm.sh" >> ~/.bashrc```.  
+
 ## Linux
 
 * [Debian, Ubuntu and derivatives see here](GettingStartedDeb.md)


### PR DESCRIPTION
Added instructions on how to solve `-bash: dnvm: command not found` for OsX
- When I followed the instructions above I ran into the `-bash: dnvm: command not found`. This is solved by executing `source dnvm.sh`, which I added to the description. 
- I also added some instructions on how to put this into your bash-start-script so that it will be ready with every new Terminal session/window
