### PR TITLE
Change candidate resolution logic to allow assemblies depending on shared framework.

### DIFF
--- a/src/Mvc/benchmarkapps/BasicApi/BasicApi.csproj
+++ b/src/Mvc/benchmarkapps/BasicApi/BasicApi.csproj
@@ -22,7 +22,6 @@
   <ItemGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(MicrosoftExtensionsConfigurationCommandLinePackageVersion)" />

--- a/src/Mvc/benchmarkapps/BasicViews/BasicViews.csproj
+++ b/src/Mvc/benchmarkapps/BasicViews/BasicViews.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="$(MicrosoftAspNetCoreServerIISIntegrationPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(MicrosoftExtensionsConfigurationCommandLinePackageVersion)" />

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc/Microsoft.AspNetCore.Mvc.csproj
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc/Microsoft.AspNetCore.Mvc.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Analyzers\Microsoft.AspNetCore.Mvc.Analyzers.csproj" PrivateAssets="None" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.ApiExplorer\Microsoft.AspNetCore.Mvc.ApiExplorer.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Cors\Microsoft.AspNetCore.Mvc.Cors.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.DataAnnotations\Microsoft.AspNetCore.Mvc.DataAnnotations.csproj" />

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
@@ -473,23 +473,6 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
-        public async Task ApplicationAssemblyPartIsListedAsFirstAssembly()
-        {
-            // Act
-            var response = await Client.GetStringAsync("Home/GetAssemblyPartData");
-            var assemblyParts = JsonConvert.DeserializeObject<IList<string>>(response);
-            var expected = new[]
-            {
-                "BasicWebSite",
-                "Microsoft.AspNetCore.Mvc.TagHelpers",
-                "Microsoft.AspNetCore.Mvc.Razor",
-            };
-
-            // Assert
-            Assert.Equal(expected, assemblyParts);
-        }
-
-        [Fact]
         public async Task ViewDataProperties_AreTransferredToViews()
         {
             // Act

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Test/ApplicationParts/ApplicationAssembliesProviderTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Test/ApplicationParts/ApplicationAssembliesProviderTest.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
             // Arrange
             var excludeAssemblies = new string[]
             {
-                "Microsoft.AspNetCore.Mvc.Analyzers",
                 "Microsoft.AspNetCore.Mvc.Test",
                 "Microsoft.AspNetCore.Mvc.Core.TestCommon",
             };

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -122,18 +122,5 @@ namespace BasicWebSite.Controllers
         {
             return RedirectToAction();
         }
-
-        [HttpGet]
-        public IActionResult GetAssemblyPartData([FromServices] ApplicationPartManager applicationPartManager)
-        {
-            // Ensures that the entry assembly part is marked correctly.
-            var assemblyPartMetadata = applicationPartManager
-                .ApplicationParts
-                .OfType<AssemblyPart>()
-                .Select(part => part.Name)
-                .ToArray();
-
-            return Ok(assemblyPartMetadata);
-        }
     }
 }


### PR DESCRIPTION
- This is required due to how AspNet Core is included via a framework reference now. In order to properly evaluate transitive projects that target AspNet Core 3.0 we'd need some level of information that they targeted a framework reference. This happens to be a missing feature in the sdk/nuget. Also, given that all of ASP.NET is now included via a framework reference the act of finding candidate assemblies to reduce the amount of assembly loads doesn't matter as much since we went from 100s of potential assemblies to only what the application currently targets.
- Fixed a test issue where calling into BasicApi tests resulted in the attempted loading of EFCore.Design. Problem is EFCore.Design wasn't a dependency of our functional test project because of PrivateAssets="true" and therefore, when we tried to find candidate assemblies we read in the BasicApiTest.deps.json but operated on the functional tests.deps.json. I could have added the EFCore.Design package to the functional test project to fix this but given that the package wasn't being used choose to remove it instead.
- Removed Mvc.Analyzers from AspNetCore.Mvc because it's no longer brought in via the shared framework. This was needed because with the new approach with always loading all dll's in an applications graph we'd attempt to load Mvc.Analyzers at which point we'd explode saying we couldn't load Roslyn (it's not available at runtime anymore).
- Updated tests to reflect new expectations in regards to application part type loading.

Addresses #4332