### PR TITLE
Stop shipping packages for assemblies which are shared-framework-only

### DIFF
--- a/build/SharedFrameworkOnly.props
+++ b/build/SharedFrameworkOnly.props
@@ -1,0 +1,33 @@
+<!--
+  This lists all assemblies which are part of the Microsoft.AspNetCore.App shared framework
+  and should not ship as NuGet packages.
+-->
+<Project>
+
+  <Import Project="..\src\Framework\Microsoft.AspNetCore.App.props" />
+
+  <ItemGroup>
+    <!-- Packages to be removed from the shared framework but not done yet. -->
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.JsonPatch" />
+
+    <!-- Packages for Razor runtime compilation -->
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Razor.Language" />
+    <SharedFrameworkAndPackage Include="Microsoft.CodeAnalysis.Razor" />
+
+    <!-- Assemblies required by the SignalR client. -->
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Http.Features" />
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
+
+    <!-- Assemblies produced by this repo that will move to aspnet/Extensions after repo refactoring is tone -->
+    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Identity.Core" />
+    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Identity.Stores" />
+    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Localization.Abstractions" />
+    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Localization" />
+
+    <SharedFrameworkOnlyPackage Include="@(Dependency)" Exclude="@(SharedFrameworkAndPackage)" />
+  </ItemGroup>
+
+</Project>

--- a/build/SharedFrameworkOnly.props
+++ b/build/SharedFrameworkOnly.props
@@ -19,7 +19,7 @@
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
 
-    <!-- Assemblies produced by this repo that will move to aspnet/Extensions after repo refactoring is tone -->
+    <!-- Assemblies produced by this repo that will move to aspnet/Extensions after repo refactoring is done -->
     <SharedFrameworkAndPackage Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
     <SharedFrameworkAndPackage Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <SharedFrameworkAndPackage Include="Microsoft.Extensions.Identity.Core" />

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -13,166 +13,169 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86' " />
+    <!-- Packages that go to nuget.org -->
     <PackageArtifact Include="dotnet-dev-certs" Category="ship" />
     <PackageArtifact Include="dotnet-sql-cache" Category="ship" />
     <PackageArtifact Include="dotnet-user-secrets" Category="ship" />
     <PackageArtifact Include="dotnet-watch" Category="ship" />
-    <PackageArtifact Include="Internal.WebHostBuilderFactory.Sources" Category="noship" />
-    <PackageArtifact Include="Internal.AspNetCore.Universe.Lineup" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
     <PackageArtifact Include="runtime.$(SharedFxRid).Microsoft.AspNetCore.App" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModule" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Facebook" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Google" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Twitter" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.WsFederation" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Buffering" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ChunkingCookieManager.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Connections.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Extensions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Elm" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HostFiltering" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Hosting.WindowsServices" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Html.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections.Client" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections.Common" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Extensions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Http.Features" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HttpOverrides" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HttpsPolicy" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HttpSys.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Specification.Tests" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.UI" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Identity" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.JsonPatch" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Localization.Routing" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Localization" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.MiddlewareAnalysis" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Analyzers" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Core" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Cors" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Testing" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.NodeServices.Sockets" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.NodeServices" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Owin" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.RangeHelper.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Razor.Language" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCompression" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Rewrite" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing.DecisionTree.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IIS" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Core" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Https" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Session" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Common" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Specification.Tests" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices.Extensions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.TestHost" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore" Category="ship" />
-    <PackageArtifact Include="Microsoft.CodeAnalysis.Razor.Workspaces" Category="shipoob" />
     <PackageArtifact Include="Microsoft.CodeAnalysis.Razor" Category="ship" />
-    <PackageArtifact Include="Microsoft.CodeAnalysis.Remote.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.DotNet.Web.Client.ItemTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.DotNet.Web.ItemTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.DotNet.Web.ProjectTemplates.3.0" Category="ship" />
     <PackageArtifact Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.ApiDescription.Design" Category="ship" />
-    <PackageArtifact Include="Microsoft.Extensions.ApplicationModelDetection" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Diagnostics.HealthChecks" Category="ship"  />
-    <PackageArtifact Include="Microsoft.Extensions.Buffers.MemoryPool.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.Buffers.Testing.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.Extensions.Identity.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Identity.Stores" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Localization.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Localization" Category="ship" />
-    <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="ship" />
     <PackageArtifact Include="Microsoft.NET.Sdk.Razor" Category="ship" />
     <PackageArtifact Include="Microsoft.Owin.Security.Interop" Category="ship" />
