### PR TITLE
[WIP] Add components project structure

### DIFF
--- a/src/Components/Components.sln
+++ b/src/Components/Components.sln
@@ -5,11 +5,17 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{354ECA44-E8B5-4CB8-90BD-8AC7C9687358}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Components", "src\Components\Components.csproj", "{686CE7FA-4B50-4319-937F-F8B1E48DEB38}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Components", "src\Components\Components.csproj", "{686CE7FA-4B50-4319-937F-F8B1E48DEB38}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C0FE4D20-6ADF-4396-85E9-F1F7A86FC7EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Components.Tests", "test\Components.Tests\Components.Tests.csproj", "{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Components.Tests", "test\Components.Tests\Components.Tests.csproj", "{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Components.FunctionalTests", "test\Components.FunctionalTests\Components.FunctionalTests.csproj", "{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebSites", "WebSites", "{A6768EC1-428A-4504-8DC5-EFDAD524E3A8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComponentsWebSite", "test\WebSites\ComponentsWebSite\ComponentsWebSite.csproj", "{600369C2-69A0-4C4D-B838-3CB2DAF01C53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,9 +25,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -48,9 +51,42 @@ Global
 		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x64.Build.0 = Release|Any CPU
 		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x86.ActiveCfg = Release|Any CPU
 		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x86.Build.0 = Release|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Debug|x64.Build.0 = Debug|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Debug|x86.Build.0 = Debug|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Release|x64.ActiveCfg = Release|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Release|x64.Build.0 = Release|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Release|x86.ActiveCfg = Release|Any CPU
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A}.Release|x86.Build.0 = Release|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Debug|x64.Build.0 = Debug|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Debug|x86.Build.0 = Debug|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Release|x64.ActiveCfg = Release|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Release|x64.Build.0 = Release|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Release|x86.ActiveCfg = Release|Any CPU
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{686CE7FA-4B50-4319-937F-F8B1E48DEB38} = {354ECA44-E8B5-4CB8-90BD-8AC7C9687358}
 		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4} = {C0FE4D20-6ADF-4396-85E9-F1F7A86FC7EE}
+		{38FDAB8C-8B3F-455C-93E3-7D2C2CE1834A} = {C0FE4D20-6ADF-4396-85E9-F1F7A86FC7EE}
+		{A6768EC1-428A-4504-8DC5-EFDAD524E3A8} = {C0FE4D20-6ADF-4396-85E9-F1F7A86FC7EE}
+		{600369C2-69A0-4C4D-B838-3CB2DAF01C53} = {A6768EC1-428A-4504-8DC5-EFDAD524E3A8}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C6D3268-A5AD-4B65-8217-DA9D5E2A3139}
 	EndGlobalSection
 EndGlobal

--- a/src/Components/Components.sln
+++ b/src/Components/Components.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{354ECA44-E8B5-4CB8-90BD-8AC7C9687358}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Components", "src\Components\Components.csproj", "{686CE7FA-4B50-4319-937F-F8B1E48DEB38}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C0FE4D20-6ADF-4396-85E9-F1F7A86FC7EE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Components.Tests", "test\Components.Tests\Components.Tests.csproj", "{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|x64.Build.0 = Debug|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Debug|x86.Build.0 = Debug|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Release|x64.ActiveCfg = Release|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Release|x64.Build.0 = Release|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Release|x86.ActiveCfg = Release|Any CPU
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38}.Release|x86.Build.0 = Release|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Debug|x64.Build.0 = Debug|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Debug|x86.Build.0 = Debug|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x64.ActiveCfg = Release|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x64.Build.0 = Release|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x86.ActiveCfg = Release|Any CPU
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{686CE7FA-4B50-4319-937F-F8B1E48DEB38} = {354ECA44-E8B5-4CB8-90BD-8AC7C9687358}
+		{F82F6EC6-D247-4CB7-BC20-BC7891631BB4} = {C0FE4D20-6ADF-4396-85E9-F1F7A86FC7EE}
+	EndGlobalSection
+EndGlobal

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -1,0 +1,13 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <!-- Temporary until we can replace PackageRef with ProjectRef -->
+    <SubFolderRepoBuild>true</SubFolderRepoBuild>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <Import Project="version.props" />
+  <Import Project="dependencies.props" />
+
+</Project>

--- a/src/Components/NuGetPackageVerifier.json
+++ b/src/Components/NuGetPackageVerifier.json
@@ -1,0 +1,7 @@
+{
+  "Default": {
+    "rules": [
+      "DefaultCompositeRule"
+    ]
+  }
+}

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -1,0 +1,14 @@
+# Components library shared by MVC and Blazor
+
+## Run end-to-end tests
+
+Prerequisites:
+- Install [selenium-standalone](https://www.npmjs.com/package/selenium-standalone) (requires Java 8 or 9)
+  - [Open JDK9](http://jdk.java.net/java-se-ri/9)
+  - `npm install -g selenium-standalone`
+  - `selenium-standalone install`
+- Chrome
+
+Run `selenium-standalone start`
+
+Run `build.cmd /t:Test` or `build.sh /t:Test`

--- a/src/Components/build.cmd
+++ b/src/Components/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET RepoRoot="%~dp0..\.."
+%RepoRoot%\build.cmd -LockFile %RepoRoot%\korebuild-lock.txt -Path %~dp0 %*

--- a/src/Components/build.sh
+++ b/src/Components/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/build.sh" --path "$DIR" --lockfile "$repo_root/korebuild-lock.txt" "$@"

--- a/src/Components/build/repo.props
+++ b/src/Components/build/repo.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="..\..\..\build\dependencies.props" />
+  <Import Project="..\..\..\build\runtimes.props" />
+  <PropertyGroup>
+    <!-- TODO: temporary while we reorganize source code and refactor dependency management -->
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+  </PropertyGroup>
+</Project>

--- a/src/Components/dependencies.props
+++ b/src/Components/dependencies.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Fallback when not building from command line. -->
+    <InternalAspNetCoreSdkPackageVersion Condition="'$(InternalAspNetCoreSdkPackageVersion)' == ''">2.2.0-preview2-20181004.6</InternalAspNetCoreSdkPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Components/dependencies.props
+++ b/src/Components/dependencies.props
@@ -5,6 +5,10 @@
 
   <PropertyGroup>
     <!-- Fallback when not building from command line. -->
-    <InternalAspNetCoreSdkPackageVersion Condition="'$(InternalAspNetCoreSdkPackageVersion)' == ''">2.2.0-preview2-20181004.6</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion Condition="'$(InternalAspNetCoreSdkPackageVersion)' == ''">3.0.0-alpha1-20181105.4</InternalAspNetCoreSdkPackageVersion>
+    <LastGoodAspBuildVersion>3.0.0-alpha1-10584</LastGoodAspBuildVersion>
+    <MicrosoftAspNetCoreHostingPackageVersion Condition=" '$(MicrosoftAspNetCoreHostingPackageVersion)' == '' ">$(LastGoodAspBuildVersion)</MicrosoftAspNetCoreHostingPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelPackageVersion Condition=" '$(MicrosoftAspNetCoreServerKestrelPackageVersion)' == '' ">$(LastGoodAspBuildVersion)</MicrosoftAspNetCoreServerKestrelPackageVersion>
+    <MicrosoftAspNetCoreStaticFilesPackageVersion Condition=" '$(MicrosoftAspNetCoreStaticFilesPackageVersion)' == '' ">$(LastGoodAspBuildVersion)</MicrosoftAspNetCoreStaticFilesPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Components/global.json
+++ b/src/Components/global.json
@@ -1,0 +1,8 @@
+{
+    "sdk": {
+        "version": "3.0.100-preview-009730"
+    },
+    "msbuild-sdks": {
+        "Internal.AspNetCore.Sdk": "3.0.0-alpha1-20181105.4"
+    }
+}

--- a/src/Components/src/Components/Components.csproj
+++ b/src/Components/src/Components/Components.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>ASP.NET Core library for components that can be used as part of ASP.NET Core MVC and Blazor.</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>aspnetcore;components</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/src/Components/src/Directory.Build.props
+++ b/src/Components/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Components/test/Components.FunctionalTests/Components.FunctionalTests.csproj
+++ b/src/Components/test/Components.FunctionalTests/Components.FunctionalTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(MicrosoftAspNetCoreHostingPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
+    <PackageReference Include="Selenium.Support" Version="3.12.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Components\Components.csproj" />
+    <ProjectReference Include="..\WebSites\ComponentsWebSite\ComponentsWebSite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/BrowserFixture.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/BrowserFixture.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Remote;
+using System;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure
+{
+    public class BrowserFixture : IDisposable
+    {
+        public IWebDriver Browser { get; }
+
+        public ILogs Logs { get; }
+
+        public ITestOutputHelper Output { get; set; }
+
+        public BrowserFixture()
+        {
+            var opts = new ChromeOptions();
+
+            // Comment this out if you want to watch or interact with the browser (e.g., for debugging)
+            opts.AddArgument("--headless");
+
+            // Log errors
+            opts.SetLoggingPreference(LogType.Browser, LogLevel.All);
+
+            // On Windows/Linux, we don't need to set opts.BinaryLocation
+            // But for Travis Mac builds we do
+            var binaryLocation = Environment.GetEnvironmentVariable("TEST_CHROME_BINARY");
+            if (!string.IsNullOrEmpty(binaryLocation))
+            {
+                opts.BinaryLocation = binaryLocation;
+                Console.WriteLine($"Set {nameof(ChromeOptions)}.{nameof(opts.BinaryLocation)} to {binaryLocation}");
+            }
+
+            try
+            {
+                var driver = new RemoteWebDriver(opts);
+                driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1);
+                Browser = driver;
+                Logs = new RemoteLogs(driver);
+            }
+            catch (WebDriverException ex)
+            {
+                var message =
+                    "Failed to connect to the web driver. Please see the readme and follow the instructions to install selenium." +
+                    "Remember to start the web driver with `selenium-standalone start` before running the end-to-end tests.";
+                throw new InvalidOperationException(message, ex);
+            }
+        }
+
+        public void Dispose()
+        {
+            Browser.Dispose();
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/BrowserTestBase.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/BrowserTestBase.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using OpenQA.Selenium;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure
+{
+    [CaptureSeleniumLogs]
+    public class BrowserTestBase : IClassFixture<BrowserFixture>
+    {
+        private static readonly AsyncLocal<IWebDriver> _browser = new AsyncLocal<IWebDriver>();
+        private static readonly AsyncLocal<ILogs> _logs = new AsyncLocal<ILogs>();
+        private static readonly AsyncLocal<ITestOutputHelper> _output = new AsyncLocal<ITestOutputHelper>();
+
+        public static IWebDriver Browser => _browser.Value;
+
+        public static ILogs Logs => _logs.Value;
+
+        public static ITestOutputHelper Output => _output.Value;
+
+        public BrowserTestBase(BrowserFixture browserFixture, ITestOutputHelper output)
+        {
+            _browser.Value = browserFixture.Browser;
+            _logs.Value = browserFixture.Logs;
+            _output.Value = output;
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/CaptureSeleniumLogsAttribute.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/CaptureSeleniumLogsAttribute.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+using System;
+using System.Linq;
+using System.Reflection;
+using OpenQA.Selenium;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure
+{
+    // This has to use BeforeAfterTestAttribute because running the log capture
+    // in the BrowserFixture.Dispose method is too late, and we can't add logging
+    // to the test.
+    public class CaptureSeleniumLogsAttribute : BeforeAfterTestAttribute
+    {
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            if (!typeof(BrowserTestBase).IsAssignableFrom(methodUnderTest.DeclaringType))
+            {
+                throw new InvalidOperationException("This should only be used with BrowserTestBase");
+            }
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            var browser = BrowserTestBase.Browser;
+            var logs = BrowserTestBase.Logs;
+            var output = BrowserTestBase.Output;
+
+            // Put browser logs first, the test UI will truncate output after a certain length
+            // and the browser logs will include exceptions thrown by js in the browser.
+            foreach (var kind in logs.AvailableLogTypes.OrderBy(k => k == LogType.Browser ? 0 : 1))
+            {
+                output.WriteLine($"{kind} Logs from Selenium:");
+                
+                var entries = logs.GetLog(kind);
+                foreach (LogEntry entry in entries)
+                {
+                    output.WriteLine($"[{entry.Timestamp}] - {entry.Level} - {entry.Message}");
+                }
+
+                output.WriteLine("");
+                output.WriteLine("");
+            }
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/AspNetEnvironment.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/AspNetEnvironment.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
+{
+    public enum AspNetEnvironment
+    {
+        Development,
+        Production
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/AspNetSiteServerFixture.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/AspNetSiteServerFixture.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Hosting;
+using System;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
+{
+    public class AspNetSiteServerFixture<TEntryPoint> : WebHostServerFixture
+    {
+        public delegate IWebHost BuildWebHost(string[] args);
+
+        public BuildWebHost BuildWebHostMethod { get; set; }
+
+        public AspNetEnvironment Environment { get; set; } = AspNetEnvironment.Production;
+
+        public AspNetSiteServerFixture()
+        {
+            BuildWebHostMethod = (BuildWebHost)Delegate.CreateDelegate(typeof(BuildWebHost), typeof(TEntryPoint).GetMethod("BuildWebHost"));
+        }
+
+        protected override IWebHost CreateWebHost()
+        {
+            if (BuildWebHostMethod == null)
+            {
+                throw new InvalidOperationException(
+                    $"No value was provided for {nameof(BuildWebHostMethod)}");
+            }
+
+            var sampleSitePath = FindSampleOrTestSitePath(
+                BuildWebHostMethod.Method.DeclaringType.Assembly.GetName().Name);
+
+            return BuildWebHostMethod(new[]
+            {
+                "--urls", "http://127.0.0.1:0",
+                "--contentroot", sampleSitePath,
+                "--environment", Environment.ToString(),
+            });
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/ServerFixture.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/ServerFixture.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
+{
+    public abstract class ServerFixture : IDisposable
+    {
+        public Uri RootUri => _rootUriInitializer.Value;
+
+        private readonly Lazy<Uri> _rootUriInitializer;
+
+        public ServerFixture()
+        {
+            _rootUriInitializer = new Lazy<Uri>(() =>
+                new Uri(StartAndGetRootUri()));
+        }
+
+        public abstract void Dispose();
+
+        protected abstract string StartAndGetRootUri();
+
+        protected static string FindSolutionDir()
+        {
+            return FindClosestDirectoryContaining(
+                "Components.sln",
+                Path.GetDirectoryName(typeof(ServerFixture).Assembly.Location));
+        }
+
+        protected static string FindSampleOrTestSitePath(string projectName)
+        {
+            var solutionDir = FindSolutionDir();
+            var possibleLocations = new[]
+            {
+                Path.Combine(solutionDir, "test", "WebSites", projectName)
+            };
+
+            return possibleLocations.FirstOrDefault(Directory.Exists)
+                ?? throw new ArgumentException($"Cannot find a sample or test site with name '{projectName}'.");
+        }
+
+        private static string FindClosestDirectoryContaining(
+            string filename,
+            string startDirectory)
+        {
+            var dir = startDirectory;
+            while (true)
+            {
+                if (File.Exists(Path.Combine(dir, filename)))
+                {
+                    return dir;
+                }
+
+                dir = Directory.GetParent(dir)?.FullName;
+                if (string.IsNullOrEmpty(dir))
+                {
+                    throw new FileNotFoundException(
+                        $"Could not locate a file called '{filename}' in " +
+                        $"directory '{startDirectory}' or any parent directory.");
+                }
+            }
+        }
+
+        protected static void RunInBackgroundThread(Action action)
+        {
+            var isDone = new ManualResetEvent(false);
+
+            new Thread(() =>
+            {
+                action();
+                isDone.Set();
+            }).Start();
+
+            isDone.WaitOne();
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/StaticSiteServerFixture.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/StaticSiteServerFixture.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
+{
+    // Although this is not used for anything meaningful related to Blazor yet, it
+    // will be used later when there's a mechanism for publishing standalone Blazor
+    // apps as a set of purely static files and we need E2E testing on the result.
+
+    public class StaticSiteServerFixture : WebHostServerFixture
+    {
+        public string SampleSiteName { get; set; }
+
+        protected override IWebHost CreateWebHost()
+        {
+            if (string.IsNullOrEmpty(SampleSiteName))
+            {
+                throw new InvalidOperationException($"No value was provided for {nameof(SampleSiteName)}");
+            }
+
+            var sampleSitePath = FindSampleOrTestSitePath(SampleSiteName);
+
+            return new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(sampleSitePath)
+                .UseWebRoot(string.Empty)
+                .UseStartup<StaticSiteStartup>()
+                .UseUrls("http://127.0.0.1:0")
+                .Build();
+        }
+
+        private class StaticSiteStartup
+        {
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseFileServer();
+            }
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/WebHostServerFixture.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/ServerFixtures/WebHostServerFixture.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
+{
+    public abstract class WebHostServerFixture : ServerFixture
+    {
+        private IWebHost _host;
+
+        protected override string StartAndGetRootUri()
+        {
+            _host = CreateWebHost();
+            RunInBackgroundThread(_host.Start);
+            return _host.ServerFeatures
+                .Get<IServerAddressesFeature>()
+                .Addresses.First();
+        }
+
+        public override void Dispose()
+        {
+            // This can be null if creating the webhost throws, we don't want to throw here and hide
+            // the original exception.
+            _host?.StopAsync();
+        }
+
+        protected abstract IWebHost CreateWebHost();
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/ServerTestBase.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/ServerTestBase.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure
+{
+    public abstract class ServerTestBase<TServerFixture>
+        : BrowserTestBase, IClassFixture<TServerFixture>
+        where TServerFixture: ServerFixture
+    {
+        protected readonly TServerFixture _serverFixture;
+
+        public ServerTestBase(BrowserFixture browserFixture, TServerFixture serverFixture, ITestOutputHelper output)
+            : base(browserFixture, output)
+        {
+            _serverFixture = serverFixture;
+        }
+
+        public void Navigate(string relativeUrl, bool noReload = false)
+        {
+            var absoluteUrl = new Uri(_serverFixture.RootUri, relativeUrl);
+
+            if (noReload)
+            {
+                var existingUrl = Browser.Url;
+                if (string.Equals(existingUrl, absoluteUrl.AbsoluteUri, StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+
+            Browser.Navigate().GoToUrl("about:blank");
+            Browser.Navigate().GoToUrl(absoluteUrl);
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/Infrastructure/WaitAssert.cs
+++ b/src/Components/test/Components.FunctionalTests/Infrastructure/WaitAssert.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure
+{
+    // XUnit assertions, but hooked into Selenium's polling mechanism
+
+    public class WaitAssert
+    {
+        private readonly static TimeSpan DefaultTimeout = TimeSpan.FromSeconds(2);
+
+        public static void Equal<T>(T expected, Func<T> actual)
+            => WaitAssertCore(() => Assert.Equal(expected, actual()));
+
+        public static void True(Func<bool> actual)
+            => WaitAssertCore(() => Assert.True(actual()));
+
+        public static void True(Func<bool> actual, TimeSpan timeout)
+            => WaitAssertCore(() => Assert.True(actual()), timeout);
+
+        public static void False(Func<bool> actual)
+            => WaitAssertCore(() => Assert.False(actual()));
+
+        public static void Contains(string expectedSubstring, Func<string> actualString)
+            => WaitAssertCore(() => Assert.Contains(expectedSubstring, actualString()));
+
+        public static void Collection<T>(Func<IEnumerable<T>> actualValues, params Action<T>[] elementInspectors)
+            => WaitAssertCore(() => Assert.Collection(actualValues(), elementInspectors));
+
+        public static void Empty(Func<IEnumerable> actualValues)
+            => WaitAssertCore(() => Assert.Empty(actualValues()));
+
+        public static void Single(Func<IEnumerable> actualValues)
+            => WaitAssertCore(() => Assert.Single(actualValues()));
+
+        private static void WaitAssertCore(Action assertion, TimeSpan timeout = default)
+        {
+            if (timeout == default)
+            {
+                timeout = DefaultTimeout;
+            }
+
+            try
+            {
+                new WebDriverWait(BrowserTestBase.Browser, timeout).Until(_ =>
+                {
+                    try
+                    {
+                        assertion();
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                });
+            }
+            catch (WebDriverTimeoutException)
+            {
+                // Instead of reporting it as a timeout, report the Xunit exception
+                assertion();
+            }
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/SampleTest.cs
+++ b/src/Components/test/Components.FunctionalTests/SampleTest.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures;
+using OpenQA.Selenium;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Components.FunctionalTests
+{
+    public class SampleTest :
+        IClassFixture<AspNetSiteServerFixture<ComponentsWebSite.Program>>,
+        IClassFixture<BrowserFixture>
+    {
+        public SampleTest(
+            BrowserFixture browserFixture,
+            AspNetSiteServerFixture<ComponentsWebSite.Program> serverFixture)
+        {
+            Browser = browserFixture.Browser;
+            RootUri = serverFixture.RootUri;
+        }
+
+        public IWebDriver Browser { get; }
+
+        public Uri RootUri { get; }
+
+        [Fact]
+        public void CanLoadPage()
+        {
+            // Arrange
+            Browser.Url = RootUri.ToString();
+
+            // Act
+            Browser.Navigate();
+
+            // Assert
+            Assert.Contains("Hello world", Browser.PageSource);
+        }
+    }
+}

--- a/src/Components/test/Components.FunctionalTests/xunit.runner.json
+++ b/src/Components/test/Components.FunctionalTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/src/Components/test/Components.Tests/Components.Tests.csproj
+++ b/src/Components/test/Components.Tests/Components.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\shared\*.cs" />
+    <Content Include="TestFiles\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Components\Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/test/Components.Tests/Components.Tests.csproj
+++ b/src/Components/test/Components.Tests/Components.Tests.csproj
@@ -2,13 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\shared\*.cs" />
-    <Content Include="TestFiles\**" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Components.csproj" />

--- a/src/Components/test/Directory.Build.props
+++ b/src/Components/test/Directory.Build.props
@@ -5,7 +5,7 @@
     <DeveloperBuildTestTfms>netcoreapp3.0</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
 
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
+    <!-- <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/test/Directory.Build.props
+++ b/src/Components/test/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <DeveloperBuildTestTfms>netcoreapp3.0</DeveloperBuildTestTfms>
+    <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
+
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Components/test/WebSites/ComponentsWebSite/ComponentsWebSite.csproj
+++ b/src/Components/test/WebSites/ComponentsWebSite/ComponentsWebSite.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(StandardTestWebsiteTfms)</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(MicrosoftAspNetCoreHostingPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Components/test/WebSites/ComponentsWebSite/Program.cs
+++ b/src/Components/test/WebSites/ComponentsWebSite/Program.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+namespace ComponentsWebSite
+{
+    public class Program
+    {
+        public static int Main(string [] args)
+        {
+            var host = BuildWebHost(args);
+
+            host.Run();
+            return 0;
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            CreateWebHostBuilder().Build();
+
+        public static IWebHostBuilder CreateWebHostBuilder()
+        {
+            return new WebHostBuilder()
+                .UseStartup<Startup>()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseKestrel();
+        }
+    }
+}

--- a/src/Components/test/WebSites/ComponentsWebSite/Properties/launchSettings.json
+++ b/src/Components/test/WebSites/ComponentsWebSite/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:57499/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "ComponentsWebSite": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:57500/"
+    }
+  }
+}

--- a/src/Components/test/WebSites/ComponentsWebSite/Startup.cs
+++ b/src/Components/test/WebSites/ComponentsWebSite/Startup.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ComponentsWebSite
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.Use(async (ctx, next) =>
+            {
+                var responseText = "Hello world";
+                ctx.Response.ContentType = "text/plain";
+                ctx.Response.ContentLength = responseText.Length;
+                await ctx.Response.WriteAsync(responseText);
+                await next();
+            });
+        }
+    }
+}

--- a/src/Components/test/WebSites/Directory.Build.props
+++ b/src/Components/test/WebSites/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <!-- Skip the parent folder to prevent getting test package references. -->
+  <Import Project="..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <DeveloperBuildTestWebsiteTfms>netcoreapp3.0</DeveloperBuildTestWebsiteTfms>
+    <StandardTestWebsiteTfms>$(DeveloperBuildTestWebsiteTfms)</StandardTestWebsiteTfms>
+    <StandardTestWebsiteTfms Condition=" '$(DeveloperBuild)' != 'true' ">netcoreapp3.0</StandardTestWebsiteTfms>
+    <StandardTestWebsiteTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestWebsiteTfms);net461</StandardTestWebsiteTfms>
+  </PropertyGroup>
+</Project>

--- a/src/Components/version.props
+++ b/src/Components/version.props
@@ -1,0 +1,12 @@
+﻿<Project>
+  <PropertyGroup>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix>alpha1</VersionSuffix>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
+    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
+    <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
+    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Adds the initial project structure for components based on the DataProtection folder. 
Next steps:
- [ ] Update the project structure to reflect the structure in extensions.
- [x] Add some basic content to ensure we can run functional tests