### PR TITLE
Add setter to HealthCheckOptions.ResultStatusCodes

### DIFF
--- a/src/Middleware/HealthChecks/src/HealthCheckOptions.cs
+++ b/src/Middleware/HealthChecks/src/HealthCheckOptions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
         /// Gets a dictionary mapping the <see cref="HealthStatus"/> to an HTTP status code applied to the response.
         /// This property can be used to configure the status codes returned for each status.
         /// </summary>
-        public IDictionary<HealthStatus, int> ResultStatusCodes { get; } = new Dictionary<HealthStatus, int>()
+        public IDictionary<HealthStatus, int> ResultStatusCodes { get; set; } = new Dictionary<HealthStatus, int>()
         {
             { HealthStatus.Healthy, StatusCodes.Status200OK },
             { HealthStatus.Degraded, StatusCodes.Status200OK },

--- a/src/Middleware/HealthChecks/src/HealthCheckOptions.cs
+++ b/src/Middleware/HealthChecks/src/HealthCheckOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -24,16 +25,44 @@ namespace Microsoft.AspNetCore.Diagnostics.HealthChecks
         /// </remarks>
         public Func<HealthCheckRegistration, bool> Predicate { get; set; }
 
-        /// <summary>
-        /// Gets a dictionary mapping the <see cref="HealthStatus"/> to an HTTP status code applied to the response.
-        /// This property can be used to configure the status codes returned for each status.
-        /// </summary>
-        public IDictionary<HealthStatus, int> ResultStatusCodes { get; set; } = new Dictionary<HealthStatus, int>()
+        private IDictionary<HealthStatus, int> _resultStatusCodes = DefaultStatusCodesMapping;
+
+        private static readonly IDictionary<HealthStatus, int> DefaultStatusCodesMapping = new Dictionary<HealthStatus, int>
         {
-            { HealthStatus.Healthy, StatusCodes.Status200OK },
-            { HealthStatus.Degraded, StatusCodes.Status200OK },
-            { HealthStatus.Unhealthy, StatusCodes.Status503ServiceUnavailable },
+            {HealthStatus.Healthy, StatusCodes.Status200OK},
+            {HealthStatus.Degraded, StatusCodes.Status200OK},
+            {HealthStatus.Unhealthy, StatusCodes.Status503ServiceUnavailable},
         };
+
+        /// <summary>
+        /// Gets or sets a dictionary mapping the <see cref="HealthStatus"/> to an HTTP status code applied
+        /// to the response. This property can be used to configure the status codes returned for each status.
+        /// </summary>
+        /// <remarks>
+        /// Setting this property to <c>null</c> resets the mapping to its default value which maps
+        /// <see cref="HealthStatus.Healthy"/> to 200 (OK), <see cref="HealthStatus.Degraded"/> to 200 (OK) and
+        /// <see cref="HealthStatus.Unhealthy"/> to 503 (Service Unavailable).
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">Thrown if at least one <see cref="HealthStatus"/> is missing when setting this property.</exception>
+        public IDictionary<HealthStatus, int> ResultStatusCodes
+        {
+            get => _resultStatusCodes;
+            set => _resultStatusCodes = value != null ? ValidateStatusCodesMapping(value) : DefaultStatusCodesMapping;
+        }
+
+        private static IDictionary<HealthStatus, int> ValidateStatusCodesMapping(IDictionary<HealthStatus,int> mapping)
+        {
+            var missingHealthStatus = ((HealthStatus[])Enum.GetValues(typeof(HealthStatus))).Except(mapping.Keys).ToList();
+            if (missingHealthStatus.Any())
+            {
+                var missing = string.Join(", ", missingHealthStatus.Select(status => $"{nameof(HealthStatus)}.{status}"));
+                var message =
+                    $"The {nameof(ResultStatusCodes)} dictionary must include an entry for all possible " +
+                    $"{nameof(HealthStatus)} values. Missing: {missing}";
+                throw new InvalidOperationException(message);
+            }
+            return mapping;
+        }
 
         /// <summary>
         /// Gets or sets a delegate used to write the response.


### PR DESCRIPTION
All other properties (`Predicate`, `ResponseWriter` and `AllowCachingResponses`) have a setter but `ResultStatusCodes` doesn't.

Without a setter, reusing the same status to http status code mapping is impossible and leads to duplicate code that looks like this:

```csharp
private static void ConfigureHealthChecks(IApplicationBuilder app, HealthCheckServiceOptions options)
{
    app.UseHealthChecks("/health", new HealthCheckOptions
    {
        ResultStatusCodes =
        {
            [HealthStatus.Healthy] = StatusCodes.Status200OK,
            [HealthStatus.Degraded] = StatusCodes.Status400BadRequest,
            [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
        }
    });
    foreach (var name in options.Registrations.Select(e => e.Name))
    {
        app.UseHealthChecks($"/health/{name}", new HealthCheckOptions
        {
            Predicate = registration => registration.Name == name,
            ResultStatusCodes =
            {
                [HealthStatus.Healthy] = StatusCodes.Status200OK,
                [HealthStatus.Degraded] = StatusCodes.Status400BadRequest,
                [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
            }
        });
    }
}
```

With a setter, this code could be rewritten in a *don't repeat yourself* (DRY) way:

```csharp
private static void ConfigureHealthChecks(IApplicationBuilder app, HealthCheckServiceOptions options)
{
    var resultStatusCodes = new Dictionary<HealthStatus, int>
    {
        [HealthStatus.Healthy] = StatusCodes.Status200OK,
        [HealthStatus.Degraded] = StatusCodes.Status400BadRequest,
        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
    };
    app.UseHealthChecks("/health", new HealthCheckOptions
    {
        ResultStatusCodes = resultStatusCodes
    });
    foreach (var name in options.Registrations.Select(e => e.Name))
    {
        app.UseHealthChecks($"/health/{name}", new HealthCheckOptions
        {
            Predicate = registration => registration.Name == name,
            ResultStatusCodes = resultStatusCodes
        });
    }
}
```