+
+    <!-- Packages for internal use only. -->
+    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86' " />
+    <PackageArtifact Include="Internal.AspNetCore.Universe.Lineup" Category="noship" />
+    <PackageArtifact Include="Internal.WebHostBuilderFactory.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModule" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Buffering" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.ChunkingCookieManager.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Connections.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Extensions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Category="shipoob" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Elm" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.HostFiltering" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Hosting" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Html.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections.Common" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Extensions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Http" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.HttpOverrides" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.HttpsPolicy" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.HttpSys.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Identity" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Localization.Routing" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Localization" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Core" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Cors" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Category="shipoob" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Category="shipoob" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.NodeServices.Sockets" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.RangeHelper.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Razor" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCompression" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Rewrite" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Routing.DecisionTree.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Routing" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.IIS" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Core" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Https" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Session" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Core" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SignalR" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="noship" />
+    <PackageArtifact Include="Microsoft.AspNetCore" Category="noship" />
+    <PackageArtifact Include="Microsoft.CodeAnalysis.Razor.Workspaces" Category="shipoob" />
+    <PackageArtifact Include="Microsoft.CodeAnalysis.Remote.Razor" Category="shipoob" />
+    <PackageArtifact Include="Microsoft.Extensions.ApplicationModelDetection" Category="noship" />
+    <PackageArtifact Include="Microsoft.Extensions.Buffers.MemoryPool.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.Extensions.Buffers.Testing.Sources" Category="noship" />
+    <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="noship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Editor.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.VisualStudio.LanguageServices.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.VisualStudio.Mac.LanguageServices.Razor" Category="shipoob" />

--- a/build/dependencies.folderbuilds.props
+++ b/build/dependencies.folderbuilds.props
@@ -2,26 +2,26 @@
 <Project>
   <PropertyGroup>
     <InternalAspNetCoreSdkPackageVersion Condition="'$(InternalAspNetCoreSdkPackageVersion)' == ''">3.0.0-build-20181114.5</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationCorePackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreAuthenticationCorePackageVersion>
-    <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreDiagnosticsPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreDiagnosticsPackageVersion>
-    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHostingPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreHostingPackageVersion>
-    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
-    <MicrosoftAspNetCoreHttpOverridesPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreHttpOverridesPackageVersion>
-    <MicrosoftAspNetCoreHttpPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreHttpPackageVersion>
-    <MicrosoftAspNetCoreHttpSysSourcesPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreHttpSysSourcesPackageVersion>
-    <MicrosoftAspNetCoreResponseCompressionPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreResponseCompressionPackageVersion>
-    <MicrosoftAspNetCoreServerHttpSysPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreServerHttpSysPackageVersion>
-    <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
-    <MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>0.7.0-alpha1-10717</MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreServerKestrelPackageVersion>
-    <MicrosoftAspNetCoreStaticFilesPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftAspNetCoreWebUtilitiesPackageVersion>3.0.0-alpha1-10717</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
-    <MicrosoftExtensionsBuffersMemoryPoolSourcesPackageVersion>3.0.0-alpha1-10717</MicrosoftExtensionsBuffersMemoryPoolSourcesPackageVersion>
-    <MicrosoftNetHttpHeadersPackageVersion>3.0.0-alpha1-10717</MicrosoftNetHttpHeadersPackageVersion>
+    <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationCorePackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreAuthenticationCorePackageVersion>
+    <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreDiagnosticsPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreDiagnosticsPackageVersion>
+    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHostingPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreHostingPackageVersion>
+    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
+    <MicrosoftAspNetCoreHttpOverridesPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreHttpOverridesPackageVersion>
+    <MicrosoftAspNetCoreHttpPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreHttpPackageVersion>
+    <MicrosoftAspNetCoreHttpSysSourcesPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreHttpSysSourcesPackageVersion>
+    <MicrosoftAspNetCoreResponseCompressionPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreResponseCompressionPackageVersion>
+    <MicrosoftAspNetCoreServerHttpSysPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreServerHttpSysPackageVersion>
+    <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
+    <MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>0.7.0-alpha1-10773</MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreServerKestrelPackageVersion>
+    <MicrosoftAspNetCoreStaticFilesPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreStaticFilesPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreWebUtilitiesPackageVersion>3.0.0-alpha1-10773</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
+    <MicrosoftExtensionsBuffersMemoryPoolSourcesPackageVersion>3.0.0-alpha1-10773</MicrosoftExtensionsBuffersMemoryPoolSourcesPackageVersion>
+    <MicrosoftNetHttpHeadersPackageVersion>3.0.0-alpha1-10773</MicrosoftNetHttpHeadersPackageVersion>
   </PropertyGroup>
 </Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="..\eng\targets\RuntimeIdentifiers.props" />
