### PR TITLE
Replace AssignToProperties with SetParameterProperties, which also clears unspecified parameter properties (imported from Blazor PR 1108)

### DIFF
--- a/src/Components/blazor/samples/StandaloneApp/Pages/FetchData.cshtml
+++ b/src/Components/blazor/samples/StandaloneApp/Pages/FetchData.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/fetchdata"
+@page "/fetchdata"
 @page "/fetchdata/{StartDate:datetime}"
 @inject HttpClient Http
 
@@ -48,14 +48,14 @@ else
 
     WeatherForecast[] forecasts;
 
-    public override void SetParameters(ParameterCollection parameters)
-    {
-        StartDate = DateTime.Now;
-        base.SetParameters(parameters);
-    }
-
     protected override async Task OnParametersSetAsync()
     {
+        // If no value was given in the URL for StartDate, apply a default
+        if (StartDate == default)
+        {
+            StartDate = DateTime.Now;
+        }
+
         forecasts = await Http.GetJsonAsync<WeatherForecast[]>(
             $"sample-data/weather.json?date={StartDate.ToString("yyyy-MM-dd")}");
 

--- a/src/Components/samples/ComponentsApp.App/Pages/FetchData.cshtml
+++ b/src/Components/samples/ComponentsApp.App/Pages/FetchData.cshtml
@@ -48,14 +48,14 @@ else
 
     WeatherForecast[] forecasts;
 
-    public override void SetParameters(ParameterCollection parameters)
-    {
-        StartDate = DateTime.Now;
-        base.SetParameters(parameters);
-    }
-
     protected override async Task OnParametersSetAsync()
     {
+        // If no value was given in the URL for StartDate, apply a default
+        if (StartDate == default)
+        {
+            StartDate = DateTime.Now;
+        }
+
         forecasts = await ForecastService.GetForecastAsync(StartDate);
     }
 }

