### PR TITLE
Replace jabbr link with slack team link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Our team members also monitor several other discussion forums:
 
 * [ASP.NET Core forum](https://forums.asp.net/1255.aspx/1?ASP+NET+5)
 * [StackOverflow](https://stackoverflow.com/) with the [`asp.net-core`](https://stackoverflow.com/questions/tagged/asp.net-core), [`asp.net-core-mvc`](https://stackoverflow.com/questions/tagged/asp.net-core-mvc), or [`entity-framework-core`](https://stackoverflow.com/questions/tagged/entity-framework-core) tags.
-* [JabbR chat room](https://jabbr.net/#/rooms/AspNetCore) for real-time discussions with the community and the people who work on the project
+* [Slack Team](http://aspnetcore.slack.com/) for real-time discussions with the community and the people who work on the project. [Get an invite](http://tattoocoder.com/aspnet-slack-sign-up/).
 
 
 ## Filing issues


### PR DESCRIPTION
Jabbr is dead yo.