### PR TITLE
#672 Pass -Proxy parameter so we can find packages

### DIFF
--- a/dnvm.ps1
+++ b/dnvm.ps1
@@ -1332,10 +1332,10 @@ function dnvm-install {
     if (!$IsNuPkg) {
         if ($VersionNuPkgOrAlias -eq "latest") {
             Write-Progress -Activity "Installing runtime" -Status "Determining latest runtime" -Id 1
-            $findPackageResult = Find-Latest -runtimeInfo:$runtimeInfo -Feed:$selectedFeed
+            $findPackageResult = Find-Latest -runtimeInfo:$runtimeInfo -Feed:$selectedFeed -Proxy:$Proxy
         }
         else {
-            $findPackageResult = Find-Package -runtimeInfo:$runtimeInfo -Feed:$selectedFeed
+            $findPackageResult = Find-Package -runtimeInfo:$runtimeInfo -Feed:$selectedFeed -Proxy:$Proxy
         }
         $Version = $findPackageResult.Version
     }


### PR DESCRIPTION
Fix for `dnvm upgrade -Proxy <server>` not working behind a proxy server, by passing parameter on to `Find-Latest` and `Find-Package` methods.

I have docu-signed the Contributor License Agreement.
#672