--- a/src/Components/src/Microsoft.AspNetCore.Components/CascadingValue.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/CascadingValue.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Components
         public void SetParameters(ParameterCollection parameters)
         {
             // Implementing the parameter binding manually, instead of just calling
-            // parameters.AssignToProperties(this), is just a very slight perf optimization
+            // parameters.SetParameterProperties(this), is just a very slight perf optimization
             // and makes it simpler impose rules about the params being required or not.
 
             var hasSuppliedValue = false;

--- a/src/Components/src/Microsoft.AspNetCore.Components/ComponentBase.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/ComponentBase.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="parameters">The parameters to apply.</param>
         public virtual void SetParameters(ParameterCollection parameters)
         {
-            parameters.AssignToProperties(this);
+            parameters.SetParameterProperties(this);
 
             if (!_hasCalledInit)
             {

--- a/src/Components/src/Microsoft.AspNetCore.Components/Layouts/LayoutDisplay.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Layouts/LayoutDisplay.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Components.Layouts
         /// <inheritdoc />
         public void SetParameters(ParameterCollection parameters)
         {
-            parameters.AssignToProperties(this);
+            parameters.SetParameterProperties(this);
             Render();
         }
 

--- a/src/Components/src/Microsoft.AspNetCore.Components/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Microsoft.AspNetCore.Components.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Components feature for ASP.NET Core.</Description>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/src/Microsoft.AspNetCore.Components/ParameterCollectionExtensions.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/ParameterCollectionExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Components.Reflection;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Microsoft.AspNetCore.Components
@@ -17,15 +16,16 @@ namespace Microsoft.AspNetCore.Components
     {
         private const BindingFlags _bindablePropertyFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase;
 
-        private readonly static IDictionary<Type, IDictionary<string, IPropertySetter>> _cachedParameterWriters = new ConcurrentDictionary<Type, IDictionary<string, IPropertySetter>>();
+        private readonly static ConcurrentDictionary<Type, WritersForType> _cachedWritersByType
+            = new ConcurrentDictionary<Type, WritersForType>();
 
         /// <summary>
-        /// Iterates through the <see cref="ParameterCollection"/>, assigning each parameter
-        /// to a property of the same name on <paramref name="target"/>.
+        /// For each parameter property on <paramref name="target"/>, updates its value to
+        /// match the corresponding entry in the <see cref="ParameterCollection"/>.
         /// </summary>
         /// <param name="parameterCollection">The <see cref="ParameterCollection"/>.</param>
         /// <param name="target">An object that has a public writable property matching each parameter's name and type.</param>
-        public static void SetParameterProperties(
+        public unsafe static void SetParameterProperties(
             in this ParameterCollection parameterCollection,
             object target)
         {
@@ -35,26 +35,36 @@ namespace Microsoft.AspNetCore.Components
             }
 
             var targetType = target.GetType();
-            if (!_cachedParameterWriters.TryGetValue(targetType, out var parameterWriters))
+            if (!_cachedWritersByType.TryGetValue(targetType, out var writers))
             {
-                parameterWriters = CreateParameterWriters(targetType);
-                _cachedParameterWriters[targetType] = parameterWriters;
+                writers = new WritersForType(targetType);
+                _cachedWritersByType[targetType] = writers;
             }
 
-            var localParameterWriter = parameterWriters.Values.ToList();
+            // We only want to iterate through the parameterCollection once, and by the end of it,
+            // need to have tracked which of the parameter properties haven't yet been written.
+            // To avoid allocating any list/dictionary to track that, here we stackalloc an array
+            // of flags and set them based on the indices of the writers we use.
+            var numWriters = writers.WritersByIndex.Count;
+            var numUsedWriters = 0;
+
+            // TODO: Once we're able to move to netstandard2.1, this can be changed to be
+            // a Span<bool> and then the enclosing method no longer needs to be 'unsafe'
+            bool* usageFlags = stackalloc bool[numWriters];
 
             foreach (var parameter in parameterCollection)
             {
                 var parameterName = parameter.Name;
-                if (!parameterWriters.TryGetValue(parameterName, out var parameterWriter))
+                if (!writers.WritersByName.TryGetValue(parameterName, out var writerWithIndex))
                 {
                     ThrowForUnknownIncomingParameterName(targetType, parameterName);
                 }
 
                 try
                 {
-                    parameterWriter.SetValue(target, parameter.Value);
-                    localParameterWriter.Remove(parameterWriter);
+                    writerWithIndex.Writer.SetValue(target, parameter.Value);
+                    usageFlags[writerWithIndex.Index] = true;
+                    numUsedWriters++;
                 }
                 catch (Exception ex)
                 {
@@ -64,43 +74,26 @@ namespace Microsoft.AspNetCore.Components
                 }
             }
 
-            foreach (var nonUsedParameter in localParameterWriter)
+            // Now we can determine whether any writers have not been used, and if there are
+            // some unused ones, find them.
+            for (var index = 0; numUsedWriters < numWriters; index++)
             {
-                nonUsedParameter.SetDefaultValue(target);
+                if (index >= numWriters)
+                {
+                    // This should not be possible
+                    throw new InvalidOperationException("Ran out of writers before marking them all as used.");
+                }
+
+                if (!usageFlags[index])
+                {
+                    writers.WritersByIndex[index].SetDefaultValue(target);
+                    numUsedWriters++;
+                }
             }
         }
 
         internal static IEnumerable<PropertyInfo> GetCandidateBindableProperties(Type targetType)
             => MemberAssignment.GetPropertiesIncludingInherited(targetType, _bindablePropertyFlags);
-
-        private static IDictionary<string, IPropertySetter> CreateParameterWriters(Type targetType)
-        {
-            var result = new Dictionary<string, IPropertySetter>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var propertyInfo in GetCandidateBindableProperties(targetType))
-            {
-                var shouldCreateWriter = propertyInfo.IsDefined(typeof(ParameterAttribute))
-                    || propertyInfo.IsDefined(typeof(CascadingParameterAttribute));
-                if (!shouldCreateWriter)
-                {
-                    continue;
-                }
-
-                var propertySetter = MemberAssignment.CreatePropertySetter(targetType, propertyInfo);
-
-                var propertyName = propertyInfo.Name;
-                if (result.ContainsKey(propertyName))
-                {
-                    throw new InvalidOperationException(
-                        $"The type '{targetType.FullName}' declares more than one parameter matching the " +
-                        $"name '{propertyName.ToLowerInvariant()}'. Parameter names are case-insensitive and must be unique.");
-                }
-
-                result.Add(propertyName, propertySetter);
-            }
-
-            return result;
-        }
 
         private static void ThrowForUnknownIncomingParameterName(Type targetType, string parameterName)
         {
@@ -127,6 +120,48 @@ namespace Microsoft.AspNetCore.Components
                 throw new InvalidOperationException(
                     $"Object of type '{targetType.FullName}' does not have a property " +
                     $"matching the name '{parameterName}'.");
+            }
+        }
+
+        class WritersForType
+        {
+            public Dictionary<string, (int Index, IPropertySetter Writer)> WritersByName { get; }
+            public List<IPropertySetter> WritersByIndex { get; }
+
+            public WritersForType(Type targetType)
+            {
+                var propertySettersByName = new Dictionary<string, IPropertySetter>(StringComparer.OrdinalIgnoreCase);
+                foreach (var propertyInfo in GetCandidateBindableProperties(targetType))
+                {
+                    var shouldCreateWriter = propertyInfo.IsDefined(typeof(ParameterAttribute))
+                        || propertyInfo.IsDefined(typeof(CascadingParameterAttribute));
+                    if (!shouldCreateWriter)
+                    {
+                        continue;
+                    }
+
+                    var propertySetter = MemberAssignment.CreatePropertySetter(targetType, propertyInfo);
+
+                    var propertyName = propertyInfo.Name;
+                    if (propertySettersByName.ContainsKey(propertyName))
+                    {
+                        throw new InvalidOperationException(
+                            $"The type '{targetType.FullName}' declares more than one parameter matching the " +
+                            $"name '{propertyName.ToLowerInvariant()}'. Parameter names are case-insensitive and must be unique.");
+                    }
+
+                    propertySettersByName.Add(propertyName, propertySetter);
+                }
+
+                // Now we know all the entries, construct the resulting list/dictionary
+                // with well-defined indices
+                WritersByIndex = new List<IPropertySetter>();
+                WritersByName = new Dictionary<string, (int, IPropertySetter)>(StringComparer.OrdinalIgnoreCase);
+                foreach (var pair in propertySettersByName)
+                {
+                    WritersByName.Add(pair.Key, (WritersByIndex.Count, pair.Value));
+                    WritersByIndex.Add(pair.Value);
+                }
             }
         }
     }

--- a/src/Components/src/Microsoft.AspNetCore.Components/ParameterCollectionExtensions.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/ParameterCollectionExtensions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Components
 
             foreach (var nonUsedParameter in localParameterWriter)
             {
-                nonUsedParameter.SetValue(target, nonUsedParameter.GetDefaultValue());
+                nonUsedParameter.SetDefaultValue(target);
             }
         }
 

