### PR TITLE
Allow post and basic client authentication mode for OIDC

### DIFF
--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/BasicAuthentication.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/BasicAuthentication.cs
@@ -1,0 +1,46 @@
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    /// <summary>
+    /// Use basic authorization header
+    /// </summary>
+    public class BasicAuthentication : IClientAuthentication
+    {
+        private readonly bool withEscaping;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="withEscaping">allow to do EscapeData on the clientId and clientSecret</param>
+        public BasicAuthentication(bool withEscaping = true)
+        {
+            this.withEscaping = withEscaping;
+        }
+
+        public HttpRequestMessage SetClientAuthentication(HttpRequestMessage message, OpenIdConnectMessage tokenEndpointRequest)
+        {
+            var idAndSecret = withEscaping ? GetUtf8EscapedIdAndSecret(tokenEndpointRequest) : GetIdAndSecret(tokenEndpointRequest);
+            var basicHeader = Convert.ToBase64String(
+                   Encoding.UTF8.GetBytes(idAndSecret));
+            message.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicHeader);
+            tokenEndpointRequest.ClientId = null;
+            tokenEndpointRequest.ClientSecret = null;
+            return message;
+        }
+
+        private string GetUtf8EscapedIdAndSecret(OpenIdConnectMessage tokenEndpointRequest)
+        {
+            return $"{Uri.EscapeDataString(tokenEndpointRequest.ClientId.ToUTF8())}:{Uri.EscapeDataString(tokenEndpointRequest.ClientSecret.ToUTF8())}";
+        }
+
+        private string GetIdAndSecret(OpenIdConnectMessage tokenEndpointRequest)
+        {
+            return $"{tokenEndpointRequest.ClientId}:{tokenEndpointRequest.ClientSecret}";
+        }
+    }
+}

--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/EncodingHelper.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/EncodingHelper.cs
@@ -1,0 +1,13 @@
+using System.Text;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    internal static class EncodingHelper
+    {
+        internal static string ToUTF8(this string text)
+        {
+            var bytes = Encoding.Default.GetBytes(text);
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/FormPost.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/FormPost.cs
@@ -1,0 +1,16 @@
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Net.Http;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    /// <summary>
+    /// Send client id and client secret in the request body 
+    /// </summary>
+    public class FormPost : IClientAuthentication
+    {
+        public HttpRequestMessage SetClientAuthentication(HttpRequestMessage message, OpenIdConnectMessage tokenEndpointRequest)
+        {
+            return message;
+        }
+    }
+}

--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/IClientAuthentication.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/IClientAuthentication.cs
@@ -1,0 +1,19 @@
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Net.Http;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    /// <summary>
+    /// Configure the client authentication mode to call access_token endpoint
+    /// </summary>
+    public interface IClientAuthentication
+    {
+        /// <summary>
+        /// Adapt the request for the client authentication
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="tokenEndpointRequest"></param>
+        /// <returns></returns>
+        HttpRequestMessage SetClientAuthentication(HttpRequestMessage message, OpenIdConnectMessage tokenEndpointRequest);
+    }
+}

--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectClientAuthenticationMode.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectClientAuthenticationMode.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    /// <summary>
+    /// Configure the client authentication mode to call access_token endpoint
+    /// </summary>
+    public class OpenIdConnectClientAuthenticationMode
+    {
+        /// <summary>
+        /// Send client id and client secret in the request body 
+        /// </summary>
+        public static IClientAuthentication Post { get; } = new FormPost();
+        /// <summary>
+        /// Use basic authorization header
+        /// </summary>
+        public static IClientAuthentication Basic { get; } = new BasicAuthentication();
+    }
+}

--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -748,6 +748,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             Logger.RedeemingCodeForTokens();
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, _configuration.TokenEndpoint);
+
+            this.Options.ClientAuthenticationMode.SetClientAuthentication(requestMessage, tokenEndpointRequest);
+
             requestMessage.Content = new FormUrlEncodedContent(tokenEndpointRequest.Parameters);
 
             var responseMessage = await Backchannel.SendAsync(requestMessage);

--- a/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Security/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             RemoteSignOutPath = new PathString("/signout-oidc");
 
             Events = new OpenIdConnectEvents();
+            ClientAuthenticationMode = OpenIdConnectClientAuthenticationMode.Post;
             Scope.Add("openid");
             Scope.Add("profile");
 
@@ -121,6 +122,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// Gets or sets the 'client_secret'.
         /// </summary>
         public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Configure the way the client authenticate on the server
+        /// https://tools.ietf.org/html/rfc6749#section-2.3.1
+        /// </summary>
+        public IClientAuthentication ClientAuthenticationMode { get; set; }
 
         /// <summary>
         /// Configuration provided directly by the developer. If provided, then MetadataAddress and the Backchannel properties


### PR DESCRIPTION
Summary of the changes
 - Added a new parameter **ClientAuthenticationMode** in **OpenIdConnectOptions** to allow to specify the client authentication mode (Basic or Post) https://tools.ietf.org/html/rfc6749#section-2.3.1
By default it's Post so no breaking change

Addresses aspnet/Security#1792
