### PR TITLE
Check connectionState in stop so we don't null ref

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -436,7 +436,7 @@ public class HubConnection {
                 exception = new RuntimeException(errorMessage);
                 logger.error("HubConnection disconnected with an error {}.", errorMessage);
             }
-            if (connectionState != null){
+            if (connectionState != null) {
                 connectionState.cancelOutstandingInvocations(exception);
                 connectionState = null;
             }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -436,8 +436,11 @@ public class HubConnection {
                 exception = new RuntimeException(errorMessage);
                 logger.error("HubConnection disconnected with an error {}.", errorMessage);
             }
-            connectionState.cancelOutstandingInvocations(exception);
-            connectionState = null;
+            if (connectionState != null){
+                connectionState.cancelOutstandingInvocations(exception);
+                connectionState = null;
+            }
+
             logger.info("HubConnection stopped.");
             hubConnectionState = HubConnectionState.DISCONNECTED;
             handshakeResponseSubject.onComplete();


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/3303
When there is a failure to fully connect the `connectionState `variable doesn't get set and so when we try to clean up the outstanding invocations in the stopConnection logic we don't check if connectionState was initialized. 
There's no test here because the exception is just logged.
