### PR TITLE
Update branding to 3.0.0-preview

### DIFF
--- a/build/AzureIntegration.targets
+++ b/build/AzureIntegration.targets
@@ -10,7 +10,8 @@
         RepositoryRoot=$(AzureIntegrationProjectRoot);
         DotNetRestoreSourcePropsPath=$(GeneratedRestoreSourcesPropsPath);
         DotNetPackageVersionPropsPath=$(GeneratedPackageVersionPropsPath);
-        BuildNumber=$(BuildNumber);
+        VersionSuffix=$(VersionSuffix);
+        BuildNumberSuffix=$(BuildNumberSuffix);
         Configuration=$(Configuration);
         IsFinalBuild=$(IsFinalBuild);
       </AzureIntegrationProjProperties>

--- a/build/CodeSign.targets
+++ b/build/CodeSign.targets
@@ -36,14 +36,14 @@
     <MSBuild Projects="@(_RepositoryProject)"
              Condition="@(_RepositoryProject->Count()) != 0"
              Targets="_GetFileSignInfo"
-             Properties="$(GetFileSignInfoProps);$(DesignTimeBuildProps);DesignTimeBuild=true;Configuration=$(Configuration);BuildNumber=$(BuildNumber);CustomAfterKoreBuildTargets=$(MSBuildThisFileFullPath)"
+             Properties="$(GetFileSignInfoProps);$(DesignTimeBuildProps);DesignTimeBuild=true;Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);CustomAfterKoreBuildTargets=$(MSBuildThisFileFullPath)"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoFileSignInfo" />
     </MSBuild>
     <MSBuild Projects="@(_ShippedRepositoryProject)"
              Condition="@(_ShippedRepositoryProject->Count()) != 0"
              Targets="_GetFileSignInfo"
-             Properties="$(GetFileSignInfoProps);$(DesignTimeBuildProps);IsFinalBuild=true;DesignTimeBuild=true;Configuration=$(Configuration);BuildNumber=$(BuildNumber);CustomAfterKoreBuildTargets=$(MSBuildThisFileFullPath)"
+             Properties="$(GetFileSignInfoProps);$(DesignTimeBuildProps);IsFinalBuild=true;DesignTimeBuild=true;Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);CustomAfterKoreBuildTargets=$(MSBuildThisFileFullPath)"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ShippedRepoFileSignInfo" />
     </MSBuild>

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -31,7 +31,7 @@
       BuildInParallel="true"
       StopOnFirstFailure="true"
       Targets="_BuildRepository"
-      Properties="BuildGroup=%(BatchedRepository.BuildGroup);BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration)" />
+      Properties="BuildGroup=%(BatchedRepository.BuildGroup);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration)" />
 
     <PropertyGroup>
       <_ReposWereBuilt>true</_ReposWereBuilt>
@@ -54,7 +54,7 @@
       BuildInParallel="$(TestProjectsInParallel)"
       StopOnFirstFailure="false"
       Targets="_TestRepository"
-      Properties="BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
+      Properties="VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
       ContinueOnError="true">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoTestResults" />
     </MSBuild>
@@ -83,7 +83,8 @@
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:DotNetPackageVersionPropsPath=$(GeneratedPackageVersionPropsPath)</RepositoryBuildArguments>
       <!-- Unset 'SignType' because we collect all outputs from repo builds and sign them at the end. -->
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:SignType=</RepositoryBuildArguments>
-      <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:BuildNumber=$(BuildNumber)</RepositoryBuildArguments>
+      <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:VersionSuffix=$(VersionSuffix)</RepositoryBuildArguments>
+      <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:BuildNumberSuffix=$(BuildNumberSuffix)</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:Configuration=$(Configuration)</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:IsFinalBuild=$(IsFinalBuild)</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) '/p:DotNetAssetRootAccessTokenSuffix=$(DotNetAssetRootAccessTokenSuffix)'</RepositoryBuildArguments>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -87,14 +87,14 @@
 
     <MSBuild Projects="@(_RepositoryProject)"
              Targets="GetArtifactInfo"
-             Properties="$(DesignTimeBuildProps);Configuration=$(Configuration);BuildNumber=$(BuildNumber);DesignTimeBuild=true;"
+             Properties="$(DesignTimeBuildProps);Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);DesignTimeBuild=true;"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
     </MSBuild>
 
     <MSBuild Projects="@(ProjectToBuild)"
              Targets="GetArtifactInfo"
