### PR TITLE
adds 'make' and 'unzip' to a clean Ubuntu server 14.04.2 for 32-bit

### DIFF
--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -35,7 +35,7 @@ sudo apt-get install mono-complete
 To build libuv you should do the following:
 
 ```
-sudo apt-get install automake libtool curl
+sudo apt-get install automake libtool curl make unzip
 curl -sSL https://github.com/libuv/libuv/archive/v1.4.2.tar.gz | sudo tar zxfv - -C /usr/local/src
 cd /usr/local/src/libuv-1.4.2
 sudo sh autogen.sh


### PR DESCRIPTION
Hi all,
We should install `make` and `unzip`  in order to prevent the following on default Ubuntu server 14.04.2 instances:

```
user@host:~$ dnvm upgrade
Determining latest version
Latest version is 1.0.0-beta4
Downloading dnx-mono.1.0.0-beta4 from https://www.nuget.org/api/v2
Download: https://www.nuget.org/api/v2/package/dnx-mono/1.0.0-beta4
######################################################################## 100.0%
Installing to /home/cmpunk/.dnx/runtimes/dnx-mono.1.0.0-beta4
dnvm needs unzip to proceed.
```
