### PR TITLE
Ensure Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets is included in 2.2.1

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -8,6 +8,7 @@
       Microsoft.AspNetCore.Server.IIS;
       Microsoft.AspNetCore.Server.IISIntegration;
       Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
+      Microsoft.AspNetCore.Server.Transport.Sockets;
     </PackagesInPatch>
   </PropertyGroup>
 

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -8,7 +8,7 @@
       Microsoft.AspNetCore.Server.IIS;
       Microsoft.AspNetCore.Server.IISIntegration;
       Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
-      Microsoft.AspNetCore.Server.Transport.Sockets;
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
     </PackagesInPatch>
   </PropertyGroup>
 


### PR DESCRIPTION
We took a change to this assembly https://github.com/aspnet/AspNetCore/pull/4066, but didn't update the corresponding infrastructure to produce new packages.

FYI @sebastienros @DamianEdwards 