### PR TITLE
Set moreData to false when response doesn't have a response body.

### DIFF
--- a/src/IISIntegration/IISIntegration.NoV1.sln
+++ b/src/IISIntegration/IISIntegration.NoV1.sln
@@ -38,7 +38,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{7E80C58E
 		build\applicationhost.iis.config = build\applicationhost.iis.config
 		build\Build.Settings = build\Build.Settings
 		build\Config.Definitions.Props = build\Config.Definitions.Props
-		build\dependencies.props = build\dependencies.props
 		build\functional-test-assets.targets = build\functional-test-assets.targets
 		build\Key.snk = build\Key.snk
 		build\launchSettings.json = build\launchSettings.json
@@ -116,7 +115,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IIS.BackwardsCompatibility.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IIS.ForwardsCompatibility.FunctionalTests", "test\IIS.ForwardsCompatibility.FunctionalTests\IIS.ForwardsCompatibility.FunctionalTests.csproj", "{D1EA5D99-28FD-4197-81DE-17098846B38B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InProcessForwardsCompatWebSite", "test\WebSites\InProcessForwardsCompatWebSite\InProcessWebSite.csproj", "{BBBC85B2-5D7A-4D09-90B1-8DBCC9059493}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InProcessWebSite", "test\WebSites\InProcessForwardsCompatWebSite\InProcessWebSite.csproj", "{BBBC85B2-5D7A-4D09-90B1-8DBCC9059493}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/IISIntegration/src/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
+++ b/src/IISIntegration/src/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
@@ -288,13 +288,13 @@ EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
 HRESULT
 http_flush_response_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
+    _In_ BOOL fMoreData,
     _Out_ BOOL* pfCompletionExpected
 )
 {
     IHttpResponse *pHttpResponse = (IHttpResponse*)pInProcessHandler->QueryHttpContext()->GetResponse();
 
     BOOL fAsync = TRUE;
-    BOOL fMoreData = TRUE;
     DWORD dwBytesSent = 0;
 
     HRESULT hr = pHttpResponse->Flush(

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.IO.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.IO.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
                         if (flush)
                         {
-                            await AsyncIO.FlushAsync();
+                            await AsyncIO.FlushAsync(moreData: true);
                             flush = false;
                         }
                     }

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
@@ -271,7 +271,6 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         private bool StatusCodeCanHaveBody()
         {
             return StatusCode != 204
-                && StatusCode != 205
                 && StatusCode != 304;
         }
 

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
@@ -243,7 +243,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             SetResponseHeaders();
 
             EnsureIOInitialized();
-            var canHaveNonEmptyBody = ResponseCanHaveBody();
+            var canHaveNonEmptyBody = StatusCodeCanHaveBody();
             if (flushHeaders)
             {
                 try
@@ -268,12 +268,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             }
         }
 
-        private bool ResponseCanHaveBody()
+        private bool StatusCodeCanHaveBody()
         {
             return StatusCode != 204
                 && StatusCode != 205
-                && StatusCode != 304
-                && Method.Equals("HEAD", StringComparison.InvariantCultureIgnoreCase);
+                && StatusCode != 304;
         }
 
         private void InitializeRequestIO()

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
@@ -243,12 +243,12 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             SetResponseHeaders();
 
             EnsureIOInitialized();
-
+            var canHaveNonEmptyBody = ResponseCanHaveBody();
             if (flushHeaders)
             {
                 try
                 {
-                    await AsyncIO.FlushAsync();
+                    await AsyncIO.FlushAsync(canHaveNonEmptyBody);
                 }
                 // Client might be disconnected at this point
                 // don't leak the exception
@@ -258,7 +258,22 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 }
             }
 
-            _writeBodyTask = WriteBody(!flushHeaders);
+            if (!canHaveNonEmptyBody)
+            {
+                _bodyOutput.Dispose();
+            }
+            else
+            {
+                _writeBodyTask = WriteBody(!flushHeaders);
+            }
+        }
+
+        private bool ResponseCanHaveBody()
+        {
+            return StatusCode != 204
+                && StatusCode != 205
+                && StatusCode != 304
+                && Method.Equals("HEAD", StringComparison.InvariantCultureIgnoreCase);
         }
 
         private void InitializeRequestIO()

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/AsyncIOEngine.Flush.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/AsyncIOEngine.Flush.cs
@@ -12,21 +12,23 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
             private readonly AsyncIOEngine _engine;
 
             private IntPtr _requestHandler;
