### PR TITLE
Added instruction to install unzip in order to unpack runtime packages

### DIFF
--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -48,6 +48,14 @@ sudo ldconfig
 
 **NOTE:** `make install` puts `libuv.so.1` in `/usr/local/lib`, in the above commands `ldconfig` is used to update `ld.so.cache` so that `dlopen` (see `man dlopen`) can load it. If you are getting libuv some other way or not running `make install` then you need to ensure that dlopen is capable of loading `libuv.so.1`.
 
+### Get unzip
+
+Unzip is needed to unpack runtime packages.
+
+```
+sudo apt-get install unzip
+```
+
 ### Get DNVM
 
 Now let's get DNVM. To do this run:

--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -15,6 +15,24 @@ Instructions on how to use the ASP.NET [Docker](https://www.docker.com/) image h
 
 The rest of this section deals with setting up a machine to run applications without the Docker image.
 
+---
+
+### Prerequisites
+
+* `Unzip`
+
+---
+
+### Get unzip
+
+`Unzip` is needed to unpack runtime packages.
+
+```
+sudo apt-get install unzip
+```
+
+---
+
 ### Get Mono
 
 Mono is how .NET applications can run on platforms other than Windows. Mono is an ongoing effort to port the .NET Framework to other platforms. In the process of developing ASP.NET 5 we worked with the Mono team to fix some bugs and add features that are needed to run ASP.NET applications. These changes are only in builds of mono that are greater than 4.0.1.
@@ -47,14 +65,6 @@ sudo ldconfig
 ```
 
 **NOTE:** `make install` puts `libuv.so.1` in `/usr/local/lib`, in the above commands `ldconfig` is used to update `ld.so.cache` so that `dlopen` (see `man dlopen`) can load it. If you are getting libuv some other way or not running `make install` then you need to ensure that dlopen is capable of loading `libuv.so.1`.
-
-### Get unzip
-
-Unzip is needed to unpack runtime packages.
-
-```
-sudo apt-get install unzip
-```
 
 ### Get DNVM
 

--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -20,15 +20,24 @@ The rest of this section deals with setting up a machine to run applications wit
 ### Prerequisites
 
 * `Unzip`
+* `Curl`
 
 ---
 
-### Get unzip
+### Get Unzip
 
 `Unzip` is needed to unpack runtime packages.
 
 ```
 sudo apt-get install unzip
+```
+
+### Get Curl
+
+`Curl` is a command line tool for transferring data specified with URL syntax.
+
+```
+sudo apt-get install curl
 ```
 
 ---
@@ -53,7 +62,7 @@ sudo apt-get install mono-complete
 To build libuv you should do the following:
 
 ```
-sudo apt-get install automake libtool curl
+sudo apt-get install automake libtool
 curl -sSL https://github.com/libuv/libuv/archive/v1.4.2.tar.gz | sudo tar zxfv - -C /usr/local/src
 cd /usr/local/src/libuv-1.4.2
 sudo sh autogen.sh


### PR DESCRIPTION
Added instruction to install **unzip** in order to prevent getting an error message when `dnvm use` is executed.
- When I followed the instructions in [Getting Started](https://github.com/aspnet/Home/blob/dev/GettingStartedDeb.md) I ran into `Cannot find dnx-mono.1.0.0-beta4, do you need to run 'dnvm install 1.0.0-beta4'?`. This is solved by installing **unzip** package.
