### PR TITLE
HubConnectionState Read Write Lock

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -469,7 +469,7 @@ public class HubConnection {
      * @param args   The arguments to be passed to the method.
      */
     public void send(String method, Object... args) {
-        if (hubConnectionState != HubConnectionState.CONNECTED) {
+        if (getConnectionState() != HubConnectionState.CONNECTED) {
             throw new RuntimeException("The 'send' method cannot be called if the connection is not active");
         }
 


### PR DESCRIPTION
Changing the locking around the hub connection state enum. 
Thanks to @ncthbrt for the issue filed. We recently changed our project structure to a few large repos which is why the PR in the aspnet/SignalR repo was left alone. 
Issue: https://github.com/aspnet/SignalR/issues/3329