### PR TITLE
Update repo links for SignalR TS client in package.json after move

### DIFF
--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -23,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aspnet/SignalR.git"
+    "url": "git+https://github.com/aspnet/AspNetCore.git"
   },
   "author": "Microsoft",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/aspnet/SignalR/issues"
+    "url": "https://github.com/aspnet/AspNetCore/issues"
   },
-  "homepage": "https://github.com/aspnet/SignalR#readme",
+  "homepage": "https://github.com/aspnet/AspNetCore#readme",
   "files": [
     "dist/**/*",
     "src/**/*"

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/aspnet/AspNetCore/issues"
   },
-  "homepage": "https://github.com/aspnet/AspNetCore#readme",
+  "homepage": "https://github.com/aspnet/AspNetCore/tree/master/src/SignalR#readme",
   "files": [
     "dist/**/*",
     "src/**/*"


### PR DESCRIPTION
The SignalR TS client sources were moved to aspnet/AspNetCore, however this change hasn’t been reflected in `package.json` that is used for showing the readme and repository links on npmjs.com.