### PR TITLE
Change Google scope in external providers sample

### DIFF
--- a/src/AuthSamples/samples/Identity.ExternalClaims/Startup.cs
+++ b/src/AuthSamples/samples/Identity.ExternalClaims/Startup.cs
@@ -40,7 +40,7 @@ namespace Identity.ExternalClaims
                 // Configure your auth keys, usually stored in Config or User Secrets
                 o.ClientId = "<yourid>";
                 o.ClientSecret = "<yoursecret>";
-                o.Scope.Add("https://www.googleapis.com/auth/plus.me");
+                o.Scope.Add("https://www.googleapis.com/auth/plus.login");
                 o.ClaimActions.MapJsonKey(ClaimTypes.Gender, "gender");
                 o.SaveTokens = true;
                 o.Events.OnCreatingTicket = ctx =>


### PR DESCRIPTION
Moved from https://github.com/aspnet/AuthSamples/pull/59

See ...

https://developers.google.com/+/web/api/rest/oauth ...

> For login purposes, use the profile or `https://www.googleapis.com/auth/plus.login` scope. The `https://www.googleapis.com/auth/plus.me` scope is not recommended as a login scope because, for users who have not upgraded to Google+, it does not return the user's name or email address. 

Cross-ref: https://github.com/aspnet/Docs/issues/3744#issuecomment-416386518

cc: @HaoK 
