### PR TITLE
Detect shared configuration in installers and fail if enabled

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
@@ -245,10 +245,13 @@
                           Value="&quot;[IISInetSrvDir]appcmd.exe&quot; unlock config /section:system.webserver/handlers" />
         <CustomAction Id="CA_UNLOCk_HANDLER" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no"/>
         <CustomAction Id="UpdateDynamicCompression" BinaryKey="IISCustomActionDll" DllEntry ="RegisterANCMCompressionCA" Execute ="deferred" Return ="ignore" Impersonate ="no" />
+        <CustomAction BinaryKey="IISCustomActionDll" Id="CheckForSharedConfiguration" DllEntry="CheckForSharedConfigurationCA" Execute="deferred" Return="check" Impersonate="no"/>
+
         <InstallExecuteSequence>
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize"></Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -60,6 +60,8 @@
         <!-- make patching UI go from welcome to ready to repair -->
         <?include  ..\IIS-Setup\iisca\wix3\FixPatchingBehavior.wxi ?>
 
+        <Property Id="IISCHECKSERVICESRUNNING" Admin="no">1</Property>
+
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
@@ -279,11 +281,13 @@
                           Value="&quot;[IISInstallDir]appcmd.exe&quot; unlock config /section:system.webserver/handlers" />
         <CustomAction Id="CA_UNLOCk_HANDLER" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no"/>
         <CustomAction Id="UpdateDynamicCompression" BinaryKey="IISCustomActionDll" DllEntry ="RegisterANCMCompressionCA" Execute ="deferred" Return ="ignore" Impersonate ="no" />
+        <CustomAction BinaryKey="IISCustomActionDll" Id="CheckForSharedConfiguration" DllEntry="CheckForSharedConfigurationCA" Execute="deferred" Return="check" Impersonate="no"/>
 
         <InstallExecuteSequence>
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize"></Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -60,8 +60,6 @@
         <!-- make patching UI go from welcome to ready to repair -->
         <?include  ..\IIS-Setup\iisca\wix3\FixPatchingBehavior.wxi ?>
 
-        <Property Id="IISCHECKSERVICESRUNNING" Admin="no">1</Property>
-
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-  <Import Project="$(RepositoryRoot)\.deps\dependencies.g.props" />
+  <Import Project="$(RepositoryRoot)\.deps\dependencies.g.props" Condition="Exists('$(RepositoryRoot)\.deps\dependencies.g.props')" />
 
   <PropertyGroup>
     <!-- Build number used by ANCM msis -->


### PR DESCRIPTION
There is a custom action that allows us to know if a shared configuration is used. It will pop open an error message saying you need to disable shared configuration to install the msi.

