### PR TITLE
Fix issue/1312 - Use caching in docker build

### DIFF
--- a/samples/latest/HelloMvc/Dockerfile
+++ b/samples/latest/HelloMvc/Dockerfile
@@ -30,9 +30,10 @@ ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
 
 ENV MONO_THREADS_PER_CPU 20
 
-COPY . /app
+COPY ./project.json /app/project.json
 WORKDIR /app
 RUN ["dnu", "restore"]
+COPY . /app
 
 EXPOSE 5004
 ENTRYPOINT ["dnx", "kestrel"]

--- a/samples/latest/HelloWeb/Dockerfile
+++ b/samples/latest/HelloWeb/Dockerfile
@@ -30,9 +30,10 @@ ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
 
 ENV MONO_THREADS_PER_CPU 20
 
-COPY . /app
+COPY ./project.json /app/project.json
 WORKDIR /app
 RUN ["dnu", "restore"]
+COPY . /app
 
 EXPOSE 5004
 ENTRYPOINT ["dnx", "kestrel"]


### PR DESCRIPTION
Per comment in issue https://github.com/aspnet/Home/issues/1312

the current state of the dockerfile in the aspnet/home repo does not use docker caching on DNU RESTORE (soon to be dotnet restore)

A small fix to the sample dockerfile can make the compile time of "second deploy" in docker 23x faster

**old-speed for every deploy & first deploy under new method:** ~3m30s
Start: 06:03:13.313
Finish: 06:06:40.640

**new-speed - second & subsequent deploys if dependencies are unchanged**: ~9s
Start: 06:00:36:036
Finish: 06:00:45:045

I also posted the FULL LOG of the difference over here: aspnet/aspnet-docker#123
