### PR TITLE
Update the list of shipping vs internal packages

### DIFF
--- a/build/SharedFrameworkOnly.props
+++ b/build/SharedFrameworkOnly.props
@@ -14,7 +14,6 @@
     <!-- Assemblies required by the SignalR client. -->
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Http.Features" />
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
-    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
 
     <SharedFrameworkOnlyPackage Include="@(Dependency)" Exclude="@(SharedFrameworkAndPackage)" />

--- a/build/SharedFrameworkOnly.props
+++ b/build/SharedFrameworkOnly.props
@@ -7,23 +7,15 @@
   <Import Project="..\src\Framework\Microsoft.AspNetCore.App.props" />
 
   <ItemGroup>
-    <!-- Packages to be removed from the shared framework but not done yet. -->
+    <!-- Packages to be removed from the shared framework but not done yet due to JSON.net dependency. -->
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.JsonPatch" />
-
-    <!-- Packages for Razor runtime compilation -->
-    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Razor.Language" />
-    <SharedFrameworkAndPackage Include="Microsoft.CodeAnalysis.Razor" />
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" />
 
     <!-- Assemblies required by the SignalR client. -->
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Http.Features" />
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
-    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" />
-
-    <!-- Assemblies produced by this repo that will move to aspnet/Extensions after repo refactoring is done -->
-    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Identity.Core" />
-    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Identity.Stores" />
-    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Localization.Abstractions" />
-    <SharedFrameworkAndPackage Include="Microsoft.Extensions.Localization" />
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
+    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
 
     <SharedFrameworkOnlyPackage Include="@(Dependency)" Exclude="@(SharedFrameworkAndPackage)" />
   </ItemGroup>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -4,9 +4,8 @@
     <PackageArtifact>
       <!-- Defines how and where the package ships.
 
-        ship = nuget.org
-        shipoob = some other mechanism
-        noship = for transporting internal bits only
+        ship = deploys to nuget.org, for production usage
+        noship = internal, experimental, or otherwise.
       -->
       <Category></Category>
     </PackageArtifact>
@@ -14,12 +13,7 @@
 
   <ItemGroup>
     <!-- Packages that go to nuget.org -->
-    <PackageArtifact Include="dotnet-dev-certs" Category="ship" />
-    <PackageArtifact Include="dotnet-sql-cache" Category="ship" />
-    <PackageArtifact Include="dotnet-user-secrets" Category="ship" />
-    <PackageArtifact Include="dotnet-watch" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
-    <PackageArtifact Include="runtime.$(SharedFxRid).Microsoft.AspNetCore.App" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Facebook" Category="ship" />
@@ -29,16 +23,15 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.WsFederation" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" />
-
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor.Cli" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor.Templates" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Components" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Components.Analyzers" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Components.Browser" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Components.Build" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Components.Razor.Extensions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Components.Server" Category="ship" />
-
+    <PackageArtifact Include="Microsoft.AspNetCore.Components" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Connections.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Category="ship" />
@@ -57,13 +50,14 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Testing" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.NodeServices" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Owin" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Common" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Specification.Tests" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices.Extensions" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.TestHost" Category="ship" />
@@ -73,96 +67,111 @@
     <PackageArtifact Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.ApiDescription.Design" Category="ship" />
     <PackageArtifact Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Category="ship" />
-    <PackageArtifact Include="Microsoft.Extensions.Identity.Core" Category="ship" />
-    <PackageArtifact Include="Microsoft.Extensions.Identity.Stores" Category="ship" />
+    <PackageArtifact Include="runtime.$(SharedFxRid).Microsoft.AspNetCore.App" Category="ship" />
+
+    <!-- Experimental packages which are not ready for production yet -->
+      <PackageArtifact Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.NodeServices.Sockets" Category="noship" />
 
     <!-- Packages for internal use only. -->