-             Properties="$(DesignTimeBuildProps);Configuration=$(Configuration);BuildNumber=$(BuildNumber);DesignTimeBuild=true"
+             Properties="$(DesignTimeBuildProps);Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);DesignTimeBuild=true"
              SkipNonexistentTargets="true"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
@@ -102,7 +102,7 @@
 
     <MSBuild Projects="@(_RepositoryProject)"
              Targets="ResolveSolutions"
-             Properties="$(DesignTimeBuildProps);Configuration=$(Configuration);BuildNumber=$(BuildNumber)"
+             Properties="$(DesignTimeBuildProps);Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix)"
              ContinueOnError="WarnAndContinue"
              BuildInParallel="true"
              Condition="@(_RepositoryProject->Count()) != 0">
@@ -116,14 +116,14 @@
     -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="GetArtifactInfo"
-             Properties="$(DesignTimeBuildProps);RepositoryRoot=%(ShippedRepository.RootPath);Configuration=$(Configuration);BuildNumber=$(BuildNumber);IsFinalBuild=true;DesignTimeBuild=true"
+             Properties="$(DesignTimeBuildProps);RepositoryRoot=%(ShippedRepository.RootPath);Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);IsFinalBuild=true;DesignTimeBuild=true"
              ContinueOnError="WarnAndContinue"
              Condition="'%(ShippedRepository.Identity)' != ''">
       <Output TaskParameter="TargetOutputs" ItemName="ShippedArtifactInfo" />
     </MSBuild>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="ResolveSolutions"
-             Properties="RepositoryRoot=%(ShippedRepository.RootPath);Configuration=$(Configuration);BuildNumber=$(BuildNumber)"
+             Properties="RepositoryRoot=%(ShippedRepository.RootPath);Configuration=$(Configuration);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix)"
              ContinueOnError="WarnAndContinue"
              Condition="'%(ShippedRepository.Identity)' != ''">
       <Output TaskParameter="TargetOutputs" ItemName="_ShippedSolution" />

--- a/src/AzureIntegration/build/repo.targets
+++ b/src/AzureIntegration/build/repo.targets
@@ -49,11 +49,11 @@
   <Target Name="BuildSiteExtension" DependsOnTargets="_CleanSiteExtension;PrepareSiteExtensionSdks">
     <MSBuild Projects="%(SiteExtensions.Identity)"
       Targets="Restore"
-      Properties="BuildNumber=$(BuildNumber)" />
+      Properties="VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix)" />
 
     <MSBuild Projects="%(SiteExtensions.Identity)"
       Targets="Pack"
-      Properties="%(SiteExtensions.BuildProperties);DotnetHomeDirectory=$(SiteExtensionWorkingDirectory);BuildNumber=$(BuildNumber);PackageOutputPath=$(SiteExtensionOutputDirectory)" />
+      Properties="%(SiteExtensions.BuildProperties);DotnetHomeDirectory=$(SiteExtensionWorkingDirectory);VersionSuffix=$(VersionSuffix);BuildNumberSuffix=$(BuildNumberSuffix);PackageOutputPath=$(SiteExtensionOutputDirectory)" />
   </Target>
 
   <Target Name="PushSiteExtension" DependsOnTargets="BuildSiteExtension">

--- a/src/AzureIntegration/version.props
+++ b/src/AzureIntegration/version.props
@@ -1,12 +1,3 @@
 <Project>
-  <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>alpha1</VersionSuffix>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
-    <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-  </PropertyGroup>
+  <Import Project="..\..\version.props" />
 </Project>

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <!--
     Currently, the shared framework builds by using PackageReference to internally generate the deps.json files and move bits between projects.
-    For local builds, this import is required to point to packages which actually exists. Run "build.cmd /t:GeneratePropsFiles /p:BuildNumber=xyz" to
+    For local builds, this import is required to point to packages which actually exists. Run "build.cmd /t:GeneratePropsFiles /p:BuildNumberSuffix=xyz" to
     build the shared framework against a particular set of packages.
   -->
   <Import Condition="Exists('..\..\obj\dependencies.g.props') AND '$(DotNetPackageVersionPropsPath)' == ''" Project="..\..\obj\dependencies.g.props" />

--- a/src/IISIntegration/Directory.Build.props
+++ b/src/IISIntegration/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
-  <Import Project="version.props" />
   <Import Project="dependencies.overrides.props" />
 
   <PropertyGroup>