--- a/src/Components/src/Microsoft.AspNetCore.Components/Reflection/IPropertySetter.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Reflection/IPropertySetter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,5 +8,7 @@ namespace Microsoft.AspNetCore.Components.Reflection
     internal interface IPropertySetter
     {
         void SetValue(object target, object value);
+
+        object GetDefaultValue();
     }
 }

--- a/src/Components/src/Microsoft.AspNetCore.Components/Reflection/IPropertySetter.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Reflection/IPropertySetter.cs
@@ -1,14 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Components.Reflection
 {
     internal interface IPropertySetter
     {
         void SetValue(object target, object value);
 
-        object GetDefaultValue();
+        void SetDefaultValue(object target);
     }
 }

--- a/src/Components/src/Microsoft.AspNetCore.Components/Reflection/MemberAssignment.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Reflection/MemberAssignment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,15 +43,23 @@ namespace Microsoft.AspNetCore.Components.Reflection
         class PropertySetter<TTarget, TValue> : IPropertySetter
         {
             private readonly Action<TTarget, TValue> _setterDelegate;
+            private object _defaultValue;
 
             public PropertySetter(MethodInfo setMethod)
             {
                 _setterDelegate = (Action<TTarget, TValue>)Delegate.CreateDelegate(
                     typeof(Action<TTarget, TValue>), setMethod);
+                var propertyType = typeof(TValue);
+                _defaultValue = propertyType.IsValueType ? Activator.CreateInstance(propertyType) : null;
             }
 
             public void SetValue(object target, object value)
                 => _setterDelegate((TTarget)target, (TValue)value);
+
+            public object GetDefaultValue()
+            {
+                return _defaultValue;
+            }
         }
     }
 }

