### PR TITLE
Run Components on netcoreapp3.0

### DIFF
--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -8,7 +8,7 @@
     <PackageTags>aspnetcore;components</PackageTags>
 
     <!-- So we can use the tool from source within the repo without having to pack -->
-    <BlazorToolsDir>$(MSBuildThisFileDirectory)src\Microsoft.AspNetCore.Components.Build\bin\$(Configuration)\netcoreapp2.1\</BlazorToolsDir>
+    <BlazorToolsDir>$(MSBuildThisFileDirectory)src\Microsoft.AspNetCore.Components.Build\bin\$(Configuration)\netcoreapp3.0\</BlazorToolsDir>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -1,5 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreApp22PackageVersion)</RuntimeFrameworkVersion>
+    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 </Project>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -1,6 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/src/Components/NuGetPackageVerifier.json
+++ b/src/Components/NuGetPackageVerifier.json
@@ -134,10 +134,10 @@
       "Microsoft.AspNetCore.Blazor.Cli": {
         "Exclusions": {
           "SIGN_STRONGNAME": {
-            "lib/netcoreapp2.1/dotnet-blazor.dll": "See comments in Microsoft.AspNetCore.Blazor.Cli.csproj"
+            "lib/netcoreapp3.0/dotnet-blazor.dll": "See comments in Microsoft.AspNetCore.Blazor.Cli.csproj"
           },
           "WRONG_PUBLICKEYTOKEN": {
-            "lib/netcoreapp2.1/dotnet-blazor.dll": "See comments in Microsoft.AspNetCore.Blazor.Cli.csproj"
+            "lib/netcoreapp3.0/dotnet-blazor.dll": "See comments in Microsoft.AspNetCore.Blazor.Cli.csproj"
           }
         }
       },

--- a/src/Components/benchmarks/Microsoft.AspNetCore.Components.Performance/Microsoft.AspNetCore.Components.Performance.csproj
+++ b/src/Components/benchmarks/Microsoft.AspNetCore.Components.Performance/Microsoft.AspNetCore.Components.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Components/blazor/samples/HostedInAspNet.Server/HostedInAspNet.Server.csproj
+++ b/src/Components/blazor/samples/HostedInAspNet.Server/HostedInAspNet.Server.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/blazor/samples/HostedInAspNet.Server/HostedInAspNet.Server.csproj
+++ b/src/Components/blazor/samples/HostedInAspNet.Server/HostedInAspNet.Server.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 

--- a/src/Components/blazor/samples/MonoSanity/MonoSanity.csproj
+++ b/src/Components/blazor/samples/MonoSanity/MonoSanity.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 

--- a/src/Components/blazor/src/Microsoft.AspNetCore.Blazor.Cli/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/blazor/src/Microsoft.AspNetCore.Blazor.Cli/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>dotnet-blazor</AssemblyName>
     <PackageId>Microsoft.AspNetCore.Blazor.Cli</PackageId>

--- a/src/Components/blazor/tooling/Microsoft.VisualStudio.LanguageServices.Blazor/Microsoft.VisualStudio.LanguageServices.Blazor.csproj
+++ b/src/Components/blazor/tooling/Microsoft.VisualStudio.LanguageServices.Blazor/Microsoft.VisualStudio.LanguageServices.Blazor.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="$(RazorPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="15.6.27413" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor.Razor" Version="$(RazorPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor.Razor" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.6.27413" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="7.10.6071" />

--- a/src/Components/build/dependencies.props
+++ b/src/Components/build/dependencies.props
@@ -8,7 +8,7 @@
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181011.3</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-preview1-34576</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion>2.1.2</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-alpha1-10605</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreRazorDesignPackageVersion>3.0.0-alpha1-10605</MicrosoftAspNetCoreRazorDesignPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview1-26907-05</MicrosoftNETCoreAppPackageVersion>
     <SignalRPackageVersion>3.0.0-alpha1-10605</SignalRPackageVersion>

--- a/src/Components/build/dependencies.props
+++ b/src/Components/build/dependencies.props
@@ -4,19 +4,17 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions"><!-- Used only in development when running the template contents directly from source -->
-    <AspNetCorePackageVersion>2.1.0</AspNetCorePackageVersion>
-    <AspNetCoreRuntimeVersion>2.1.3</AspNetCoreRuntimeVersion>
+    <AspNetCorePackageVersion>3.0.0-alpha1-10605</AspNetCorePackageVersion>
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>3.0.0-build-20181120.4</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181011.3</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-preview1-34576</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>2.1.2</MicrosoftAspNetCoreAppPackageVersion>
-    <MicrosoftAspNetCoreRazorDesignPackageVersion>2.1.2</MicrosoftAspNetCoreRazorDesignPackageVersion>
-    <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
-    <SignalRPackageVersion>1.0.0</SignalRPackageVersion>
+    <MicrosoftAspNetCoreRazorDesignPackageVersion>3.0.0-alpha1-10605</MicrosoftAspNetCoreRazorDesignPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview1-26907-05</MicrosoftNETCoreAppPackageVersion>
+    <SignalRPackageVersion>3.0.0-alpha1-10605</SignalRPackageVersion>
     <TemplateBlazorPackageVersion>0.8.0-preview1-20181122.3</TemplateBlazorPackageVersion>
     <TemplateRazorDesignPackageVersion>2.1.2</TemplateRazorDesignPackageVersion>