-    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86' " />
-    <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModule" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ChunkingCookieManager.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Connections.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Extensions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HostFiltering" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Html.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections.Common" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Extensions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HttpOverrides" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HttpsPolicy" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Identity" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Localization.Routing" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Localization" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Core" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Cors" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.NodeServices.Sockets" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.RangeHelper.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCompression" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Rewrite" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IIS" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Core" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Session" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Core" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore" Category="noship" />
-    <PackageArtifact Include="Microsoft.Extensions.ApplicationModelDetection" Category="noship" />
-    <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="noship" />
-    <PackageArtifact Include="Microsoft.Web.Xdt.Extensions" Category="shipoob" />
-    <PackageArtifact Include="Internal.WebHostBuilderFactory.Sources" Category="noship"/>
+      <!-- These packages contain CLI tools which are bundled in the .NET Core SDK. -->
+      <PackageArtifact Include="dotnet-dev-certs" Category="noship" />
+      <PackageArtifact Include="dotnet-sql-cache" Category="noship" />
+      <PackageArtifact Include="dotnet-user-secrets" Category="noship" />
+      <PackageArtifact Include="dotnet-watch" Category="noship" />
+
+    <!-- This package contains API for the .NET CLI to generate the aspnet HTTPs dev cert during CLI first-run initialization. -->
+      <PackageArtifact Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Category="noship" />
+
+    <!-- This packages contain bits used by Azure site extensions, and are not currently deployed to NuGet.org automatically like the rest of our packages. -->
+      <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86' " />
+      <PackageArtifact Include="Microsoft.Web.Xdt.Extensions" Category="noship" />
+      <PackageArtifact Include="Microsoft.Extensions.ApplicationModelDetection" Category="noship" />
+
+    <!-- This packages are produce for testing purposes only. -->
+      <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModule" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
+      <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Category="noship" Condition=" '$(OS)' == 'Windows_NT' " />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting" Category="noship" />
+
+    <!-- This package is produced for use in aspnet/EntityFrameworkCore to ensure EF tools can load a service collection from and app using ASP.NET's Program/Startup patterns/ -->
+      <PackageArtifact Include="Internal.WebHostBuilderFactory.Sources" Category="noship"/>
+
+    <!-- These packages are produced temporarily while we finish refactoring the way this repo builds. See https://github.com/aspnet/AspNetCore/issues/4246 -->
+      <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Extensions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.DataProtection" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.HostFiltering" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Hosting" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Html.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Http.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections.Common" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Http.Extensions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Http" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.HttpOverrides" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.HttpsPolicy" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Identity" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Localization.Routing" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Localization" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Core" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Cors" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Mvc" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.RangeHelper.Sources" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Razor" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.ResponseCompression" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Rewrite" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Routing" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.IIS" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Core" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.Session" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Core" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.SignalR" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore" Category="noship" />
+      <PackageArtifact Include="Microsoft.Extensions.Identity.Core" Category="noship" />
+      <PackageArtifact Include="Microsoft.Extensions.Identity.Stores" Category="noship" />
+      <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="noship" />
   </ItemGroup>
 </Project>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -108,6 +108,7 @@
       <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.ChunkingCookieManager.Sources" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="noship" />


### PR DESCRIPTION
This updates the list of packages to reflect the outcome of our last review of framework vs packages.

Changes:

* Put packages back into 'ship' which were unintentionally skipped in 3.0 refactoring
   * Libuv transport for kestrel
   * Http connection abstractions shared by SignalR client and Kestrel. Partially resolves https://github.com/aspnet/AspNetCore/issues/4370
   * Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson - this wasn't moved to the right category during https://github.com/aspnet/AspNetCore/pull/4319
* Make dotnet-\* packages internal-only. They were only shipped to NuGet.org because we had not yet enabled source-build. We plan to implement source-build in 3.0 (#3752)
* Make Microsoft.Extensions.Identity.\* packages shared-framework only (see #4523). 
* Remove unused entries for packages that moved to aspnet/AspNetCore-Tooling
* Add comments in the artifacts.props document for why each 'noship' package is in this category.