### PR TITLE
Make component parameter analyzer allow public getters. Imported from Blazor PR 1702.

### DIFF
--- a/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/ComponentParametersShouldNotBePublicAnalyzer.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/ComponentParametersShouldNotBePublicAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Components.Shared;
@@ -61,6 +61,16 @@ namespace Microsoft.AspNetCore.Components.Analyzers
         }
 
         private static bool IsPublic(PropertyDeclarationSyntax declaration)
-            => declaration.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword));
+        {
+            // If the property explicitly specifies a non-public setter, then it's valid
+            var setter = declaration.AccessorList?.Accessors.SingleOrDefault(x => x.Keyword.IsKind(SyntaxKind.SetKeyword));
+            if (setter != null && setter.Modifiers.Any(x => !x.IsKind(SyntaxKind.PublicKeyword)))
+            {
+                return false;
+            }
+
+            // Otherwise fallback to the property declaration modifiers
+            return declaration.Modifiers.Any(x => x.IsKind(SyntaxKind.PublicKeyword));
+        }
     }
 }

--- a/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/ComponentParametersShouldNotBePublicAnalyzer.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/ComponentParametersShouldNotBePublicAnalyzer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 .Where(attr => semanticModel.GetTypeInfo(attr).Type?.ToDisplayString() == ComponentsApi.ParameterAttribute.FullTypeName)
                 .FirstOrDefault();
 
-            if (parameterAttribute != null && IsPublic(declaration))
+            if (parameterAttribute != null && IsPubliclySettable(declaration))
             {
                 var identifierText = declaration.Identifier.Text;
                 if (!string.IsNullOrEmpty(identifierText))
@@ -60,11 +60,11 @@ namespace Microsoft.AspNetCore.Components.Analyzers
             }
         }
 
-        private static bool IsPublic(PropertyDeclarationSyntax declaration)
+        private static bool IsPubliclySettable(PropertyDeclarationSyntax declaration)
         {
-            // If the property explicitly specifies a non-public setter, then it's valid
+            // If the property has a setter explicitly marked private/protected/internal, then it's not public
             var setter = declaration.AccessorList?.Accessors.SingleOrDefault(x => x.Keyword.IsKind(SyntaxKind.SetKeyword));
-            if (setter != null && setter.Modifiers.Any(x => !x.IsKind(SyntaxKind.PublicKeyword)))
+            if (setter != null && setter.Modifiers.Any(x => x.IsKind(SyntaxKind.PrivateKeyword) || x.IsKind(SyntaxKind.ProtectedKeyword) || x.IsKind(SyntaxKind.InternalKeyword)))
             {
                 return false;
             }

--- a/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/Resources.Designer.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/Resources.Designer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Component parameters should not be public..
+        ///   Looks up a localized string similar to Component parameters should not have public setters..
         /// </summary>
         internal static string ComponentParametersShouldNotBePublic_Description {
             get {
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Component parameter &apos;{0}&apos; is marked public, but component parameters should not be public..
+        ///   Looks up a localized string similar to Component parameter &apos;{0}&apos; has a public setter, but component parameters should not be publicly settable..
         /// </summary>
         internal static string ComponentParametersShouldNotBePublic_Format {
             get {
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Component parameter is marked public.
+        ///   Looks up a localized string similar to Component parameter has public setter.
         /// </summary>
         internal static string ComponentParametersShouldNotBePublic_Title {
             get {

--- a/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/Resources.resx
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Analyzers/Resources.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ComponentParametersShouldNotBePublic_Description" xml:space="preserve">
-    <value>Component parameters should not be public.</value>
+    <value>Component parameters should not have public setters.</value>
   </data>
   <data name="ComponentParametersShouldNotBePublic_FixTitle" xml:space="preserve">
     <value>Make component parameter private</value>
   </data>
   <data name="ComponentParametersShouldNotBePublic_Format" xml:space="preserve">
-    <value>Component parameter '{0}' is marked public, but component parameters should not be public.</value>
+    <value>Component parameter '{0}' has a public setter, but component parameters should not be publicly settable.</value>
   </data>
   <data name="ComponentParametersShouldNotBePublic_Title" xml:space="preserve">
-    <value>Component parameter is marked public</value>
+    <value>Component parameter has public setter</value>
   </data>
 </root>

--- a/src/Components/test/Microsoft.AspNetCore.Components.Analyzers.Test/ComponentParametersShouldNotBePublicTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Analyzers.Test/ComponentParametersShouldNotBePublicTest.cs
@@ -106,6 +106,24 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
     }" + BlazorParameterSource);
         }
 
+        [Fact]
+        public void IgnoresPublicPropertiesWithNonPublicSetterWithParameterAttribute()
+        {
+            var test = @"
+    namespace ConsoleApplication1
+    {
+        using " + typeof(ParameterAttribute).Namespace + @";
+
+        class TypeName
+        {
+            [Parameter] public string BadProperty1 { get; private set; }
+            [Parameter] public object BadProperty2 { get; protected set; }
+        }
+    }" + BlazorParameterSource;
+
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new ComponentParametersShouldNotBePublicCodeFixProvider();

--- a/src/Components/test/Microsoft.AspNetCore.Components.Analyzers.Test/ComponentParametersShouldNotBePublicTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Analyzers.Test/ComponentParametersShouldNotBePublicTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                 new DiagnosticResult
                 {
                     Id = "BL9993",
-                    Message = "Component parameter 'BadProperty1' is marked public, but component parameters should not be public.",
+                    Message = "Component parameter 'BadProperty1' has a public setter, but component parameters should not be publicly settable.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[]
                     {
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                 new DiagnosticResult
                 {
                     Id = "BL9993",
-                    Message = "Component parameter 'BadProperty2' is marked public, but component parameters should not be public.",
+                    Message = "Component parameter 'BadProperty2' has a public setter, but component parameters should not be publicly settable.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[]
                     {
@@ -116,8 +116,9 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
 
         class TypeName
         {
-            [Parameter] public string BadProperty1 { get; private set; }
-            [Parameter] public object BadProperty2 { get; protected set; }
+            [Parameter] public string MyProperty1 { get; private set; }
+            [Parameter] public object MyProperty2 { get; protected set; }
+            [Parameter] public object MyProperty2 { get; internal set; }
         }
     }" + BlazorParameterSource;
 


### PR DESCRIPTION
Imported from https://github.com/aspnet/Blazor/pull/1702