### PR TITLE
Fix MSB4062 when building Microsoft.Web.Xdt.Extensions

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SamplesProject Include="$(RepositoryRoot)src\samples\**\*.csproj;"/>
+    <SamplesProject Include="$(RepositoryRoot)src\**\samples\**\*.csproj;"/>
 
     <ProjectToExclude Include="@(SamplesProject)" Condition="'$(BuildSamples)' == 'false' "/>
 

--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -5,4 +5,9 @@
   <Import Project="build\dependencies.props" />
   <Import Project="version.props" />
 
+  <PropertyGroup>
+    <EnableApiCheck>false</EnableApiCheck>
+    <GenerateSourceLinkFile>false</GenerateSourceLinkFile>
+  </PropertyGroup>
+
 </Project>

--- a/src/SiteExtensions/build/dependencies.props
+++ b/src/SiteExtensions/build/dependencies.props
@@ -3,14 +3,11 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <Import Project="..\..\..\build\dependencies.props" />
+
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>3.0.0-build-20181114.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1-rtm-31076</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0-rtm-35515</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>
-    <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
-    <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
-    <XunitPackageVersion>2.4.0</XunitPackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/SiteExtensions/build/repo.props
+++ b/src/SiteExtensions/build/repo.props
@@ -1,8 +1,7 @@
 <Project>
 
-
-  <ItemGroup>
-    <ExcludeFromPack Include="$(RepositoryRoot)src\Microsoft.Web.Xdt.Extensions\*.csproj" />
-  </ItemGroup>
-
+  <PropertyGroup>
+    <!-- Disable KoreBuild restrictions while we re-work dependency management. -->
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+  </PropertyGroup>
 </Project>

--- a/src/SiteExtensions/global.json
+++ b/src/SiteExtensions/global.json
@@ -1,8 +1,8 @@
 {
     "sdk": {
-        "version": "2.2.100-preview3-009430"
+        "version": "3.0.100-preview-009750"
     },
     "msbuild-sdks": {
-        "Internal.AspNetCore.Sdk": "3.0.0-alpha1-20181018.6"
+        "Internal.AspNetCore.Sdk": "3.0.0-build-20181114.5"
     }
 }

--- a/src/SiteExtensions/src/Microsoft.Web.Xdt.Extensions/Microsoft.Web.Xdt.Extensions.csproj
+++ b/src/SiteExtensions/src/Microsoft.Web.Xdt.Extensions/Microsoft.Web.Xdt.Extensions.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Description>Additional functionality for Xdt transforms.</Description>
     <TargetFramework>net461</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageTags>xdt</PackageTags>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Build fails with this error when build tools are updated automatically:

> error MSB4062: The "Microsoft.AspNetCore.BuildTools.Sdk_GetAssemblyFileVersion" task could not be loaded from the assembly 

This ensures Microsoft.Web.Xdt.Extensions.csproj uses the same version of build tools as the rest of the repo.

Other changes:
* Resolve build warnings about source link and API check
* Set IsPackable=false instead of using ExcludeFromPack 

Resolves https://github.com/aspnet/AspNetCore-Internal/issues/1360