### PR TITLE
Support ZDOTDIR variable to locate .zshrc

### DIFF
--- a/dnvminstall.sh
+++ b/dnvminstall.sh
@@ -59,6 +59,8 @@ fi
 if [ -z "$ZPROFILE" ]; then
     if [ -f "$HOME/.zshrc" ]; then
         ZPROFILE="$HOME/.zshrc"
+    elif [ ! -z "$ZDOTDIR" -a -f "$ZDOTDIR/.zshrc" ]; then
+    	ZPROFILE="$ZDOTDIR/.zshrc"
     fi
 fi
 


### PR DESCRIPTION
zsh uses the ZDOTDIR variable to find .zshrc etc.

For example, I placed my .zshrc and similar files under a ~/dotfiles directory so I can store them in a git repo.

See: http://zsh.sourceforge.net/Intro/intro_3.html
