### PR TITLE
Add EntityFrameworkCore to the list of submodules patching in 2.2.1

### DIFF
--- a/build/submodules.props
+++ b/build/submodules.props
@@ -39,6 +39,7 @@
     <Repository Include="Scaffolding" PatchPolicy="AlwaysUpdate" />
     <Repository Include="IISIntegration" RootPath="$(RepositoryRoot)src\IISIntegration\" />
     <Repository Include="Templating" RootPath="$(RepositoryRoot)src\Templating\" PatchPolicy="AlwaysUpdateAndCascadeVersions" />
+    <Repository Include="EntityFrameworkCore" />
 
     <!-- Test-only repos -->
     <Repository Include="AuthSamples" RootPath="$(RepositoryRoot)src\AuthSamples\" PatchPolicy="AlwaysUpdateAndCascadeVersions" />
@@ -52,7 +53,6 @@
     <ShippedRepository Include="AzureIntegration" RootPath="$(RepositoryRoot)src\AzureIntegration\" />
     <ShippedRepository Include="BasicMiddleware" />
     <ShippedRepository Include="CORS" RootPath="$(RepositoryRoot)src\CORS\" />
-    <ShippedRepository Include="EntityFrameworkCore" />
     <ShippedRepository Include="HttpSysServer" RootPath="$(RepositoryRoot)src\HttpSysServer\" />
     <ShippedRepository Include="Identity" />
     <ShippedRepository Include="JavaScriptServices" RootPath="$(RepositoryRoot)src\JavaScriptServices\" />


### PR DESCRIPTION
Depends on https://github.com/aspnet/EntityFrameworkCore/pull/14054

cc @roji

Just FYI - this won't be necessary after we implement https://github.com/aspnet/AspNetCore-Internal/issues/1338