### PR TITLE
Create temporary PR validation which just compiles, without tests

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -1,4 +1,4 @@
-# Don't run CI for this config
+# Don't run CI for this config yet. We're not ready to move official builds on to Azure Pipelines
 trigger: none
 
 # Run PR validation on all branches
@@ -10,14 +10,8 @@ pr:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    jobName: PR_FastCheck
-    jobDisplayName: Fast Check
-    agentOs: Windows
-    buildArgs: "/t:FastCheck"
-- template: jobs/default-build.yml
-  parameters:
     jobName: Windows_Build
-    jobDisplayName: "Build: Windows"
+    jobDisplayName: "Build and test: Windows"
     agentOs: Windows
     beforeBuild:
     - powershell: "& ./src/IISIntegration/tools/UpdateIISExpressCertificate.ps1; & ./src/IISIntegration/tools/update_schema.ps1"

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -103,6 +103,9 @@ jobs:
   steps:
   - checkout: self
     clean: true
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 10.x
   - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:
     - task: MicroBuildSigningPlugin@1
       displayName: Install MicroBuild Signing plugin

--- a/.azure/pipelines/pr-validation-temp.yml
+++ b/.azure/pipelines/pr-validation-temp.yml
@@ -1,0 +1,30 @@
+# This configuration is temporary while we work on getting all unit tests to pass on PR checks
+
+# Don't run CI for this config
+trigger: none
+
+# Run PR validation on all branches
+pr:
+  branches:
+    include:
+    - '*'
+
+jobs:
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Windows_Build
+    jobDisplayName: "Build only : Windows"
+    agentOs: Windows
+    buildArgs: '/p:SkipTests=true'
+- template: jobs/default-build.yml
+  parameters:
+    jobName: macOs_Build
+    jobDisplayName: "Build only : macOS"
+    agentOs: macOS
+    buildArgs: '/p:SkipTests=true'
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Linux_Build
+    jobDisplayName: "Build only : Linux"
+    agentOs: Linux
+    buildArgs: '/p:SkipTests=true'


### PR DESCRIPTION
Tests on PR validation consistently fail (#4067). It's taking much longer than anticipated to get new agents to resolve this, and it has become difficult for our devs to figure out if their work is correct or not. This splits test and build into separate PR checks, so at the very least, we can be sure our code builds.