### PR TITLE
[Components] Simple 404 Handling (Fallback Route)

### DIFF
--- a/src/Components/test/Microsoft.AspNetCore.Components.E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.E2ETest/Tests/RoutingTest.cs
@@ -89,6 +89,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void CanArriveAtFallbackPageFromBadURI()
+        {
+            SetUrlViaPushState("/Oopsie_Daisies%20%This_Aint_A_Real_Page"); 
+
+            var app = MountTestComponent<TestRouter>();
+            Assert.Equal("Oops, that component wasn't found!", app.FindElement(By.Id("test-info")).Text);
+        }
+
+        [Fact]
         public void CanFollowLinkToOtherPage()
         {
             SetUrlViaPushState("/");

--- a/src/Components/test/testapps/BasicTestApp/RouterTest/Error404.cshtml
+++ b/src/Components/test/testapps/BasicTestApp/RouterTest/Error404.cshtml
@@ -1,0 +1,2 @@
+@page "/Error404"
+<div id="test-info">Oops, that component wasn't found!</div>

--- a/src/Components/test/testapps/BasicTestApp/RouterTest/TestRouter.cshtml
+++ b/src/Components/test/testapps/BasicTestApp/RouterTest/TestRouter.cshtml
@@ -1,1 +1,1 @@
-<Router AppAssembly=typeof(BasicTestApp.Program).Assembly />
+<Router AppAssembly=typeof(BasicTestApp.Program).Assembly FallbackRoute="/Error404" />


### PR DESCRIPTION
This is a migration of [Blazor pull request 1534](https://github.com/aspnet/Blazor/pull/1534). I have talked about it there and it has been reviewed. I simply applied the same changes to the refactored sources in this repo. Essentially, it enables simple error 404 handling that causes another (fallback) component to render if no components were found for a requested route. Please visit the aforementioned link for more details.