--- a/src/Components/src/Microsoft.AspNetCore.Components/Reflection/MemberAssignment.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Reflection/MemberAssignment.cs
@@ -43,23 +43,19 @@ namespace Microsoft.AspNetCore.Components.Reflection
         class PropertySetter<TTarget, TValue> : IPropertySetter
         {
             private readonly Action<TTarget, TValue> _setterDelegate;
-            private object _defaultValue;
 
             public PropertySetter(MethodInfo setMethod)
             {
                 _setterDelegate = (Action<TTarget, TValue>)Delegate.CreateDelegate(
                     typeof(Action<TTarget, TValue>), setMethod);
                 var propertyType = typeof(TValue);
-                _defaultValue = propertyType.IsValueType ? Activator.CreateInstance(propertyType) : null;
             }
 
             public void SetValue(object target, object value)
                 => _setterDelegate((TTarget)target, (TValue)value);
 
-            public object GetDefaultValue()
-            {
-                return _defaultValue;
-            }
+            public void SetDefaultValue(object target)
+                => _setterDelegate((TTarget)target, default);
         }
     }
 }

--- a/src/Components/src/Microsoft.AspNetCore.Components/Routing/Router.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components/Routing/Router.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.Routing
         /// <inheritdoc />
         public void SetParameters(ParameterCollection parameters)
         {
-            parameters.AssignToProperties(this);
+            parameters.SetParameterProperties(this);
             var types = ComponentResolver.ResolveComponents(AppAssembly);
             Routes = RouteTable.Create(types);
             Refresh();

--- a/src/Components/test/Microsoft.AspNetCore.Components.E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.E2ETest/Tests/RoutingTest.cs
@@ -203,7 +203,17 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             var app = MountTestComponent<TestRouter>();
             app.FindElement(By.LinkText("With parameters")).Click();
+            WaitAssert.Equal("Your full name is Abc .", () => app.FindElement(By.Id("test-info")).Text);
+            AssertHighlightedLinks("With parameters");
+
+            // Can add more parameters while remaining on same page
+            app.FindElement(By.LinkText("With more parameters")).Click();
             WaitAssert.Equal("Your full name is Abc McDef.", () => app.FindElement(By.Id("test-info")).Text);
+            AssertHighlightedLinks("With parameters", "With more parameters");
+
+            // Can remove parameters while remaining on same page
+            app.FindElement(By.LinkText("With parameters")).Click();
+            WaitAssert.Equal("Your full name is Abc .", () => app.FindElement(By.Id("test-info")).Text);
             AssertHighlightedLinks("With parameters");
         }
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Test/ParameterCollectionAssignmentExtensionsTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Test/ParameterCollectionAssignmentExtensionsTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Components.Test
             var target = new HasInstanceProperties();
 
             // Act
-            parameterCollection.AssignToProperties(target);
+            parameterCollection.SetParameterProperties(target);
 
             // Assert
             Assert.Equal(123, target.IntProp);
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Components.Test
             var target = new HasInstanceProperties();
 
             // Act
-            parameterCollection.AssignToProperties(target);
+            parameterCollection.SetParameterProperties(target);
 
             // Assert
             Assert.Equal(123, target.IntProp);
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Components.Test
             var target = new HasInheritedProperties();
 
             // Act
