### PR TITLE
Fixed Dockerfile to prevent Mono ThreadPool package download timeouts.

### DIFF
--- a/samples/latest/HelloMvc/Dockerfile
+++ b/samples/latest/HelloMvc/Dockerfile
@@ -2,7 +2,9 @@ FROM microsoft/aspnet
 
 COPY project.json /app/
 WORKDIR /app
+ENV MONO_THREADS_PER_CPU=2000
 RUN ["dnu", "restore"]
+ENV MONO_THREADS_PER_CPU=100
 COPY . /app
 
 EXPOSE 5004


### PR DESCRIPTION
The Mono ThreadPool feature has the affect of throttling the number of  threads that the dnu restore command can make. As a result of this throttling when dnu restore tries to open a thread for every package download it very quickly hits that limit and package downloads start to time out or outright fail.

So to fix this without having to make programmatic changes to DNU/DNX we simply temporarily alter the environmental variable which controls that max thread count. We raise it very high while we are doing the package restore and then bring it down to a more reasonable level to prevent timeouts and/or deadlocks (20 is the default) afterwards.

For reference see: http://www.mono-project.com/archived/articlethreadpool_deadlocks/
