### PR TITLE
[Routing] [Mvc] Support RoutePattern required values in matcher and link generator

### DIFF
--- a/src/Mvc/samples/MvcSandbox/SlugifyParameterTransformer.cs
+++ b/src/Mvc/samples/MvcSandbox/SlugifyParameterTransformer.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Routing;
+
+namespace MvcSandbox
+{
+    public class SlugifyParameterTransformer : IOutboundParameterTransformer
+    {
+        public string TransformOutbound(object value)
+        {
+            // Slugify value
+            return value == null ? null : Regex.Replace(value.ToString(), "([a-z])([A-Z])", "$1-$2", RegexOptions.None, TimeSpan.FromMilliseconds(100)).ToLower();
+        }
+    }
+}
+

--- a/src/Mvc/samples/MvcSandbox/Startup.cs
+++ b/src/Mvc/samples/MvcSandbox/Startup.cs
@@ -5,11 +5,13 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +22,10 @@ namespace MvcSandbox
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddRouting(options =>
+            {
+                options.ConstraintMap["slugify"] = typeof(SlugifyParameterTransformer);
+            });
             services.AddMvc().SetCompatibilityVersion(Microsoft.AspNetCore.Mvc.CompatibilityVersion.Latest);
         }
 
@@ -37,6 +43,27 @@ namespace MvcSandbox
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");
 
+                builder.MapControllerRoute(
+                    name: "transform",
+                    template: "Transform/{controller:slugify=Home}/{action:slugify=Index}/{id?}",
+                    defaults: null,
+                    constraints: new { controller = "Home" });
+
+                builder.MapGet(
+                    "/graph",
+                    "DFA Graph",
+                    (httpContext) =>
+                    {
+                        using (var writer = new StreamWriter(httpContext.Response.Body, Encoding.UTF8, 1024, leaveOpen: true))
+                        {
+                            var graphWriter = httpContext.RequestServices.GetRequiredService<DfaGraphWriter>();
+                            var dataSource = httpContext.RequestServices.GetRequiredService<EndpointDataSource>();
+                            graphWriter.Write(dataSource, writer);
+                        }
+
+                        return Task.CompletedTask;
+                    });
+
                 builder.MapApplication();
 
                 builder.MapHealthChecks("/healthz");
@@ -50,7 +77,7 @@ namespace MvcSandbox
 
         private static Task WriteEndpoints(HttpContext httpContext)
         {
-            var dataSource = httpContext.RequestServices.GetRequiredService<CompositeEndpointDataSource>();
+            var dataSource = httpContext.RequestServices.GetRequiredService<EndpointDataSource>();
 
             var sb = new StringBuilder();
             sb.AppendLine("Endpoints:");
@@ -81,6 +108,7 @@ namespace MvcSandbox
                     factory
                         .AddConsole()
                         .AddDebug();
+                    factory.SetMinimumLevel(LogLevel.Trace);
                 })
                 .UseIISIntegration()
                 .UseKestrel()

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/ControllerLinkGeneratorExtensionsTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/ControllerLinkGeneratorExtensionsTest.cs
@@ -25,11 +25,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
             var endpoint2 = CreateEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -55,11 +55,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
             var endpoint2 = CreateEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -83,11 +83,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
             var endpoint2 = CreateEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -114,11 +114,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
             var endpoint2 = CreateEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -144,11 +144,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
             var endpoint2 = CreateEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index" });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Routing
         {
             return new RouteEndpoint(
                 (httpContext) => Task.CompletedTask,
-                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null),
+                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues),
                 order,
                 new EndpointMetadataCollection(metadata ?? Array.Empty<object>()),
                 null);

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/EndpointRoutingUrlHelperTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/EndpointRoutingUrlHelperTest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 "Home/Index",
                 defaults: new { controller = "Home", action = "Index" },
                 requiredValues: new { controller = "Home", action = "Index" },
-                metadataCollection: new EndpointMetadataCollection(new[] { new SuppressLinkGenerationMetadata() }));
+                metadata: new[] { new SuppressLinkGenerationMetadata() });
             var urlHelper = CreateUrlHelper(new[] { endpoint });
 
             // Act
@@ -273,19 +273,20 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             object requiredValues = null,
             int order = 0,
             string routeName = null,
-            EndpointMetadataCollection metadataCollection = null)
+            IList<object> metadata = null)
         {
-            if (metadataCollection == null)
+            metadata = metadata ?? new List<object>();
+
+            if (routeName != null)
             {
-                metadataCollection = new EndpointMetadataCollection(
-                    new RouteValuesAddressMetadata(routeName, new RouteValueDictionary(requiredValues)));
+                metadata.Add(new RouteNameMetadata(routeName));
             }
 
             return new RouteEndpoint(
                 (httpContext) => Task.CompletedTask,
-                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null),
+                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues),
                 order,
-                metadataCollection,
+                new EndpointMetadataCollection(metadata),
                 null);
         }
 

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/MvcEndpointDataSourceTests.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/MvcEndpointDataSourceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using Moq;
@@ -64,14 +65,12 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             var endpoint = Assert.Single(endpoints);
             var matcherEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
 
-            var routeValuesAddressMetadata = matcherEndpoint.Metadata.GetMetadata<RouteValuesAddressMetadata>();
-            Assert.NotNull(routeValuesAddressMetadata);
-            var endpointValue = routeValuesAddressMetadata.RequiredValues["Name"];
+            var endpointValue = matcherEndpoint.RoutePattern.RequiredValues["Name"];
             Assert.Equal(routeValue, endpointValue);
 
             Assert.Equal(displayName, matcherEndpoint.DisplayName);
             Assert.Equal(order, matcherEndpoint.Order);
-            Assert.Equal("Template!", matcherEndpoint.RoutePattern.RawText);
+            Assert.Equal("/Template!", matcherEndpoint.RoutePattern.RawText);
         }
 
         [Fact]
@@ -131,164 +130,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             Assert.True(actionInvokerCalled);
         }
 