-    <RazorPackageVersion>2.1.0</RazorPackageVersion>
+    <RazorPackageVersion>3.0.0-alpha1-10605</RazorPackageVersion>
     <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.8.0-preview1-20181126.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
 
     <!-- When updating this, ensure you also update Browser.JS/package.json to reference the corresponding version of @dotnet/jsinterop -->

--- a/src/Components/build/repo.props
+++ b/src/Components/build/repo.props
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
+    <DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/samples/ComponentsApp.Server/ComponentsApp.Server.csproj
+++ b/src/Components/samples/ComponentsApp.Server/ComponentsApp.Server.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+      <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCorePackageVersion)" />
       <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
     </ItemGroup>
 

--- a/src/Components/src/Microsoft.AspNetCore.Components.Browser.JS/Microsoft.AspNetCore.Components.Browser.JS.csproj
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Browser.JS/Microsoft.AspNetCore.Components.Browser.JS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Description>JavaScript runtime files needed for ASP.NET Core Components browser rendering.</Description>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>

--- a/src/Components/src/Microsoft.AspNetCore.Components.Build/Microsoft.AspNetCore.Components.Build.csproj
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Build/Microsoft.AspNetCore.Components.Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <Description>Build mechanism for ASP.NET Core Components.</Description>
     <OutputType>Exe</OutputType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Components/src/Microsoft.AspNetCore.Components.Build/Microsoft.AspNetCore.Components.Build.nuspec
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Build/Microsoft.AspNetCore.Components.Build.nuspec
@@ -20,10 +20,10 @@
   </metadata>
   <files>
     <file src="..\..\THIRD-PARTY-NOTICES.txt" />
-    <file src="$publishdir$netcoreapp2.1\Microsoft.AspNetCore.Components.TagHelperWorkaround.dll" target="lib/netstandard1.0/" />
+    <file src="$publishdir$netcoreapp3.0\Microsoft.AspNetCore.Components.TagHelperWorkaround.dll" target="lib/netstandard1.0/" />
     <file src="build\**" target="build" />
     <file src="targets\**" target="targets" />
-    <file src="$publishdir$netcoreapp2.1\**\*" target="tools/" />
+    <file src="$publishdir$netcoreapp3.0\**\*" target="tools/" />
     <file src="..\Microsoft.AspNetCore.Components.Browser.JS\dist\blazor.*.js" target="tools\blazor" />
   </files>
 </package>

--- a/src/Components/src/Microsoft.AspNetCore.Components.Server/Builder/BlazorApplicationBuilderExtensions.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Server/Builder/BlazorApplicationBuilderExtensions.cs
@@ -165,16 +165,23 @@ namespace Microsoft.AspNetCore.Builder
         private static IContentTypeProvider CreateContentTypeProvider(bool enableDebugging)
         {
             var result = new FileExtensionContentTypeProvider();
-            result.Mappings.Add(".dll", MediaTypeNames.Application.Octet);
-            result.Mappings.Add(".mem", MediaTypeNames.Application.Octet);
-            result.Mappings.Add(".wasm", WasmMediaTypeNames.Application.Wasm);
+            AddMapping(result, ".dll", MediaTypeNames.Application.Octet);
+            AddMapping(result, ".wasm", WasmMediaTypeNames.Application.Wasm);
 
             if (enableDebugging)
             {
-                result.Mappings.Add(".pdb", MediaTypeNames.Application.Octet);
+                AddMapping(result, ".pdb", MediaTypeNames.Application.Octet);
             }
 
             return result;
+        }
+
+        private static void AddMapping(FileExtensionContentTypeProvider provider, string name, string mimeType)
+        {
+            if (!provider.Mappings.ContainsKey(name))
+            {
+                provider.Mappings.Add(name, mimeType);
+            }
         }
     }
 }

--- a/src/Components/test/Microsoft.AspNetCore.Components.Analyzers.Test/Microsoft.AspNetCore.Components.Analyzers.Test.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Analyzers.Test/Microsoft.AspNetCore.Components.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Browser.Test/Microsoft.AspNetCore.Components.Browser.Test.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Browser.Test/Microsoft.AspNetCore.Components.Browser.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/Microsoft.AspNetCore.Components.Build.Test.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/Microsoft.AspNetCore.Components.Build.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
@@ -6,12 +6,12 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.AspNetCore.Components;
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 using System.Threading.Tasks;
 
 #line default
 #line hidden
-    using Microsoft.AspNetCore.Components;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 219

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [12] ) - System
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
-        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [36] ) - "*, Microsoft.AspNetCore.Components"

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |using System.Threading.Tasks|
-Generated Location: (222:9,0 [28] )
+Generated Location: (266:10,0 [28] )
 |using System.Threading.Tasks|
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -6,12 +6,12 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.AspNetCore.Components;
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 using System.Threading.Tasks;
 
 #line default
 #line hidden
