### PR TITLE
Fix for ArgumentException thrown due to empty user secrets ID

### DIFF
--- a/src/Framework/pkg/Microsoft.AspNetCore.App.targets
+++ b/src/Framework/pkg/Microsoft.AspNetCore.App.targets
@@ -14,7 +14,7 @@
   -->
   <Target Name="_GetUserSecretsAssemblyAttribute"
           BeforeTargets="GetAssemblyAttributes"
-          Condition="' $(UserSecretsId)' != '' AND '$(GenerateUserSecretsAttribute)' != 'false' AND '$(GeneratedUserSecretsAttributeFile)' == '' ">
+          Condition=" '$(UserSecretsId)' != '' AND '$(GenerateUserSecretsAttribute)' != 'false' AND '$(GeneratedUserSecretsAttributeFile)' == '' ">
 
     <!--
       If the Microsoft.Extensions.Configuration.UserSecrets package 2.2 or higher is referenced directly,


### PR DESCRIPTION
Default apps fail with

> ArgumentException: Value cannot be null or an empty string.Parameter name: userSecretId

This is because the assembly attribute generation is incorrect.