-        public static TheoryData GetSingleActionData_Conventional
-        {
-            get => GetSingleActionData(true);
-        }
-
-        public static TheoryData GetSingleActionData_Attribute
-        {
-            get => GetSingleActionData(false);
-        }
-
-        private static TheoryData GetSingleActionData(bool isConventionalRouting)
-        {
-            var data = new TheoryData<string, string, string[]>
-                {
-                    {"{controller}/{action}/{id?}", null, new[] { "TestController/TestAction/{id?}" }},
-                    {"{controller}/{id?}", null, isConventionalRouting ? new string[] { } : new[] { "TestController/{id?}" }},
-                    {"{action}/{id?}", null, isConventionalRouting ? new string[] { } : new[] { "TestAction/{id?}" }},
-                    {"{Controller}/{Action}/{id?}", null, new[] { "TestController/TestAction/{id?}" }},
-                    {"{Controller}/{Action}/{id?}/{more?}", null, new[] { "TestController/TestAction/{id?}/{more?}" }},
-                    {"{CONTROLLER}/{ACTION}/{id?}", null, new[] { "TestController/TestAction/{id?}" }},
-                    {"{controller}/{action=TestAction}", "TestController/{action=TestAction}", new[] { "TestController", "TestController/TestAction" }},
-                    {"{controller}/{action=TestAction}/{id?}", "TestController/{action=TestAction}/{id?}", new[] { "TestController", "TestController/TestAction/{id?}" }},
-                    {"{controller}/{action=TESTACTION}/{id?}", "TestController/{action=TESTACTION}/{id?}", new[] { "TestController", "TestController/TESTACTION/{id?}" }},
-                    {"{controller}/{action=TestAction}/{id?}/{more}", null, new[] { "TestController/TestAction/{id?}/{more}" }},
-                    {"{controller=TestController}/{action=TestAction}/{id?}", "{controller=TestController}/{action=TestAction}/{id?}", new[] { "", "TestController", "TestController/TestAction/{id?}" }},
-                    {"{controller=TestController}/{action=TestAction}/{id?}/{more?}", "{controller=TestController}/{action=TestAction}/{id?}/{more?}", new[] { "", "TestController", "TestController/TestAction/{id?}/{more?}" }},
-                    {"{controller}/{action}/{*catchAll}", null, new[] { "TestController/TestAction/{*catchAll}" }},
-                    {"{controller}/{action=TestAction}/{*catchAll}", "TestController/{action=TestAction}/{*catchAll}", new[] { "TestController", "TestController/TestAction/{*catchAll}" }},
-                    {"{controller}/{action=TestAction}/{id?}/{*catchAll}", "TestController/{action=TestAction}/{id?}/{*catchAll}", new[] { "TestController", "TestController/TestAction/{id?}/{*catchAll}" }},
-                    {"{controller}/{action=TestAction}/{id?}/{**catchAll}", "TestController/{action=TestAction}/{id?}/{**catchAll}", new[] { "TestController", "TestController/TestAction/{id?}/{**catchAll}" }},
-                    {"{controller}/{action}.{ext?}", null, new[] { "TestController/TestAction.{ext?}" }},
-                    {"{controller}/{action=TestAction}.{ext?}", "TestController/{action=TestAction}.{ext?}", new[] { "TestController", "TestController/TestAction.{ext?}" }},
-                    {"{controller}/{action=TestAction}.{ext?}/{more?}", "TestController/{action=TestAction}.{ext?}/{more?}", new[] { "TestController", "TestController/TestAction.{ext?}/{more?}" }},
-                    {"{controller}/{action=TestAction}.{ext?}/{more}", null, new[] { "TestController/TestAction.{ext?}/{more}" }},
-                    {"{controller:upper-case}/{action:upper-case=TestAction}.{ext?}", "TESTCONTROLLER/{action:upper-case=TestAction}.{ext?}", new[] { "TESTCONTROLLER", "TESTCONTROLLER/TESTACTION.{ext?}" }},
-                };
-
-            return data;
-        }
-
-        [Theory]
-        [MemberData(nameof(GetSingleActionData_Conventional))]
-        public void Endpoints_Conventional_SingleAction(string endpointInfoRoute, string suppressMatchingTemplate, string[] finalEndpointPatterns)
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(string.Empty, endpointInfoRoute));
-
-            // Act
-            var endpoints = dataSource.Endpoints.ToList();
-
-            // Assert
-
-            // Ensure there are no endpoints with duplicate Order values
-            Assert.DoesNotContain(endpoints.GroupBy(e => Assert.IsType<RouteEndpoint>(e).Order), g => g.Count() > 1);
-
-            endpoints = endpoints.OrderBy(e => Assert.IsType<RouteEndpoint>(e).Order).ToList();
-
-            AssertSuppressMatchingTemplate(suppressMatchingTemplate, endpoints);
-
-            var inspectors = finalEndpointPatterns
-                .Select(t => new Action<Endpoint>(e => Assert.Equal(t, Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText)))
-                .ToArray();
-
-            // Assert
-            Assert.Collection(endpoints, inspectors);
-        }
-
-        [Theory]
-        [MemberData(nameof(GetSingleActionData_Attribute))]
-        public void Endpoints_AttributeRouting_SingleAction(string endpointInfoRoute, string suppressMatchingTemplate, string[] finalEndpointPatterns)
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                attributeRouteTemplate: endpointInfoRoute,
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-
-            // Act
-            var endpoints = dataSource.Endpoints.ToList();
-
-            // Ensure there are no endpoints with duplicate Order values
-            Assert.DoesNotContain(endpoints.GroupBy(e => Assert.IsType<RouteEndpoint>(e).Order), g => g.Count() > 1);
-
-            endpoints = endpoints.OrderBy(e => Assert.IsType<RouteEndpoint>(e).Order).ToList();
-
-            AssertSuppressMatchingTemplate(suppressMatchingTemplate, endpoints);
-
-            // Assert
-            var inspectors = finalEndpointPatterns
-                .Select(t => new Action<Endpoint>(e => Assert.Equal(t, Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText)))
-                .ToArray();
-
-            // Assert
-            Assert.Collection(endpoints, inspectors);
-        }
-
-        [Theory]
-        [InlineData("{area}/{controller}/{action}/{id?}", null, new[] { "TestArea/TestController/TestAction/{id?}" })]
-        [InlineData("{controller}/{action}/{id?}", null, new string[] { })]
-        [InlineData("{area=TestArea}/{controller}/{action}/{id?}", null, new[] { "TestArea/TestController/TestAction/{id?}" })]
-        [InlineData("{area=TestArea}/{controller}/{action=TestAction}/{id?}", "TestArea/TestController/{action=TestAction}/{id?}", new[] { "TestArea/TestController", "TestArea/TestController/TestAction/{id?}"})]
-        [InlineData("{area=TestArea}/{controller=TestController}/{action=TestAction}/{id?}", "{area=TestArea}/{controller=TestController}/{action=TestAction}/{id?}", new[] { "", "TestArea", "TestArea/TestController", "TestArea/TestController/TestAction/{id?}" })]
-        [InlineData("{area:exists}/{controller}/{action}/{id?}", null, new[] { "TestArea/TestController/TestAction/{id?}" })]
-        [InlineData("{area:exists:upper-case}/{controller}/{action}/{id?}", null, new[] { "TESTAREA/TestController/TestAction/{id?}" })]
-        public void Endpoints_AreaSingleAction(string endpointInfoRoute, string suppressMatchingTemplate, string[] finalEndpointTemplates)
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction", area = "TestArea" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-
-            var services = new ServiceCollection();
-            services.AddRouting();
-            services.AddSingleton(actionDescriptorCollection);
-
-            var routeOptionsSetup = new MvcCoreRouteOptionsSetup();
-            services.Configure<RouteOptions>(routeOptionsSetup.Configure);
-            services.Configure<RouteOptions>(options =>
-            {
-                options.ConstraintMap["upper-case"] = typeof(UpperCaseParameterTransform);
-            });
-
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(string.Empty, endpointInfoRoute, serviceProvider: services.BuildServiceProvider()));
-
-            // Act
-            var endpoints = dataSource.Endpoints.ToList();
-
-            // Assert
-
-            // Ensure there are no endpoints with duplicate Order values
-            Assert.DoesNotContain(endpoints.GroupBy(e => Assert.IsType<RouteEndpoint>(e).Order), g => g.Count() > 1);
-
-            endpoints = endpoints.OrderBy(e => Assert.IsType<RouteEndpoint>(e).Order).ToList();
-
-            AssertSuppressMatchingTemplate(suppressMatchingTemplate, endpoints);
-
-            var inspectors = finalEndpointTemplates
-                .Select(t => new Action<Endpoint>(e => Assert.Equal(t, Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText)))
-                .ToArray();
-
-            // Assert
-            Assert.Collection(endpoints, inspectors);
-        }
-
-        private static void AssertSuppressMatchingTemplate(string suppressMatchingTemplate, List<Endpoint> endpoints)
-        {
-            if (suppressMatchingTemplate != null)
-            {
-                var suppressMatchingEndpoint = endpoints.First();
-                Assert.True(suppressMatchingEndpoint.Metadata.GetMetadata<ISuppressMatchingMetadata>()?.SuppressMatching);
-                Assert.Equal(suppressMatchingTemplate, Assert.IsType<RouteEndpoint>(suppressMatchingEndpoint).RoutePattern.RawText);
-                endpoints.Remove(suppressMatchingEndpoint);
-            }
-        }
-
         [Fact]
         public void Endpoints_SingleAction_ConventionalRoute_ContainsParameterWithNullRequiredRouteValue()
         {
@@ -321,34 +162,14 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             var endpoints = dataSource.Endpoints;
 
             // Assert
-            Assert.Collection(endpoints,
-                (e) => Assert.Equal("TestController/TestAction/{page}", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
-        }
-
-        [Fact]
-        public void Endpoints_SingleAction_WithActionDefault()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                string.Empty,
-                "{controller}/{action}",
-                new RouteValueDictionary(new { action = "TestAction" })));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(endpoints,
+            Assert.Collection(endpoints.Cast<RouteEndpoint>(),
                 (e) =>
                 {
-                    Assert.Equal("TestController/{action=TestAction}", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText);
-                    Assert.True(e.Metadata.GetMetadata<ISuppressMatchingMetadata>().SuppressMatching);
-                },
-                (e) => Assert.Equal("TestController", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText),
-                (e) => Assert.Equal("TestController/TestAction", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
+                    Assert.Equal("{controller}/{action}/{page}", e.RoutePattern.RawText);
+                    Assert.Equal("TestController", e.RoutePattern.RequiredValues["controller"]);
+                    Assert.Equal("TestAction", e.RoutePattern.RequiredValues["action"]);
+                    Assert.False(e.RoutePattern.RequiredValues.ContainsKey("page"));
+                });
         }
 
         [Fact]
