### PR TITLE
[Routing] Support RoutePattern required values in matcher and link generator

### DIFF
--- a/src/Routing/benchmarks/Microsoft.AspNetCore.Routing.Performance/EndpointRoutingBenchmarkBase.cs
+++ b/src/Routing/benchmarks/Microsoft.AspNetCore.Routing.Performance/EndpointRoutingBenchmarkBase.cs
@@ -116,11 +116,14 @@ namespace Microsoft.AspNetCore.Routing
             params object[] metadata)
         {
             var endpointMetadata = new List<object>(metadata ?? Array.Empty<object>());
-            endpointMetadata.Add(new RouteValuesAddressMetadata(routeName, new RouteValueDictionary(requiredValues)));
+            if (routeName != null)
+            {
+                endpointMetadata.Add(new RouteNameMetadata(routeName));
+            }
 
             return new RouteEndpoint(
                 (context) => Task.CompletedTask,
-                RoutePatternFactory.Parse(template, defaults, constraints),
+                RoutePatternFactory.Parse(template, defaults, constraints, requiredValues),
                 order,
                 new EndpointMetadataCollection(endpointMetadata),
                 displayName);
@@ -139,16 +142,13 @@ namespace Microsoft.AspNetCore.Routing
 
         protected void CreateOutboundRouteEntry(TreeRouteBuilder treeRouteBuilder, RouteEndpoint endpoint)
         {
-            var routeValuesAddressMetadata = endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-            var requiredValues = routeValuesAddressMetadata?.RequiredValues ?? new RouteValueDictionary();
-
             treeRouteBuilder.MapOutbound(
                 NullRouter.Instance,
                 new RouteTemplate(RoutePatternFactory.Parse(
                     endpoint.RoutePattern.RawText,
                     defaults: endpoint.RoutePattern.Defaults,
                     parameterPolicies: null)),
-                requiredLinkValues: new RouteValueDictionary(requiredValues),
+                requiredLinkValues: new RouteValueDictionary(endpoint.RoutePattern.RequiredValues),
                 routeName: null,
                 order: 0);
         }

--- a/src/Routing/samples/RoutingSandbox/Framework/FrameworkConfigurationBuilder.cs
+++ b/src/Routing/samples/RoutingSandbox/Framework/FrameworkConfigurationBuilder.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace RoutingSandbox.Framework
+{
+    public class FrameworkConfigurationBuilder
+    {
+        private readonly FrameworkEndpointDataSource _dataSource;
+
+        internal FrameworkConfigurationBuilder(FrameworkEndpointDataSource dataSource)
+        {
+            _dataSource = dataSource;
+        }
+
+        public void AddPattern(string pattern)
+        {
+            AddPattern(RoutePatternFactory.Parse(pattern));
+        }
+
+        public void AddPattern(RoutePattern pattern)
+        {    
+            _dataSource.Patterns.Add(pattern);
+        }
+
+        public void AddHubMethod(string hub, string method, RequestDelegate requestDelegate)
+        {
+            _dataSource.HubMethods.Add(new HubMethod
+            {
+                Hub = hub,
+                Method = method,
+                RequestDelegate = requestDelegate
+            });
+        }
+    }
+}

--- a/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointDataSource.cs
+++ b/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointDataSource.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace RoutingSandbox.Framework
+{
+    internal class FrameworkEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
+    {
+        private readonly RoutePatternTransformer _routePatternTransformer;
+        private readonly List<Action<EndpointModel>> _conventions;
+
+        public List<RoutePattern> Patterns { get; }
+        public List<HubMethod> HubMethods { get; }
+
+        private List<Endpoint> _endpoints;
+
+        public FrameworkEndpointDataSource(RoutePatternTransformer routePatternTransformer)
+        {
+            _routePatternTransformer = routePatternTransformer;
+            _conventions = new List<Action<EndpointModel>>();
+
+            Patterns = new List<RoutePattern>();
+            HubMethods = new List<HubMethod>();
+        }
+
+        public override IReadOnlyList<Endpoint> Endpoints
+        {
+            get
+            {
+                if (_endpoints == null)
+                {
+                    _endpoints = BuildEndpoints();
+                }
+
+                return _endpoints;
+            }
+        }
+
+        private List<Endpoint> BuildEndpoints()
+        {
+            List<Endpoint> endpoints = new List<Endpoint>();
+
+            foreach (var hubMethod in HubMethods)
+            {
+                var requiredValues = new { hub = hubMethod.Hub, method = hubMethod.Method };
+                var order = 1;
+
+                foreach (var pattern in Patterns)
+                {
+                    var resolvedPattern = _routePatternTransformer.SubstituteRequiredValues(pattern, requiredValues);
+                    if (resolvedPattern == null)
+                    {
+                        continue;
+                    }
+
+                    var endpointModel = new RouteEndpointModel(
+                        hubMethod.RequestDelegate,
+                        resolvedPattern,
+                        order++);
+                    endpointModel.DisplayName = $"{hubMethod.Hub}.{hubMethod.Method}";
+
+                    foreach (var convention in _conventions)
+                    {
+                        convention(endpointModel);
+                    }
+
+                    endpoints.Add(endpointModel.Build());
+                }
+            }
+
+            return endpoints;
+        }
+
+        public override IChangeToken GetChangeToken()
+        {
+            return NullChangeToken.Singleton;
+        }
+
+        public void Apply(Action<EndpointModel> convention)
+        {
+            _conventions.Add(convention);
+        }
+    }
+
+    internal class HubMethod
+    {
+        public string Hub { get; set; }
+        public string Method { get; set; }
+        public RequestDelegate RequestDelegate { get; set; }
+    }
+}

--- a/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointRouteBuilderExtensions.cs
+++ b/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RoutingSandbox.Framework
+{
+    public static class FrameworkEndpointRouteBuilderExtensions
+    {
+        public static IEndpointConventionBuilder MapFramework(this IEndpointRouteBuilder builder, Action<FrameworkConfigurationBuilder> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var dataSource = builder.ServiceProvider.GetRequiredService<FrameworkEndpointDataSource>();
+
+            var configurationBuilder = new FrameworkConfigurationBuilder(dataSource);
+            configure(configurationBuilder);
+
+            builder.DataSources.Add(dataSource);
+
+            return dataSource;
+        }
+    }
+}

--- a/src/Routing/samples/RoutingSandbox/RoutingSandbox.csproj
+++ b/src/Routing/samples/RoutingSandbox/RoutingSandbox.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Routing/samples/RoutingSandbox/SlugifyParameterTransformer.cs
+++ b/src/Routing/samples/RoutingSandbox/SlugifyParameterTransformer.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Routing;
+
+namespace RoutingSandbox
+{
+    public class SlugifyParameterTransformer : IOutboundParameterTransformer
+    {
+        public string TransformOutbound(object value)
+        {
+            // Slugify value
+            return value == null ? null : Regex.Replace(value.ToString(), "([a-z])([A-Z])", "$1-$2", RegexOptions.None, TimeSpan.FromMilliseconds(100)).ToLower();
+        }
+    }
+}

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/CompositeEndpointDataSource.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/CompositeEndpointDataSource.cs
@@ -167,13 +167,14 @@ namespace Microsoft.AspNetCore.Routing
                         sb.Append(", Defaults: new { ");
                         sb.Append(string.Join(", ", FormatValues(routeEndpoint.RoutePattern.Defaults)));
                         sb.Append(" }");
-                        var routeValuesAddressMetadata = routeEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
+                        var routeNameMetadata = routeEndpoint.Metadata.GetMetadata<IRouteNameMetadata>();
                         sb.Append(", Route Name: ");
-                        sb.Append(routeValuesAddressMetadata?.RouteName);
-                        if (routeValuesAddressMetadata?.RequiredValues != null)
+                        sb.Append(routeNameMetadata?.RouteName);
+                        var routeValues = routeEndpoint.RoutePattern.RequiredValues;
+                        if (routeValues.Count > 0)
                         {
                             sb.Append(", Required Values: new { ");
-                            sb.Append(string.Join(", ", FormatValues(routeValuesAddressMetadata.RequiredValues)));
+                            sb.Append(string.Join(", ", FormatValues(routeValues)));
                             sb.Append(" }");
                         }
                         sb.Append(", Order: ");

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Routing
                 _uriBuildingContextPool,
                 endpoint.RoutePattern,
                 new RouteValueDictionary(endpoint.RoutePattern.Defaults),
-                endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>()?.RequiredValues.Keys,
+                endpoint.RoutePattern.RequiredValues.Keys,
                 policies);
         }
 

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/IRouteNameMetadata.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/IRouteNameMetadata.cs
@@ -1,26 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
     /// Represents metadata used during link generation to find
