### PR TITLE
Change build components to C++ Win10 17134 SDK

### DIFF
--- a/korebuild.json
+++ b/korebuild.json
@@ -17,7 +17,7 @@
         "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
         "Microsoft.VisualStudio.Component.VC.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.15063.Desktop"
+        "Microsoft.VisualStudio.Component.Windows10SDK.17134"
       ]
     }
   }

--- a/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
@@ -13,7 +13,7 @@
   <!-- General properties -->
 
   <PropertyGroup>
-    <IisOobWinSdkVersion Condition="'$(IisOobWinSdkVersion)' == ''">10.0.15063.0</IisOobWinSdkVersion>
+    <IisOobWinSdkVersion Condition="'$(IisOobWinSdkVersion)' == ''">10.0.17134.0</IisOobWinSdkVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(IisOobWinSdkVersion)</WindowsTargetPlatformVersion>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>bin\$(Configuration)\$(PlatformShortname)\</OutDir>

--- a/src/Servers/IIS/src/AspNetCoreModuleV1/AspNetCore/AspNetCore.vcxproj
+++ b/src/Servers/IIS/src/AspNetCoreModuleV1/AspNetCore/AspNetCore.vcxproj
@@ -26,7 +26,7 @@
     <ProjectName>AspNetCore</ProjectName>
     <TargetName>aspnetcore</TargetName>
     <LinkIncremental>false</LinkIncremental>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/Servers/IIS/src/AspNetCoreModuleV1/IISLib/IISLib.vcxproj
+++ b/src/Servers/IIS/src/AspNetCoreModuleV1/IISLib/IISLib.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>IISLib</RootNamespace>
     <ProjectName>IISLib</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore-Internal/issues/1505. 15063 doesn't exist on VS16.0 (VS2019). 

This will conflict with https://github.com/aspnet/AspNetCore/pull/4311; I'm opening this to find any build issues primarily. 