@@ -375,9 +196,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             // Assert
             Assert.Collection(endpoints1,
-                (e) => Assert.Equal("TestController/{action=TestAction}", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText),
-                (e) => Assert.Equal("TestController", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText),
-                (e) => Assert.Equal("TestController/TestAction", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
+                (e) => Assert.Equal("{controller}/{action}", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
             Assert.Same(endpoints1, endpoints2);
 
             actionDescriptorCollectionProviderMock.VerifyGet(m => m.ActionDescriptors, Times.Once);
@@ -417,9 +236,13 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             var endpoints = dataSource.Endpoints;
 
             Assert.Collection(endpoints,
-                (e) => Assert.Equal("TestController/{action=TestAction}", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText),
-                (e) => Assert.Equal("TestController", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText),
-                (e) => Assert.Equal("TestController/TestAction", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
+                (e) =>
+                {
+                    var routePattern = Assert.IsType<RouteEndpoint>(e).RoutePattern;
+                    Assert.Equal("{controller}/{action}", routePattern.RawText);
+                    Assert.Equal("TestController", routePattern.RequiredValues["controller"]);
+                    Assert.Equal("TestAction", routePattern.RequiredValues["action"]);
+                });
 
             actionDescriptorCollectionProviderMock
                 .Setup(m => m.ActionDescriptors)
@@ -435,7 +258,13 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             Assert.NotSame(endpoints, newEndpoints);
             Assert.Collection(newEndpoints,
-                (e) => Assert.Equal("NewTestController/NewTestAction", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
+                (e) =>
+                {
+                    var routePattern = Assert.IsType<RouteEndpoint>(e).RoutePattern;
+                    Assert.Equal("{controller}/{action}", routePattern.RawText);
+                    Assert.Equal("NewTestController", routePattern.RequiredValues["controller"]);
+                    Assert.Equal("NewTestAction", routePattern.RequiredValues["action"]);
+                });
         }
 
         [Fact]
@@ -456,37 +285,19 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             var endpoints = dataSource.Endpoints;
 
             // Assert
-            Assert.Collection(endpoints,
-                (e) => Assert.Equal("TestController/TestAction1", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText),
-                (e) => Assert.Equal("TestController/TestAction2", Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText));
-        }
-
-        [Theory]
-        [InlineData("{controller}/{action}", new[] { "TestController1/TestAction1", "TestController1/TestAction2", "TestController1/TestAction3", "TestController2/TestAction1" })]
-        [InlineData("{controller}/{action:regex((TestAction1|TestAction2))}", new[] { "TestController1/TestAction1", "TestController1/TestAction2", "TestController2/TestAction1" })]
-        [InlineData("{controller}/{action:regex((TestAction1|TestAction2)):upper-case}", new[] { "TestController1/TESTACTION1", "TestController1/TESTACTION2", "TestController2/TESTACTION1" })]
-        public void Endpoints_MultipleActions(string endpointInfoRoute, string[] finalEndpointTemplates)
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController1", action = "TestAction1" },
-                new { controller = "TestController1", action = "TestAction2" },
-                new { controller = "TestController1", action = "TestAction3" },
-                new { controller = "TestController2", action = "TestAction1" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                string.Empty,
-                endpointInfoRoute));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            var inspectors = finalEndpointTemplates
-                .Select(t => new Action<Endpoint>(e => Assert.Equal(t, Assert.IsType<RouteEndpoint>(e).RoutePattern.RawText)))
-                .ToArray();
-
-            // Assert
-            Assert.Collection(endpoints, inspectors);
+            Assert.Collection(endpoints.Cast<RouteEndpoint>(),
+                (e) =>
+                {
+                    Assert.Equal("{controller}/{action}", e.RoutePattern.RawText);
+                    Assert.Equal("TestController", e.RoutePattern.RequiredValues["controller"]);
+                    Assert.Equal("TestAction1", e.RoutePattern.RequiredValues["action"]);
+                },
+                (e) =>
+                {
+                    Assert.Equal("{controller}/{action}", e.RoutePattern.RawText);
+                    Assert.Equal("TestController", e.RoutePattern.RequiredValues["controller"]);
+                    Assert.Equal("TestAction2", e.RoutePattern.RequiredValues["action"]);
+                });
         }
 
         [Fact]
@@ -505,9 +316,9 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             // Assert
             var endpoint = Assert.Single(endpoints);
             var matcherEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
-            var routeValuesAddressNameMetadata = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-            Assert.NotNull(routeValuesAddressNameMetadata);
-            Assert.Equal(string.Empty, routeValuesAddressNameMetadata.RouteName);
+            var routeNameMetadata = matcherEndpoint.Metadata.GetMetadata<IRouteNameMetadata>();
+            Assert.NotNull(routeNameMetadata);
+            Assert.Equal(string.Empty, routeNameMetadata.RouteName);
         }
 
         [Fact]
@@ -530,18 +341,18 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    var routeValuesAddressMetadata = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-                    Assert.NotNull(routeValuesAddressMetadata);
-                    Assert.Equal("namedRoute", routeValuesAddressMetadata.RouteName);
-                    Assert.Equal("named/Home/Index/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    var routeNameMetadata = matcherEndpoint.Metadata.GetMetadata<IRouteNameMetadata>();
+                    Assert.NotNull(routeNameMetadata);
+                    Assert.Equal("namedRoute", routeNameMetadata.RouteName);
+                    Assert.Equal("named/{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
                 },
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    var routeValuesAddressMetadata = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-                    Assert.NotNull(routeValuesAddressMetadata);
-                    Assert.Equal("namedRoute", routeValuesAddressMetadata.RouteName);
-                    Assert.Equal("named/Products/Details/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    var routeNameMetadata = matcherEndpoint.Metadata.GetMetadata<IRouteNameMetadata>();
+                    Assert.NotNull(routeNameMetadata);
+                    Assert.Equal("namedRoute", routeNameMetadata.RouteName);
+                    Assert.Equal("named/{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
                 });
         }
 
@@ -569,25 +380,33 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Home/Index/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("Index", matcherEndpoint.RoutePattern.RequiredValues["action"]);
+                    Assert.Equal("Home", matcherEndpoint.RoutePattern.RequiredValues["controller"]);
                     Assert.Equal(1, matcherEndpoint.Order);
                 },
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("named/Home/Index/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("named/{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("Index", matcherEndpoint.RoutePattern.RequiredValues["action"]);
+                    Assert.Equal("Home", matcherEndpoint.RoutePattern.RequiredValues["controller"]);
                     Assert.Equal(2, matcherEndpoint.Order);
                 },
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Products/Details/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("Details", matcherEndpoint.RoutePattern.RequiredValues["action"]);
+                    Assert.Equal("Products", matcherEndpoint.RoutePattern.RequiredValues["controller"]);
                     Assert.Equal(1, matcherEndpoint.Order);
                 },
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("named/Products/Details/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("named/{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("Details", matcherEndpoint.RoutePattern.RequiredValues["action"]);
+                    Assert.Equal("Products", matcherEndpoint.RoutePattern.RequiredValues["controller"]);
                     Assert.Equal(2, matcherEndpoint.Order);
                 });
         }
@@ -631,10 +450,27 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             // Assert
             Assert.Collection(
-                endpoints.Cast<RouteEndpoint>().OrderBy(e => e.RoutePattern.RawText),
-                e => Assert.Equal("en-CA/home/about", e.RoutePattern.RawText),
-                e => Assert.Equal("en-NZ/home/index", e.RoutePattern.RawText),
-                e => Assert.Equal("home/index", e.RoutePattern.RawText));
+                endpoints.Cast<RouteEndpoint>(),
+                e =>
+                {
+                    Assert.Equal("{locale}/{controller}/{action}", e.RoutePattern.RawText);
+                    Assert.Equal("home", e.RoutePattern.RequiredValues["controller"]);
+                    Assert.Equal("index", e.RoutePattern.RequiredValues["action"]);
+                    Assert.Equal("en-NZ", e.RoutePattern.RequiredValues["locale"]);
+                },
+                e =>
+                {
+                    Assert.Equal("{locale}/{controller}/{action}", e.RoutePattern.RawText);
+                    Assert.Equal("home", e.RoutePattern.RequiredValues["controller"]);
+                    Assert.Equal("about", e.RoutePattern.RequiredValues["action"]);
+                    Assert.Equal("en-CA", e.RoutePattern.RequiredValues["locale"]);
+                },
+                e =>
+                {
+                    Assert.Equal("{controller}/{action}", e.RoutePattern.RawText);
+                    Assert.Equal("home", e.RoutePattern.RequiredValues["controller"]);
+                    Assert.Equal("index", e.RoutePattern.RequiredValues["action"]);
+                });
         }
 
         [Fact]
