### PR TITLE
Remove VS.Web.CodeGeneration packages from the fallback folder cache

### DIFF
--- a/docs/PackageArchives.md
+++ b/docs/PackageArchives.md
@@ -46,10 +46,6 @@ The result of this typically means including the transitive graph of the followi
   - Packages that Microsoft.NET.Sdk adds implicitly
     - Microsoft.NETCore.App
     - NETStandard.Library
-  - Packages that are a PackageReference/DotNetCliToolReference in basic ASP.NET Core templates. In addition to packages above, this typically includes:
-    - Microsoft.EntityFrameworkCore.Tools{.DotNet}
-    - Microsoft.VisualStudio.Web.CodeGeneration.Design
-    - Microsoft.VisualStudio.Web.BrowserLink
 
 ### Example
 

--- a/src/PackageArchive/Scenario.WebApp/Scenario.WebApp.csproj
+++ b/src/PackageArchive/Scenario.WebApp/Scenario.WebApp.csproj
@@ -16,14 +16,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="$(MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="$(MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Contracts" Version="$(MicrosoftVisualStudioWebCodeGenerationContractsPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Core" Version="$(MicrosoftVisualStudioWebCodeGenerationCorePackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="$(MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="$(MicrosoftVisualStudioWebCodeGenerationEntityFrameworkCorePackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Templating" Version="$(MicrosoftVisualStudioWebCodeGenerationTemplatingPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="$(MicrosoftVisualStudioWebCodeGenerationUtilsPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration" Version="$(MicrosoftVisualStudioWebCodeGenerationPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" Version="$(MicrosoftVisualStudioWebCodeGeneratorsMvcPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Reacting to https://github.com/aspnet/Templating/pull/802

These packages are no longer part of the default project templates in 2.2, and will require an internet connection to restore.