### PR TITLE
Add time-saving fix for doing a build

### DIFF
--- a/GettingStartedDeb.md
+++ b/GettingStartedDeb.md
@@ -14,6 +14,8 @@ cd aspnet-home/samples/latest/HelloWeb
 docker build -t aspnet-home-helloweb .
 ```
 
+If this build fails when setting up colord, due to a failed chfn, it is likely due to Linux kernel PAM auditing code.  To use a patched image that disables auditing, edit the Dockerfile and replace the FROM ubuntu:14.04 line with FROM sequenceiq/pam:ubuntu-14.04, or follow the instructions at https://github.com/sequenceiq/docker-pam to create a patch from source code.
+
 ### Run a docker container
 ```
 docker run -it -p 5004:5004 aspnet-home-helloweb


### PR DESCRIPTION
These instructions fail for the docker build step on Ubuntu 14.04.3.  After digging for a long time, I found a patch, and added a note to this document about how to use it.

My story:
I created a new Ubuntu 14.04.3 VM on Azure and followed the Linux docker instructions and it fails on colord.  Scrolling back in the output, it is doing something with chfn, which apparently has something to do with the linux kernel's PAM auditing code not allowing login in non-init namespaces.  After a lot of time with digging, I found a simple but perhaps controversial fix, replacing the FROM line with a patched ubuntu from this git repo:  https://github.com/sequenceiq/docker-pam

The simple fix is to use a patched docker image (or build it yourself):
# FROM ubuntu:14.04

FROM sequenceiq/pam:ubuntu-14.04
