### PR TITLE
Move transformation tests from AzureIntegration

### DIFF
--- a/src/SiteExtensions/SiteExtensions.sln
+++ b/src/SiteExtensions/SiteExtensions.sln
@@ -5,9 +5,13 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0ED05384-4F64-44BA-A4AA-47519DA26E8C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.AzureAppServices.SiteExtension", "src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj", "{69E22952-302D-4C56-B2BE-7C086EB05C79}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.AzureAppServices.SiteExtension", "src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj", "{69E22952-302D-4C56-B2BE-7C086EB05C79}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.Xdt.Extensions", "src\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj", "{637E1D65-7F1C-476B-AD0A-30B295DF5414}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.Xdt.Extensions", "src\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj", "{637E1D65-7F1C-476B-AD0A-30B295DF5414}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{6C71D9CD-271C-41CB-ACCD-9EABED6C9E80}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests", "test\Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests\Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests.csproj", "{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{69E22952-302D-4C56-B2BE-7C086EB05C79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,9 +47,28 @@ Global
 		{637E1D65-7F1C-476B-AD0A-30B295DF5414}.Release|x64.Build.0 = Release|Any CPU
 		{637E1D65-7F1C-476B-AD0A-30B295DF5414}.Release|x86.ActiveCfg = Release|Any CPU
 		{637E1D65-7F1C-476B-AD0A-30B295DF5414}.Release|x86.Build.0 = Release|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Debug|x64.Build.0 = Debug|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Debug|x86.Build.0 = Debug|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Release|x64.ActiveCfg = Release|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Release|x64.Build.0 = Release|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Release|x86.ActiveCfg = Release|Any CPU
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{69E22952-302D-4C56-B2BE-7C086EB05C79} = {0ED05384-4F64-44BA-A4AA-47519DA26E8C}
 		{637E1D65-7F1C-476B-AD0A-30B295DF5414} = {0ED05384-4F64-44BA-A4AA-47519DA26E8C}
+		{A0798DB8-7681-4F00-94EC-CC966F4F3CD0} = {6C71D9CD-271C-41CB-ACCD-9EABED6C9E80}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7ACE43EF-2C19-4D80-B7DB-0169D9302623}
 	EndGlobalSection
 EndGlobal

--- a/src/SiteExtensions/build/dependencies.props
+++ b/src/SiteExtensions/build/dependencies.props
@@ -7,7 +7,10 @@
     <InternalAspNetCoreSdkPackageVersion>2.2.0-preview2-20181004.6</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1-rtm-31076</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0-rtm-35515</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
+    <XunitPackageVersion>2.3.1</XunitPackageVersion>
+    <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/SiteExtensions/build/dependencies.props
+++ b/src/SiteExtensions/build/dependencies.props
@@ -9,7 +9,7 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0-rtm-35515</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
-    <XunitPackageVersion>2.3.1</XunitPackageVersion>
+    <XunitPackageVersion>2.4.0</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
 

--- a/src/SiteExtensions/global.json
+++ b/src/SiteExtensions/global.json
@@ -1,8 +1,8 @@
 {
     "sdk": {
-        "version": "2.2.100-preview2-009404"
+        "version": "2.2.100-preview3-009430"
     },
     "msbuild-sdks": {
-        "Internal.AspNetCore.Sdk": "2.2.0-preview2-20181011.10"
+        "Internal.AspNetCore.Sdk": "2.2.0-preview2-20181024.5"
     }
 }

--- a/src/SiteExtensions/test/Directory.Build.props
+++ b/src/SiteExtensions/test/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
+    <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
+
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests.csproj
+++ b/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\applicationHost.xdt" Link="applicationHost.xdt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="config_empty.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="config_existingemptyvalue.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="config_existingline.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="config_existingvalue.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Web.Xdt.Extensions\Microsoft.Web.Xdt.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/TransformTest.cs
+++ b/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/TransformTest.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Xml;
+using Microsoft.Web.XmlTransform;
+using Xunit;
+
+namespace Microsoft.AspNetCore.AzureAppServices.SiteExtension
+{
+    public class TransformTest
+    {
+        private static readonly string XdtExtensionPath = AppDomain.CurrentDomain.BaseDirectory;
+
+        [Theory]
+        [InlineData("config_empty.xml")]
+        [InlineData("config_existingline.xml")]
+        [InlineData("config_existingEmptyValue.xml")]
+        public void Transform_EmptyConfig_Added(string configFile)
+        {
+            var doc = LoadDocAndRunTransform(configFile);
+
+            Assert.Equal(2, doc.ChildNodes.Count);
+            var envNode = doc["configuration"]?["system.webServer"]?["runtime"]?["environmentVariables"];
+
+            Assert.NotNull(envNode);
+
+            Assert.Equal(3, envNode.ChildNodes.Count);
+
+            var depsElement = envNode.FirstChild;
+            Assert.Equal("add", depsElement.Name);
+            Assert.Equal("DOTNET_ADDITIONAL_DEPS", depsElement.Attributes["name"].Value);
+            Assert.Equal($@"{XdtExtensionPath}\additionalDeps\Microsoft.AspNetCore.AzureAppServices.HostingStartup\;" +
+                         @"%ProgramFiles%\dotnet\additionalDeps\Microsoft.AspNetCore.AzureAppServices.HostingStartup\",
+                depsElement.Attributes["value"].Value);
+
+            var sharedStoreElement = depsElement.NextSibling;
+            Assert.Equal("add", sharedStoreElement.Name);
+            Assert.Equal("DOTNET_SHARED_STORE", sharedStoreElement.Attributes["name"].Value);
+            Assert.Equal($@"{XdtExtensionPath}\store", sharedStoreElement.Attributes["value"].Value);
+
+            var startupAssembliesElement = sharedStoreElement.NextSibling;
+            Assert.Equal("add", startupAssembliesElement.Name);
+            Assert.Equal("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", startupAssembliesElement.Attributes["name"].Value);
+            Assert.Equal("Microsoft.AspNetCore.AzureAppServices.HostingStartup", startupAssembliesElement.Attributes["value"].Value);
+        }
+
+        [Fact]
+        public void Transform_ExistingValue_AppendsValue()
+        {
+            var doc = LoadDocAndRunTransform("config_existingvalue.xml");
+
+            Assert.Equal(2, doc.ChildNodes.Count);
+            var envNode = doc["configuration"]?["system.webServer"]?["runtime"]?["environmentVariables"];
+
+            Assert.NotNull(envNode);
+
+            Assert.Equal(3, envNode.ChildNodes.Count);
+
+            var depsElement = envNode.FirstChild;
+            Assert.Equal("add", depsElement.Name);
+            Assert.Equal("DOTNET_ADDITIONAL_DEPS", depsElement.Attributes["name"].Value);
+            Assert.Equal(@"ExistingValue1;"+
+                         $@"{XdtExtensionPath}\additionalDeps\Microsoft.AspNetCore.AzureAppServices.HostingStartup\;" +
+                         @"%ProgramFiles%\dotnet\additionalDeps\Microsoft.AspNetCore.AzureAppServices.HostingStartup\",
+                depsElement.Attributes["value"].Value);
+
+            var sharedStoreElement = depsElement.NextSibling;
+            Assert.Equal("add", sharedStoreElement.Name);
+            Assert.Equal("DOTNET_SHARED_STORE", sharedStoreElement.Attributes["name"].Value);
+            Assert.Equal($@"ExistingValue3;{XdtExtensionPath}\store", sharedStoreElement.Attributes["value"].Value);
+
+            var startupAssembliesElement = sharedStoreElement.NextSibling;
+            Assert.Equal("add", startupAssembliesElement.Name);
+            Assert.Equal("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", startupAssembliesElement.Attributes["name"].Value);
+            Assert.Equal("ExistingValue2;Microsoft.AspNetCore.AzureAppServices.HostingStartup", startupAssembliesElement.Attributes["value"].Value);
+        }
+
+        private static XmlDocument LoadDocAndRunTransform(string docName)
+        {
+            // Microsoft.Web.Hosting.Transformers.ApplicationHost.SiteExtensionDefinition.Transform
+            // (See Microsoft.Web.Hosting, Version=7.1.0.0) replaces variables for you in Azure.
+            var transformFile = File.ReadAllText("applicationHost.xdt");
+            transformFile = transformFile.Replace("%XDT_EXTENSIONPATH%", XdtExtensionPath);
+            var transform = new XmlTransformation(transformFile, isTransformAFile: false, logger: null);
+            var doc = new XmlDocument();
+            doc.Load(docName);
+            Assert.True(transform.Apply(doc));
+            return doc;
+        }
+    }
+}

--- a/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_empty.xml
+++ b/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_empty.xml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0"?>
+<configuration>
+</configuration>

--- a/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_existingemptyvalue.xml
+++ b/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_existingemptyvalue.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <runtime>
+      <environmentVariables>
+        <add name="DOTNET_ADDITIONAL_DEPS" value="" />
+        <add name="DOTNET_SHARED_STORE" value="" />
+        <add name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" value="" />
+      </environmentVariables>
+    </runtime>
+  </system.webServer>
+</configuration>

--- a/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_existingline.xml
+++ b/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_existingline.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <runtime>
+      <environmentVariables>
+        <add name="DOTNET_ADDITIONAL_DEPS" />
+        <add name="DOTNET_SHARED_STORE" />
+        <add name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" />
+      </environmentVariables>
+    </runtime>
+  </system.webServer>
+</configuration>

--- a/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_existingvalue.xml
+++ b/src/SiteExtensions/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/config_existingvalue.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <runtime>
+      <environmentVariables>
+        <add name="DOTNET_ADDITIONAL_DEPS" value="ExistingValue1" />
+        <add name="DOTNET_SHARED_STORE" value="ExistingValue3" />
+        <add name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" value="ExistingValue2" />
+      </environmentVariables>
+    </runtime>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
We had some XTD Transformation tests for logging site extension, move them here because XDT itself moved.