+            private bool _moreData;
 
             public AsyncFlushOperation(AsyncIOEngine engine)
             {
                 _engine = engine;
             }
 
-            public void Initialize(IntPtr requestHandler)
+            public void Initialize(IntPtr requestHandler, bool moreData)
             {
                 _requestHandler = requestHandler;
+                _moreData = moreData;
             }
 
             protected override bool InvokeOperation(out int hr, out int bytes)
             {
                 bytes = 0;
-                hr = NativeMethods.HttpFlushResponseBytes(_requestHandler, out var fCompletionExpected);
+                hr = NativeMethods.HttpFlushResponseBytes(_requestHandler, _moreData, out var fCompletionExpected);
 
                 return !fCompletionExpected;
             }
@@ -36,6 +38,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
                 base.ResetOperation();
 
                 _requestHandler = default;
+                _moreData = false;
                 _engine.ReturnOperation(this);
             }
         }

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/AsyncIOEngine.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/AsyncIOEngine.cs
@@ -90,10 +90,10 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
         }
 
 
-        public ValueTask FlushAsync()
+        public ValueTask FlushAsync(bool moreData)
         {
             var flush = GetFlushOperation();
-            flush.Initialize(_handler);
+            flush.Initialize(_handler, moreData);
             Run(flush);
             return new ValueTask(flush, 0);
         }

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/IAsyncIOEngine.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/IAsyncIOEngine.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
     {
         ValueTask<int> ReadAsync(Memory<byte> memory);
         ValueTask<int> WriteAsync(ReadOnlySequence<byte> data);
-        ValueTask FlushAsync();
+        ValueTask FlushAsync(bool moreData);
         void NotifyCompletion(int hr, int bytes);
     }
 }

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/WebSocketsAsyncIOEngine.Initialize.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/WebSocketsAsyncIOEngine.Initialize.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
             protected override bool InvokeOperation(out int hr, out int bytes)
             {
-                hr = NativeMethods.HttpFlushResponseBytes(_requestHandler, out var completionExpected);
+                hr = NativeMethods.HttpFlushResponseBytes(_requestHandler, true, out var completionExpected);
                 bytes = 0;
                 return !completionExpected;
             }

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/WebSocketsAsyncIOEngine.Initialize.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/WebSocketsAsyncIOEngine.Initialize.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
             protected override bool InvokeOperation(out int hr, out int bytes)
             {
-                hr = NativeMethods.HttpFlushResponseBytes(_requestHandler, true, out var completionExpected);
+                hr = NativeMethods.HttpFlushResponseBytes(_requestHandler, fMoreData: true, out var completionExpected);
                 bytes = 0;
                 return !completionExpected;
             }

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/WebSocketsAsyncIOEngine.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/Core/IO/WebSocketsAsyncIOEngine.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
             }
         }
 
