### PR TITLE
Add prerelease label to deb installer package version

### DIFF
--- a/src/Installers/Debian/Runtime.debproj
+++ b/src/Installers/Debian/Runtime.debproj
@@ -30,11 +30,11 @@
 
     <!-- PackageVersion does not match the ASP.NET Core runtime verison. -->
     <PackageVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</PackageVersion>
-    <!-- Deb installers are versioned as M.N.P~Build following the core-setup convention -->
-    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)~$(BuildNumber)</PackageVersion>
+    <!-- Deb installers are versioned as M.N.P~PreReleaseLabel-Build following the core-setup convention -->
+    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)~$(PreReleaseLabel)-$(BuildNumber)</PackageVersion>
     <PackageRevision>1</PackageRevision>
 
-    <!-- Needed some creativity to convert the PackageVersion M.N.P-Build to the installer version M.N.P~Build, The conditional handles stabilized builds -->
+    <!-- Needed some creativity to convert the PackageVersion M.N.P-PreReleaseLabel-Build to the installer version M.N.P~PreReleaseLabel-Build, The conditional handles stabilized builds -->
     <DotnetRuntimeDependencyVersion>$(MicrosoftNETCoreAppPackageVersion)</DotnetRuntimeDependencyVersion>
     <DotnetRuntimeDependencyVersion Condition="$(DotnetRuntimeDependencyVersion.Contains('-'))">$(DotnetRuntimeDependencyVersion.Substring(0, $(DotnetRuntimeDependencyVersion.IndexOf('-'))))~$(DotnetRuntimeDependencyVersion.Substring($([MSBuild]::Add($(DotnetRuntimeDependencyVersion.IndexOf('-')), 1))))</DotnetRuntimeDependencyVersion>
   </PropertyGroup>


### PR DESCRIPTION
Somewhere on the way from 2.2.0-preview2 to now, we lost the pre-release label in the package version of non-final deb installers. As such we were producing packages like:
```
aspnetagent@aspnetci-a-104:~/tmp/johluo/Installers$ dpkg-deb --info aspnetcore-runtime-2.2.0-rtm-35636-x64.deb
 new debian package, version 2.0.
 size 22822628 bytes: control archive=7456 bytes.
     699 bytes,    11 lines      control
   33900 bytes,   244 lines      md5sums
 Package: aspnetcore-runtime-2.2
 Version: 2.2.0~35636-1
 Architecture: amd64
 Maintainer: Microsoft <nugetaspnet@microsoft.com>
 Installed-Size: 77475
 Depends: libc6 (>= 2.14), dotnet-runtime-2.2 (>= 2.2.0~rtm-27105-02)
 Section: devel
 Priority: standard
 Homepage: https://asp.net
 Description: Microsoft ASP.NET Core 2.2.0-rtm-35636 Shared Framework
  Shared Framework for hosting of Microsoft ASP.NET Core applications. It is ...
```
The version should be `2.2.0~rtm-35636-1` instead of `2.2.0~35636-1`

This change adds the pre-release label back. @muratg I think we'll need to make this change in 2.2 since otherwise, it would not be possible to test the debian installers until the final version (i.e. the version without build numbers). Note that if we do not want to make packaging related changes in 2.2. anymore, we could set the `IsFinalBuild` flag to true on builds where we intend to run tests with .deb installers.