### PR TITLE
Replace ManualResetEvent with TaskCompletionSource in TestHost tests

### DIFF
--- a/src/Hosting/TestHost/test/Utilities.cs
+++ b/src/Hosting/TestHost/test/Utilities.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    internal static class Utilities
+    {
+        internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
+
+        internal static Task<T> WithTimeout<T>(this Task<T> task) => task.WithTimeout(DefaultTimeout);
+
+        internal static async Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout)
+        {
+            var completedTask = await Task.WhenAny(task, Task.Delay(timeout));
+
+            if (completedTask == task)
+            {
+                return await task;
+            }
+            else
+            {
+                throw new TimeoutException("The task has timed out.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1326#issuecomment-440348646
https://github.com/aspnet/AspNetCore-Internal/issues/1431

Addresses failures in ClientDisposalCloses and ClientCancellationAborts likely caused by deadlocks.