### PR TITLE
Fix package layout for ANCM packages

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -71,7 +71,7 @@
 
     <NpmProjectDirectory Include="$(RepositoryRoot)src\Middleware\CORS\test\FunctionalTests\" />
 
-    <ProjectToBuild Condition=" '$(OS)' == 'Windows_NT' " Include="$(RepositoryRoot)src\Servers\**\*.vcxproj">
+    <ProjectToBuild Condition=" '$(OS)' == 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' " Include="$(RepositoryRoot)src\Servers\**\*.vcxproj">
       <!-- Required to prevent triggering double-builds. See src\Servers\IIS\ResolveIisReferences.targets for details. -->
       <AdditionalProperties Condition="'$(SharedFxRid)' == 'win-x64'">Platform=x64</AdditionalProperties>
       <AdditionalProperties Condition="'$(SharedFxRid)' == 'win-x86'">Platform=x86</AdditionalProperties>

--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <SignOutput Condition=" '$(SignType)' != '' ">true</SignOutput>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <Import Project="MicroBuild.Plugin.props" Condition="'$(MicroBuildSentinelFile)' == ''" />

--- a/src/Servers/IIS/ResolveIisReferences.targets
+++ b/src/Servers/IIS/ResolveIisReferences.targets
@@ -79,6 +79,8 @@ with the right MSBuild incantations to get output copied to the right place.
       <!-- Prepend LinkBase to output path. -->
       <NativeContent>
         <Link>%(LinkBase)%(FileName)%(Extension)</Link>
+        <!-- Don't put this content in a nuget package. -->
+        <Pack>false</Pack>
       </NativeContent>
     </ItemGroup>
 

--- a/src/Servers/IIS/src/Microsoft.AspNetCore.AspNetCoreModule/Microsoft.AspNetCore.AspNetCoreModule.pkgproj
+++ b/src/Servers/IIS/src/Microsoft.AspNetCore.AspNetCoreModule/Microsoft.AspNetCore.AspNetCoreModule.pkgproj
@@ -8,7 +8,6 @@
     <PackageTags>aspnetcore</PackageTags>
     <PackageTitle>Microsoft ASP.NET Core Module</PackageTitle>
     <Pack>true</Pack>
-    <ContentTargetFolders>content</ContentTargetFolders>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageDescription>ASP.NET Core Module</PackageDescription>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
@@ -19,7 +18,7 @@
     <Content Include="..\AspNetCoreModuleV1\AspNetCore\bin\$(Configuration)\Win32\aspnetcore.pdb" PackagePath="contentFiles/any/any/x86" />
     <Content Include="..\AspNetCoreModuleV1\AspNetCore\bin\$(Configuration)\x64\aspnetcore.dll" PackagePath="contentFiles/any/any/x64" />
     <Content Include="..\AspNetCoreModuleV1\AspNetCore\bin\$(Configuration)\x64\aspnetcore.pdb" PackagePath="contentFiles/any/any/x64" />
-    <Content Include="..\AspNetCoreModuleV1\AspNetCore\bin\$(Configuration)\x64\*.xml" PackagePath="" />
+    <Content Include="..\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml" PackagePath="/aspnetcore_schema.xml" />
     <Content Include="Microsoft.AspNetCore.AspNetCoreModule.props" PackagePath="build\" />
     <Reference Include="AspNetCoreModule" />
   </ItemGroup>

--- a/src/Servers/IIS/src/Microsoft.AspNetCore.AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2.pkgproj
+++ b/src/Servers/IIS/src/Microsoft.AspNetCore.AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2.pkgproj
@@ -8,7 +8,6 @@
     <PackageTags>aspnetcore</PackageTags>
     <PackageTitle>Microsoft ASP.NET Core Module</PackageTitle>
     <Pack>true</Pack>
-    <ContentTargetFolders>content</ContentTargetFolders>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageDescription>ASP.NET Core Module</PackageDescription>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
@@ -25,8 +24,8 @@
     <Content Include="..\AspNetCoreModuleV2\OutOfProcessRequestHandler\bin\$(Configuration)\x64\aspnetcorev2_outofprocess.dll" PackagePath="contentFiles/any/any/x64/2.0.0" />
     <Content Include="..\AspNetCoreModuleV2\OutOfProcessRequestHandler\bin\$(Configuration)\x64\aspnetcorev2_outofprocess.pdb" PackagePath="contentFiles/any/any/x64/2.0.0" />
 
-    <Content Include="..\AspNetCoreModuleV2\AspNetCore\bin\$(Configuration)\x64\*.xml" PackagePath="" />
-    <Content Include="..\AspNetCoreModuleV2\AspNetCore\ancm.mof" />
+    <Content Include="..\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml" PackagePath="/" />
+    <Content Include="..\AspNetCoreModuleV2\AspNetCore\ancm.mof" PackagePath="/" />
     <Content Include="Microsoft.AspNetCore.AspNetCoreModule.props.in" PackagePath="build\" />
     <Reference Include="AspNetCoreModuleV2" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1527

Package layout broke in https://github.com/aspnet/AspNetCore/pull/4968. This wasn't caught by PR validation b/c we don't build the MSIs on PRs.