### PR TITLE
Set Microsoft.Owin.Security.Interop to 'noship' for 2.2

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -190,7 +190,7 @@
     <PackageArtifact Include="Microsoft.Extensions.Localization" Category="ship" />
     <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="ship" />
     <PackageArtifact Include="Microsoft.NET.Sdk.Razor" Category="ship" />
-    <PackageArtifact Include="Microsoft.Owin.Security.Interop" Category="ship" />
+    <PackageArtifact Include="Microsoft.Owin.Security.Interop" Category="noship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Editor.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.VisualStudio.LanguageServices.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.VisualStudio.Mac.LanguageServices.Razor" Category="shipoob" />


### PR DESCRIPTION
As discussed with @muratg @blowdart @Tratcher.

See also https://github.com/dotnet/versions/pull/404