### PR TITLE
Section trx files to prevent overwrite

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -123,7 +123,7 @@ jobs:
     inputs:
       testRunTitle: $(AgentOsName)-$(BuildConfiguration)
       testRunner: vstest
-      testResultsFiles: 'artifacts/logs/**/*.trx'
+      testResultsFiles: '**/artifacts/**/*.trx'
       mergeTestResults: true
   - ${{ if eq(parameters.artifacts.publish, 'true') }}:
     - task: PublishBuildArtifacts@1

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -146,7 +146,7 @@
 
     <Copy
        SourceFiles="@(RepositoryArtifacts)"
-       DestinationFolder="$(BuildDir)" />
+       DestinationFolder="$(BuildDir)/$(RepositoryToBuild)" />
 
     <Move
        SourceFiles="@(RepositoryMSBuildArtifacts)"

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -142,7 +142,6 @@
     <ItemGroup>
       <RepositoryArtifacts Include="$(RepositoryArtifactsBuildDirectory)*" />
       <RepositoryMSBuildArtifacts Include="$(RepositoryArtifactsMSBuildDirectory)**\*" />
-
     </ItemGroup>
 
     <Copy

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -152,7 +152,7 @@
 
     <Copy
       SourceFiles="@(RepositoryLogArtifacts)"
-      DestinationFolder="$(BuildDir)\$(RepositoryToBuild)\%(RecursiveDir)" />
+      DestinationFolder="$(ArtifactsDir)logs\$(RepositoryToBuild)\%(RecursiveDir)" />
 
     <Move
        SourceFiles="@(RepositoryMSBuildArtifacts)"

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -141,11 +141,13 @@
 
     <ItemGroup>
       <RepositoryArtifacts Include="$(RepositoryArtifactsBuildDirectory)*" />
+      <RepositoryMSBuildArtifacts Include="$(RepositoryArtifactsMSBuildDirectory)**\*" />
+
     </ItemGroup>
 
     <Copy
        SourceFiles="@(RepositoryArtifacts)"
-       DestinationFolder="$(BuildDir)/" />
+       DestinationFolder="$(BuildDir)" />
 
     <Move
        SourceFiles="@(RepositoryMSBuildArtifacts)"

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -121,6 +121,7 @@
       <RepositoryArtifactsRoot>$(BuildRepositoryRoot)artifacts\</RepositoryArtifactsRoot>
       <RepositoryArtifactsBuildDirectory>$(RepositoryArtifactsRoot)build\</RepositoryArtifactsBuildDirectory>
       <RepositoryArtifactsMSBuildDirectory>$(RepositoryArtifactsRoot)msbuild\</RepositoryArtifactsMSBuildDirectory>
+      <RepositoryArtifactsLogsDirectory>$(RepositoryArtifactsRoot)logs\</RepositoryArtifactsLogsDirectory>
     </PropertyGroup>
 
     <Message Text="============ Building $(RepositoryToBuild) ============" Importance="High" />
@@ -140,13 +141,18 @@
     <Error Text="Building $(RepositoryToBuild) failed: $(_BuildScriptToExecute) exited code $(BuildExitCode)" Condition=" '$(BuildExitCode)' != '0' " />
 
     <ItemGroup>
-      <RepositoryArtifacts Include="$(RepositoryArtifactsBuildDirectory)*" />
+      <RepositoryBuildArtifacts Include="$(RepositoryArtifactsBuildDirectory)*" />
+      <RepositoryLogArtifacts Include="$(RepositoryArtifactsLogsDirectory)**\*" />
       <RepositoryMSBuildArtifacts Include="$(RepositoryArtifactsMSBuildDirectory)**\*" />
     </ItemGroup>
 
     <Copy
-       SourceFiles="@(RepositoryArtifacts)"
-       DestinationFolder="$(BuildDir)/$(RepositoryToBuild)" />
+       SourceFiles="@(RepositoryBuildArtifacts)"
+       DestinationFolder="$(BuildDir)/" />
+
+    <Copy
+      SourceFiles="@(RepositoryLogArtifacts)"
+      DestinationFolder="$(BuildDir)\$(RepositoryToBuild)\%(RecursiveDir)" />
 
     <Move
        SourceFiles="@(RepositoryMSBuildArtifacts)"

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -121,7 +121,6 @@
       <RepositoryArtifactsRoot>$(BuildRepositoryRoot)artifacts\</RepositoryArtifactsRoot>
       <RepositoryArtifactsBuildDirectory>$(RepositoryArtifactsRoot)build\</RepositoryArtifactsBuildDirectory>
       <RepositoryArtifactsMSBuildDirectory>$(RepositoryArtifactsRoot)msbuild\</RepositoryArtifactsMSBuildDirectory>
-      <RepositoryArtifactsLogsDirectory>$(RepositoryArtifactsRoot)logs\</RepositoryArtifactsLogsDirectory>
     </PropertyGroup>
 
     <Message Text="============ Building $(RepositoryToBuild) ============" Importance="High" />
@@ -141,18 +140,12 @@
     <Error Text="Building $(RepositoryToBuild) failed: $(_BuildScriptToExecute) exited code $(BuildExitCode)" Condition=" '$(BuildExitCode)' != '0' " />
 
     <ItemGroup>
-      <RepositoryBuildArtifacts Include="$(RepositoryArtifactsBuildDirectory)*" />
-      <RepositoryLogArtifacts Include="$(RepositoryArtifactsLogsDirectory)**\*" />
-      <RepositoryMSBuildArtifacts Include="$(RepositoryArtifactsMSBuildDirectory)**\*" />
+      <RepositoryArtifacts Include="$(RepositoryArtifactsBuildDirectory)*" />
     </ItemGroup>
 
     <Copy
-       SourceFiles="@(RepositoryBuildArtifacts)"
+       SourceFiles="@(RepositoryArtifacts)"
        DestinationFolder="$(BuildDir)/" />
-
-    <Copy
-      SourceFiles="@(RepositoryLogArtifacts)"
-      DestinationFolder="$(ArtifactsDir)logs\$(RepositoryToBuild)\%(RecursiveDir)" />
 
     <Move
        SourceFiles="@(RepositoryMSBuildArtifacts)"


### PR DESCRIPTION
It seems like we might be overwriting some trx files because they have the same name. This is an attempt to put those in separate folders to prevent such behavior.