@@ -689,8 +525,8 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         public void NoDefaultValues_RequiredValues_UsedToCreateDefaultValues()
         {
             // Arrange
-            var expectedDefaults = new RouteValueDictionary(new { controller = "Foo", action = "Bar" });
-            var actionDescriptorCollection = GetActionDescriptorCollection(requiredValues: expectedDefaults);
+            var requiredValues = new RouteValueDictionary(new { controller = "Foo", action = "Bar" });
+            var actionDescriptorCollection = GetActionDescriptorCollection(requiredValues: requiredValues);
             var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
             dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(string.Empty, "{controller}/{action}"));
 
@@ -700,30 +536,8 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             // Assert
             var endpoint = Assert.Single(endpoints);
             var matcherEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
-            Assert.Equal("Foo/Bar", matcherEndpoint.RoutePattern.RawText);
-            AssertIsSubset(expectedDefaults, matcherEndpoint.RoutePattern.Defaults);
-        }
-
-        [Fact]
-        public void RequiredValues_NotPresent_InDefaultValues_IsAddedToDefaultValues()
-        {
-            // Arrange
-            var requiredValues = new RouteValueDictionary(
-                new { controller = "Foo", action = "Bar", subarea = "test" });
-            var expectedDefaults = requiredValues;
-            var actionDescriptorCollection = GetActionDescriptorCollection(requiredValues: requiredValues);
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(
-                CreateEndpointInfo(string.Empty, "{subarea}/{controller=Home}/{action=Index}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            var endpoint = Assert.Single(endpoints);
-            var matcherEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
-            Assert.Equal("test/Foo/Bar", matcherEndpoint.RoutePattern.RawText);
-            AssertIsSubset(expectedDefaults, matcherEndpoint.RoutePattern.Defaults);
+            Assert.Equal("{controller}/{action}", matcherEndpoint.RoutePattern.RawText);
+            AssertIsSubset(requiredValues, matcherEndpoint.RoutePattern.RequiredValues);
         }
 
         [Fact]
@@ -743,51 +557,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             // Assert
             Assert.Empty(endpoints);
-        }
-
-        [Fact]
-        public void RequiredValues_IsSubsetOf_DefaultValues()
-        {
-            // Arrange
-            var requiredValues = new RouteValueDictionary(
-                new { controller = "Foo", action = "Bar", subarea = "test" });
-            var expectedDefaults = new RouteValueDictionary(
-                new { controller = "Foo", action = "Bar", subarea = "test", subscription = "general" });
-            var actionDescriptorCollection = GetActionDescriptorCollection(requiredValues);
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(
-                CreateEndpointInfo(
-                    string.Empty,
-                    "{controller=Home}/{action=Index}/{subscription=general}",
-                    defaults: new RouteValueDictionary(new { subarea = "test", })));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Foo/Bar/{subscription=general}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Foo/Bar", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Foo/Bar/{subscription=general}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
         }
 
         [Fact]
@@ -812,8 +581,11 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             // Assert
             var endpoint = Assert.Single(endpoints);
             var matcherEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
-            Assert.Equal("Foo/Baz/{id?}", matcherEndpoint.RoutePattern.RawText);
-            AssertIsSubset(expectedDefaults, matcherEndpoint.RoutePattern.Defaults);
+            Assert.Equal("{controller}/{action}/{id?}", matcherEndpoint.RoutePattern.RawText);
+            Assert.Equal("Foo", matcherEndpoint.RoutePattern.RequiredValues["controller"]);
+            Assert.Equal("Baz", matcherEndpoint.RoutePattern.RequiredValues["action"]);
+            Assert.Equal("Foo", matcherEndpoint.RoutePattern.Defaults["controller"]);
+            Assert.False(matcherEndpoint.RoutePattern.Defaults.ContainsKey("action"));
         }
 
         [Fact]
@@ -845,147 +617,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         }
 
         [Fact]
