### PR TITLE
Fix IE 11 handshake split

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HandshakeProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/HandshakeProtocol.ts
@@ -40,20 +40,7 @@ export class HandshakeProtocol {
             // optional content after is additional messages
             const responseLength = separatorIndex + 1;
             messageData = String.fromCharCode.apply(null, binaryData.slice(0, responseLength));
-
-            if (binaryData.byteLength > responseLength) {
-                remainingData = binaryData.slice(responseLength);
-                // IE 11 does not have .slice() on Uint8Array, we polyfill it with Array.prototype.slice()
-                // which returns an Array object, that doesn't have .buffer, which is an ArrayBuffer
-                // so we need to convert it into a Uint8Array and .buffer that
-                if (remainingData.buffer) {
-                    remainingData = remainingData.buffer;
-                } else {
-                    remainingData = new Uint8Array(remainingData).buffer;
-                }
-            } else {
-                remainingData = null;
-            }
+            remainingData = (binaryData.byteLength > responseLength) ? binaryData.slice(responseLength).buffer : null;
         } else {
             const textData: string = data;
             const separatorIndex = textData.indexOf(TextMessageFormat.RecordSeparator);

--- a/src/SignalR/clients/ts/signalr/src/HandshakeProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/HandshakeProtocol.ts
@@ -40,7 +40,20 @@ export class HandshakeProtocol {
             // optional content after is additional messages
             const responseLength = separatorIndex + 1;
             messageData = String.fromCharCode.apply(null, binaryData.slice(0, responseLength));
-            remainingData = (binaryData.byteLength > responseLength) ? binaryData.slice(responseLength).buffer : null;
+
+            if (binaryData.byteLength > responseLength) {
+                remainingData = binaryData.slice(responseLength);
+                // IE 11 does not have .slice() on Uint8Array, we polyfill it with Array.prototype.slice()
+                // which returns an Array object, that doesn't have .buffer, which is an ArrayBuffer
+                // so we need to convert it into a Uint8Array and .buffer that
+                if (remainingData.buffer) {
+                    remainingData = remainingData.buffer;
+                } else {
+                    remainingData = new Uint8Array(remainingData).buffer;
+                }
+            } else {
+                remainingData = null;
+            }
         } else {
             const textData: string = data;
             const separatorIndex = textData.indexOf(TextMessageFormat.RecordSeparator);

--- a/src/SignalR/clients/ts/signalr/src/browser-index.ts
+++ b/src/SignalR/clients/ts/signalr/src/browser-index.ts
@@ -16,7 +16,8 @@ if (!Uint8Array.prototype.indexOf) {
 }
 if (!Uint8Array.prototype.slice) {
     Object.defineProperty(Uint8Array.prototype, "slice", {
-        value: Array.prototype.slice,
+        // wrap the slice in Uint8Array so it looks like a Uint8Array.slice call
+        value: (start?: number, end?: number) => new Uint8Array(Array.prototype.slice(start, end)),
         writable: true,
     });
 }


### PR DESCRIPTION
Part of investigating sauce lab flakiness

No tests because there is no way to purposefully hit this code path in functional tests.

Tested manually by adding a delay in server code to force this to happen.