### PR TITLE
Crossgen linux-arm shared framework

### DIFF
--- a/.azure/pipelines/ci-official.yml
+++ b/.azure/pipelines/ci-official.yml
@@ -193,8 +193,10 @@ phases:
       /p:BuildNumber=$(Build.BuildNumber)
     displayName: Build linux-x64 runtime
   - script: >
-      ./build.sh
-      --ci
+      ./dockerbuild.sh
+      ubuntu
+      /t:Prepare
+      /t:GeneratePropsFiles
       /t:BuildSharedFx
       /p:SharedFxRID=linux-arm
       /p:BuildNumber=$(Build.BuildNumber)

--- a/build/docker/ubuntu.Dockerfile
+++ b/build/docker/ubuntu.Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420
+
+ARG USER
+ARG USER_ID
+ARG GROUP_ID
+
+WORKDIR /code/build
+RUN mkdir -p "/home/$USER" && chown "${USER_ID}:${GROUP_ID}" "/home/$USER"
+ENV HOME "/home/$USER"
+
+# Set the user to non-root
+USER $USER_ID:$GROUP_ID
+
+# Skip package initilization
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -18,8 +18,7 @@
     <OutputPath>$(ArtifactsConfigurationDir)$(SharedFxRid)\$(MSBuildProjectName)\</OutputPath>
     <BaseIntermediateOutputPath>$(RepositoryRoot)obj\fx\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
-    <CrossgenOutput Condition="'$(SharedFxRid)' == 'linux-arm'">false</CrossgenOutput>
-    <CrossgenSymbolsOutput Condition=" '$(CrossgenOutput)' == 'false' OR '$(SharedFxRid)' == 'osx-x64'">false</CrossgenSymbolsOutput>
+    <CrossgenSymbolsOutput Condition=" '$(CrossgenOutput)' == 'false' OR '$(SharedFxRid)' == 'osx-x64' OR '$(SharedFxRid)' == 'linux-arm'">false</CrossgenSymbolsOutput>
 
     <IncludeSymbols>true</IncludeSymbols>
     <NuspecFile>$(MSBuildThisFileDirectory)runtime.fx.nuspec</NuspecFile>


### PR DESCRIPTION
Addresses linux-arm as part of https://github.com/aspnet/AspNetCore/issues/3652. The docker environment is required for 2.2. I'll do a no-op merge to master since 3.0 doesn't require crossgen to be run inside a x86 environment.