### PR TITLE
Make ResponseCompression call DisposeAsync

### DIFF
--- a/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
+++ b/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -39,13 +39,9 @@ namespace Microsoft.AspNetCore.ResponseCompression
             _innerSendFileFeature = innerSendFileFeature;
         }
 
-        protected override void Dispose(bool disposing)
+        internal ValueTask FinishCompressionAsync()
         {
-            if (_compressionStream != null)
-            {
-                _compressionStream.Dispose();
-                _compressionStream = null;
-            }
+            return _compressionStream?.DisposeAsync() ?? new ValueTask();
         }
 
         public override bool CanRead => false;

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -68,9 +68,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             try
             {
                 await _next(context);
-                // This is not disposed via a using statement because we don't want to flush the compression buffer for unhandled exceptions,
-                // that may cause secondary exceptions.
-                bodyWrapperStream.Dispose();
+                await bodyWrapperStream.FinishCompressionAsync();
             }
             finally
             {


### PR DESCRIPTION
https://github.com/aspnet/BasicMiddleware/issues/247

GZipStream.Dispose calls sync Write and Flush. This causes threads to get blocked and can starve the threadpool. In 3.0 we can call the new DisposeAsync instead.