--- a/src/IISIntegration/build/native.targets
+++ b/src/IISIntegration/build/native.targets
@@ -7,10 +7,10 @@
       <VersionHeaderContents Include="%0a" />
       <VersionHeaderContents Include="// This file is auto-generated" />
       <VersionHeaderContents Include="%0a" />
-      <VersionHeaderContents Include="#define FileVersion $(AspNetCoreModuleVersionMajor),$(AspNetCoreModuleVersionMinor),$(AssemblyBuild),$(AspNetCoreModuleVersionRevision)" />
-      <VersionHeaderContents Include="#define FileVersionStr &quot;$(AspNetCoreModuleVersionMajor).$(AspNetCoreModuleVersionMinor).$(AssemblyBuild).$(AspNetCoreModuleVersionRevision)\0&quot;" />
-      <VersionHeaderContents Include="#define ProductVersion $(AspNetCoreModuleVersionMajor),$(AspNetCoreModuleVersionMinor),$(AssemblyBuild),$(AspNetCoreModuleVersionRevision)" />
-      <VersionHeaderContents Include="#define ProductVersionStr &quot;$(AspNetCoreModuleVersionMajor).$(AspNetCoreModuleVersionMinor).$(AssemblyBuild).$(AspNetCoreModuleVersionRevision)\0&quot;" />
+      <VersionHeaderContents Include="#define FileVersion $(AspNetCoreModuleVersionMajor),$(AspNetCoreMinorVersion),$(AssemblyBuild),$(AspNetCorePatchVersion)" />
+      <VersionHeaderContents Include="#define FileVersionStr &quot;$(AspNetCoreModuleVersionMajor).$(AspNetCoreMinorVersion).$(AssemblyBuild).$(AspNetCorePatchVersion)\0&quot;" />
+      <VersionHeaderContents Include="#define ProductVersion $(AspNetCoreModuleVersionMajor),$(AspNetCoreMinorVersion),$(AssemblyBuild),$(AspNetCorePatchVersion)" />
+      <VersionHeaderContents Include="#define ProductVersionStr &quot;$(AspNetCoreModuleVersionMajor).$(AspNetCoreMinorVersion).$(AssemblyBuild).$(AspNetCorePatchVersion)\0&quot;" />
       <VersionHeaderContents Include="#define PlatformToolset &quot;$(PlatformToolset)\0&quot;" />
       <VersionHeaderContents Include="#define CommitHash &quot;$(CommitHash)\0&quot;" />
     </ItemGroup>

--- a/src/IISIntegration/build/repo.props
+++ b/src/IISIntegration/build/repo.props
@@ -5,6 +5,8 @@
     <!-- TODO: temporary while we reorganize source code and refactor dependency management -->
     <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
 
+    <AspNetCoreModuleOutOfProcessVersion>2.0.0</AspNetCoreModuleOutOfProcessVersion>
+
     <StressTestWebSiteZipOutputPath>$(BuildDir)StressTestWebSite.zip</StressTestWebSiteZipOutputPath>
   </PropertyGroup>
 

--- a/src/IISIntegration/dependencies.overrides.props
+++ b/src/IISIntegration/dependencies.overrides.props
@@ -6,6 +6,7 @@
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
 
   <PropertyGroup Label="Package Versions: Pinned">
+    <AspNetCoreModuleOutOfProcessVersion>2.0.0</AspNetCoreModuleOutOfProcessVersion>
   <!-- The AspNetCoreModule package versions are pinned to an older version for forwards and backwards compatibility tests. -->
     <MicrosoftAspNetCoreAspNetCoreModuleStablePackageVersion>2.2.0-preview3-35497</MicrosoftAspNetCoreAspNetCoreModuleStablePackageVersion>
     <MicrosoftAspNetCoreAspNetCoreModuleV2StablePackageVersion>2.2.0-preview3-35497</MicrosoftAspNetCoreAspNetCoreModuleV2StablePackageVersion>

--- a/src/IISIntegration/version.props
+++ b/src/IISIntegration/version.props
@@ -1,17 +1,8 @@
 ﻿<Project>
+  <Import Project="..\..\version.props" />
   <PropertyGroup>
