### PR TITLE
Use MVC 2.1 at design time for Razor 3.0 projects.

### DIFF
--- a/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
+++ b/src/Razor/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
@@ -50,6 +50,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup Condition="'$(RazorLangVersion)'==''">
     <RazorLangVersion Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true'">3.0</RazorLangVersion>
+
+    <!--
+      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
+      functionally equivalent. This will be undone in the near future.
+    -->
+    <RazorLangVersion Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true' AND '$(DesignTimeBuild)' == 'true'">2.1</RazorLangVersion>
   </PropertyGroup>
 
   <!--
@@ -57,6 +63,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <PropertyGroup Condition="'$(RazorDefaultConfiguration)'==''">
     <RazorDefaultConfiguration Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true'">MVC-3.0</RazorDefaultConfiguration>
+
+    <!--
+      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
+      functionally equivalent. This will be undone in the near future.
+    -->
+    <RazorDefaultConfiguration Condition="'$(_TargetingNETCoreApp30OrLater)' == 'true' AND '$(DesignTimeBuild)' == 'true'">MVC-2.1</RazorDefaultConfiguration>
   </PropertyGroup>
 
   <ItemGroup>
@@ -65,15 +77,32 @@ Copyright (c) .NET Foundation. All rights reserved.
       it here. The IDE is hardcoded to inject 2.0 support when needed. The settings flowing through MSBuild should reflect
       the project's runtime.
     -->
-    <RazorConfiguration Include="MVC-3.0">
+    <RazorConfiguration Include="MVC-3.0" Condition="'$(DesignTimeBuild)' != 'true'">
       <Extensions>MVC-3.0;$(CustomRazorExtension)</Extensions>
+    </RazorConfiguration>
+
+    <!--
+      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
+      functionally equivalent. This will be undone in the near future.
+    -->
+    <RazorConfiguration Include="MVC-2.1" Condition="'$(DesignTimeBuild)' == 'true'">
+      <Extensions>MVC-2.1;$(CustomRazorExtension)</Extensions>
     </RazorConfiguration>
   </ItemGroup>
 
   <ItemGroup>
-    <RazorExtension Include="MVC-3.0">
+    <RazorExtension Include="MVC-3.0" Condition="'$(DesignTimeBuild)' != 'true'">
       <AssemblyName>Microsoft.AspNetCore.Mvc.Razor.Extensions</AssemblyName>
       <AssemblyFilePath>$(RazorSdkDirectoryRoot)extensions\mvc-3-0\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</AssemblyFilePath>
+    </RazorExtension>
+
+    <!--
+      For dev16 the Razor toolings bits don't currently understand 3.0 projects. Therefore, we default to 2.1 which is currently
+      functionally equivalent. This will be undone in the near future.
+    -->
+    <RazorExtension Include="MVC-2.1" Condition="'$(DesignTimeBuild)' == 'true'">
+      <AssemblyName>Microsoft.AspNetCore.Mvc.Razor.Extensions</AssemblyName>
+      <AssemblyFilePath>$(RazorSdkDirectoryRoot)extensions\mvc-2-1\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</AssemblyFilePath>
     </RazorExtension>
   </ItemGroup>
 


### PR DESCRIPTION
- When we detect a design time build we force tooling to use 2.1
- In runtime builds (i.e. rzc) it still uses the 3.0 configuration for 3.0 apps.

Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/736832


/cc @mkArtakMSFT 