### PR TITLE
Check HubConnection state before running invoke logic

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -31,6 +31,7 @@ Later on, this will be checked using this condition:
       Microsoft.AspNetCore.Authentication.Google;
       Microsoft.AspNetCore.Http;
       Microsoft.AspNetCore.Server.IIS;
+      java:signalr;
     </PackagesInPatch>
   </PropertyGroup>
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -454,7 +454,7 @@ public class HubConnection {
      */
     public void send(String method, Object... args) {
         if (hubConnectionState != HubConnectionState.CONNECTED) {
-            throw new RuntimeException("The 'send' method cannot be called if the connection is not active");
+            throw new RuntimeException("The 'send' method cannot be called if the connection is not active.");
         }
 
         InvocationMessage invocationMessage = new InvocationMessage(null, method, args);
@@ -473,7 +473,7 @@ public class HubConnection {
     @SuppressWarnings("unchecked")
     public <T> Single<T> invoke(Class<T> returnType, String method, Object... args) {
         if (hubConnectionState != HubConnectionState.CONNECTED) {
-            throw new RuntimeException("The 'invoke' method cannot be called if the connection is not active");
+            throw new RuntimeException("The 'invoke' method cannot be called if the connection is not active.");
         }
 
         String id = connectionState.getNextInvocationId();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -472,6 +472,10 @@ public class HubConnection {
      */
     @SuppressWarnings("unchecked")
     public <T> Single<T> invoke(Class<T> returnType, String method, Object... args) {
+        if (hubConnectionState != HubConnectionState.CONNECTED) {
+            throw new RuntimeException("The 'invoke' method cannot be called if the connection is not active");
+        }
+
         String id = connectionState.getNextInvocationId();
         InvocationMessage invocationMessage = new InvocationMessage(id, method, args);
 

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -900,7 +900,7 @@ class HubConnectionTest {
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
 
         Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.send("inc"));
-        assertEquals("The 'send' method cannot be called if the connection is not active", exception.getMessage());
+        assertEquals("The 'send' method cannot be called if the connection is not active.", exception.getMessage());
     }
 
     @Test
@@ -909,7 +909,7 @@ class HubConnectionTest {
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
 
         Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.invoke(String.class, "inc", "arg1"));
-        assertEquals("The 'invoke' method cannot be called if the connection is not active", exception.getMessage());
+        assertEquals("The 'invoke' method cannot be called if the connection is not active.", exception.getMessage());
     }
 
     @Test

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -904,6 +904,15 @@ class HubConnectionTest {
     }
 
     @Test
+    public void cannotInvokeBeforeStart()  {
+        HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+        Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.invoke(String.class, "inc", "arg1"));
+        assertEquals("The 'invoke' method cannot be called if the connection is not active", exception.getMessage());
+    }
+
+    @Test
     public void doesNotErrorWhenReceivingInvokeWithIncorrectArgumentLength()  {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);


### PR DESCRIPTION
Before calling methods that require the HubConnection to be connected we run a simple connection state check like 
https://github.com/aspnet/AspNetCore/blob/e310ccac7b30e901f657f81c86c4048fecfedf7b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java#L464-L466

Addresses #4393


### Description

Before being able to send invocations from a SignalR hub, it's important that we ensure that the current HubConnection is active and in the connected state. If the HubConnection isn't connected we should fail immediately without attmepting to send any invocations. Otherwise we could run into a case where users can write the connected
```java
HubConnection hubConnection = new HubConnectionBuilder.create("Some hub url");
// There should be an awaited call to start before invoke.
hubConnection.invoke(String.class, "hubMethod", "arg")
```

### Customer Impact

With this change, when a customer tries to invoke a hub method when their client is not connected, they will get a helpful error message letting them know that they are in the disconnected state.

### Regression
N/A

### Risk
Low. This is purely a defensive change. We woul be adding a check to the HubConnection state before continuing to the rest of the invoke logic to ensure that we fail fast with a helpful error message. This also has an associate test. 
