### PR TITLE
Diagnostics Exception Page: Adjust font-weight to make it easier to read

### DIFF
--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.css
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.css
@@ -5,11 +5,6 @@
     background-color: #fff;
 }
 
-h1, h2, h3, h4, h5 {
-    /*font-family: 'Segoe UI',Tahoma,Arial,Helvetica,sans-serif;*/
-    font-weight: 100;
-}
-
 h1 {
     color: #44525e;
     margin: 15px 0 15px 0;
@@ -22,10 +17,12 @@ h2 {
 h3 {
     color: #363636;
     margin: 5px 5px 0 0;
+    font-weight: normal;
 }
 
 code {
     font-family: Consolas, "Courier New", courier, monospace;
+    font-weight: bold;
 }
 
 body .titleerror {


### PR DESCRIPTION
Summary of the changes 
 - Adjust font-weight to make diagnostics exception page easier to read.

---
The exception page will look as follows with the changes in this pull request
![image](https://user-images.githubusercontent.com/1302542/49692418-901ec780-fb28-11e8-9f9e-100ce5c97336.png)

Originally from https://github.com/aspnet/Diagnostics/pull/501 
Reviewed by @Eilon & approved on Oct 10, 2018.
Requested to re-open this PR in this repo by @natemcmaster on Dec 7, 2018.
