### PR TITLE
Fix test asset casing in Hosting funcational tests

### DIFF
--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
             {
                 var logger = loggerFactory.CreateLogger(testName);
 
-                var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "TestAssets",
+                var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "testassets",
                     "Microsoft.AspNetCore.Hosting.TestSites");
 
                 var deploymentParameters = new DeploymentParameters(

--- a/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
+++ b/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
             {
                 var logger = loggerFactory.CreateLogger(nameof(InjectedStartup_DefaultApplicationNameIsEntryAssembly));
 
-                var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "TestAssets", "IStartupInjectionAssemblyName");
+                var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "testassets", "IStartupInjectionAssemblyName");
 
                 var deploymentParameters = new DeploymentParameters(
                     applicationPath,


### PR DESCRIPTION
This addresses the Ubuntu test failure due to casing of the directories:
http://aspnetci/viewLog.html?buildId=598876&tab=buildResultsDiv&buildTypeId=Releases_21Public_UbuntuUniverse

@natemcmaster it looks like the casing changed during the modo merge. https://github.com/aspnet/Hosting/tree/release/2.1/test/TestAssets

System.IO.DirectoryNotFoundException : Application path /mnt/work/e37dd45d8cd1eaf4/src/Hosting/test/TestAssets/Microsoft.AspNetCore.Hosting.TestSites does not exist.

@muratg test only changes to 2.1.