### PR TITLE
Removed dot from dnx run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ You should also be able to run `dnx` and see the help text of the `dnx` command.
 3. Run ```dnu restore``` to restore the packages required by that sample.
 4. You should see a bunch of output as all the dependencies of the app are downloaded from MyGet.
 5. Run the sample using the appropriate DNX command:
-    - For the console app run  `dnx . run`.
-    - For the web apps run `dnx . web` on Windows or `dnx . kestrel` on OS X/Linux.
+    - For the console app run  `dnx run`.
+    - For the web apps run `dnx web` on Windows or `dnx kestrel` on OS X/Linux.
 6. You should see the output of the console app or a message that says the site is now started.
 7. You can navigate to the web apps in a browser by navigating to `http://localhost:5001` or `http://localhost:5004` if running on OS X/Linux.
 


### PR DESCRIPTION
The dot (current folder) isn't needed when using the latest dnx