-    using Microsoft.AspNetCore.Components;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 219

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [12] ) - System
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
-        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [36] ) - "*, Microsoft.AspNetCore.Components"

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |using System.Threading.Tasks|
-Generated Location: (222:9,0 [28] )
+Generated Location: (266:10,0 [28] )
 |using System.Threading.Tasks|
 
 Source Location: (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
@@ -6,12 +6,12 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.AspNetCore.Components;
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 using System.Threading.Tasks;
 
 #line default
 #line hidden
-    using Microsoft.AspNetCore.Components;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 219

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [12] ) - System
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
-        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [36] ) - "*, Microsoft.AspNetCore.Components"

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |using System.Threading.Tasks|
-Generated Location: (222:9,0 [28] )
+Generated Location: (266:10,0 [28] )
 |using System.Threading.Tasks|
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -6,12 +6,12 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.AspNetCore.Components;
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 using System.Threading.Tasks;
 
 #line default
 #line hidden
-    using Microsoft.AspNetCore.Components;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 219

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [12] ) - System
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
-        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [36] ) - "*, Microsoft.AspNetCore.Components"

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |using System.Threading.Tasks|
-Generated Location: (222:9,0 [28] )
+Generated Location: (266:10,0 [28] )
 |using System.Threading.Tasks|
 
 Source Location: (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -3,15 +3,15 @@
 namespace Test
 {
     #line hidden
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Components;
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 using System;
 
 #line default
 #line hidden
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Components;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 219

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -1,10 +1,10 @@
 Document - 
     NamespaceDeclaration -  - Test
-        UsingDirective - (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml) - System
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
         UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml) - System
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [36] ) - "*, Microsoft.AspNetCore.Components"

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/DesignTimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |using System|
-Generated Location: (140:6,0 [12] )
+Generated Location: (282:10,0 [12] )
 |using System|
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
@@ -6,8 +6,8 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using System.Threading.Tasks;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 1998

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [14] ) - System
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
-        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -6,8 +6,8 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using System.Threading.Tasks;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 1998

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [14] ) - System
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
-        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
@@ -6,8 +6,8 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using System.Threading.Tasks;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 1998

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [14] ) - System
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
-        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -6,8 +6,8 @@ namespace Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using System.Threading.Tasks;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 1998

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -3,8 +3,8 @@ Document -
         UsingDirective - (3:1,1 [14] ) - System
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
-        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -3,11 +3,11 @@
 namespace Test
 {
     #line hidden
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using System;
     public class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
         #pragma warning disable 1998

--- a/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -1,10 +1,10 @@
 Document - 
     NamespaceDeclaration -  - Test
-        UsingDirective - (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml) - System
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        UsingDirective - (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml) - System
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/src/Components/test/Microsoft.AspNetCore.Components.E2ETest/Microsoft.AspNetCore.Components.E2ETest.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.E2ETest/Microsoft.AspNetCore.Components.E2ETest.csproj
@@ -1,24 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Requires 2.1 because of the dependency on applications -->
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- WebDriver is not strong-named signed -->
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- 
-      Lots of specific versions used here because:
-      1. We want to require 2.1.0 in our libraries
-      2. We have a special requirement for Razor.Design at 2.1.2 - this is OK because it's non-transitive
-      3. We want to test against 2.1.3 in our applications
-
-    -->
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCorePackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Selenium.Support" Version="3.12.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.12.0" />

--- a/src/Components/test/Microsoft.AspNetCore.Components.Razor.Extensions.Test/Microsoft.AspNetCore.Components.Razor.Extensions.Test.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Razor.Extensions.Test/Microsoft.AspNetCore.Components.Razor.Extensions.Test.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <!-- 
+    <!--
       Retains compilation settings so we can create a compilation during tests with the same data
       used to compile this assembly.
     -->

--- a/src/Components/test/Microsoft.AspNetCore.Components.Server.Test/Microsoft.AspNetCore.Components.Server.Test.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Server.Test/Microsoft.AspNetCore.Components.Server.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Test/Microsoft.AspNetCore.Components.Test.csproj
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Test/Microsoft.AspNetCore.Components.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-  
+
     <!-- Shared sources -->
     <Compile Include="..\shared\**\*.cs" Link="Helpers\%(Filename)%(Extension)" />
   </ItemGroup>

--- a/src/Components/test/testapps/TestServer/TestServer.csproj
+++ b/src/Components/test/testapps/TestServer/TestServer.csproj
@@ -1,11 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Before I can finish off the Razor Components template and have working tests for it, I need the Components packages to support running on `netcoreapp3.0`. This does that.

This PR does *not* update the Components packages to depend on 3.0 versions of the ASP.NET Core packages. It just means you *can* use the Components packages with 3.0 versions of the ASP.NET Core packages. Updating the package references so it uses the version currently being built in the repo is a future task.