### PR TITLE
Workaround #4804

### DIFF
--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance.Views/Microsoft.AspNetCore.Mvc.Performance.Views.csproj
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance.Views/Microsoft.AspNetCore.Mvc.Performance.Views.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -6,8 +6,6 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
 
     <_EnableAllInclusiveRazorSdk>true</_EnableAllInclusiveRazorSdk>
-    <RazorLangVersion>3.0</RazorLangVersion>
-    <RazorDefaultConfiguration>MVC-3.0</RazorDefaultConfiguration>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mvc/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
+++ b/src/Mvc/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
@@ -1,13 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <!--  Workaround https://github.com/dotnet/core-setup/issues/3726 -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
 
     <_EnableAllInclusiveRazorSdk>true</_EnableAllInclusiveRazorSdk>
-    <RazorLangVersion>3.0</RazorLangVersion>
-    <RazorDefaultConfiguration>MVC-3.0</RazorDefaultConfiguration>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a workaround for a workaround that currently have in d16p1.

The Razor SDK maps all netcoreapp3.0 projects to MVC-2.1 at design time,
however this only really works if you have the Razor.Design package.
Since we have internal builds available that support MVC-3.0 we can just
manually hardcode the correct targeting of the project.