-    /// the associated endpoint using route values.
+    /// the associated endpoint using route name.
     /// </summary>
-    [Obsolete("Route values are now specified on a RoutePattern.")]
-    public interface IRouteValuesAddressMetadata
+    public interface IRouteNameMetadata
     {
         /// <summary>
         /// Gets the route name. Can be null.
         /// </summary>
         string RouteName { get; }
-
-        /// <summary>
-        /// Gets the required route values.
-        /// </summary>
-        IReadOnlyDictionary<string, object> RequiredValues { get; }
     }
 }

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/Patterns/DefaultRoutePatternTransformer.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/Patterns/DefaultRoutePatternTransformer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                 updatedDefaults ?? original.Defaults,
                 original.ParameterPolicies,
                 requiredValues,
-                updatedParameters ?? original.Parameters, 
+                updatedParameters ?? original.Parameters,
                 updatedSegments ?? original.PathSegments);
         }
 

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/RouteNameMetadata.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/RouteNameMetadata.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    /// <summary>
+    /// Metadata used during link generation to find the associated endpoint using route name.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    public sealed class RouteNameMetadata : IRouteNameMetadata
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="RouteNameMetadata"/> with the provided route name.
+        /// </summary>
+        /// <param name="routeName">The route name. Can be null.</param>
+        public RouteNameMetadata(string routeName)
+        {
+            RouteName = routeName;
+        }
+
+        /// <summary>
+        /// Gets the route name. Can be null.
+        /// </summary>
+        public string RouteName { get; }
+
+        internal string DebuggerToString()
+        {
+            return $"Name: {RouteName}";
+        }
+    }
+}

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressMetadata.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressMetadata.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Routing
     /// Metadata used during link generation to find the associated endpoint using route values.
     /// </summary>
     [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [Obsolete("Route values are now specified on a RoutePattern.")]
     public sealed class RouteValuesAddressMetadata : IRouteValuesAddressMetadata
     {
         private static readonly IReadOnlyDictionary<string, object> EmptyRouteValues =

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Routing
                     continue;
                 }
 
-                var metadata = endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
+                var metadata = endpoint.Metadata.GetMetadata<IRouteNameMetadata>();
                 if (metadata == null && routeEndpoint.RoutePattern.RequiredValues.Count == 0)
                 {
                     continue;
@@ -137,8 +137,8 @@ namespace Microsoft.AspNetCore.Routing
                 }
 
                 var entry = CreateOutboundRouteEntry(
-                    routeEndpoint, 
-                    metadata?.RequiredValues ?? routeEndpoint.RoutePattern.RequiredValues, 
+                    routeEndpoint,
+                    routeEndpoint.RoutePattern.RequiredValues,
                     metadata?.RouteName);
 
                 var outboundMatch = new OutboundMatch() { Entry = entry };

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorProcessTemplateTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorProcessTemplateTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
@@ -309,14 +309,6 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Equal("/Foo/Bar%3Fencodeme%3F/Home/In%3Fdex?query=some%3Fquery#Fragment?", path);
         }
 
