### PR TITLE
2.2: Remove the aspnet/Common git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,10 +26,6 @@
 	path = modules/Caching
 	url = https://github.com/aspnet/Caching.git
 	branch = release/2.2
-[submodule "modules/Common"]
-	path = modules/Common
-	url = https://github.com/aspnet/Common.git
-	branch = release/2.2
 [submodule "modules/Configuration"]
 	path = modules/Configuration
 	url = https://github.com/aspnet/Configuration.git

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -25,12 +25,10 @@
     <PackageArtifact Include="dotnet-sql-cache" Category="ship" />
     <PackageArtifact Include="dotnet-user-secrets" Category="ship" />
     <PackageArtifact Include="dotnet-watch" Category="ship" />
-    <PackageArtifact Include="Internal.AspNetCore.Analyzers" Category="noship" />
     <PackageArtifact Include="Internal.AspNetCore.Universe.Lineup" Category="noship" PackageType="Lineup" />
     <PackageArtifact Include="Internal.WebHostBuilderFactory.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.All" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Analyzer.Testing" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Analyzers" Category="shipoob" />
     <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
@@ -252,7 +250,6 @@
     <PackageArtifact Include="Microsoft.Extensions.Logging.Testing" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.Logging.TraceSource" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Logging" Category="ship" AppMetapackage="true" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.NonCapturingTimer.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.Options.ConfigurationExtensions" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Options.DataAnnotations" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Options" Category="ship" AppMetapackage="true" AllMetapackage="true" />

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -55,9 +55,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" AllMetapackage="true"/>
-    <PackageArtifact Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Buffering" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Certificates.Generation.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.ChunkingCookieManager.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Connections.Abstractions" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
@@ -173,7 +171,6 @@
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.TestHost" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Testing" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
@@ -212,8 +209,6 @@
     <PackageArtifact Include="Microsoft.Extensions.Caching.Redis" Category="ship" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Caching.StackExchangeRedis" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Caching.SqlServer" Category="ship" AppMetapackage="true" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.ClosedGenericMatcher.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.CommandLineUtils.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.Configuration.Abstractions" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Configuration.AzureKeyVault" Category="ship" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Configuration.Binder" Category="ship" AppMetapackage="true" AllMetapackage="true" />
@@ -226,7 +221,6 @@
     <PackageArtifact Include="Microsoft.Extensions.Configuration.UserSecrets" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Configuration.Xml" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Configuration" Category="ship" AppMetapackage="true" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.CopyOnWriteDictionary.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.DependencyInjection.Abstractions" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.DependencyInjection" Category="ship" AppMetapackage="true" AllMetapackage="true" />
@@ -239,7 +233,6 @@
     <PackageArtifact Include="Microsoft.Extensions.FileProviders.Embedded" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.FileProviders.Physical" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.FileSystemGlobbing" Category="ship" AppMetapackage="true" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.HashCodeCombiner.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.Hosting.Abstractions" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Hosting" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Http.Polly" Category="ship" AppMetapackage="false" AllMetapackage="false" />
@@ -260,22 +253,10 @@
     <PackageArtifact Include="Microsoft.Extensions.Logging.TraceSource" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Logging" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.NonCapturingTimer.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.ObjectMethodExecutor.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.ObjectPool" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Options.ConfigurationExtensions" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Options.DataAnnotations" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.Options" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Extensions.ParameterDefaultValue.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.Primitives" Category="ship" AppMetapackage="true" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.Process.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.PropertyActivator.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.PropertyHelper.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.RazorViews.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.SecurityHelper.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.StackTrace.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.TypeNameHelper.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.ValueStopwatch.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.WebEncoders.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.WebEncoders" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="ship" AppMetapackage="true" AllMetapackage="true" />
     <PackageArtifact Include="Microsoft.NET.Sdk.Razor" Category="ship" />

--- a/build/buildorder.props
+++ b/build/buildorder.props
@@ -7,7 +7,6 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <RepositoryBuildOrder Include="Common" Order="1" />
     <RepositoryBuildOrder Include="Microsoft.Data.Sqlite" Order="1" />
     <RepositoryBuildOrder Include="DependencyInjection" Order="2" />
     <RepositoryBuildOrder Include="FileSystem" Order="2" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,6 +5,26 @@
     <MicrosoftNETCoreAppPackageVersion>2.2.0-rtm-27023-02</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>2.2.0-rtm-27023-02</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <SystemDataSqlClientPackageVersion>4.6.0-rtm-27023-03</SystemDataSqlClientPackageVersion>
+    <!-- Packages from aspnet/Extensions -->
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
+    <MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion>
+    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion>
+    <MicrosoftExtensionsObjectPoolPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsObjectPoolPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsPrimitivesPackageVersion>
+    <MicrosoftExtensionsProcessSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsProcessSourcesPackageVersion>
+    <MicrosoftExtensionsPropertyActivatorSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsPropertyActivatorSourcesPackageVersion>
+    <MicrosoftExtensionsPropertyHelperSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsPropertyHelperSourcesPackageVersion>
+    <MicrosoftExtensionsRazorViewsSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsRazorViewsSourcesPackageVersion>
+    <MicrosoftExtensionsSecurityHelperSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsSecurityHelperSourcesPackageVersion>
+    <MicrosoftExtensionsStackTraceSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsStackTraceSourcesPackageVersion>
+    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
+    <MicrosoftExtensionsValueStopwatchSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsValueStopwatchSourcesPackageVersion>
+    <MicrosoftExtensionsWebEncodersSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsWebEncodersSourcesPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,6 +6,7 @@
     <MicrosoftNETCoreDotNetAppHostPackageVersion>2.2.0-rtm-27023-02</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <SystemDataSqlClientPackageVersion>4.6.0-rtm-27023-03</SystemDataSqlClientPackageVersion>
     <!-- Packages from aspnet/Extensions -->
