### PR TITLE
System.Console reference in beta8 ConsoleApp is wrong

### DIFF
--- a/samples/1.0.0-beta8/ConsoleApp/project.json
+++ b/samples/1.0.0-beta8/ConsoleApp/project.json
@@ -9,7 +9,7 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "System.Console": "4.0.0-beta-beta8"
+                "System.Console": "4.0.0-23427"
             }
         }
     }


### PR DESCRIPTION
4.0.0-beta-beta8 doesn't exist
Changed to the latest version that exists right now