-            parameterCollection.AssignToProperties(target);
+            parameterCollection.SetParameterProperties(target);
 
             // Assert
             Assert.Equal(123, target.IntProp);
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void NoIncomingParameterMatchesDeclaredParameter_LeavesValueUnchanged()
+        public void NoIncomingParameterMatchesDeclaredParameter_SetValuesDefault()
         {
             // Arrange
             var existingObjectValue = new object();
@@ -86,12 +86,12 @@ namespace Microsoft.AspNetCore.Components.Test
             var parameterCollection = new ParameterCollectionBuilder().Build();
 
             // Act
-            parameterCollection.AssignToProperties(target);
+            parameterCollection.SetParameterProperties(target);
 
             // Assert
-            Assert.Equal(456, target.IntProp);
-            Assert.Equal("Existing value", target.StringProp);
-            Assert.Same(existingObjectValue, target.ObjectPropCurrentValue);
+            Assert.Equal(0, target.IntProp);
+            Assert.Null(target.StringProp);
+            Assert.Null(target.ObjectPropCurrentValue);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(
-                () => parameterCollection.AssignToProperties(target));
+                () => parameterCollection.SetParameterProperties(target));
 
             // Assert
             Assert.Equal(
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(
-                () => parameterCollection.AssignToProperties(target));
+                () => parameterCollection.SetParameterProperties(target));
 
             // Assert
             Assert.Equal(default, target.IntProp);
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(
-                () => parameterCollection.AssignToProperties(target));
+                () => parameterCollection.SetParameterProperties(target));
 
             // Assert
             Assert.Equal(
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(
-                () => parameterCollection.AssignToProperties(target));
+                () => parameterCollection.SetParameterProperties(target));
 
             // Assert
             Assert.Equal(
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                parameterCollection.AssignToProperties(target));
+                parameterCollection.SetParameterProperties(target));
 
             // Assert
             Assert.Equal(
@@ -205,14 +205,14 @@ namespace Microsoft.AspNetCore.Components.Test
             // an allowed scenario because there would be no way for the consumer to specify
             // both property values, and it's no good leaving the shadowed one unset because the
             // base class can legitimately depend on it for correct functioning.
-            
+
             // Arrange
             var parameterCollection = new ParameterCollectionBuilder().Build();
             var target = new HasParameterClashingWithInherited();
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                parameterCollection.AssignToProperties(target));
+                parameterCollection.SetParameterProperties(target));
 
             // Assert
             Assert.Equal(
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Components.Test
         {
             // "internal" to show we're not requiring public accessors, but also
             // to keep the assertions simple in the tests
-            
+
             [Parameter] internal int IntProp { get; set; }
             [Parameter] internal string StringProp { get; set; }
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Test/RenderTreeDiffBuilderTest.cs
@@ -1557,7 +1557,7 @@ namespace Microsoft.AspNetCore.Components.Test
             public void Init(RenderHandle renderHandle) { }
             public void SetParameters(ParameterCollection parameters)
             {
-                parameters.AssignToProperties(this);
+                parameters.SetParameterProperties(this);
             }
         }
 

--- a/src/Components/test/Microsoft.AspNetCore.Components.Test/RendererTest.cs
+++ b/src/Components/test/Microsoft.AspNetCore.Components.Test/RendererTest.cs
@@ -1202,7 +1202,7 @@ namespace Microsoft.AspNetCore.Components.Test
                 => RenderHandle = renderHandle;
 
             public void SetParameters(ParameterCollection parameters)
-                => parameters.AssignToProperties(this);
+                => parameters.SetParameterProperties(this);
         }
 
         private class EventComponent : AutoRenderComponent, IComponent, IHandleEvent
@@ -1310,7 +1310,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             public void SetParameters(ParameterCollection parameters)
             {
-                parameters.AssignToProperties(this);
+                parameters.SetParameterProperties(this);
                 Render();
             }
 

--- a/src/Components/test/shared/AutoRenderComponent.cs
+++ b/src/Components/test/shared/AutoRenderComponent.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
 
         public virtual void SetParameters(ParameterCollection parameters)
         {
-            parameters.AssignToProperties(this);
+            parameters.SetParameterProperties(this);
             TriggerRender();
         }
 

--- a/src/Components/test/testapps/BasicTestApp/RouterTest/Links.cshtml
+++ b/src/Components/test/testapps/BasicTestApp/RouterTest/Links.cshtml
@@ -10,7 +10,8 @@
     <li><NavLink href="Other" Match=NavLinkMatch.All>Other with base-relative URL (matches all)</NavLink></li>
     <li><NavLink href="/subdir/Other?abc=123">Other with query</NavLink></li>
     <li><NavLink href="/subdir/Other#blah">Other with hash</NavLink></li>
-    <li><NavLink href="/subdir/WithParameters/Name/Abc/LastName/McDef">With parameters</NavLink></li>
+    <li><NavLink href="/subdir/WithParameters/Name/Abc">With parameters</NavLink></li>
+    <li><NavLink href="/subdir/WithParameters/Name/Abc/LastName/McDef">With more parameters</NavLink></li>
 </ul>
 
 <button onclick=@(x => uriHelper.NavigateTo("Other"))>

--- a/src/Components/test/testapps/BasicTestApp/RouterTest/WithParameters.cshtml
+++ b/src/Components/test/testapps/BasicTestApp/RouterTest/WithParameters.cshtml
@@ -1,3 +1,4 @@
+@page "/WithParameters/Name/{firstName}"
 @page "/WithParameters/Name/{firstName}/LastName/{lastName}"
 <div id="test-info">Your full name is @FirstName @LastName.</div>
 <Links />


### PR DESCRIPTION
Imported from https://github.com/aspnet/Blazor/pull/1108