### PR TITLE
Resolve C26496 compiler errors when building in release mode with VS 15.9

### DIFF
--- a/src/IISIntegration/src/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/IISIntegration/src/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -106,7 +106,7 @@ APPLICATION_INFO::CreateApplication(IHttpContext& pHttpContext)
             }
             return S_OK;
         }
-        catch (ConfigurationLoadException &ex)
+        catch (const ConfigurationLoadException &ex)
         {
             EventLog::Error(
                 ASPNETCORE_CONFIGURATION_LOAD_ERROR,

--- a/src/IISIntegration/src/AspNetCoreModuleV2/CommonLib/BaseOutputManager.h
+++ b/src/IISIntegration/src/AspNetCoreModuleV2/CommonLib/BaseOutputManager.h
@@ -55,7 +55,7 @@ protected:
         {
             func();
         }
-        catch (std::runtime_error& exception)
+        catch (const std::runtime_error& exception)
         {
             EventLog::Warn(ASPNETCORE_EVENT_GENERAL_WARNING, exceptionMessage.c_str(), GetModuleName().c_str(), to_wide_string(exception.what(), GetConsoleOutputCP()).c_str());
         }


### PR DESCRIPTION
Updating CI machines to VS 15.9 causes the project to fail to compile with C26496 errors. This adds `const` keywords to resolve the compiler errors.