### PR TITLE
Fix compiling Mvc.sln in 2.2

### DIFF
--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Microsoft.AspNetCore.Mvc.Core.csproj
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Microsoft.AspNetCore.Mvc.Core.csproj
@@ -17,7 +17,7 @@ Microsoft.AspNetCore.Mvc.RouteAttribute</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepositoryRoot)\src\Shared\RangeHelper\**\*.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\Shared\RangeHelper\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mvc.sln was not compiling in VS because RangeHelper.cs could not be resolved.

I copied what master does to reference the file.