### PR TITLE
Update Dockerfile calling syntax

### DIFF
--- a/samples/latest/HelloMvc/Dockerfile
+++ b/samples/latest/HelloMvc/Dockerfile
@@ -1,9 +1,38 @@
-FROM microsoft/aspnet
+FROM ubuntu:14.04
 
-COPY project.json /app/
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+
+ENV DNX_USER_HOME /opt/dnx
+
+RUN apt-get -qq update && apt-get -qqy install curl unzip mono-complete
+
+RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
+RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
+	&& dnvm upgrade -u \
+	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+ENV MONO_THREADS_PER_CPU 20
+
+COPY . /app
 WORKDIR /app
 RUN ["dnu", "restore"]
-COPY . /app
 
 EXPOSE 5004
-ENTRYPOINT ["dnx", "project.json", "kestrel"]
+ENTRYPOINT ["dnx", "kestrel"]

--- a/samples/latest/HelloMvc/NuGet.Config
+++ b/samples/latest/HelloMvc/NuGet.Config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
+    <add key="NuGetorg" value="https://nuget.org/api/v2/" />
+  </packageSources>
+</configuration>

--- a/samples/latest/HelloWeb/Dockerfile
+++ b/samples/latest/HelloWeb/Dockerfile
@@ -1,9 +1,38 @@
-FROM microsoft/aspnet
+FROM ubuntu:14.04
 
-COPY project.json /app/
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+
+ENV DNX_USER_HOME /opt/dnx
+
+RUN apt-get -qq update && apt-get -qqy install curl unzip mono-complete
+
+RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
+RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
+	&& dnvm upgrade -u \
+	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+ENV MONO_THREADS_PER_CPU 20
+
+COPY . /app
 WORKDIR /app
 RUN ["dnu", "restore"]
-COPY . /app
 
 EXPOSE 5004
-ENTRYPOINT ["dnx", "project.json", "kestrel"]
+ENTRYPOINT ["dnx", "kestrel"]

--- a/samples/latest/HelloWeb/NuGet.Config
+++ b/samples/latest/HelloWeb/NuGet.Config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
+    <add key="NuGetorg" value="https://nuget.org/api/v2/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This is for https://github.com/aspnet/Home/issues/936

@anurse and @BrennanConroy Give me a shipit on the Dockerfile and general idea?

Issues with existing setup. 
- Latest sample is supposed to always run against the latest DNX, not beta7. So it needs to run against the latest unstable.
- uname detection for clr fallback doesn't work on wheezy based Ubuntu. So I am going from Ubuntu 14.04 directly.
- Copying project.json, restoring, then copying app would overwrite the project.lock.json with one from my build context. Which would not work because it would overwrite the lock file that was created in restore with the one from the context. This probably doesn't break people if everything lines up 100% but is not really correct.
- Need NuGet.Config in a location that restore will use so that it gets packages from aspnetvnext instead of NuGet.org as it is running against nightly builds.