-        public ValueTask FlushAsync()
+        public ValueTask FlushAsync(bool moreData)
         {
             lock (_contextLock)
             {

--- a/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/NativeMethods.cs
+++ b/src/IISIntegration/src/Microsoft.AspNetCore.Server.IIS/NativeMethods.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Server.IIS
         private static extern unsafe int http_write_response_bytes(IntPtr pInProcessHandler, HttpApiTypes.HTTP_DATA_CHUNK* pDataChunks, int nChunks, out bool fCompletionExpected);
 
         [DllImport(AspNetCoreModuleDll)]
-        private static extern int http_flush_response_bytes(IntPtr pInProcessHandler, out bool fCompletionExpected);
+        private static extern int http_flush_response_bytes(IntPtr pInProcessHandler, bool fMoreData, out bool fCompletionExpected);
 
         [DllImport(AspNetCoreModuleDll)]
         private static extern unsafe HttpApiTypes.HTTP_REQUEST_V2* http_get_raw_request(IntPtr pInProcessHandler);
@@ -171,9 +171,9 @@ namespace Microsoft.AspNetCore.Server.IIS
             return http_write_response_bytes(pInProcessHandler, pDataChunks, nChunks, out fCompletionExpected);
         }
 
-        public static int HttpFlushResponseBytes(IntPtr pInProcessHandler, out bool fCompletionExpected)
+        public static int HttpFlushResponseBytes(IntPtr pInProcessHandler, bool fMoreData, out bool fCompletionExpected)
         {
-            return http_flush_response_bytes(pInProcessHandler, out fCompletionExpected);
+            return http_flush_response_bytes(pInProcessHandler, fMoreData, out fCompletionExpected);
         }
 
         public static unsafe HttpApiTypes.HTTP_REQUEST_V2* HttpGetRawRequest(IntPtr pInProcessHandler)

--- a/src/IISIntegration/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
+++ b/src/IISIntegration/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Net.Http.Headers;
@@ -73,6 +75,22 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
             // ReadAsStringAsync returns empty string for empty results
             Assert.Equal(body ?? string.Empty, await response.Content.ReadAsStringAsync());
+        }
+
+        [ConditionalTheory]
+        [InlineData(204, "GET")]
+        [InlineData(205, "GET")]
+        [InlineData(304, "GET")]
+        [InlineData(200, "HEAD")]
+        [InlineData(204, "HEAD")]
+        [InlineData(205, "HEAD")]
+        [InlineData(304, "HEAD")]
+        public async Task ResponseCode(int code, string method)
+        {
+            var request = new HttpRequestMessage(new HttpMethod(method), _fixture.Client.BaseAddress + $"SetCustomErorCode?code={code}");
+            var response = await _fixture.Client.SendAsync(request);
+            Assert.Equal((HttpStatusCode)code, response.StatusCode);
+            Assert.DoesNotContain(response.Headers, h => h.Key.Equals("transfer-encoding", StringComparison.InvariantCultureIgnoreCase));
         }
 
         [ConditionalFact]

--- a/src/IISIntegration/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
+++ b/src/IISIntegration/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
@@ -78,10 +78,10 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalTheory]
+        [RequiresNewHandler]
         [InlineData(204, "GET")]
-        [InlineData(205, "GET")]
         [InlineData(304, "GET")]
-        public async Task ResponseCode(int code, string method)
+        public async Task TransferEncodingNotSetForStatusCodes(int code, string method)
         {
             var request = new HttpRequestMessage(new HttpMethod(method), _fixture.Client.BaseAddress + $"SetCustomErorCode?code={code}");
             var response = await _fixture.Client.SendAsync(request);

--- a/src/IISIntegration/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
+++ b/src/IISIntegration/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
@@ -81,10 +81,6 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         [InlineData(204, "GET")]
         [InlineData(205, "GET")]
         [InlineData(304, "GET")]
-        [InlineData(200, "HEAD")]
-        [InlineData(204, "HEAD")]
-        [InlineData(205, "HEAD")]
-        [InlineData(304, "HEAD")]
         public async Task ResponseCode(int code, string method)
         {
             var request = new HttpRequestMessage(new HttpMethod(method), _fixture.Client.BaseAddress + $"SetCustomErorCode?code={code}");


### PR DESCRIPTION
For https://github.com/aspnet/EntityFrameworkCore/issues/14015

@muratg @Eilon @DamianEdwards for patch consideration.

### Description:
Today, when and HTTP/2 request is sent to ANCM Inprocess, on a 204 response, IIS will add the header "transfer-encoding"="chunked". This is an invalid response and HTTP.Sys aborts the response with HTTP_1_1_REQUIRED. Web browsers like chrome explicitly show the error HTTP_1_1_REQUIRED when returning a 204. Other browser still have the issue, but they retry a HTTP/1.1 request afterwards. 

This means that all HTTP responses which:
- Set a status code of 204
- Use HTTPS
- Support HTTP/2

will explicitly fail in chrome and silently fail/retry in other browsers.

### Customer Impact

If customers want to use the 204 response code, they will have to add a middleware to set ContentLength=0 on responses with status code 204. 

For example:
```c#
app.Use(async (ctx, next) =>
{
  await next();
  if (ctx.Response.StatusCode == 204)
  {
    ctx.Response.ContentLength = 0;
  }
});
```

### Regression?

Regression from all of our server behavior (Kestrel, ANCM + Kestrel).

### Risk:
Low. The change only affects 204, 205, and 304 status code responses, which aren't allowed to have a body anyways. This change only sets a bool to false on flush, which is checked when IIS is determining if it should set the encoding to chunked or not.
