### PR TITLE
Remove implicit reference to InteralAspNetCoreSdk

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMPackageResolver/ANCMPackageResolver.csproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMPackageResolver/ANCMPackageResolver.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Remove="Internal.AspNetCore.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="$(MicrosoftAspNetCoreAspNetCoreModulePackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
To fix WindowsInstallers in 2.1. I'll come up with a better solution for restoring through wixprojs later.
