### PR TITLE
Fixed dnx command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You should also be able to run `dnx` and see the help text of the `dnx` command.
 4. You should see a bunch of output as all the dependencies of the app are downloaded from MyGet.
 5. Run the sample using the appropriate DNX command:
     - For the console app run  `dnx run`.
-    - For the web apps run `dnx kestrel`.
+    - For the web apps run `dnx web`.
 6. You should see the output of the console app or a message that says the site is now started.
 7. You can navigate to the web apps in a browser by navigating to `http://localhost:5004`
 


### PR DESCRIPTION
According to https://github.com/aspnet/Home/blob/dev/samples/1.0.0-rc1-final/HelloWeb/project.json the command to run web app is `dnx web` instead of `dnx kestrel`. So I updated the README.

I confirmed this by testing it on an Ubuntu 14.04 x64 machine.