-        private class UpperCaseParameterTransform : IOutboundParameterTransformer
-        {
-            public string TransformOutbound(object value)
-            {
-                return value?.ToString()?.ToUpperInvariant();
-            }
-        }
-
         [Fact]
         public void GetLink_ParameterTransformer()
         {
@@ -346,7 +338,7 @@ namespace Microsoft.AspNetCore.Routing
             // Arrange
             var endpoint = EndpointFactory.CreateRouteEndpoint(
                 "{controller:upper-case}/{name}",
-                requiredValues: new { controller = "Home", name = "Test", c = "hithere", },
+                requiredValues: new { controller = "Home", name = "Test", },
                 policies: new { c = new UpperCaseParameterTransform(), });
 
             Action<IServiceCollection> configure = (s) =>
@@ -586,24 +578,24 @@ namespace Microsoft.AspNetCore.Routing
                 "Home/Index",
                 order: 3,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpointController = EndpointFactory.CreateRouteEndpoint(
                 "Home",
                 order: 2,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpointEmpty = EndpointFactory.CreateRouteEndpoint(
                 "",
                 order: 1,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             // This endpoint should be used to generate the link when an id is present
             var endpointControllerActionParameter = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 order: 0,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpointControllerAction, endpointController, endpointEmpty, endpointControllerActionParameter);
 
@@ -642,11 +634,11 @@ namespace Microsoft.AspNetCore.Routing
             var homeIndex = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var homeLogin = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Login", })) });
+                requiredValues: new { controller = "Home", action = "Login", });
 
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 
@@ -685,11 +677,11 @@ namespace Microsoft.AspNetCore.Routing
             var homeIndex = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var homeLogin = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Login", })) });
+                requiredValues: new { controller = "Home", action = "Login", });
 
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/EndpointFactory.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/EndpointFactory.cs
@@ -3,9 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.TestObjects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing
 {
@@ -20,17 +24,22 @@ namespace Microsoft.AspNetCore.Routing
             string displayName = null,
             params object[] metadata)
         {
-            var d = new List<object>(metadata ?? Array.Empty<object>());
-            if (requiredValues != null)
-            {
-                d.Add(new RouteValuesAddressMetadata(new RouteValueDictionary(requiredValues)));
-            }
+            var routePattern = RoutePatternFactory.Parse(template, defaults, policies, requiredValues);
 
+            return CreateRouteEndpoint(routePattern, order, displayName, metadata);
+        }
+
+        public static RouteEndpoint CreateRouteEndpoint(
+            RoutePattern routePattern = null,
+            int order = 0,
+            string displayName = null,
+            IList<object> metadata = null)
+        {
             return new RouteEndpoint(
                 TestConstants.EmptyRequestDelegate,
-                RoutePatternFactory.Parse(template, defaults, policies),
+                routePattern,
                 order,
-                new EndpointMetadataCollection(d),
+                new EndpointMetadataCollection(metadata ?? Array.Empty<object>()),
                 displayName);
         }
     }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -59,11 +59,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -86,11 +86,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -116,11 +116,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -145,11 +145,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -177,11 +177,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Patterns/DefaultRoutePatternTransformerTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Patterns/DefaultRoutePatternTransformerTest.cs