-    <DotNetMajorVersion>3</DotNetMajorVersion>
-    <DotNetMinorVersion>0</DotNetMinorVersion>
-    <DotNetPatchVersion>0</DotNetPatchVersion>
-    <PreReleaseLabel>alpha1</PreReleaseLabel>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">$([System.DateTime]::Now.ToString('yyMMdd'))-99</BuildNumber>
-    <VersionPrefix>$(DotNetMajorVersion).$(DotNetMinorVersion).$(DotNetPatchVersion)</VersionPrefix>
-    <AspNetCoreModuleVersionMajor>13</AspNetCoreModuleVersionMajor>
-    <AspNetCoreModuleVersionMinor>$(DotNetMinorVersion)</AspNetCoreModuleVersionMinor>
-    <AspNetCoreModuleVersionRevision>$(DotNetPatchVersion)</AspNetCoreModuleVersionRevision>
-    <PackageVersion>$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' != 'false' ">$(VersionPrefix)-$(PreReleaseLabel)-$(BuildNumber)</PackageVersion>
-    <Version>$(PackageVersion)</Version>
+
+
     <AspNetCoreModuleOutOfProcessVersion>2.0.0</AspNetCoreModuleOutOfProcessVersion>
   </PropertyGroup>
 </Project>

--- a/src/IISIntegration/version.props
+++ b/src/IISIntegration/version.props
@@ -1,8 +1,3 @@
 ﻿<Project>
   <Import Project="..\..\version.props" />
-  <PropertyGroup>
-
-
-    <AspNetCoreModuleOutOfProcessVersion>2.0.0</AspNetCoreModuleOutOfProcessVersion>
-  </PropertyGroup>
 </Project>

--- a/src/Installers/Debian/Runtime.debproj
+++ b/src/Installers/Debian/Runtime.debproj
@@ -31,7 +31,7 @@
     <!-- PackageVersion does not match the ASP.NET Core runtime verison. -->
     <PackageVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</PackageVersion>
     <!-- Deb installers are versioned as M.N.P~PreReleaseLabel-Build following the core-setup convention -->
-    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)~$(PreReleaseLabel)-$(BuildNumber)</PackageVersion>
+    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)~$(PreReleaseLabel)-$(BuildNumberSuffix)</PackageVersion>
     <PackageRevision>1</PackageRevision>
 
     <!-- Needed some creativity to convert the PackageVersion M.N.P-PreReleaseLabel-Build to the installer version M.N.P~PreReleaseLabel-Build, The conditional handles stabilized builds -->

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <GuidInputs>$(Version);$(Platform)</GuidInputs>
-    <GuidInputs Condition="'$(IsFinalBuild)' != 'true'">$(GuidInputs);$(BuildNumber)</GuidInputs>
+    <GuidInputs Condition="'$(IsFinalBuild)' != 'true'">$(GuidInputs);$(BuildNumberSuffix)</GuidInputs>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(OutputPath)..\InstallerTasks\InstallerTasks.dll" TaskName="RepoTasks.GenerateGuid" />

