### PR TITLE
Remove nameof from log events

### DIFF
--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/MvcCoreLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/MvcCoreLoggerExtensions.cs
@@ -652,7 +652,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             _transformingClientError = LoggerMessage.Define<Type, int?, Type>(
                 LogLevel.Trace,
-                new EventId(49, nameof(Infrastructure.ClientErrorResultFilter)),
+                new EventId(49, "ClientErrorResultFilter"),
                 "Replacing {InitialActionResultType} with status code {StatusCode} with {ReplacedActionResultType}.");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Cors/CorsLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Cors/CorsLoggerExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Cors
         {
             _notMostEffectiveFilter = LoggerMessage.Define<Type>(
                LogLevel.Debug,
-               new EventId(1, nameof(NotMostEffectiveFilter)),
+               new EventId(1, "NotMostEffectiveFilter"),
                "Skipping the execution of current filter as its not the most effective filter implementing the policy {FilterPolicy}.");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Formatters.Json/MvcJsonLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Formatters.Json/MvcJsonLoggerExtensions.cs
@@ -16,12 +16,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             _jsonInputFormatterCrashed = LoggerMessage.Define(
                 LogLevel.Debug,
-                new EventId(1, nameof(JsonInputException)),
+                new EventId(1, "JsonInputException"),
                 "JSON input formatter threw an exception.");
 
             _jsonResultExecuting = LoggerMessage.Define<string>(
                 LogLevel.Information,
-                new EventId(1, nameof(JsonResultExecuting)),
+                new EventId(1, "JsonResultExecuting"),
                 "Executing JsonResult, writing value of type '{Type}'.");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/LoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/LoggerExtensions.cs
@@ -15,12 +15,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         {
             _failedToCreateXmlSerializer = LoggerMessage.Define<string>(
                 LogLevel.Warning,
-                new EventId(1, nameof(FailedToCreateXmlSerializer)),
+                new EventId(1, "FailedToCreateXmlSerializer"),
                 "An error occurred while trying to create an XmlSerializer for the type '{Type}'.");
 
             _failedToCreateDataContractSerializer = LoggerMessage.Define<string>(
                 LogLevel.Warning,
-                new EventId(2, nameof(FailedToCreateDataContractSerializer)),
+                new EventId(2, "FailedToCreateDataContractSerializer"),
                 "An error occurred while trying to create a DataContractSerializer for the type '{Type}'.");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Razor/MvcRazorLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Razor/MvcRazorLoggerExtensions.cs
@@ -36,27 +36,27 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         {
             _viewCompilerStartCodeGeneration = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(1, nameof(ViewCompilerStartCodeGeneration)),
+                new EventId(1, "ViewCompilerStartCodeGeneration"),
                 "Code generation for the Razor file at '{FilePath}' started.");
 
             _viewCompilerEndCodeGeneration = LoggerMessage.Define<string, double>(
                 LogLevel.Debug,
-                new EventId(2, nameof(ViewCompilerEndCodeGeneration)),
+                new EventId(2, "ViewCompilerEndCodeGeneration"),
                 "Code generation for the Razor file at '{FilePath}' completed in {ElapsedMilliseconds}ms.");
 
             _viewCompilerLocatedCompiledView = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(3, nameof(ViewCompilerLocatedCompiledView)),
+                new EventId(3, "ViewCompilerLocatedCompiledView"),
                 "Initializing Razor view compiler with compiled view: '{ViewName}'.");
 
             _viewCompilerNoCompiledViewsFound = LoggerMessage.Define(
                 LogLevel.Debug,
-                new EventId(4, nameof(ViewCompilerNoCompiledViewsFound)),
+                new EventId(4, "ViewCompilerNoCompiledViewsFound"),
                 "Initializing Razor view compiler with no compiled views.");
 
             _viewCompilerLocatedCompiledViewForPath = LoggerMessage.Define<string>(
                 LogLevel.Trace,
-                new EventId(5, nameof(ViewCompilerLocatedCompiledViewForPath)),
+                new EventId(5, "ViewCompilerLocatedCompiledViewForPath"),
                 "Located compiled view for view at path '{Path}'.");
 
             _viewCompilerRecompilingCompiledView = LoggerMessage.Define<string>(
@@ -66,52 +66,52 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
             _viewCompilerCouldNotFindFileToCompileForPath = LoggerMessage.Define<string>(
                 LogLevel.Trace,
-                new EventId(7, nameof(ViewCompilerCouldNotFindFileAtPath)),
+                new EventId(7, "ViewCompilerCouldNotFindFileAtPath"),
                 "Could not find a file for view at path '{Path}'.");
 
             _viewCompilerFoundFileToCompileForPath = LoggerMessage.Define<string>(
                 LogLevel.Trace,
-                new EventId(8, nameof(ViewCompilerFoundFileToCompile)),
+                new EventId(8, "ViewCompilerFoundFileToCompile"),
                 "Found file at path '{Path}'.");
 
             _viewCompilerInvalidatingCompiledFile = LoggerMessage.Define<string>(
                 LogLevel.Trace,
-                new EventId(9, nameof(ViewCompilerInvalidingCompiledFile)),
+                new EventId(9, "ViewCompilerInvalidingCompiledFile"),
                 "Invalidating compiled view at path '{Path}' with a file since the checksum did not match.");
 
             _viewLookupCacheMiss = LoggerMessage.Define<string, string>(
                 LogLevel.Debug,
-                new EventId(1, nameof(ViewLookupCacheMiss)),
+                new EventId(1, "ViewLookupCacheMiss"),
                 "View lookup cache miss for view '{ViewName}' in controller '{ControllerName}'.");
 
             _viewLookupCacheHit = LoggerMessage.Define<string, string>(
                 LogLevel.Debug,
-                new EventId(2, nameof(ViewLookupCacheHit)),
+                new EventId(2, "ViewLookupCacheHit"),
                 "View lookup cache hit for view '{ViewName}' in controller '{ControllerName}'.");
 
             _precompiledViewFound = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(3, nameof(PrecompiledViewFound)),
+                new EventId(3, "PrecompiledViewFound"),
                 "Using precompiled view for '{RelativePath}'.");
 
             _generatedCodeToAssemblyCompilationStart = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(1, nameof(GeneratedCodeToAssemblyCompilationStart)),
+                new EventId(1, "GeneratedCodeToAssemblyCompilationStart"),
                 "Compilation of the generated code for the Razor file at '{FilePath}' started.");
 
             _generatedCodeToAssemblyCompilationEnd = LoggerMessage.Define<string, double>(
                 LogLevel.Debug,
-                new EventId(2, nameof(GeneratedCodeToAssemblyCompilationEnd)),
+                new EventId(2, "GeneratedCodeToAssemblyCompilationEnd"),
                 "Compilation of the generated code for the Razor file at '{FilePath}' completed in {ElapsedMilliseconds}ms.");
 
             _tagHelperComponentInitialized = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(2, nameof(TagHelperComponentInitialized)),
