### PR TITLE
Update CONTRIBUTING.md due to obsolete 'Templates' repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ For non-security related bugs please log a new issue in the appropriate GitHub r
 * [Identity](https://github.com/aspnet/Identity)
 * [MVC](https://github.com/aspnet/Mvc)
 * [Razor](https://github.com/aspnet/Razor)
-* [Templates](https://github.com/aspnet/Templates)
+* [Templating](https://github.com/aspnet/templating)
 * [Tooling](https://github.com/aspnet/Tooling)
 * [SignalR](https://github.com/aspnet/SignalR)
 


### PR DESCRIPTION
Recommending a change to the Contributing guidelines now that the 'Templates' repository is obsolete.  Perhaps this is the desired intent for history; otherwise, just FYI that you may want to update this document.  Thanks.

Contributing guidelines for this repository reference an obsolete [Templates](https://github.com/aspnet/Templates) repository.  

Instead, potentially suggesting links to appropriate ASP.NET Core template repository.