+    <InternalAspNetCoreAnalyzersPackageVersion>2.2.0-rtm-35542</InternalAspNetCoreAnalyzersPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreTestingPackageVersion>
@@ -13,6 +14,8 @@
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion>
     <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
+    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>2.2.0-rtm-35542</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
     <MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion>
     <MicrosoftExtensionsObjectPoolPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsObjectPoolPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>2.2.0-rtm-35542</MicrosoftExtensionsPrimitivesPackageVersion>

--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -25,13 +25,17 @@
 
   <ItemGroup>
     <!-- Packages from aspnet/Extensions -->
+    <ExtensionsDependency Include="Internal.AspNetCore.Analyzers" Version="$(InternalAspNetCoreAnalyzersPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.AspNetCore.Analyzer.Testing" Version="$(MicrosoftAspNetCoreAnalyzerTestingPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="$(MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.AspNetCore.Certificates.Generation.Sources" Version="$(MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)"  />
     <ExtensionsDependency Include="Microsoft.Extensions.ClosedGenericMatcher.Sources" Version="$(MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.ClosedGenericMatcher.Sources" Version="$(MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.Extensions.CopyOnWriteDictionary.Sources" Version="$(MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.Extensions.HashCodeCombiner.Sources" Version="$(MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.NonCapturingTimer.Sources" Version="$(MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.Extensions.ObjectMethodExecutor.Sources" Version="$(MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion)" />
     <ExtensionsDependency Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)" AllMetapackage="true" AppMetapackage="true" />
     <ExtensionsDependency Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" AllMetapackage="true" AppMetapackage="true" />

--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -10,9 +10,45 @@
       <!-- When true, this dependency will be included in the Microsoft.AspNetCore.All metapackage. -->
       <AllMetapackage>false</AllMetapackage>
     </ExternalDependency>
+
+    <!-- For dependencies from aspnet/Extensions -->
+    <ExtensionsDependency>
+      <!-- The NuGet package version. Floating versions not allowed. -->
+      <Version></Version>
+      <!-- When true, this dependency will be included in the Microsoft.AspNetCore.App metapackage. -->
+      <AppMetapackage>false</AppMetapackage>
+      <!-- When true, this dependency will be included in the Microsoft.AspNetCore.All metapackage. -->
+      <AllMetapackage>false</AllMetapackage>
+      <IsExtensionsPackage>true</IsExtensionsPackage>
+    </ExtensionsDependency>
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <!-- Packages from aspnet/Extensions -->
+    <ExtensionsDependency Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="$(MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.AspNetCore.Certificates.Generation.Sources" Version="$(MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)"  />
+    <ExtensionsDependency Include="Microsoft.Extensions.ClosedGenericMatcher.Sources" Version="$(MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.CopyOnWriteDictionary.Sources" Version="$(MicrosoftExtensionsCopyOnWriteDictionarySourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.HashCodeCombiner.Sources" Version="$(MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.ObjectMethodExecutor.Sources" Version="$(MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)" AllMetapackage="true" AppMetapackage="true" />
+    <ExtensionsDependency Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" AllMetapackage="true" AppMetapackage="true" />
+    <ExtensionsDependency Include="Microsoft.Extensions.Process.Sources" Version="$(MicrosoftExtensionsProcessSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.PropertyActivator.Sources" Version="$(MicrosoftExtensionsPropertyActivatorSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.PropertyHelper.Sources" Version="$(MicrosoftExtensionsPropertyHelperSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.RazorViews.Sources" Version="$(MicrosoftExtensionsRazorViewsSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.SecurityHelper.Sources" Version="$(MicrosoftExtensionsSecurityHelperSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.StackTrace.Sources" Version="$(MicrosoftExtensionsStackTraceSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.TypeNameHelper.Sources" Version="$(MicrosoftExtensionsTypeNameHelperSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.ValueStopwatch.Sources" Version="$(MicrosoftExtensionsValueStopwatchSourcesPackageVersion)" />
+    <ExtensionsDependency Include="Microsoft.Extensions.WebEncoders.Sources" Version="$(MicrosoftExtensionsWebEncodersSourcesPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ExternalDependency Include="@(ExtensionsDependency)" />
+
     <ExternalDependency Include="AngleSharp" Version="$(AngleSharpPackageVersion)" />
     <ExternalDependency Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
     <ExternalDependency Include="Castle.Core" Version="$(CastleCorePackageVersion)" />

--- a/build/submodules.props
+++ b/build/submodules.props
@@ -42,7 +42,6 @@
     <Repository Include="BasicMiddleware" />
     <Repository Include="BrowserLink" />
     <Repository Include="Caching" />
-    <Repository Include="Common" />
     <Repository Include="Configuration" />
     <Repository Include="CORS" />
     <Repository Include="DataProtection" RootPath="$(RepositoryRoot)src\DataProtection\" />


### PR DESCRIPTION
React to https://github.com/aspnet/Extensions/pull/428

As a part of merging and reducing the number of repos we use, the aspnet/Common repo was renamed to aspnet/Extensions and it now builds on its own

Related: the same change will be made for 2.1, hopefully later this week https://github.com/aspnet/AspNetCore/pull/3671

Internal PR to update ProdCon: https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline/pullrequest/147949