### PR TITLE
Fix HttpSys Caching_SendFileWithFullContentLength_Cached test

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
 
         public ResponseCachingTests()
         {
-            _absoluteFilePath = Directory.GetFiles(Directory.GetCurrentDirectory()).First();
+            _absoluteFilePath = Path.Combine(Directory.GetCurrentDirectory(), "Microsoft.AspNetCore.Server.HttpSys.dll");
             _fileLength = new FileInfo(_absoluteFilePath).Length;
         }
 


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1500

The test was picking the first file from the local directory and using it as test content. For netcoreapp2 this was Microsoft.AspNetCore.Server.HttpSys.dll, but for net461 it was Castle.Core.dll. Castle was much larger so it caused different behavior and failed the net461 tests.