### PR TITLE
adds windows support

### DIFF
--- a/dnvm.sh
+++ b/dnvm.sh
@@ -1,6 +1,10 @@
 # dnvm.sh
 # Source this file from your .bash-profile or script to use
 
+unset DNX_USER_HOME
+unset DNX_GLOBAL_HOME
+unset DNX_HOME
+
 # "Constants"
 _DNVM_BUILDNUMBER="beta8-15516"
 _DNVM_AUTHORS="Microsoft Open Technologies, Inc."
@@ -30,6 +34,17 @@ if [ "$NO_COLOR" != "1" ]; then
     Whi='\e[0;37m';     BWhi='\e[1;37m';    UWhi='\e[4;37m';    IWhi='\e[0;97m';    BIWhi='\e[1;97m';   On_Whi='\e[47m';    On_IWhi='\e[0;107m';
 fi
 
+__dnvm_current_os()
+{
+    local uname=$(uname)
+	if [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ] || [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
+		echo "win"
+	elif [[ $uname == "Darwin" ]]; then
+        echo "darwin"
+    else
+        echo "linux"
+    fi
+}
 
 [[ "$_DNVM_BUILDNUMBER" = {{* ]] && _DNVM_BUILDNUMBER="HEAD"
 
@@ -46,15 +61,19 @@ if [ -z "$DNX_USER_HOME" ]; then
     eval DNX_USER_HOME="~/$_DNVM_RUNTIME_FOLDER_NAME"
 fi
 
+if [ $(__dnvm_current_os)=="win" ]; then
+    eval DNX_USER_HOME="/c/Users/$USERNAME/$_DNVM_RUNTIME_FOLDER_NAME"
+fi
+
 if [ -z "$DNX_GLOBAL_HOME" ]; then
     eval DNX_GLOBAL_HOME="/usr/local/lib/dnx"
 fi
 
 if [ -z "$DNX_HOME" ]; then
     # Set to the user home value
-    eval DNX_HOME="$DNX_USER_HOME:$DNX_GLOBAL_HOME"
+    eval DNX_HOME="$DNX_USER_HOME;$DNX_GLOBAL_HOME"
 elif [[ $DNX_HOME != *"$DNX_GLOBAL_HOME"* ]]; then
-    eval DNX_HOME="$DNX_HOME:$DNX_GLOBAL_HOME"
+    eval DNX_HOME="$DNX_HOME;$DNX_GLOBAL_HOME"
 fi
 
 _DNVM_USER_PACKAGES="$DNX_USER_HOME/runtimes"
@@ -64,15 +83,7 @@ _DNVM_DNVM_DIR="$DNX_USER_HOME/dnvm"
 
 DNX_ACTIVE_FEED=""
 
-__dnvm_current_os()
-{
-    local uname=$(uname)
-    if [[ $uname == "Darwin" ]]; then
-        echo "darwin"
-    else
-        echo "linux"
-    fi
-}
+
 
 __dnvm_os_runtime_defaults()
 {
@@ -364,6 +375,7 @@ __dnvm_requested_version_or_alias() {
 # This will be more relevant if we support global installs
 __dnvm_locate_runtime_bin_from_full_name() {
     local runtimeFullName=$1
+	
     for v in `echo $DNX_HOME | tr ":" "\n"`; do
         if [ -e "$v/runtimes/$runtimeFullName/bin" ]; then
             echo "$v/runtimes/$runtimeFullName/bin" && return
@@ -627,6 +639,7 @@ dnvm()
                 local runtimeFolder="$runtimeDir/$runtimeFullName"
 
                 local exist=0
+				
                 for folder in `echo $DNX_HOME | tr ":" "\n"`; do
                     if [ -e "$folder/runtimes/$runtimeFullName" ]; then
                         echo "$runtimeFullName already installed in $folder"
@@ -848,10 +861,11 @@ dnvm()
             [[ ! -d $_DNVM_USER_PACKAGES ]] && echo "$_DNVM_RUNTIME_FRIENDLY_NAME is not installed." && return 1
 
             local searchGlob="$_DNVM_RUNTIME_PACKAGE_NAME-*"
-
             local runtimes=""
-            for location in `echo $DNX_HOME | tr ":" "\n"`; do
+            for location in `echo $DNX_HOME | tr ";" "\n"`; do
                 location+="/runtimes"
+				
+				echo $location
                 if [ -d "$location" ]; then
                     local oruntimes="$(find $location -name "$searchGlob" \( -type d -or -type l \) -prune -exec basename {} \;)"
                     for v in `echo $oruntimes | tr "\n" " "`; do


### PR DESCRIPTION
adds windows support to dnvm.sh 
-adds a condition to the __dnvm_current_os function which checks if you are using cygwin
-if on windows, sets a DNX_USER_HOME path which does not conflict with the colon delimeter used elsewhere
-if the variables are not unset at the start, somehow they are getting set incorrectly elsewhere

tested with the following commands among others
dnvm install -r coreclr -arch x64 latest -OS win -u
dnvm use -r coreclr -arch x64 1.0.0-beta8-15618 -p
