### PR TITLE
Remove the BrowserLink submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,6 @@
 	path = modules/BasicMiddleware
 	url = https://github.com/aspnet/BasicMiddleware.git
 	branch = release/2.1
-[submodule "modules/BrowserLink"]
-	path = modules/BrowserLink
-	url = https://github.com/aspnet/BrowserLink.git
-	branch = release/2.1
 [submodule "modules/CORS"]
 	path = modules/CORS
 	url = https://github.com/aspnet/CORS.git

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -195,7 +195,6 @@
     <PackageArtifact Include="Microsoft.VisualStudio.Editor.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.VisualStudio.LanguageServices.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.VisualStudio.Mac.LanguageServices.Razor" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.VisualStudio.Web.BrowserLink" AllMetapackage="true" Category="ship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGeneration.Contracts" Category="ship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGeneration.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Category="ship" />

--- a/build/buildorder.props
+++ b/build/buildorder.props
@@ -12,7 +12,6 @@
     <RepositoryBuildOrder Include="Hosting" Order="7" />
     <RepositoryBuildOrder Include="EntityFrameworkCore" Order="8" />
     <RepositoryBuildOrder Include="HttpSysServer" Order="8" />
-    <RepositoryBuildOrder Include="BrowserLink" Order="8" />
     <RepositoryBuildOrder Include="BasicMiddleware" Order="9" />
     <RepositoryBuildOrder Include="Antiforgery" Order="9" />
     <RepositoryBuildOrder Include="IISIntegration" Order="10" RootPath="$(RepositoryRoot)src\IISIntegration\" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -146,7 +146,7 @@
     <MicrosoftVisualStudioShellInterop90PackageVersion>9.0.30729</MicrosoftVisualStudioShellInterop90PackageVersion>
     <MicrosoftVisualStudioShellInteropPackageVersion>7.10.6071</MicrosoftVisualStudioShellInteropPackageVersion>
     <MicrosoftVisualStudioTextUIPackageVersion>15.6.161-preview</MicrosoftVisualStudioTextUIPackageVersion>
-    <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.1.1.</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
+    <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.1.1</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>4.5.0</MicrosoftWin32RegistryPackageVersion>
     <MonoAddinsPackageVersion>1.3.8</MonoAddinsPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -146,6 +146,7 @@
     <MicrosoftVisualStudioShellInterop90PackageVersion>9.0.30729</MicrosoftVisualStudioShellInterop90PackageVersion>
     <MicrosoftVisualStudioShellInteropPackageVersion>7.10.6071</MicrosoftVisualStudioShellInteropPackageVersion>
     <MicrosoftVisualStudioTextUIPackageVersion>15.6.161-preview</MicrosoftVisualStudioTextUIPackageVersion>
+    <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.1.1.</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>4.5.0</MicrosoftWin32RegistryPackageVersion>
     <MonoAddinsPackageVersion>1.3.8</MonoAddinsPackageVersion>

--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -165,6 +165,7 @@
     <ExternalDependency Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellInterop80PackageVersion)" />
     <ExternalDependency Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90PackageVersion)" />
     <ExternalDependency Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIPackageVersion)" />
+    <ExternalDependency Include="Microsoft.VisualStudio.Web.BrowserLink" Version="$(MicrosoftVisualStudioWebBrowserLinkPackageVersion)" AllMetapackage="true"  />
     <ExternalDependency Include="Microsoft.Web.Xdt" Version="$(MicrosoftWebXdtPackageVersion)" />
     <ExternalDependency Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <ExternalDependency Include="Mono.Addins" Version="$(MonoAddinsPackageVersion)" />

--- a/build/submodules.props
+++ b/build/submodules.props
@@ -52,7 +52,6 @@
     <ShippedRepository Include="Antiforgery" />
     <ShippedRepository Include="AzureIntegration" RootPath="$(RepositoryRoot)src\AzureIntegration\" />
     <ShippedRepository Include="BasicMiddleware" />
-    <ShippedRepository Include="BrowserLink" />
     <ShippedRepository Include="CORS" />
     <ShippedRepository Include="Diagnostics" />
     <ShippedRepository Include="EntityFrameworkCore" />


### PR DESCRIPTION
This removes the submodule to https://github.com/aspnet/BrowserLink. This repo will build on its own, separately from this repo.

Resolves https://github.com/aspnet/AspNetCore-Internal/issues/1340