### PR TITLE
Add signcheck exclusions

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -13,6 +13,9 @@
 
     <DependencyPackageDir>$(RepositoryRoot).deps\build\</DependencyPackageDir>
     <SignedDependencyPackageDir>$(RepositoryRoot).deps\Signed\Packages\</SignedDependencyPackageDir>
+    <SignCheckExclusionsFile>$(RepositoryRoot)eng\signcheck.exclusions.txt</SignCheckExclusionsFile>
+    <!-- This creates false-positives on many of the native .dll's we produce or re-distribute from other teams. -->
+    <DisableSignCheckStrongName>true</DisableSignCheckStrongName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/signcheck.exclusions.txt
+++ b/eng/signcheck.exclusions.txt
@@ -1,0 +1,5 @@
+content/sdk/*/AppHostTemplate/apphost.exe;AspNetCoreRuntime.*.nupkg; Exclude the apphost because this is expected to be code-signed by customers after the SDK modifies it.
+content/*.js;Microsoft.DotNet.Web.Spa.ProjectTemplates.*.nupkg; Exclude JavaScript files from codesigning in project templates
+content/*.js;Microsoft.DotNet.Web.ProjectTemplates.*.nupkg; Exclude JavaScript files from codesigning in project templates
+Templates/*.js;Microsoft.VisualStudio.Web.CodeGenerators.Mvc.*.nupkg; Exclude JavaScript files from codesigning in code generators
+*.js;signalr-*-javadoc.jar; Exclude JavaScript files in the generated javadocs

--- a/eng/signcheck.exclusions.txt
+++ b/eng/signcheck.exclusions.txt
@@ -3,4 +3,3 @@ content/*.js;Microsoft.DotNet.Web.Spa.ProjectTemplates.*.nupkg; Exclude JavaScri
 content/*.js;Microsoft.DotNet.Web.ProjectTemplates.*.nupkg; Exclude JavaScript files from codesigning in project templates
 Templates/*.js;Microsoft.VisualStudio.Web.CodeGenerators.Mvc.*.nupkg; Exclude JavaScript files from codesigning in code generators
 *.js;signalr-*-javadoc.jar; Exclude JavaScript files in the generated javadocs
-*.dll|*.exe;IIS.StressTestWebSite.zip; This is a test asset which is only produced for manual upload into IIS stress testing.

--- a/eng/signcheck.exclusions.txt
+++ b/eng/signcheck.exclusions.txt
@@ -3,3 +3,4 @@ content/*.js;Microsoft.DotNet.Web.Spa.ProjectTemplates.*.nupkg; Exclude JavaScri
 content/*.js;Microsoft.DotNet.Web.ProjectTemplates.*.nupkg; Exclude JavaScript files from codesigning in project templates
 Templates/*.js;Microsoft.VisualStudio.Web.CodeGenerators.Mvc.*.nupkg; Exclude JavaScript files from codesigning in code generators
 *.js;signalr-*-javadoc.jar; Exclude JavaScript files in the generated javadocs
+*.dll|*.exe;IIS.StressTestWebSite.zip; This is a test asset which is only produced for manual upload into IIS stress testing.

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -15,7 +15,7 @@
   <Import Condition="Exists('..\..\obj\dependencies.g.props') AND '$(DotNetPackageVersionPropsPath)' == ''" Project="..\..\obj\dependencies.g.props" />
 
   <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.shfxproj' ">
-    <OutputPath>$(ArtifactsConfigurationDir)$(SharedFxRid)\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath>$(RepositoryRoot)bin\fx\$(SharedFxRid)\$(MSBuildProjectName)\</OutputPath>
     <BaseIntermediateOutputPath>$(RepositoryRoot)obj\fx\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
     <CrossgenSymbolsOutput Condition=" '$(CrossgenOutput)' == 'false' OR '$(SharedFxRid)' == 'osx-x64'">false</CrossgenSymbolsOutput>


### PR DESCRIPTION
Preparing to consume a new version of BuildTools. These are the failures that signcheck would catch.

There were a few others, but those are covered by:
* https://github.com/aspnet/AzureIntegration/pull/248
* https://github.com/aspnet/AspNetCore/pull/3984