### PR TITLE
Enable symbols generation for crossgen'ed assemblies on linux-arm

### DIFF
--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -18,7 +18,7 @@
     <OutputPath>$(ArtifactsConfigurationDir)$(SharedFxRid)\$(MSBuildProjectName)\</OutputPath>
     <BaseIntermediateOutputPath>$(RepositoryRoot)obj\fx\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
-    <CrossgenSymbolsOutput Condition=" '$(CrossgenOutput)' == 'false' OR '$(SharedFxRid)' == 'osx-x64' OR '$(SharedFxRid)' == 'linux-arm'">false</CrossgenSymbolsOutput>
+    <CrossgenSymbolsOutput Condition=" '$(CrossgenOutput)' == 'false' OR '$(SharedFxRid)' == 'osx-x64'">false</CrossgenSymbolsOutput>
 
     <IncludeSymbols>true</IncludeSymbols>
     <NuspecFile>$(MSBuildThisFileDirectory)runtime.fx.nuspec</NuspecFile>


### PR DESCRIPTION
Amending https://github.com/aspnet/AspNetCore/pull/3876

Turns out it's possible to produce symbols for crossgen'ed assemblies on linux-arm and I was only running into failures since I was running the build in an unclean environment.
