### PR TITLE
Remove Roslyn from the shared framework

### DIFF
--- a/build/CodeSign.props
+++ b/build/CodeSign.props
@@ -5,13 +5,10 @@
       <!-- Microsoft.AspNetCore.App -->
       <FilesToSign Include="Newtonsoft.Json.dll"                                           Certificate="$(AssemblySigning3rdPartyCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Newtonsoft.Json.Bson.dll"                                      Certificate="$(AssemblySigning3rdPartyCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Remotion.Linq.dll"                                             Certificate="$(AssemblySigning3rdPartyCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="System.Interactive.Async.dll"                                  Certificate="$(AssemblySigning3rdPartyCertName)" Container="Microsoft.AspNetCore.App" />
 
     <!-- These files came from the aspnet/Extensions build, but have to be re-signed because we crossgen them. -->
       <FilesToSign Include="Microsoft.Extensions.Caching.Abstractions.dll"                  Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.Caching.Memory.dll"                        Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.Extensions.Caching.SqlServer.dll"                     Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.Configuration.Abstractions.dll"            Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.Configuration.Binder.dll"                  Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.Configuration.CommandLine.dll"             Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
@@ -49,30 +46,17 @@
       <FilesToSign Include="Microsoft.Extensions.Options.dll"                               Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.Primitives.dll"                            Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.WebEncoders.dll"                           Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-    <!-- These files came from the aspnet/EntityFrameworkCore build, but have to be re-signed because we crossgen them. -->
-      <FilesToSign Include="Microsoft.EntityFrameworkCore.Abstractions.dll"                 Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.EntityFrameworkCore.Design.dll"                       Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.EntityFrameworkCore.InMemory.dll"                     Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.EntityFrameworkCore.Relational.dll"                   Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.EntityFrameworkCore.SqlServer.dll"                    Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.EntityFrameworkCore.dll"                              Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
 
     <!-- These files came from partner teams. They have to be re-signed because we crossgen them and redistributable them in our installers. -->
 
       <!-- Microsoft.AspNetCore.App -->
-      <FilesToSign Include="Microsoft.CodeAnalysis.CSharp.dll"                              Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.CodeAnalysis.dll"                                     Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.DotNet.PlatformAbstractions.dll"                      Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.Extensions.DependencyModel.dll"                       Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.IdentityModel.JsonWebTokens.dll"                      Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.IdentityModel.Logging.dll"                            Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.IdentityModel.Protocols.dll"                          Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.IdentityModel.Protocols.OpenIdConnect.dll"            Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.IdentityModel.Protocols.WsFederation.dll"             Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="Microsoft.IdentityModel.Tokens.dll"                             Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.IdentityModel.Tokens.Saml.dll"                        Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="Microsoft.IdentityModel.Xml.dll"                                Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="System.Data.SqlClient.dll"                                      Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.IdentityModel.Tokens.Jwt.dll"                            Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.IO.Pipelines.dll"                                        Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.Net.Http.Formatting.dll"                                 Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
@@ -81,7 +65,6 @@
       <FilesToSign Include="System.Security.Cryptography.Pkcs.dll"                          Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.Security.Cryptography.Xml.dll"                           Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.Security.Permissions.dll"                                Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
-      <FilesToSign Include="System.Text.Encoding.CodePages.dll"                             Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.Text.Encodings.Web.dll"                                  Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
       <FilesToSign Include="System.Threading.Channels.dll"                                  Certificate="$(AssemblySigningCertName)" Container="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -44,6 +44,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.MiddlewareAnalysis" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Analyzers" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Testing" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.NodeServices" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Owin" Category="ship" />
@@ -131,7 +132,6 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" Category="shipoob" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="noship" />

--- a/src/Framework/Microsoft.AspNetCore.App.props
+++ b/src/Framework/Microsoft.AspNetCore.App.props
@@ -149,7 +149,6 @@
     <Dependency Include="System.Security.Cryptography.Pkcs"                            Version="$(SystemSecurityCryptographyPkcsPackageVersion)" />
     <Dependency Include="System.Security.Cryptography.Xml"                             Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
     <Dependency Include="System.Security.Permissions"                                  Version="$(SystemSecurityPermissionsPackageVersion)" />
-    <Dependency Include="System.Text.Encoding.CodePages"                               Version="$(SystemTextEncodingCodePagesPackageVersion)" />
     <Dependency Include="System.Text.Encodings.Web"                                    Version="$(SystemTextEncodingsWebPackageVersion)" />
     <Dependency Include="System.Threading.Channels"                                    Version="$(SystemThreadingChannelsPackageVersion)" />
   </ItemGroup>

--- a/src/Framework/Microsoft.AspNetCore.App.props
+++ b/src/Framework/Microsoft.AspNetCore.App.props
@@ -59,13 +59,11 @@
     <Dependency Include="Microsoft.AspNetCore.Mvc.Formatters.Json"                     Version="$(MicrosoftAspNetCoreMvcFormattersJsonPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.Formatters.Xml"                      Version="$(MicrosoftAspNetCoreMvcFormattersXmlPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.Localization"                        Version="$(MicrosoftAspNetCoreMvcLocalizationPackageVersion)" />
-    <Dependency Include="Microsoft.AspNetCore.Mvc.Razor.Extensions"                    Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.Razor"                               Version="$(MicrosoftAspNetCoreMvcRazorPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.RazorPages"                          Version="$(MicrosoftAspNetCoreMvcRazorPagesPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.TagHelpers"                          Version="$(MicrosoftAspNetCoreMvcTagHelpersPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.ViewFeatures"                        Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc"                                     Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <Dependency Include="Microsoft.AspNetCore.Razor.Language"                          Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Razor.Runtime"                           Version="$(MicrosoftAspNetCoreRazorRuntimePackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Razor"                                   Version="$(MicrosoftAspNetCoreRazorPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.ResponseCaching.Abstractions"            Version="$(MicrosoftAspNetCoreResponseCachingAbstractionsPackageVersion)" />
@@ -91,10 +89,6 @@
     <Dependency Include="Microsoft.AspNetCore.WebSockets"                              Version="$(MicrosoftAspNetCoreWebSocketsPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.WebUtilities"                            Version="$(MicrosoftAspNetCoreWebUtilitiesPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore"                                         Version="$(MicrosoftAspNetCorePackageVersion)" />
-    <Dependency Include="Microsoft.CodeAnalysis.CSharp"                                Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <Dependency Include="Microsoft.CodeAnalysis.Razor"                                 Version="$(MicrosoftCodeAnalysisRazorPackageVersion)" />
-    <Dependency Include="Microsoft.CodeAnalysis.Common"                                Version="$(MicrosoftCodeAnalysisCommonPackageVersion)"
-           AssemblyName="Microsoft.CodeAnalysis" />
     <Dependency Include="Microsoft.DotNet.PlatformAbstractions"                        Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
     <Dependency Include="Microsoft.Extensions.Caching.Abstractions"                    Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
     <Dependency Include="Microsoft.Extensions.Caching.Memory"                          Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />


### PR DESCRIPTION
Reacting to https://github.com/aspnet/Mvc/pull/8755.

This is one more step towards resolving #4004. This removes Roslyn from the shared framework.