@@ -335,5 +335,24 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                 kvp => Assert.Equal(new KeyValuePair<string, object>("area", "Admin"), kvp),
                 kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
         }
+
+        [Fact]
+        public void SubstituteRequiredValues_NullRequiredValueParameter_Fail()
+        {
+            // Arrange
+            var template = "PageRoute/Attribute/{page}";
+            var defaults = new { area = (string)null, page = (string)null, controller = "Home", action = "Index", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { area = (string)null, page = (string)null, controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Null(actual);
+        }
     }
 }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressMetadataTests.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressMetadataTests.cs
@@ -13,7 +13,9 @@ namespace Microsoft.AspNetCore.Routing
         [Fact]
         public void DebuggerToString_NoNameAndRequiredValues_ReturnsString()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var metadata = new RouteValuesAddressMetadata(null, new Dictionary<string, object>());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal("Name:  - Required values: ", metadata.DebuggerToString());
         }
@@ -21,11 +23,13 @@ namespace Microsoft.AspNetCore.Routing
         [Fact]
         public void DebuggerToString_HasNameAndRequiredValues_ReturnsString()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var metadata = new RouteValuesAddressMetadata("Name!", new Dictionary<string, object>
             {
                 ["requiredValue1"] = "One",
                 ["requiredValue2"] = 2,
             });
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal("Name: Name! - Required values: requiredValue1 = \"One\", requiredValue2 = \"2\"", metadata.DebuggerToString());
         }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Routing
         public void EndpointDataSource_ChangeCallback_Refreshes_OutboundMatches()
         {
             // Arrange 1
-            var endpoint1 = CreateEndpoint("/a", metadataRequiredValues: new { });
+            var endpoint1 = CreateEndpoint("/a", routeName: "a");
             var dynamicDataSource = new DynamicEndpointDataSource(new[] { endpoint1 });
 
             // Act 1
@@ -93,21 +93,21 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Same(endpoint1, actual);
 
             // Arrange 2
-            var endpoint2 = CreateEndpoint("/b", metadataRequiredValues: new { });
+            var endpoint2 = CreateEndpoint("/b", routeName: "b");
 
             // Act 2
             // Trigger change
             dynamicDataSource.AddEndpoint(endpoint2);
 
             // Arrange 2
-            var endpoint3 = CreateEndpoint("/c", metadataRequiredValues: new { });
+            var endpoint3 = CreateEndpoint("/c", routeName: "c");
 
             // Act 2
             // Trigger change
             dynamicDataSource.AddEndpoint(endpoint3);
 
             // Arrange 3
-            var endpoint4 = CreateEndpoint("/d", metadataRequiredValues: new { });
+            var endpoint4 = CreateEndpoint("/d", routeName: "d");
 
             // Act 3
             // Trigger change
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.Routing
             var expected = CreateEndpoint(
                 "api/orders/{id}",
                 defaults: new { controller = "Orders", action = "GetById" },
-                routePatternRequiredValues: new { controller = "Orders", action = "GetById" });
+                metadataRequiredValues: new { controller = "Orders", action = "GetById" });
             var addressScheme = CreateAddressScheme(expected);
 
             // Act
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Routing
             // Arrange
             var endpoint = EndpointFactory.CreateRouteEndpoint(
                 "/a",
-                metadata: new object[] { new SuppressLinkGenerationMetadata(), new EncourageLinkGenerationMetadata(), new RouteValuesAddressMetadata(string.Empty), });
+                metadata: new object[] { new SuppressLinkGenerationMetadata(), new EncourageLinkGenerationMetadata(), new RouteNameMetadata(string.Empty), });
 
             // Act
             var addressScheme = CreateAddressScheme(endpoint);
