### PR TITLE
Filter paths in SiteExtension trigger

### DIFF
--- a/.azure/pipelines/site-extensions.yml
+++ b/.azure/pipelines/site-extensions.yml
@@ -2,6 +2,9 @@ trigger:
   branches:
     include:
     - release/2.2
+  paths:
+    include:
+    - src/SiteExtensions
 
 name: $(Date:yyMMdd)-$(Rev:rr)
 


### PR DESCRIPTION
To avoid needlessly rebuilding logging site extension.