### PR TITLE
Win-arm shared framework

### DIFF
--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -44,6 +44,8 @@ phases:
     displayName: Build NuGet packages and win-x64 runtime
   - script: build.cmd -ci /p:SkipTests=true /p:Configuration=$(BuildConfiguration) /p:BuildNumber=$(Build.BuildNumber) /t:BuildSharedFx /p:SharedFxRID=win-x86
     displayName: Build win-x86 runtime
+  - script: build.cmd -ci /p:SkipTests=true /p:Configuration=$(BuildConfiguration) /p:BuildNumber=$(Build.BuildNumber) /t:BuildSharedFx /p:SharedFxRID=win-arm
+    displayName: Build win-arm runtime
   - powershell: >
       src/Installers/Windows/clone_and_build_ancm.ps1
       -GitCredential '$(dn-bot-devdiv-build-rw-code-rw)'
@@ -56,6 +58,7 @@ phases:
       src/Installers/Windows/build.ps1
       -x64 artifacts/runtime/aspnetcore-runtime-internal-2.2.0-preview3-$(Build.BuildNumber)-win-x64.zip
       -x86 artifacts/runtime/aspnetcore-runtime-internal-2.2.0-preview3-$(Build.BuildNumber)-win-x86.zip
+      -x86 artifacts/runtime/aspnetcore-runtime-internal-2.2.0-preview3-$(Build.BuildNumber)-win-arm.zip
       -Config $(BuildConfiguration)
       -BuildNumber $(Build.BuildNumber)
       -SignType $(_SignType)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,7 @@
     <SupportedRuntimeIdentifiers>
       win-x64;
       win-x86;
+      win-arm;
       osx-x64;
       linux-musl-x64;
       linux-x64;

--- a/build/SharedFx.props
+++ b/build/SharedFx.props
@@ -65,7 +65,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WindowsSharedFxRIDs Include="win-x64;win-x86"/>
+    <WindowsSharedFxRIDs Include="win-x64;win-x86;win-arm"/>
     <NonWindowsSharedFxRIDs Include="osx-x64" CrossgenSymbols="false" />
     <NonWindowsSharedFxRIDs Include="linux-musl-x64" />
     <NonWindowsSharedFxRIDs Include="linux-x64" />

--- a/build/repo.props
+++ b/build/repo.props
@@ -18,6 +18,7 @@
     <IntermediateInstaller Include="win-x86" FileExt=".wixlib" />
     <IntermediateInstaller Include="win-x64" FileExt=".zip" />
     <IntermediateInstaller Include="win-x64" FileExt=".wixlib" />
+    <IntermediateInstaller Include="win-arm" FileExt=".zip" />
     <IntermediateInstaller Include="osx-x64" FileExt=".tar.gz" />
     <IntermediateInstaller Include="linux-x64" FileExt=".tar.gz" />
     <IntermediateInstaller Include="linux-arm" FileExt=".tar.gz" />
@@ -27,6 +28,7 @@
     <NativeInstaller Include="win-x86" FileExt=".zip" />
     <NativeInstaller Include="win-x64" FileExt=".exe" />
     <NativeInstaller Include="win-x64" FileExt=".zip" />
+    <NativeInstaller Include="win-arm" FileExt=".zip" />
     <NativeInstaller Include="osx-x64" FileExt=".tar.gz" />
     <NativeInstaller Include="linux-x64" FileExt=".tar.gz" />
     <NativeInstaller Include="linux-arm" FileExt=".tar.gz" />


### PR DESCRIPTION
Adding win-arm to the list of shared frameworks we will produce. TODO:
- [x] ensure the x86-hosted crossgen is used to produce the win-arm shared framework
- [ ] set-up testing for win-arm

Addresses #https://github.com/aspnet/AspNetCore-Internal/issues/1128