@@ -369,7 +369,6 @@ namespace Microsoft.AspNetCore.Routing
             string template,
             object defaults = null,
             object metadataRequiredValues = null,
-            object routePatternRequiredValues = null,
             int order = 0,
             string routeName = null,
             EndpointMetadataCollection metadataCollection = null)
@@ -377,16 +376,16 @@ namespace Microsoft.AspNetCore.Routing
             if (metadataCollection == null)
             {
                 var metadata = new List<object>();
-                if (!string.IsNullOrEmpty(routeName) || metadataRequiredValues != null)
+                if (!string.IsNullOrEmpty(routeName))
                 {
-                    metadata.Add(new RouteValuesAddressMetadata(routeName, new RouteValueDictionary(metadataRequiredValues)));
+                    metadata.Add(new RouteNameMetadata(routeName));
                 }
                 metadataCollection = new EndpointMetadataCollection(metadata);
             }
 
             return new RouteEndpoint(
                 TestConstants.EmptyRequestDelegate,
-                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues: routePatternRequiredValues),
+                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues: metadataRequiredValues),
                 order,
                 metadataCollection,
                 null);

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/RoutePatternPrecedenceTests.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/RoutePatternPrecedenceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.Template
 {
@@ -22,6 +23,21 @@ namespace Microsoft.AspNetCore.Routing.Template
         {
             var parsed = RoutePatternFactory.Parse(template);
             return func(parsed);
+        }
+
+        [Fact]
+        public void InboundPrecedence_ParameterWithRequiredValue_HasPrecedence()
+        {
+            var parameterPrecedence = RoutePatternFactory.Parse(
+                "{controller}").InboundPrecedence;
+
+            var requiredValueParameterPrecedence = RoutePatternFactory.Parse(
+                "{controller}",
+                defaults: null,
+                parameterPolicies: null,
+                requiredValues: new { controller = "Home" }).InboundPrecedence;
+
+            Assert.True(requiredValueParameterPrecedence < parameterPrecedence);
         }
     }
 }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
