### PR TITLE
Re-enable IISIntegration tests

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/ApplicationPublisher.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/ApplicationPublisher.cs
@@ -43,6 +43,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 {
                     parameters += $" --runtime {GetRuntimeIdentifier(deploymentParameters)}";
                 }
+                else
+                {
+                    // Workaround for https://github.com/aspnet/websdk/issues/422
+                    parameters += " -p:UseAppHost=false";
+                }
 
                 parameters += $" {deploymentParameters.AdditionalPublishParameters}";
 

--- a/src/IISIntegration/build/repo.props
+++ b/src/IISIntegration/build/repo.props
@@ -14,7 +14,6 @@
     <ExcludeFromTest Include="$(RepositoryRoot)test\TestSites\*.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\IISTestSite\*.csproj" />
     <ExcludeSolutions Include="$(RepositoryRoot)IISIntegration.NoV1.sln" />
-    <ExcludeFromTest Include="$(RepositoryRoot)test\**\*.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipIISTests)' == 'true'" >

--- a/src/IISIntegration/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/IISIntegration/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             await StartAsync(deploymentParameters);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip="https://github.com/aspnet/AspNetCore/issues/3950")]
         [RequiresIIS(IISCapability.PoolEnvironmentVariables)]
         public async Task StartsWithPortableAndBootstraperExe()
         {


### PR DESCRIPTION
I'll keep https://github.com/aspnet/AspNetCore/issues/3950 open until we get new websdk and remove the workaround.