+                new EventId(2, "TagHelperComponentInitialized"),
                 "Tag helper component '{ComponentName}' initialized.");
 
             _tagHelperComponentProcessed = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(3, nameof(TagHelperComponentProcessed)),
+                new EventId(3, "TagHelperComponentProcessed"),
                 "Tag helper component '{ComponentName}' processed.");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.RazorPages/PageLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.RazorPages/PageLoggerExtensions.cs
@@ -30,27 +30,27 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
 
             _handlerMethodExecuting = LoggerMessage.Define<string, string[], ModelValidationState>(
                 LogLevel.Information,
-                new EventId(101, nameof(ExecutingHandlerMethod)),
+                new EventId(101, "ExecutingHandlerMethod"),
                 "Executing handler method {HandlerName} with arguments ({Arguments}) - ModelState is {ValidationState}");
 
             _handlerMethodExecuted = LoggerMessage.Define<string, string>(
                 LogLevel.Information,
-                new EventId(102, nameof(ExecutedHandlerMethod)),
+                new EventId(102, "ExecutedHandlerMethod"),
                 "Executed handler method {HandlerName}, returned result {ActionResult}.");
 
             _implicitHandlerMethodExecuting = LoggerMessage.Define<ModelValidationState>(
                 LogLevel.Information,
-                new EventId(103, nameof(ExecutingImplicitHandlerMethod)),
+                new EventId(103, "ExecutingImplicitHandlerMethod"),
                 "Executing an implicit handler method - ModelState is {ValidationState}");
 
             _implicitHandlerMethodExecuted = LoggerMessage.Define<string>(
                 LogLevel.Information,
-                new EventId(104, nameof(ExecutedImplicitHandlerMethod)),
+                new EventId(104, "ExecutedImplicitHandlerMethod"),
                 "Executed an implicit handler method, returned result {ActionResult}.");
 
             _pageFilterShortCircuit = LoggerMessage.Define<object>(
                LogLevel.Debug,
-                new EventId(3, nameof(PageFilterShortCircuited)),
+                new EventId(3, "PageFilterShortCircuited"),
                "Request was short circuited at page filter '{PageFilter}'.");
 
             _malformedPageDirective = LoggerMessage.Define<string, string[]>(
@@ -60,22 +60,22 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
 
             _notMostEffectiveFilter = LoggerMessage.Define<Type>(
                LogLevel.Debug,
-                new EventId(1, nameof(NotMostEffectiveFilter)),
+                new EventId(1, "NotMostEffectiveFilter"),
                "Skipping the execution of current filter as its not the most effective filter implementing the policy {FilterPolicy}.");
 
             _beforeExecutingMethodOnFilter = LoggerMessage.Define<string, string, string>(
                 LogLevel.Trace,
-                new EventId(1, nameof(BeforeExecutingMethodOnFilter)),
+                new EventId(1, "BeforeExecutingMethodOnFilter"),
                 "{FilterType}: Before executing {Method} on filter {Filter}.");
 
             _afterExecutingMethodOnFilter = LoggerMessage.Define<string, string, string>(
                 LogLevel.Trace,
-                new EventId(2, nameof(AfterExecutingMethodOnFilter)),
+                new EventId(2, "AfterExecutingMethodOnFilter"),
                 "{FilterType}: After executing {Method} on filter {Filter}.");
 
             _unsupportedAreaPath = LoggerMessage.Define<string>(
                 LogLevel.Warning,
-                new EventId(1, nameof(UnsupportedAreaPath)),
+                new EventId(1, "UnsupportedAreaPath"),
                 "The page at '{FilePath}' is located under the area root directory '/Areas/' but does not follow the path format '/Areas/AreaName/Pages/Directory/FileName.cshtml");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.TagHelpers/MvcTagHelpersLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.TagHelpers/MvcTagHelpersLoggerExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         {
             _distributedFormatterDeserializedFailed = LoggerMessage.Define<string>(
                 LogLevel.Error,
-                new EventId(1, nameof(DistributedFormatterDeserializationException)),
+                new EventId(1, "DistributedFormatterDeserializationException"),
                 "Couldn't deserialize cached value for key {Key}.");
         }
 

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.ViewFeatures/MvcViewFeaturesLoggerExtensions.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.ViewFeatures/MvcViewFeaturesLoggerExtensions.cs
@@ -42,83 +42,83 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         {
             _viewComponentExecuting = LoggerMessage.Define<string, string[]>(
                 LogLevel.Debug,
-                new EventId(1, nameof(ViewComponentExecuting)),
+                new EventId(1, "ViewComponentExecuting"),
                 "Executing view component {ViewComponentName} with arguments ({Arguments}).");
 
             _viewComponentExecuted = LoggerMessage.Define<string, double, string>(
                 LogLevel.Debug,
-                new EventId(2, nameof(ViewComponentExecuted)),
+                new EventId(2, "ViewComponentExecuted"),
                 "Executed view component {ViewComponentName} in {ElapsedMilliseconds}ms and returned " +
                 "{ViewComponentResult}");
 
             _partialViewResultExecuting = LoggerMessage.Define<string>(
                 LogLevel.Information,
-                new EventId(1, nameof(PartialViewResultExecuting)),
+                new EventId(1, "PartialViewResultExecuting"),
                 "Executing PartialViewResult, running view {PartialViewName}.");
 
             _partialViewFound = LoggerMessage.Define<string, double>(
                 LogLevel.Debug,
-                new EventId(2, nameof(PartialViewFound)),
+                new EventId(2, "PartialViewFound"),
                 "The partial view path '{PartialViewFilePath}' was found in {ElapsedMilliseconds}ms.");
 
             _partialViewNotFound = LoggerMessage.Define<string, IEnumerable<string>>(
                 LogLevel.Error,
-                new EventId(3, nameof(PartialViewNotFound)),
+                new EventId(3, "PartialViewNotFound"),
                 "The partial view '{PartialViewName}' was not found. Searched locations: {SearchedViewLocations}");
 
             _partialViewResultExecuted = LoggerMessage.Define<string, double>(
                 LogLevel.Information,
-                new EventId(4, nameof(PartialViewResultExecuted)),
+                new EventId(4, "PartialViewResultExecuted"),
                 "Executed PartialViewResult - view {PartialViewName} executed in {ElapsedMilliseconds}ms.");
 
             _antiforgeryTokenInvalid = LoggerMessage.Define<string>(
                 LogLevel.Information,
-                new EventId(1, nameof(AntiforgeryTokenInvalid)),
+                new EventId(1, "AntiforgeryTokenInvalid"),
                 "Antiforgery token validation failed. {Message}");
 
             _viewComponentResultExecuting = LoggerMessage.Define<string>(
                 LogLevel.Information,
-                new EventId(1, nameof(ViewComponentResultExecuting)),
+                new EventId(1, "ViewComponentResultExecuting"),
                 "Executing ViewComponentResult, running {ViewComponentName}.");
 
             _viewResultExecuting = LoggerMessage.Define<string>(
                 LogLevel.Information,
-                new EventId(1, nameof(ViewResultExecuting)),
+                new EventId(1, "ViewResultExecuting"),
                 "Executing ViewResult, running view {ViewName}.");
 
             _viewFound = LoggerMessage.Define<string, double>(
                 LogLevel.Debug,
-                new EventId(2, nameof(ViewFound)),
+                new EventId(2, "ViewFound"),
                 "The view path '{ViewFilePath}' was found in {ElapsedMilliseconds}ms.");
 
             _viewNotFound = LoggerMessage.Define<string, IEnumerable<string>>(
                 LogLevel.Error,
-                new EventId(3, nameof(ViewNotFound)),
+                new EventId(3, "ViewNotFound"),
                 "The view '{ViewName}' was not found. Searched locations: {SearchedViewLocations}");
 
             _viewResultExecuted = LoggerMessage.Define<string, double>(
                 LogLevel.Information,
-                new EventId(4, nameof(ViewResultExecuted)),
+                new EventId(4, "ViewResultExecuted"),
                 "Executed ViewResult - view {ViewName} executed in {ElapsedMilliseconds}ms.");
 
             _tempDataCookieNotFound = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(1, nameof(TempDataCookieNotFound)),
+                new EventId(1, "TempDataCookieNotFound"),
                 "The temp data cookie {CookieName} was not found.");
 
             _tempDataCookieLoadSuccess = LoggerMessage.Define<string>(
                 LogLevel.Debug,
-                new EventId(2, nameof(TempDataCookieLoadSuccess)),
+                new EventId(2, "TempDataCookieLoadSuccess"),
                 "The temp data cookie {CookieName} was used to successfully load temp data.");
 
             _tempDataCookieLoadFailure = LoggerMessage.Define<string>(
                 LogLevel.Warning,
-                new EventId(3, nameof(TempDataCookieLoadFailure)),
+                new EventId(3, "TempDataCookieLoadFailure"),
                 "The temp data cookie {CookieName} could not be loaded.");
 
             _notMostEffectiveFilter = LoggerMessage.Define<Type>(
                 LogLevel.Trace,
-                new EventId(1, nameof(NotMostEffectiveFilter)),
+                new EventId(1, "NotMostEffectiveFilter"),
                 "Skipping the execution of current filter as its not the most effective filter implementing the policy {FilterPolicy}.");
         }
 


### PR DESCRIPTION
related to [aspnet/Mvc#6818](https://github.com/aspnet/Mvc/issues/6818) & #4495 

Removing `nameof` from log event name to prevent accidentally breaking changes by renaming variables.