-        public void Endpoints_ConventionalRoutes_NonDefaultAndDefaultValuesEndingWithOptional_IncludeFullRouteAsHighPriority()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "Home", action = "Index" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller}/{action=Index}/{id?}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Home/{action=Index}/{id?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Home", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Home/Index/{id?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_ConventionalRoutes_DefaultValuesEndingWithOptional_IncludeFullRouteAsHighPriority()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "Home", action = "Index" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller=Home}/{action=Index}/{id?}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("{controller=Home}/{action=Index}/{id?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Home", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("Home/Index/{id?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(4, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_ConventionalRoutes_DefaultValues_Shortened()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller=TestController}/{action=TestAction}/{id=17}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("{controller=TestController}/{action=TestAction}/{id=17}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(4, matcherEndpoint.Order);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction/{id=17}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(5, matcherEndpoint.Order);
-                });
-        }
-
-        [Fact]
         public void Endpoints_ConventionalRoutes_DefaultValuesAndCatchAll_EndpointInfoDefaultsNotModified()
         {
             // Arrange
@@ -1007,251 +638,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         }
 
         [Fact]
-        public void Endpoints_ConventionalRoutes_DefaultValuesAndCatchAll_Shortened()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller=TestController}/{action=TestAction}/{id=17}/{**catchAll}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("{controller=TestController}/{action=TestAction}/{id=17}/{**catchAll}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(4, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction/{id=17}/{**catchAll}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(5, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_ConventionalRoutes_DefaultValuesAndOptional_Shortened()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller=TestController}/{action=TestAction}/{id=17}/{more?}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("{controller=TestController}/{action=TestAction}/{id=17}/{more?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(4, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction/{id=17}/{more?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("17", matcherEndpoint.RoutePattern.Defaults["id"]);
-                    Assert.Equal(5, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_ConventionalRoutes_OptionalExtension_IncludeFullRouteAsHighPriority()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller}/{action=TestAction}.{ext?}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/{action=TestAction}.{ext?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction.{ext?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_ConventionalRoutes_MultipleOptionalAndCatchAll_IncludeFullRouteAsHighPriority()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-            dataSource.ConventionalEndpointInfos.Add(CreateEndpointInfo(
-                name: string.Empty,
-                template: "{controller=TestController}/{action=TestAction}/{id?}/{more?}/{**catchAll}"));
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("{controller=TestController}/{action=TestAction}/{id?}/{more?}/{**catchAll}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(3, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction/{id?}/{more?}/{**catchAll}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(4, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_AttributeRoutes_CatchAllWithDefault_IncludeFullRouteAsHighPriority()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                "/TeamName/{*Name=DefaultName}/",
-                new { controller = "TestController", action = "TestAction" });
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TeamName/{*Name=DefaultName}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(0, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TeamName", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("DefaultName", matcherEndpoint.RoutePattern.Defaults["Name"]);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TeamName/{*Name=DefaultName}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("DefaultName", matcherEndpoint.RoutePattern.Defaults["Name"]);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-                });
-        }
-
-        [Fact]
         public void Endpoints_AttributeRoutes_DefaultDifferentCaseFromRouteValue_UseDefaultCase()
         {
             // Arrange
@@ -1269,66 +655,11 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 (ep) =>
                 {
                     var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/{action=TESTACTION}/{id?}", matcherEndpoint.RoutePattern.RawText);
+                    Assert.Equal("{controller}/{action=TESTACTION}/{id?}", matcherEndpoint.RoutePattern.RawText);
                     Assert.Equal("TESTACTION", matcherEndpoint.RoutePattern.Defaults["action"]);
                     Assert.Equal(0, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, true);
 
-                    var routeValuesAddress = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-                    Assert.Equal("TESTACTION", routeValuesAddress.RequiredValues["action"]);
-
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("TESTACTION", matcherEndpoint.RoutePattern.Defaults["action"]);
-                    Assert.Equal(1, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-
-                    var routeValuesAddress = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-                    Assert.Equal("TESTACTION", routeValuesAddress.RequiredValues["action"]);
-                },
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TESTACTION/{id?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal("TESTACTION", matcherEndpoint.RoutePattern.Defaults["action"]);
-                    Assert.Equal(2, matcherEndpoint.Order);
-                    AssertMatchingSuppressed(matcherEndpoint, false);
-
-                    var routeValuesAddress = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-                    Assert.Equal("TESTACTION", routeValuesAddress.RequiredValues["action"]);
-                });
-        }
-
-        [Fact]
-        public void Endpoints_AttributeRoutes_ActionMetadataDoesNotOverrideDataSourceMetadata()
-        {
-            // Arrange
-            var actionDescriptorCollection = GetActionDescriptorCollection(
-                CreateActionDescriptor(new { controller = "TestController", action = "TestAction" },
-                "{controller}/{action}/{id?}",
-                new List<object> { new RouteValuesAddressMetadata("fakeroutename", new RouteValueDictionary(new { fake = "Fake!" })) })
-                );
-            var dataSource = CreateMvcEndpointDataSource(actionDescriptorCollection);
-
-            // Act
-            var endpoints = dataSource.Endpoints;
-
-            // Assert
-            Assert.Collection(
-                endpoints,
-                (ep) =>
-                {
-                    var matcherEndpoint = Assert.IsType<RouteEndpoint>(ep);
-                    Assert.Equal("TestController/TestAction/{id?}", matcherEndpoint.RoutePattern.RawText);
-                    Assert.Equal(0, matcherEndpoint.Order);
-
-                    var routeValuesAddress = matcherEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-                    Assert.Equal("{controller}/{action}/{id?}", routeValuesAddress.RouteName);
-                    Assert.Equal("TestController", routeValuesAddress.RequiredValues["controller"]);
-                    Assert.Equal("TestAction", routeValuesAddress.RequiredValues["action"]);
+                    Assert.Equal("TestAction", matcherEndpoint.RoutePattern.RequiredValues["action"]);
                 });
         }
 
@@ -1345,16 +676,21 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             var services = new ServiceCollection();
             services.AddSingleton(actionDescriptorCollectionProvider);
+
+            var routeOptionsSetup = new MvcCoreRouteOptionsSetup();
+            services.Configure<RouteOptions>(routeOptionsSetup.Configure);
             services.AddRouting(options =>
             {
                 options.ConstraintMap["upper-case"] = typeof(UpperCaseParameterTransform);
             });
+
             var serviceProvider = services.BuildServiceProvider();
 
             var dataSource = new MvcEndpointDataSource(
                 actionDescriptorCollectionProvider,
                 mvcEndpointInvokerFactory ?? new MvcEndpointInvokerFactory(new ActionInvokerFactory(Array.Empty<IActionInvokerProvider>())),
-                serviceProvider.GetRequiredService<ParameterPolicyFactory>());
+                serviceProvider.GetRequiredService<ParameterPolicyFactory>(),
+                serviceProvider.GetRequiredService<RoutePatternTransformer>());
 
             var defaultEndpointConventionBuilder = new DefaultEndpointConventionBuilder();
             dataSource.AttributeRoutingConventionResolvers.Add((actionDescriptor) =>
@@ -1387,14 +723,14 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 services.AddRouting();
                 services.AddSingleton(typeof(UpperCaseParameterTransform), new UpperCaseParameterTransform());
 
-	            var routeOptionsSetup = new MvcCoreRouteOptionsSetup();
-	            services.Configure<RouteOptions>(routeOptionsSetup.Configure);
-	            services.Configure<RouteOptions>(options =>
-	            {
-	                options.ConstraintMap["upper-case"] = typeof(UpperCaseParameterTransform);
-	            });
+                var routeOptionsSetup = new MvcCoreRouteOptionsSetup();
+                services.Configure<RouteOptions>(routeOptionsSetup.Configure);
+                services.Configure<RouteOptions>(options =>
+                {
+                    options.ConstraintMap["upper-case"] = typeof(UpperCaseParameterTransform);
+                });
 
-	            serviceProvider = services.BuildServiceProvider();
+                serviceProvider = services.BuildServiceProvider();
             }
 
             var parameterPolicyFactory = serviceProvider.GetRequiredService<ParameterPolicyFactory>();

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/PageLinkGeneratorExtensionsTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/PageLinkGeneratorExtensionsTest.cs
@@ -25,11 +25,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "About/{id}",
                 defaults: new { page = "/About", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/About", })) });
+                requiredValues:new { page = "/About", });
             var endpoint2 = CreateEndpoint(
                 "Admin/ManageUsers/{handler?}",
                 defaults: new { page = "/Admin/ManageUsers", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/Admin/ManageUsers", })) });
+                requiredValues:new { page = "/Admin/ManageUsers", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -54,11 +54,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "About/{id}",
                 defaults: new { page = "/About", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/About", })) });
+                requiredValues:new { page = "/About", });
             var endpoint2 = CreateEndpoint(
                 "Admin/ManageUsers/{handler?}",
                 defaults: new { page = "/Admin/ManageUsers", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/Admin/ManageUsers", })) });
+                requiredValues:new { page = "/Admin/ManageUsers", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -82,11 +82,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "About/{id}",
                 defaults: new { page = "/About", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/About", })) });
+                requiredValues:new { page = "/About", });
             var endpoint2 = CreateEndpoint(
                 "Admin/ManageUsers",
                 defaults: new { page = "/Admin/ManageUsers", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/Admin/ManageUsers", })) });
+                requiredValues:new { page = "/Admin/ManageUsers", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -112,11 +112,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "About/{id}",
                 defaults: new { page = "/About", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/About", })) });
+                requiredValues:new { page = "/About", });
             var endpoint2 = CreateEndpoint(
                 "Admin/ManageUsers",
                 defaults: new { page = "/Admin/ManageUsers", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/Admin/ManageUsers", })) });
+                requiredValues:new { page = "/Admin/ManageUsers", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -142,11 +142,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "About/{id}",
                 defaults: new { page = "/About", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/About", })) });
+                requiredValues:new { page = "/About", });
             var endpoint2 = CreateEndpoint(
                 "Admin/ManageUsers",
                 defaults: new { page = "/Admin/ManageUsers", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/Admin/ManageUsers", })) });
+                requiredValues:new { page = "/Admin/ManageUsers", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Routing
         {
             return new RouteEndpoint(
                 (httpContext) => Task.CompletedTask,
-                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null),
+                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues),
                 order,
                 new EndpointMetadataCollection(metadata ?? Array.Empty<object>()),
                 null);

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
@@ -323,7 +323,7 @@ Hello from page";
             var expected =
 @"<a href=""/Accounts/Manage/RenderPartials"">Link inside area</a>
 <a href=""/Products/List/old/20"">Link to external area</a>
-<a href=""/Accounts"">Link to area action</a>
+<a href="""">Link to area action</a>
 <a href=""/Admin"">Link to non-area page</a>";
 
             // Act

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTestsBase.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTestsBase.cs
@@ -1294,8 +1294,6 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("/", result.Link);
         }
 
-
-
         [Fact]
         public virtual async Task AttributeRoutedAction_InArea_LinkToConventionalRoutedActionInArea()
         {

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.About.html
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.About.html
@@ -1,4 +1,4 @@
-
+﻿
 
 <!DOCTYPE html>
 <html>
@@ -12,8 +12,8 @@
 <body>
     <h1 style="font-family: cursive;">ASP.NET vNext - About</h1>
     <p>| <a href="/" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Home</a>
-       | <a href="/Home/About" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
-       | <a href="/Home/Help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
+       | <a href="/home/about" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
+       | <a href="/home/help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
     <div>
         
 

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.Help.html
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.Help.html
@@ -1,4 +1,4 @@
-
+﻿
 
 <!DOCTYPE html>
 <html>
@@ -12,8 +12,8 @@
 <body>
     <h1 style="font-family: cursive;">ASP.NET vNext - Help</h1>
     <p>| <a href="/" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Home</a>
-       | <a href="/Home/About" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
-       | <a href="/Home/Help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
+       | <a href="/home/about" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
+       | <a href="/home/help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
     <div>
         
 

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.Index.html
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.Index.html
@@ -1,4 +1,4 @@
-
+﻿
 
 <!DOCTYPE html>
 <html>
@@ -19,8 +19,8 @@
 <body>
     <h1 style="font-family: cursive;">ASP.NET vNext - Home Page</h1>
     <p>| <a href="/" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Home</a>
-       | <a href="/Home/About" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
-       | <a href="/Home/Help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
+       | <a href="/home/about" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
+       | <a href="/home/help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
     <div>
         
 

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.ViewComponentTagHelpers.html
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Home.ViewComponentTagHelpers.html
@@ -1,4 +1,4 @@
-
+﻿
 
 <!DOCTYPE html>
 <html>
@@ -12,8 +12,8 @@
 <body>
     <h1 style="font-family: cursive;">ASP.NET vNext - </h1>
     <p>| <a href="/" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Home</a>
-       | <a href="/Home/About" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
-       | <a href="/Home/Help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
+       | <a href="/home/about" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My About</a> 
+       | <a href="/home/help" style="background-color: gray;color: white;border-radius: 3px;border: 1px solid black;padding: 3px;font-family: cursive;">My Help</a> |</p>
     <div>
         
 <div>Items: </div>

--- a/src/Mvc/test/WebSites/RoutingWebSite/Controllers/DebugController.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Controllers/DebugController.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Internal;
+
+namespace RoutingWebSite
+{
+    // This controller is reachable via traditional routing.
+    public class DebugController : Controller
+    {
+        private readonly DfaGraphWriter _graphWriter;
+        private readonly EndpointDataSource _endpointDataSource;
+
+        public DebugController(DfaGraphWriter graphWriter, EndpointDataSource endpointDataSource)
+        {
+            _graphWriter = graphWriter;
+            _endpointDataSource = endpointDataSource;
+        }
+
+        public IActionResult Graph()
+        {
+            var sw = new StringWriter();
+            _graphWriter.Write(_endpointDataSource, sw);
+
+            return Content(sw.ToString());
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Startup.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace RoutingWebSite

--- a/src/Routing/benchmarks/Microsoft.AspNetCore.Routing.Performance/EndpointRoutingBenchmarkBase.cs
+++ b/src/Routing/benchmarks/Microsoft.AspNetCore.Routing.Performance/EndpointRoutingBenchmarkBase.cs
@@ -116,11 +116,14 @@ namespace Microsoft.AspNetCore.Routing
             params object[] metadata)
         {
             var endpointMetadata = new List<object>(metadata ?? Array.Empty<object>());
-            endpointMetadata.Add(new RouteValuesAddressMetadata(routeName, new RouteValueDictionary(requiredValues)));
+            if (routeName != null)
+            {
+                endpointMetadata.Add(new RouteNameMetadata(routeName));
+            }
 
             return new RouteEndpoint(
                 (context) => Task.CompletedTask,
-                RoutePatternFactory.Parse(template, defaults, constraints),
+                RoutePatternFactory.Parse(template, defaults, constraints, requiredValues),
                 order,
                 new EndpointMetadataCollection(endpointMetadata),
                 displayName);
@@ -139,16 +142,13 @@ namespace Microsoft.AspNetCore.Routing
 
         protected void CreateOutboundRouteEntry(TreeRouteBuilder treeRouteBuilder, RouteEndpoint endpoint)
         {
-            var routeValuesAddressMetadata = endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
-            var requiredValues = routeValuesAddressMetadata?.RequiredValues ?? new RouteValueDictionary();
-
             treeRouteBuilder.MapOutbound(
                 NullRouter.Instance,
                 new RouteTemplate(RoutePatternFactory.Parse(
                     endpoint.RoutePattern.RawText,
                     defaults: endpoint.RoutePattern.Defaults,
                     parameterPolicies: null)),
-                requiredLinkValues: new RouteValueDictionary(requiredValues),
+                requiredLinkValues: new RouteValueDictionary(endpoint.RoutePattern.RequiredValues),
                 routeName: null,
                 order: 0);
         }

--- a/src/Routing/samples/RoutingSandbox/Framework/FrameworkConfigurationBuilder.cs
+++ b/src/Routing/samples/RoutingSandbox/Framework/FrameworkConfigurationBuilder.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace RoutingSandbox.Framework
+{
+    public class FrameworkConfigurationBuilder
+    {
+        private readonly FrameworkEndpointDataSource _dataSource;
+
+        internal FrameworkConfigurationBuilder(FrameworkEndpointDataSource dataSource)
+        {
+            _dataSource = dataSource;
+        }
+
+        public void AddPattern(string pattern)
+        {
+            AddPattern(RoutePatternFactory.Parse(pattern));
+        }
+
+        public void AddPattern(RoutePattern pattern)
+        {    
+            _dataSource.Patterns.Add(pattern);
+        }
+
+        public void AddHubMethod(string hub, string method, RequestDelegate requestDelegate)
+        {
+            _dataSource.HubMethods.Add(new HubMethod
+            {
+                Hub = hub,
+                Method = method,
+                RequestDelegate = requestDelegate
+            });
+        }
+    }
+}

--- a/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointDataSource.cs
+++ b/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointDataSource.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace RoutingSandbox.Framework
+{
+    internal class FrameworkEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
+    {
+        private readonly RoutePatternTransformer _routePatternTransformer;
+        private readonly List<Action<EndpointModel>> _conventions;
+
+        public List<RoutePattern> Patterns { get; }
+        public List<HubMethod> HubMethods { get; }
+
+        private List<Endpoint> _endpoints;
+
+        public FrameworkEndpointDataSource(RoutePatternTransformer routePatternTransformer)
+        {
+            _routePatternTransformer = routePatternTransformer;
+            _conventions = new List<Action<EndpointModel>>();
+
+            Patterns = new List<RoutePattern>();
+            HubMethods = new List<HubMethod>();
+        }
+
+        public override IReadOnlyList<Endpoint> Endpoints
+        {
+            get
+            {
+                if (_endpoints == null)
+                {
+                    _endpoints = BuildEndpoints();
+                }
+
+                return _endpoints;
+            }
+        }
+
+        private List<Endpoint> BuildEndpoints()
+        {
+            List<Endpoint> endpoints = new List<Endpoint>();
+
+            foreach (var hubMethod in HubMethods)
+            {
+                var requiredValues = new { hub = hubMethod.Hub, method = hubMethod.Method };
+                var order = 1;
+
+                foreach (var pattern in Patterns)
+                {
+                    var resolvedPattern = _routePatternTransformer.SubstituteRequiredValues(pattern, requiredValues);
+                    if (resolvedPattern == null)
+                    {
+                        continue;
+                    }
+
+                    var endpointModel = new RouteEndpointModel(
+                        hubMethod.RequestDelegate,
+                        resolvedPattern,
+                        order++);
+                    endpointModel.DisplayName = $"{hubMethod.Hub}.{hubMethod.Method}";
+
+                    foreach (var convention in _conventions)
+                    {
+                        convention(endpointModel);
+                    }
+
+                    endpoints.Add(endpointModel.Build());
+                }
+            }
+
+            return endpoints;
+        }
+
+        public override IChangeToken GetChangeToken()
+        {
+            return NullChangeToken.Singleton;
+        }
+
+        public void Apply(Action<EndpointModel> convention)
+        {
+            _conventions.Add(convention);
+        }
+    }
+
+    internal class HubMethod
+    {
+        public string Hub { get; set; }
+        public string Method { get; set; }
+        public RequestDelegate RequestDelegate { get; set; }
+    }
+}

--- a/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointRouteBuilderExtensions.cs
+++ b/src/Routing/samples/RoutingSandbox/Framework/FrameworkEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RoutingSandbox.Framework
+{
+    public static class FrameworkEndpointRouteBuilderExtensions
+    {
+        public static IEndpointConventionBuilder MapFramework(this IEndpointRouteBuilder builder, Action<FrameworkConfigurationBuilder> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var dataSource = builder.ServiceProvider.GetRequiredService<FrameworkEndpointDataSource>();
+
+            var configurationBuilder = new FrameworkConfigurationBuilder(dataSource);
+            configure(configurationBuilder);
+
+            builder.DataSources.Add(dataSource);
+
+            return dataSource;
+        }
+    }
+}

--- a/src/Routing/samples/RoutingSandbox/RoutingSandbox.csproj
+++ b/src/Routing/samples/RoutingSandbox/RoutingSandbox.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Routing/samples/RoutingSandbox/SlugifyParameterTransformer.cs
+++ b/src/Routing/samples/RoutingSandbox/SlugifyParameterTransformer.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Routing;
+
+namespace RoutingSandbox
+{
+    public class SlugifyParameterTransformer : IOutboundParameterTransformer
+    {
+        public string TransformOutbound(object value)
+        {
+            // Slugify value
+            return value == null ? null : Regex.Replace(value.ToString(), "([a-z])([A-Z])", "$1-$2", RegexOptions.None, TimeSpan.FromMilliseconds(100)).ToLower();
+        }
+    }
+}

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/CompositeEndpointDataSource.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/CompositeEndpointDataSource.cs
@@ -167,13 +167,14 @@ namespace Microsoft.AspNetCore.Routing
                         sb.Append(", Defaults: new { ");
                         sb.Append(string.Join(", ", FormatValues(routeEndpoint.RoutePattern.Defaults)));
                         sb.Append(" }");
-                        var routeValuesAddressMetadata = routeEndpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
+                        var routeNameMetadata = routeEndpoint.Metadata.GetMetadata<IRouteNameMetadata>();
                         sb.Append(", Route Name: ");
-                        sb.Append(routeValuesAddressMetadata?.RouteName);
-                        if (routeValuesAddressMetadata?.RequiredValues != null)
+                        sb.Append(routeNameMetadata?.RouteName);
+                        var routeValues = routeEndpoint.RoutePattern.RequiredValues;
+                        if (routeValues.Count > 0)
                         {
                             sb.Append(", Required Values: new { ");
-                            sb.Append(string.Join(", ", FormatValues(routeValuesAddressMetadata.RequiredValues)));
+                            sb.Append(string.Join(", ", FormatValues(routeValues)));
                             sb.Append(" }");
                         }
                         sb.Append(", Order: ");

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Routing
                 _uriBuildingContextPool,
                 endpoint.RoutePattern,
                 new RouteValueDictionary(endpoint.RoutePattern.Defaults),
-                endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>()?.RequiredValues.Keys,
+                endpoint.RoutePattern.RequiredValues.Keys,
                 policies);
         }
 

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/IRouteNameMetadata.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/IRouteNameMetadata.cs
@@ -1,26 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
     /// Represents metadata used during link generation to find
-    /// the associated endpoint using route values.
+    /// the associated endpoint using route name.
     /// </summary>
-    [Obsolete("Route values are now specified on a RoutePattern.")]
-    public interface IRouteValuesAddressMetadata
+    public interface IRouteNameMetadata
     {
         /// <summary>
         /// Gets the route name. Can be null.
         /// </summary>
         string RouteName { get; }
-
-        /// <summary>
-        /// Gets the required route values.
-        /// </summary>
-        IReadOnlyDictionary<string, object> RequiredValues { get; }
     }
 }

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/Patterns/DefaultRoutePatternTransformer.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/Patterns/DefaultRoutePatternTransformer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                 updatedDefaults ?? original.Defaults,
                 original.ParameterPolicies,
                 requiredValues,
-                updatedParameters ?? original.Parameters, 
+                updatedParameters ?? original.Parameters,
                 updatedSegments ?? original.PathSegments);
         }
 

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/RouteNameMetadata.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/RouteNameMetadata.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    /// <summary>
+    /// Metadata used during link generation to find the associated endpoint using route name.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    public sealed class RouteNameMetadata : IRouteNameMetadata
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="RouteNameMetadata"/> with the provided route name.
+        /// </summary>
+        /// <param name="routeName">The route name. Can be null.</param>
+        public RouteNameMetadata(string routeName)
+        {
+            RouteName = routeName;
+        }
+
+        /// <summary>
+        /// Gets the route name. Can be null.
+        /// </summary>
+        public string RouteName { get; }
+
+        internal string DebuggerToString()
+        {
+            return $"Name: {RouteName}";
+        }
+    }
+}

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressMetadata.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressMetadata.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Routing
     /// Metadata used during link generation to find the associated endpoint using route values.
     /// </summary>
     [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [Obsolete("Route values are now specified on a RoutePattern.")]
     public sealed class RouteValuesAddressMetadata : IRouteValuesAddressMetadata
     {
         private static readonly IReadOnlyDictionary<string, object> EmptyRouteValues =

--- a/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
+++ b/src/Routing/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Routing
                     continue;
                 }
 
-                var metadata = endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>();
+                var metadata = endpoint.Metadata.GetMetadata<IRouteNameMetadata>();
                 if (metadata == null && routeEndpoint.RoutePattern.RequiredValues.Count == 0)
                 {
                     continue;
@@ -137,8 +137,8 @@ namespace Microsoft.AspNetCore.Routing
                 }
 
                 var entry = CreateOutboundRouteEntry(
-                    routeEndpoint, 
-                    metadata?.RequiredValues ?? routeEndpoint.RoutePattern.RequiredValues, 
+                    routeEndpoint,
+                    routeEndpoint.RoutePattern.RequiredValues,
                     metadata?.RouteName);
 
                 var outboundMatch = new OutboundMatch() { Entry = entry };

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorProcessTemplateTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorProcessTemplateTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
@@ -309,14 +309,6 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Equal("/Foo/Bar%3Fencodeme%3F/Home/In%3Fdex?query=some%3Fquery#Fragment?", path);
         }
 
-        private class UpperCaseParameterTransform : IOutboundParameterTransformer
-        {
-            public string TransformOutbound(object value)
-            {
-                return value?.ToString()?.ToUpperInvariant();
-            }
-        }
-
         [Fact]
         public void GetLink_ParameterTransformer()
         {
@@ -346,7 +338,7 @@ namespace Microsoft.AspNetCore.Routing
             // Arrange
             var endpoint = EndpointFactory.CreateRouteEndpoint(
                 "{controller:upper-case}/{name}",
-                requiredValues: new { controller = "Home", name = "Test", c = "hithere", },
+                requiredValues: new { controller = "Home", name = "Test", },
                 policies: new { c = new UpperCaseParameterTransform(), });
 
             Action<IServiceCollection> configure = (s) =>
@@ -586,24 +578,24 @@ namespace Microsoft.AspNetCore.Routing
                 "Home/Index",
                 order: 3,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpointController = EndpointFactory.CreateRouteEndpoint(
                 "Home",
                 order: 2,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpointEmpty = EndpointFactory.CreateRouteEndpoint(
                 "",
                 order: 1,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             // This endpoint should be used to generate the link when an id is present
             var endpointControllerActionParameter = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 order: 0,
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpointControllerAction, endpointController, endpointEmpty, endpointControllerActionParameter);
 
@@ -642,11 +634,11 @@ namespace Microsoft.AspNetCore.Routing
             var homeIndex = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var homeLogin = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Login", })) });
+                requiredValues: new { controller = "Home", action = "Login", });
 
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 
@@ -685,11 +677,11 @@ namespace Microsoft.AspNetCore.Routing
             var homeIndex = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var homeLogin = EndpointFactory.CreateRouteEndpoint(
                 "{controller}/{action}/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Login", })) });
+                requiredValues: new { controller = "Home", action = "Login", });
 
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/EndpointFactory.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/EndpointFactory.cs
@@ -3,9 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.TestObjects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing
 {
@@ -20,17 +24,22 @@ namespace Microsoft.AspNetCore.Routing
             string displayName = null,
             params object[] metadata)
         {
-            var d = new List<object>(metadata ?? Array.Empty<object>());
-            if (requiredValues != null)
-            {
-                d.Add(new RouteValuesAddressMetadata(new RouteValueDictionary(requiredValues)));
-            }
+            var routePattern = RoutePatternFactory.Parse(template, defaults, policies, requiredValues);
 
+            return CreateRouteEndpoint(routePattern, order, displayName, metadata);
+        }
+
+        public static RouteEndpoint CreateRouteEndpoint(
+            RoutePattern routePattern = null,
+            int order = 0,
+            string displayName = null,
+            IList<object> metadata = null)
+        {
             return new RouteEndpoint(
                 TestConstants.EmptyRequestDelegate,
-                RoutePatternFactory.Parse(template, defaults, policies),
+                routePattern,
                 order,
-                new EndpointMetadataCollection(d),
+                new EndpointMetadataCollection(metadata ?? Array.Empty<object>()),
                 displayName);
         }
     }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -59,11 +59,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -86,11 +86,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -116,11 +116,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -145,11 +145,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -177,11 +177,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
                 "Home/Index/{id?}",
                 defaults: new { controller = "Home", action = "Index", },
-                metadata: new[] { new RouteValuesAddressMetadata(new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
+                requiredValues: new { controller = "Home", action = "Index", });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Patterns/DefaultRoutePatternTransformerTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Patterns/DefaultRoutePatternTransformerTest.cs
@@ -335,5 +335,24 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                 kvp => Assert.Equal(new KeyValuePair<string, object>("area", "Admin"), kvp),
                 kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
         }
+
+        [Fact]
+        public void SubstituteRequiredValues_NullRequiredValueParameter_Fail()
+        {
+            // Arrange
+            var template = "PageRoute/Attribute/{page}";
+            var defaults = new { area = (string)null, page = (string)null, controller = "Home", action = "Index", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { area = (string)null, page = (string)null, controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Null(actual);
+        }
     }
 }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressMetadataTests.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressMetadataTests.cs
@@ -13,7 +13,9 @@ namespace Microsoft.AspNetCore.Routing
         [Fact]
         public void DebuggerToString_NoNameAndRequiredValues_ReturnsString()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var metadata = new RouteValuesAddressMetadata(null, new Dictionary<string, object>());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal("Name:  - Required values: ", metadata.DebuggerToString());
         }
@@ -21,11 +23,13 @@ namespace Microsoft.AspNetCore.Routing
         [Fact]
         public void DebuggerToString_HasNameAndRequiredValues_ReturnsString()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var metadata = new RouteValuesAddressMetadata("Name!", new Dictionary<string, object>
             {
                 ["requiredValue1"] = "One",
                 ["requiredValue2"] = 2,
             });
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal("Name: Name! - Required values: requiredValue1 = \"One\", requiredValue2 = \"2\"", metadata.DebuggerToString());
         }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Routing
         public void EndpointDataSource_ChangeCallback_Refreshes_OutboundMatches()
         {
             // Arrange 1
-            var endpoint1 = CreateEndpoint("/a", metadataRequiredValues: new { });
+            var endpoint1 = CreateEndpoint("/a", routeName: "a");
             var dynamicDataSource = new DynamicEndpointDataSource(new[] { endpoint1 });
 
             // Act 1
@@ -93,21 +93,21 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Same(endpoint1, actual);
 
             // Arrange 2
-            var endpoint2 = CreateEndpoint("/b", metadataRequiredValues: new { });
+            var endpoint2 = CreateEndpoint("/b", routeName: "b");
 
             // Act 2
             // Trigger change
             dynamicDataSource.AddEndpoint(endpoint2);
 
             // Arrange 2
-            var endpoint3 = CreateEndpoint("/c", metadataRequiredValues: new { });
+            var endpoint3 = CreateEndpoint("/c", routeName: "c");
 
             // Act 2
             // Trigger change
             dynamicDataSource.AddEndpoint(endpoint3);
 
             // Arrange 3
-            var endpoint4 = CreateEndpoint("/d", metadataRequiredValues: new { });
+            var endpoint4 = CreateEndpoint("/d", routeName: "d");
 
             // Act 3
             // Trigger change
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.Routing
             var expected = CreateEndpoint(
                 "api/orders/{id}",
                 defaults: new { controller = "Orders", action = "GetById" },
-                routePatternRequiredValues: new { controller = "Orders", action = "GetById" });
+                metadataRequiredValues: new { controller = "Orders", action = "GetById" });
             var addressScheme = CreateAddressScheme(expected);
 
             // Act
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Routing
             // Arrange
             var endpoint = EndpointFactory.CreateRouteEndpoint(
                 "/a",
-                metadata: new object[] { new SuppressLinkGenerationMetadata(), new EncourageLinkGenerationMetadata(), new RouteValuesAddressMetadata(string.Empty), });
+                metadata: new object[] { new SuppressLinkGenerationMetadata(), new EncourageLinkGenerationMetadata(), new RouteNameMetadata(string.Empty), });
 
             // Act
             var addressScheme = CreateAddressScheme(endpoint);
@@ -369,7 +369,6 @@ namespace Microsoft.AspNetCore.Routing
             string template,
             object defaults = null,
             object metadataRequiredValues = null,
-            object routePatternRequiredValues = null,
             int order = 0,
             string routeName = null,
             EndpointMetadataCollection metadataCollection = null)
@@ -377,16 +376,16 @@ namespace Microsoft.AspNetCore.Routing
             if (metadataCollection == null)
             {
                 var metadata = new List<object>();
-                if (!string.IsNullOrEmpty(routeName) || metadataRequiredValues != null)
+                if (!string.IsNullOrEmpty(routeName))
                 {
-                    metadata.Add(new RouteValuesAddressMetadata(routeName, new RouteValueDictionary(metadataRequiredValues)));
+                    metadata.Add(new RouteNameMetadata(routeName));
                 }
                 metadataCollection = new EndpointMetadataCollection(metadata);
             }
 
             return new RouteEndpoint(
                 TestConstants.EmptyRequestDelegate,
-                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues: routePatternRequiredValues),
+                RoutePatternFactory.Parse(template, defaults, parameterPolicies: null, requiredValues: metadataRequiredValues),
                 order,
                 metadataCollection,
                 null);

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/RoutePatternPrecedenceTests.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/RoutePatternPrecedenceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.Template
 {
@@ -22,6 +23,21 @@ namespace Microsoft.AspNetCore.Routing.Template
         {
             var parsed = RoutePatternFactory.Parse(template);
             return func(parsed);
+        }
+
+        [Fact]
+        public void InboundPrecedence_ParameterWithRequiredValue_HasPrecedence()
+        {
+            var parameterPrecedence = RoutePatternFactory.Parse(
+                "{controller}").InboundPrecedence;
+
+            var requiredValueParameterPrecedence = RoutePatternFactory.Parse(
+                "{controller}",
+                defaults: null,
+                parameterPolicies: null,
+                requiredValues: new { controller = "Home" }).InboundPrecedence;
+
+            Assert.True(requiredValueParameterPrecedence < parameterPrecedence);
         }
     }
 }

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
@@ -1304,10 +1304,104 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var binder = new TemplateBinder(
                 UrlEncoder.Default,
                 new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
-                RoutePatternFactory.Parse(template),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = (string)null, action = "Param", controller = "ConventionalTransformer", page = (string)null }),
                 defaults,
                 requiredKeys: defaults.Keys,
                 parameterPolicies: new (string, IParameterPolicy)[] { ("param", new LengthRouteConstraint(500)), ("param", new SlugifyParameterTransformer()), });
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
+        [Fact]
+        public void BindValues_AmbientAndExplicitValuesDoNotMatch_Success()
+        {
+            // Arrange
+            var expected = "/Travel/Flight";
+
+            var template = "{area}/{controller}/{action}";
+            var defaults = new RouteValueDictionary(new { action = "Index" });
+            var ambientValues = new RouteValueDictionary(new { area = "Travel", controller = "Rail", action = "Index" });
+            var explicitValues = new RouteValueDictionary(new { controller = "Flight", action = "Index" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = "Travel", action = "SomeAction", controller = "Flight", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
+        [Fact]
+        public void BindValues_LinkingFromPageToAController_Success()
+        {
+            // Arrange
+            var expected = "/LG2/SomeAction";
+
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new RouteValueDictionary();
+            var ambientValues = new RouteValueDictionary(new { page = "/LGAnotherPage", id = "17" });
+            var explicitValues = new RouteValueDictionary(new { controller = "LG2", action = "SomeAction" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = (string)null, action = "SomeAction", controller = "LG2", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
+        [Fact]
+        public void BindValues_HasUnmatchingAmbientValues_Discard()
+        {
+            // Arrange
+            var expected = "/Admin/LG3/SomeAction?anothervalue=5";
+
+            var template = "Admin/LG3/SomeAction/{id?}";
+            var defaults = new RouteValueDictionary(new { controller = "LG3", action = "SomeAction", area = "Admin" });
+            var ambientValues = new RouteValueDictionary(new { controller = "LG1", action = "LinkToAnArea", id = "17" });
+            var explicitValues = new RouteValueDictionary(new { controller = "LG3", area = "Admin", action = "SomeAction", anothervalue = "5" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = "Admin", action = "SomeAction", controller = "LG3", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
 
             // Act
             var result = binder.GetValues(ambientValues, explicitValues);

--- a/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/TestObjects/UpperCaseParameterTransform.cs
+++ b/src/Routing/test/Microsoft.AspNetCore.Routing.Tests/TestObjects/UpperCaseParameterTransform.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Routing.TestObjects
+{
+    public class UpperCaseParameterTransform : IOutboundParameterTransformer
+    {
+        public string TransformOutbound(object value)
+        {
+            return value?.ToString()?.ToUpperInvariant();
+        }
+    }
+}

--- a/src/Routing/test/WebSites/RoutingWebSite/UseEndpointRoutingStartup.cs
+++ b/src/Routing/test/WebSites/RoutingWebSite/UseEndpointRoutingStartup.cs
@@ -98,7 +98,7 @@ namespace RoutingWebSite
                         return response.WriteAsync(
                             "Link: " + linkGenerator.GetPathByRouteValues(httpContext, "WithSingleAsteriskCatchAll", new { }));
                     },
-                    new RouteValuesAddressMetadata(routeName: "WithSingleAsteriskCatchAll", requiredValues: new RouteValueDictionary()));
+                    new RouteNameMetadata(routeName: "WithSingleAsteriskCatchAll"));
                 routes.MapGet(
                     "/WithDoubleAsteriskCatchAll/{**path}",
                     (httpContext) =>
@@ -111,7 +111,7 @@ namespace RoutingWebSite
                         return response.WriteAsync(
                             "Link: " + linkGenerator.GetPathByRouteValues(httpContext, "WithDoubleAsteriskCatchAll", new { }));
                     },
-                    new RouteValuesAddressMetadata(routeName: "WithDoubleAsteriskCatchAll", requiredValues: new RouteValueDictionary()));
+                    new RouteNameMetadata(routeName: "WithDoubleAsteriskCatchAll"));
             });
 
             app.Map("/Branch1", branch => SetupBranch(branch, "Branch1"));


### PR DESCRIPTION
 - DFA matcher uses required values to denormalize routes
 - Link generator uses required values to calculate route precedence
 - Obsolete IRouteValuesAddressMetadata
 - React in MVC to provide required values with RoutePattern in datasource

re: https://github.com/aspnet/Routing/pull/914 and https://github.com/aspnet/Mvc/pull/8731