### PR TITLE
Remove Microsoft.AspNetCore.Razor.Design

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -124,7 +124,6 @@
     <PackageArtifact Include="Microsoft.AspNetCore.NodeServices" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Owin" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.RangeHelper.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Design" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Razor.Language" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources" Category="noship" />


### PR DESCRIPTION
We're no longer producing the package in 3.0. 