### PR TITLE
Update Dockerfiles and allows kestrel to listen for * domains

### DIFF
--- a/samples/latest/HelloMvc/Dockerfile
+++ b/samples/latest/HelloMvc/Dockerfile
@@ -1,38 +1,8 @@
-FROM ubuntu:14.04
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-
-ENV DNX_USER_HOME /opt/dnx
-
-RUN apt-get -qq update && apt-get -qqy install curl unzip mono-complete
-
-RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
-RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
-	&& dnvm upgrade -u \
-	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
-
-# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
-RUN apt-get -qqy install \
-	autoconf \
-	automake \
-	build-essential \
-	libtool
-
-RUN LIBUV_VERSION=1.4.2 \
-	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
-	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
-	&& sh autogen.sh && ./configure && make && make install \
-	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
-	&& ldconfig
-
-ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
-
-ENV MONO_THREADS_PER_CPU 20
+FROM microsoft/aspnet
 
 COPY . /app
 WORKDIR /app
 RUN ["dnu", "restore"]
 
 EXPOSE 5004
-ENTRYPOINT ["dnx", "kestrel"]
+ENTRYPOINT ["dnx", "-p", "project.json", "web"]

--- a/samples/latest/HelloMvc/project.json
+++ b/samples/latest/HelloMvc/project.json
@@ -17,7 +17,7 @@
         "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5004"
+        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
     },
     "frameworks": {
          "dnx451": { },

--- a/samples/latest/HelloWeb/Dockerfile
+++ b/samples/latest/HelloWeb/Dockerfile
@@ -1,38 +1,8 @@
-FROM ubuntu:14.04
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-
-ENV DNX_USER_HOME /opt/dnx
-
-RUN apt-get -qq update && apt-get -qqy install curl unzip mono-complete
-
-RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
-RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
-	&& dnvm upgrade -u \
-	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
-
-# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
-RUN apt-get -qqy install \
-	autoconf \
-	automake \
-	build-essential \
-	libtool
-
-RUN LIBUV_VERSION=1.4.2 \
-	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
-	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
-	&& sh autogen.sh && ./configure && make && make install \
-	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
-	&& ldconfig
-
-ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
-
-ENV MONO_THREADS_PER_CPU 20
+FROM microsoft/aspnet
 
 COPY . /app
 WORKDIR /app
 RUN ["dnu", "restore"]
 
 EXPOSE 5004
-ENTRYPOINT ["dnx", "kestrel"]
+ENTRYPOINT ["dnx", "-p", "project.json", "web"]

--- a/samples/latest/HelloWeb/project.json
+++ b/samples/latest/HelloWeb/project.json
@@ -18,7 +18,7 @@
         "Microsoft.Extensions.Logging.Console": "1.0.0-*"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5004"
+        "web": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:5004"
     },
     "frameworks": {
         "dnx451": { },


### PR DESCRIPTION
- Fix "web" command mismatch with kestrel entrypoint by updating Dockerfiles
- Allow multiple domains with server.urls *