+  <Import Project="SharedFrameworkOnly.props" />
 
   <PropertyGroup>
     <!-- This repo does not have solutions to build -->

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -22,12 +22,16 @@
     <CompileDependsOn>$(CompileDependsOn);BuildProjects;PackSharedSources</CompileDependsOn>
     <CompileDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(CompileDependsOn);PackProjects;BuildRepositories;BuildSharedFx</CompileDependsOn>
     <PackageDependsOn Condition=" '$(_ProjectsOnly)' == 'true'">$(PackageDependsOn);PackProjects</PackageDependsOn>
+    <PackageDependsOn Condition=" '$(_ProjectsOnly)' != 'true'">$(PackageDependsOn);RemoveSharedFrameworkOnlyRefsFromNuspec</PackageDependsOn>
     <PackageDependsOn Condition="'$(TestOnly)' != 'true'">$(PackageDependsOn);CodeSign</PackageDependsOn>
     <TestDependsOn>$(TestDependsOn);TestProjects</TestDependsOn>
     <TestDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(TestDependsOn);_TestRepositories</TestDependsOn>
     <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);GetProjectArtifactInfo</GetArtifactInfoDependsOn>
     <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);ResolveSharedSourcesPackageInfo</GetArtifactInfoDependsOn>
     <GetArtifactInfoDependsOn  Condition="'$(_ProjectsOnly)' != 'true'">$(GetArtifactInfoDependsOn);ResolveRepoInfo</GetArtifactInfoDependsOn>
+
+    <!-- Package modification must happen before code signing. -->
+    <CodeSignDependsOn>$(CodeSignDependsOn);RemoveSharedFrameworkOnlyRefsFromNuspec</CodeSignDependsOn>
   </PropertyGroup>
 
   <Target Name="PrepareOutputPaths">
@@ -299,6 +303,28 @@
   <Target Name="VerifyPackageArtifactConfig">
     <Error Text="Invalid configuration of %(PackageArtifact.Identity). PackageArtifact must have the 'Category' metadata."
            Condition="'%(PackageArtifact.Category)' == '' " />
+
+    <ItemGroup>
+      <ExternalDependencyInSharedFx Include="@(Dependency)" Exclude="@(PackageArtifact)" />
+      <SharedFrameworkShippingPackage Include="@(SharedFrameworkOnlyPackage)" Exclude="@(SharedFrameworkAndPackage);@(ExternalDependencyInSharedFx);@(PackageArtifact->WithMetadataValue('Category','noship'))" />
+    </ItemGroup>
+
+    <Error Text="Assemblies which ship in the shared framework should not also ship as NuGet packages, unless explicitly allowed. Please update the following to 'noship': %0A - @(SharedFrameworkShippingPackage, '%0A - '). "
+           Condition=" @(SharedFrameworkShippingPackage->Count()) != 0 " />
+  </Target>
+
+  <!-- This is temporary until we can use FrameworkReference to build our own packages. -->
+  <Target Name="RemoveSharedFrameworkOnlyRefsFromNuspec">
+    <ItemGroup>
+      <_BuildOutput Include="$(BuildDir)%(PackageArtifact.Identity).*.nupkg"
+                    Condition=" '%(PackageArtifact.Category)' == 'ship' " />
+
+      <SharedFxPackageRefToHide Include="@(SharedFrameworkOnlyPackage)" Exclude="@(ExternalDependency)" />
+    </ItemGroup>
+
+    <RepoTasks.RemoveSharedFrameworkDependencies Condition="@(_BuildOutput->Count()) != 0"
+      Files="@(_BuildOutput)"
+      FrameworkOnlyPackages="@(SharedFxPackageRefToHide)" />
   </Target>
 
   <Target Name="VerifyExternalDependencyConfig">

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -286,7 +286,7 @@
     <WriteLinesToFile File="$(RepositoryRoot)artifacts\packages.csv" Lines="PackageId,Version;@(ArtifactInfo->WithMetadataValue('ArtifactType', 'NuGetPackage')->'%(PackageId),%(Version)')" Overwrite="true" />
   </Target>
 
