### PR TITLE
Changing the name of the dnx command from 'web' to 'kestrel' to be co…

### DIFF
--- a/samples/1.0.0-beta8/HelloMvc/project.json
+++ b/samples/1.0.0-beta8/HelloMvc/project.json
@@ -18,7 +18,7 @@
         "Microsoft.Framework.Logging.Console": "1.0.0-beta8"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
+        "kestrel": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
     },
     "frameworks": {
          "dnx451": { },

--- a/samples/1.0.0-beta8/HelloWeb/project.json
+++ b/samples/1.0.0-beta8/HelloWeb/project.json
@@ -18,7 +18,7 @@
         "Microsoft.Framework.Logging.Console": "1.0.0-beta8"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
+        "kestrel": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
     },
     "frameworks": {
         "dnx451": { },

--- a/samples/1.0.0-rc1-final/HelloMvc/project.json
+++ b/samples/1.0.0-rc1-final/HelloMvc/project.json
@@ -17,7 +17,7 @@
         "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
+        "kestrel": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
     },
     "frameworks": {
          "dnx451": { },

--- a/samples/1.0.0-rc1-final/HelloWeb/project.json
+++ b/samples/1.0.0-rc1-final/HelloWeb/project.json
@@ -18,7 +18,7 @@
         "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
+        "kestrel": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
     },
     "frameworks": {
         "dnx451": { },

--- a/samples/latest/HelloMvc/project.json
+++ b/samples/latest/HelloMvc/project.json
@@ -17,7 +17,7 @@
         "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5004"
+        "kestrel": "Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5004"
     },
     "frameworks": {
          "dnx451": { },

--- a/samples/latest/HelloWeb/project.json
+++ b/samples/latest/HelloWeb/project.json
@@ -18,7 +18,7 @@
         "Microsoft.Extensions.Logging.Console": "1.0.0-*"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5004"
+        "kestrel": "Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5004"
     },
     "frameworks": {
         "dnx451": { },


### PR DESCRIPTION
Renaming the name of the command from 'web' to kestrel to:
- Ensure consistency between documentation and code
- Ensure consistency between the binary used for the server and the name of the command
