### PR TITLE
PipeThroughputBenchmark to cover more cases

### DIFF
--- a/src/Servers/Kestrel/perf/Kestrel.Performance/PipeThroughputBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/PipeThroughputBenchmark.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         [Params(128, 4096)]
         public int Length { get; set; }
 
-        [Params(1, 2, 4, 16)]
+        [Params(1, 16)]
         public int Chunks { get; set; }
 
         [Benchmark(OperationsPerInvoke = InnerLoopCount)]

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/PipeThroughputBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/PipeThroughputBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,10 +6,13 @@ using System.Buffers;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByMethod)]
     public class PipeThroughputBenchmark
     {
         private PipeReader _reader;
@@ -39,11 +42,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             _writer = pipe.Writer;
         }
 
-        [Params(1, 2, 4, 8, 16)]
-        public int Chunks { get; set; }
-
-        [Params(128, 256)]
+        [Params(128, 4096, 8192)]
         public int Length { get; set; }
+
+        [Params(2, 4, 16)]
+        public int Chunks { get; set; }
 
         [Benchmark]
         public Task Parse_ParallelAsync()


### PR DESCRIPTION
```
                Method | Length | Chunks |       Mean |      Error |     StdDev |        Op/s | Allocated |
---------------------- |------- |------- |-----------:|-----------:|-----------:|------------:|----------:|
   Parse_ParallelAsync |    128 |      1 |   220.6 ns |  1.5512 ns |  1.4510 ns | 4,533,594.4 |     640 B |
   Parse_ParallelAsync |    128 |      2 |   278.5 ns |  2.7348 ns |  2.5581 ns | 3,590,931.7 |     640 B |
   Parse_ParallelAsync |    128 |      4 |   370.3 ns |  4.0975 ns |  3.4216 ns | 2,700,506.4 |     640 B |
   Parse_ParallelAsync |    128 |     16 |   740.1 ns |  8.5636 ns |  8.0104 ns | 1,351,178.2 |     640 B |
   Parse_ParallelAsync |   4096 |      1 |   594.5 ns |  6.7791 ns |  6.0095 ns | 1,682,215.5 |     640 B |
   Parse_ParallelAsync |   4096 |      2 |   664.4 ns |  9.6278 ns |  9.0058 ns | 1,505,151.6 |     640 B |
   Parse_ParallelAsync |   4096 |      4 |   692.4 ns |  6.3556 ns |  5.9450 ns | 1,444,246.2 |     640 B |
   Parse_ParallelAsync |   4096 |     16 | 1,001.6 ns | 10.5697 ns |  9.8869 ns |   998,373.3 |     640 B |
                       |        |        |            |            |            |             |           |
 Parse_SequentialAsync |    128 |      1 |   305.6 ns |  0.7858 ns |  0.6966 ns | 3,272,369.7 |       0 B |
 Parse_SequentialAsync |    128 |      2 |   320.9 ns |  1.0169 ns |  0.9015 ns | 3,116,371.4 |       0 B |
 Parse_SequentialAsync |    128 |      4 |   341.1 ns |  0.9681 ns |  0.8084 ns | 2,931,337.7 |       0 B |
 Parse_SequentialAsync |    128 |     16 |   520.9 ns | 10.0641 ns | 14.7518 ns | 1,919,708.6 |       0 B |
 Parse_SequentialAsync |   4096 |      1 |   306.4 ns |  0.5031 ns |  0.4201 ns | 3,264,029.4 |       0 B |
 Parse_SequentialAsync |   4096 |      2 |   318.5 ns |  1.2733 ns |  1.1287 ns | 3,140,166.6 |       0 B |
 Parse_SequentialAsync |   4096 |      4 |   341.5 ns |  1.6186 ns |  1.4349 ns | 2,928,156.1 |       0 B |
 Parse_SequentialAsync |   4096 |     16 |   485.1 ns |  7.7856 ns |  7.2826 ns | 2,061,508.5 |       0 B |
```

/cc @pakrym @halter73 @davidfowl 