-  <Target Name="ComputeGraph" DependsOnTargets="GetProjectArtifactInfo;GetFxProjectArtifactInfo;ResolveRepoInfo;GeneratePropsFiles">
+  <Target Name="ComputeGraph" DependsOnTargets="ResolveSharedSourcesPackageInfo;GetProjectArtifactInfo;GetFxProjectArtifactInfo;ResolveRepoInfo;GeneratePropsFiles">
     <ItemGroup>
       <_UndeclaredPackageArtifact Include="%(ArtifactInfo.PackageId)" Condition="'%(ArtifactInfo.ArtifactType)' == 'NuGetPackage'" />
       <_UndeclaredPackageArtifact Remove="@(PackageArtifact)" />

--- a/build/tasks/RemoveSharedFrameworkDependencies.cs
+++ b/build/tasks/RemoveSharedFrameworkDependencies.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+
+namespace RepoTasks
+{
+    // This is temporary until we can use FrameworkReference to build our own packages
+    public class RemoveSharedFrameworkDependencies : Task
+    {
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        [Required]
+        public ITaskItem[] FrameworkOnlyPackages { get; set; }
+
+        public override bool Execute()
+        {
+            var dependencyToRemove = FrameworkOnlyPackages.Select(p => p.ItemSpec).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in Files)
+            {
+                FilterDependencies(file.ItemSpec, dependencyToRemove);
+            }
+            return !Log.HasLoggedErrors;
+        }
+
+        private void FilterDependencies(string targetPath, ISet<string> dependencyToRemove)
+        {
+            var fileName = Path.GetFileName(targetPath);
+            Log.LogMessage($"Updating {fileName}");
+
+            using (var fileStream = File.Open(targetPath, FileMode.Open))
+            using (var package = new ZipArchive(fileStream, ZipArchiveMode.Update))
+            using (var packageReader = new PackageArchiveReader(fileStream, leaveStreamOpen: true))
+            {
+                var dirty = false;
+                var nuspecFile = packageReader.GetNuspecFile();
+                using (var stream = package.OpenFile(nuspecFile))
+                {
+                    var reader = Manifest.ReadFrom(stream, validateSchema: true);
+                    stream.Position = 0;
+                    var packageBuilder = new PackageBuilder(stream, basePath: null);
+                    var updatedGroups = new List<PackageDependencyGroup>();
+
+                    foreach (var group in packageBuilder.DependencyGroups)
+                    {
+                        var packages = new List<PackageDependency>();
+                        var updatedGroup = new PackageDependencyGroup(group.TargetFramework, packages);
+                        foreach (var dependency in group.Packages)
+                        {
+                            if (dependencyToRemove.Contains(dependency.Id))
+                            {
+                                dirty = true;
+                                Log.LogMessage($"  Remove dependency on '{dependency.Id}'");
+                                continue;
+                            }
+
+                            packages.Add(dependency);
+                        }
+
+                        updatedGroups.Add(updatedGroup);
+                    }
+
+                    if (dirty)
+                    {
+                        packageBuilder.DependencyGroups.Clear();
+                        packageBuilder.DependencyGroups.AddRange(updatedGroups);
+
+                        var updatedManifest = Manifest.Create(packageBuilder);
+                        stream.Position = 0;
+                        stream.SetLength(0);
+                        updatedManifest.Save(stream);
+                    }
+                    else
+                    {
+                        Log.LogMessage($"No changes made to {fileName}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build/tasks/RepoTasks.csproj
+++ b/build/tasks/RepoTasks.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(RepoTasksSdkPath)\Sdk.props" Condition="'$(RepoTasksSdkPath)' != '' "/>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/tasks/RepoTasks.tasks
+++ b/build/tasks/RepoTasks.tasks
@@ -10,4 +10,5 @@
   <UsingTask TaskName="RepoTasks.OrderBy" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.GenerateSharedFrameworkMetadataFiles" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.PublishToAzureBlob" AssemblyFile="$(_RepoTaskAssembly)" />
+  <UsingTask TaskName="RepoTasks.RemoveSharedFrameworkDependencies" AssemblyFile="$(_RepoTaskAssembly)" />
 </Project>


### PR DESCRIPTION
Resolves #3756.

The removes the need to ship packages for assemblies which are part of Microsoft.AspNetCore.App. The implementation of this requires first building packages, and then modifying .nuspec's and categorizing packages as "noship".

This can be improved after we finish merging all git submodules. Once that is done, we can replace PackageReference's with ProjectReference's and avoid producing "turd" .nupkg's altogether. Also, once NuGet implements https://github.com/NuGet/Home/issues/7342, we can use FrameworkReference to build our packages.