### PR TITLE
Change consumes behavior to ignore requests with no content type

### DIFF
--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/ConsumesAttribute.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/ConsumesAttribute.cs
@@ -76,7 +76,10 @@ namespace Microsoft.AspNetCore.Mvc
 
                 // Confirm the request's content type is more specific than a media type this action supports e.g. OK
                 // if client sent "text/plain" data and this action supports "text/*".
-                if (requestContentType == null || !IsSubsetOfAnyContentType(requestContentType))
+                //
+                // Requests without a content type do not return a 415. It is a common pattern to place [Consumes] on
+                // a controller and have GET actions
+                if (requestContentType != null && !IsSubsetOfAnyContentType(requestContentType))
                 {
                     context.Result = new UnsupportedMediaTypeResult();
                 }

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/ConsumesAttributeTests.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/ConsumesAttributeTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void OnResourceExecuting_NullOrEmptyRequestContentType_SetsUnsupportedMediaTypeResult(string contentType)
+        public void OnResourceExecuting_NullOrEmptyRequestContentType_IsNoOp(string contentType)
         {
             // Arrange
             var httpContext = new DefaultHttpContext();
@@ -348,8 +348,7 @@ namespace Microsoft.AspNetCore.Mvc
             consumesFilter.OnResourceExecuting(resourceExecutingContext);
 
             // Assert
-            Assert.NotNull(resourceExecutingContext.Result);
-            Assert.IsType<UnsupportedMediaTypeResult>(resourceExecutingContext.Result);
+            Assert.Null(resourceExecutingContext.Result);
         }
 
         [Theory]

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/ConsumesMatcherPolicyTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/ConsumesMatcherPolicyTest.cs
@@ -92,6 +92,11 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 edges.OrderBy(e => e.State),
                 e =>
                 {
+                    Assert.Equal(string.Empty, e.State);
+                    Assert.Equal(new[] { endpoints[1], endpoints[4], }, e.Endpoints.ToArray());
+                },
+                e =>
+                {
                     Assert.Equal("*/*", e.State);
                     Assert.Equal(new[] { endpoints[1], endpoints[4], }, e.Endpoints.ToArray());
                 },
@@ -123,7 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         }
 
         [Fact] // See explanation in GetEdges for how this case is different
-        public void GetEdges_GroupsByContentType_CreatesHttp405Endpoint()
+        public void GetEdges_GroupsByContentType_CreatesHttp415Endpoint()
         {
             // Arrange
             var endpoints = new[]
@@ -143,6 +148,11 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             // Assert
             Assert.Collection(
                 edges.OrderBy(e => e.State),
+                e =>
+                {
+                    Assert.Equal(string.Empty, e.State);
+                    Assert.Equal(new[] { endpoints[0], endpoints[1], endpoints[2], }, e.Endpoints.ToArray());
+                },
                 e =>
                 {
                     Assert.Equal("*/*", e.State);
@@ -190,6 +200,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             var edges = new PolicyJumpTableEdge[]
             {
                 // In reverse order of how they should be processed
+                new PolicyJumpTableEdge(string.Empty, 0),
                 new PolicyJumpTableEdge("*/*", 1),
                 new PolicyJumpTableEdge("application/*", 2),
                 new PolicyJumpTableEdge("text/*", 3),

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ConsumesAttributeTestsBase.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ConsumesAttributeTestsBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Arrange
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                "http://localhost/ConsumesAttribute_Company/CreateProduct");
+                "http://localhost/ConsumesAttribute_WithFallbackActionController/CreateProduct");
 
             // Act
             var response = await Client.SendAsync(request);
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
-        public async Task NoRequestContentType_Selects_IfASingleActionWithConstraintIsPresent_ReturnsUnsupported()
+        public async Task NoRequestContentType_Selects_IfASingleActionWithConstraintIsPresent()
         {
             // Arrange
             var request = new HttpRequestMessage(
@@ -58,7 +58,32 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Act
             var response = await Client.SendAsync(request);
-            await response.AssertStatusCodeAsync(HttpStatusCode.UnsupportedMediaType);
+            var body = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("ConsumesAttribute_PassThrough_Product_Json", body);
+        }
+
+        [Fact]
+        public async Task NoRequestContentType_MultipleMatches_IfAMultipleActionWithConstraintIsPresent()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                "http://localhost/ConsumesAttribute_PassThrough/CreateProductMultiple");
+
+            // Act
+            try
+            {
+                var response = await Client.SendAsync(request);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            }
+            catch
+            {
+            }
         }
 
         [Theory]

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ConsumesAttributeTestsBase.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ConsumesAttributeTestsBase.cs
@@ -74,16 +74,10 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 "http://localhost/ConsumesAttribute_PassThrough/CreateProductMultiple");
 
             // Act
-            try
-            {
-                var response = await Client.SendAsync(request);
+            var response = await Client.SendAsync(request);
 
-                // Assert
-                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-            }
-            catch
-            {
-            }
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         }
 
         [Theory]

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/ActionConstraints/ConsumesAttribute_PassThroughController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/ActionConstraints/ConsumesAttribute_PassThroughController.cs
@@ -14,5 +14,17 @@ namespace BasicWebSite.Controllers.ActionConstraints
         {
             return Content("ConsumesAttribute_PassThrough_Product_Json");
         }
+
+        [Consumes("application/json")]
+        public IActionResult CreateProductMultiple(Product_Json jsonInput)
+        {
+            return Content("ConsumesAttribute_PassThrough_Product_Json");
+        }
+
+        [Consumes("application/xml")]
+        public IActionResult CreateProductMultiple(Product_Xml jsonInput)
+        {
+            return Content("ConsumesAttribute_PassThrough_Product_Xml");
+        }
     }
 }

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/ActionConstraints/ConsumesAttribute_WithFallbackActionController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/ActionConstraints/ConsumesAttribute_WithFallbackActionController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace BasicWebSite.Controllers.ActionConstraints
 {
-    [Route("ConsumesAttribute_Company/[action]")]
+    [Route("ConsumesAttribute_WithFallbackActionController/[action]")]
     public class ConsumesAttribute_WithFallbackActionController : Controller
     {
         [Consumes("application/json")]

--- a/src/Mvc/test/WebSites/BasicWebSite/StartupWithEndpointRouting.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/StartupWithEndpointRouting.cs
@@ -29,6 +29,8 @@ namespace BasicWebSite
 
         public void Configure(IApplicationBuilder app)
         {
+            app.UseDeveloperExceptionPage();
+
             // Initializes the RequestId service for each request
             app.UseMiddleware<RequestIdMiddleware>();
 


### PR DESCRIPTION
Change consumes behavior to ignore requests with no content type
 - Consumes action constraint ignores empty content type
 - ConsumesMatcherPolicy ignores empty content type

Reverts https://github.com/aspnet/Mvc/issues/8174

Addresses #4396
