### PR TITLE
HttpParse .IndexOf(...) >= 0 to .Contains(...)

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -394,7 +394,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             // Check for CR in value
             var valueBuffer = new Span<byte>(headerLine + valueStart, valueEnd - valueStart + 1);
-            if (valueBuffer.IndexOf(ByteCR) >= 0)
+            if (valueBuffer.Contains(ByteCR))
             {
                 RejectRequestHeader(headerLine, length);
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 return false;
             }
 
-            var pathEncoded = pathSegment.IndexOf('%') >= 0;
+            var pathEncoded = pathSegment.Contains('%');
 
             // Compare with Http1Connection.OnOriginFormTarget
 


### PR DESCRIPTION
Is faster and added to coreclr for this purpose https://github.com/dotnet/corefx/issues/27526