### PR TITLE
Add SignalR to common repository list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ For non-security related bugs please log a new issue in the appropriate GitHub r
 * [Razor](https://github.com/aspnet/Razor)
 * [Templates](https://github.com/aspnet/Templates)
 * [Tooling](https://github.com/aspnet/Tooling)
+* [SignalR](https://github.com/aspnet/SignalR)
 
 Or browse the full list of repos in the [aspnet](https://github.com/aspnet/) organization.
 


### PR DESCRIPTION
Add SignalR to the common repository list (to make sure it gets into netstandart2.1^^).