### PR TITLE
Edit to latest version of libuv in Doc

### DIFF
--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -36,13 +36,13 @@ To build libuv you should do the following:
 
 ```
 sudo apt-get install automake libtool curl
-curl -sSL https://github.com/libuv/libuv/archive/v1.4.2.tar.gz | sudo tar zxfv - -C /usr/local/src
-cd /usr/local/src/libuv-1.4.2
+curl -sSL https://github.com/libuv/libuv/archive/v1.6.1.tar.gz | sudo tar zxfv - -C /usr/local/src
+cd /usr/local/src/libuv-1.6.1
 sudo sh autogen.sh
 sudo ./configure
 sudo make 
 sudo make install
-sudo rm -rf /usr/local/src/libuv-1.4.2 && cd ~/
+sudo rm -rf /usr/local/src/libuv-1.6.1 && cd ~/
 sudo ldconfig
 ```
 


### PR DESCRIPTION
On [`libuv`](https://github.com/libuv/libuv/releases) the latest version is 1.6.1, but you doc is still showing v1.4.2.