@@ -1304,10 +1304,104 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var binder = new TemplateBinder(
                 UrlEncoder.Default,
                 new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
-                RoutePatternFactory.Parse(template),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = (string)null, action = "Param", controller = "ConventionalTransformer", page = (string)null }),
                 defaults,
                 requiredKeys: defaults.Keys,
                 parameterPolicies: new (string, IParameterPolicy)[] { ("param", new LengthRouteConstraint(500)), ("param", new SlugifyParameterTransformer()), });
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
+        [Fact]
+        public void BindValues_AmbientAndExplicitValuesDoNotMatch_Success()
+        {
+            // Arrange
+            var expected = "/Travel/Flight";
+
+            var template = "{area}/{controller}/{action}";
+            var defaults = new RouteValueDictionary(new { action = "Index" });
+            var ambientValues = new RouteValueDictionary(new { area = "Travel", controller = "Rail", action = "Index" });
+            var explicitValues = new RouteValueDictionary(new { controller = "Flight", action = "Index" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = "Travel", action = "SomeAction", controller = "Flight", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
+        [Fact]
+        public void BindValues_LinkingFromPageToAController_Success()
+        {
+            // Arrange
+            var expected = "/LG2/SomeAction";
+
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new RouteValueDictionary();
+            var ambientValues = new RouteValueDictionary(new { page = "/LGAnotherPage", id = "17" });
+            var explicitValues = new RouteValueDictionary(new { controller = "LG2", action = "SomeAction" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = (string)null, action = "SomeAction", controller = "LG2", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
+        [Fact]
+        public void BindValues_HasUnmatchingAmbientValues_Discard()
+        {
+            // Arrange
+            var expected = "/Admin/LG3/SomeAction?anothervalue=5";
+
+            var template = "Admin/LG3/SomeAction/{id?}";
+            var defaults = new RouteValueDictionary(new { controller = "LG3", action = "SomeAction", area = "Admin" });
+            var ambientValues = new RouteValueDictionary(new { controller = "LG1", action = "LinkToAnArea", id = "17" });
+            var explicitValues = new RouteValueDictionary(new { controller = "LG3", area = "Admin", action = "SomeAction", anothervalue = "5" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = "Admin", action = "SomeAction", controller = "LG3", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
 
             // Act
             var result = binder.GetValues(ambientValues, explicitValues);

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/TestObjects/UpperCaseParameterTransform.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/TestObjects/UpperCaseParameterTransform.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Routing.TestObjects
+{
+    public class UpperCaseParameterTransform : IOutboundParameterTransformer
+    {
+        public string TransformOutbound(object value)
+        {
+            return value?.ToString()?.ToUpperInvariant();
+        }
+    }
+}

--- a/src/Routing/test/WebSites/RoutingWebSite/UseEndpointRoutingStartup.cs
+++ b/src/Routing/test/WebSites/RoutingWebSite/UseEndpointRoutingStartup.cs
@@ -98,7 +98,7 @@ namespace RoutingWebSite
                         return response.WriteAsync(
                             "Link: " + linkGenerator.GetPathByRouteValues(httpContext, "WithSingleAsteriskCatchAll", new { }));
                     },
-                    new RouteValuesAddressMetadata(routeName: "WithSingleAsteriskCatchAll", requiredValues: new RouteValueDictionary()));
+                    new RouteNameMetadata(routeName: "WithSingleAsteriskCatchAll"));
                 routes.MapGet(
                     "/WithDoubleAsteriskCatchAll/{**path}",
                     (httpContext) =>
@@ -111,7 +111,7 @@ namespace RoutingWebSite
                         return response.WriteAsync(
                             "Link: " + linkGenerator.GetPathByRouteValues(httpContext, "WithDoubleAsteriskCatchAll", new { }));
                     },
-                    new RouteValuesAddressMetadata(routeName: "WithDoubleAsteriskCatchAll", requiredValues: new RouteValueDictionary()));
+                    new RouteNameMetadata(routeName: "WithDoubleAsteriskCatchAll"));
             });
 
             app.Map("/Branch1", branch => SetupBranch(branch, "Branch1"));


### PR DESCRIPTION
 - DFA matcher uses required values to denormalize routes
 - Link generator uses required values to calculate route precedence
 - Obsolete IRouteValuesAddressMetadata

re: https://github.com/aspnet/Routing/pull/914