--- a/src/Installers/Windows/build.ps1
+++ b/src/Installers/Windows/build.ps1
@@ -67,7 +67,7 @@ try {
             -clp:Summary `
             "-p:SharedFrameworkHarvestRootPath=$repoRoot/obj/sfx/" `
             "-p:Configuration=$Configuration" `
-            "-p:BuildNumber=$BuildNumber" `
+            "-p:BuildNumberSuffix=$BuildNumber" `
             "-p:SignType=$SignType" `
             "-p:IsFinalBuild=$IsFinalBuild" `
             "-bl:$repoRoot/artifacts/logs/installers.msbuild.binlog" `

--- a/src/templating/version.props
+++ b/src/templating/version.props
@@ -1,12 +1,3 @@
 ﻿<Project>
-  <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>alpha1</VersionSuffix>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND ('$(VersionSuffix)' == 'servicing' OR '$(VersionSuffix)' == 'rtm') ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'servicing' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
-    <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-  </PropertyGroup>
+  <Import Project="..\..\version.props" />
 </Project>

--- a/version.props
+++ b/version.props
@@ -6,6 +6,7 @@
     <PreReleaseLabel>preview</PreReleaseLabel>
     <PreReleaseBrandingLabel>Preview</PreReleaseBrandingLabel>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
+    <!-- ANCM versioning is intentionally 10 + AspNetCoreMajorVersion because earlier versions of ANCM shipped as 8.x. -->
     <AspNetCoreModuleVersionMajor>1$(AspNetCoreMajorVersion)</AspNetCoreModuleVersionMajor>
 
     <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>

--- a/version.props
+++ b/version.props
@@ -3,13 +3,43 @@
     <AspNetCoreMajorVersion>3</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>0</AspNetCoreMinorVersion>
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
-    <PreReleaseLabel>alpha1</PreReleaseLabel>
-    <PreReleaseBrandingLabel>Alpha 1</PreReleaseBrandingLabel>
-    <BuildNumber Condition="'$(BuildNumber)' == '' OR '$(UsingLocalBuildNumber)' == 'true'">$([System.DateTime]::Now.ToString('yyMMdd'))-99</BuildNumber>
-    <VersionPrefix>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</VersionPrefix>
+    <PreReleaseLabel>preview</PreReleaseLabel>
+    <PreReleaseBrandingLabel>Preview</PreReleaseBrandingLabel>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
-    <VersionSuffix>$(PreReleaseLabel)-$(BuildNumber)</VersionSuffix>
-    <BrandingVersionSuffix>$(PreReleaseBrandingLabel) Build $(BuildNumber)</BrandingVersionSuffix>
+    <AspNetCoreModuleVersionMajor>1$(AspNetCoreMajorVersion)</AspNetCoreModuleVersionMajor>
+
+    <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>
+    <OfficialBuildId Condition="'$(OfficialBuildId)' == '' AND '$(TEAMCITY_VERSION)' != ''">$([System.DateTime]::Now.ToString('yyyyMMdd')).$(BUILD_NUMBER)</OfficialBuildId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OfficialBuildId)' != '' AND '$(BuildNumberSuffix)' == '' ">
+    <!-- This *mostly*  implements core versioning. Spec: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md -->
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+
+    <!-- _BuildNumber from CI is assumed to have format "yyyyMMdd.r". -->
+    <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+    <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+    <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+    <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+    <!-- yy * 1000 + mm * 50 + dd -->
+    <_BuildNumberShortDate>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_BuildNumberYY), 1000)), $([MSBuild]::Multiply($(_BuildNumberMM), 50)))), $(_BuildNumberDD)))</_BuildNumberShortDate>
+
+    <VersionSuffixBuildOfTheDay>$([System.Convert]::ToInt32($(_BuildNumberR)))</VersionSuffixBuildOfTheDay>
+
+    <!-- This is where we currently differ from the core versioning spec. This can be removed when we get official builds running in Azure Pipelines. -->
+    <VersionSuffixBuildOfTheDayPadded Condition=" '$(TEAMCITY_VERSION)' == '' ">$(VersionSuffixBuildOfTheDay.PadLeft(2, '0'))</VersionSuffixBuildOfTheDayPadded>
+    <VersionSuffixBuildOfTheDayPadded Condition=" '$(TEAMCITY_VERSION)' != '' ">$(VersionSuffixBuildOfTheDay.PadLeft(4, '0'))</VersionSuffixBuildOfTheDayPadded>
+
+    <!-- TODO: consider using semver 2.0 instead, when/if https://github.com/dotnet/core-setup/issues/4795 is resolved -->
+    <BuildNumberSuffix>$(_BuildNumberShortDate)-$(VersionSuffixBuildOfTheDayPadded)</BuildNumberSuffix>
+  </PropertyGroup>
+
+   <PropertyGroup>
+    <BuildNumberSuffix Condition=" '$(BuildNumberSuffix)' == '' ">0</BuildNumberSuffix>
+    <VersionPrefix>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</VersionPrefix>
+    <VersionSuffix>$(PreReleaseLabel)-$(BuildNumberSuffix)</VersionSuffix>
+    <BrandingVersionSuffix>$(PreReleaseBrandingLabel) Build $(BuildNumberSuffix)</BrandingVersionSuffix>
 
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->
     <IsServicingBuild Condition=" '$(PreReleaseLabel)' == 'servicing' ">true</IsServicingBuild>


### PR DESCRIPTION
This _mostly_ implements https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md.

Changes:
* This uses date-based versioning
* Builds are `3.0.0-preview-$(buildnumber)`, not alpha1 or preview1.

Notable deviations:

* This uses a 4x left-padded number, not 2x. This is temporary until we get official builds running in Azure Pipelines. 4x is necessary because TeamCity build counters do not reset each day.
* This uses semver 1.0, not 2.0 like the Extensions or EFCore packages. We can update to semver 2.0 if https://github.com/dotnet/core-setup/issues/4795 is resolved.
