### PR TITLE
Disable AllowSynchronousIO by default in all servers

### DIFF
--- a/src/Hosting/TestHost/src/AsyncStreamWrapper.cs
+++ b/src/Hosting/TestHost/src/AsyncStreamWrapper.cs
@@ -21,13 +21,17 @@ namespace Microsoft.AspNetCore.TestHost
 
         public override bool CanRead => _inner.CanRead;
 
-        public override bool CanSeek => _inner.CanSeek;
+        public override bool CanSeek => false;
 
         public override bool CanWrite => _inner.CanWrite;
 
-        public override long Length => _inner.Length;
+        public override long Length => throw new NotSupportedException("The stream is not seekable.");
 
-        public override long Position { get => _inner.Position; set => _inner.Position = value; }
+        public override long Position
+        {
+            get => throw new NotSupportedException("The stream is not seekable.");
+            set => throw new NotSupportedException("The stream is not seekable.");
+        }
 
         public override void Flush()
         {
@@ -72,12 +76,12 @@ namespace Microsoft.AspNetCore.TestHost
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            return _inner.Seek(offset, origin);
+            throw new NotSupportedException("The stream is not seekable.");
         }
 
         public override void SetLength(long value)
         {
-            _inner.SetLength(value);
+            throw new NotSupportedException("The stream is not seekable.");
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -81,9 +81,9 @@ namespace Microsoft.AspNetCore.TestHost
         /// Gets or sets a value that controls whether synchronous IO is allowed for the <see cref="HttpContext.Request"/> and <see cref="HttpContext.Response"/>
         /// </summary>
         /// <remarks>
-        /// Defaults to true.
+        /// Defaults to false.
         /// </remarks>
-        public bool AllowSynchronousIO { get; set; } = true;
+        public bool AllowSynchronousIO { get; set; } = false;
 
         private IHttpApplication<Context> Application
         {

--- a/src/Mvc/Mvc.Formatters.Xml/src/XmlDataContractSerializerOutputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/XmlDataContractSerializerOutputFormatter.cs
@@ -254,6 +254,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             var dataContractSerializer = GetCachedSerializer(wrappingType);
 
+            // Opt into sync IO support until we can work out an alternative https://github.com/aspnet/AspNetCore/issues/6397
+            var syncIOFeature = context.HttpContext.Features.Get<Http.Features.IHttpBodyControlFeature>();
+            if (syncIOFeature != null)
+            {
+                syncIOFeature.AllowSynchronousIO = true;
+            }
+
             using (var textWriter = context.WriterFactory(context.HttpContext.Response.Body, writerSettings.Encoding))
             {
                 using (var xmlWriter = CreateXmlWriter(context, textWriter, writerSettings))

--- a/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerOutputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerOutputFormatter.cs
@@ -230,6 +230,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             var xmlSerializer = GetCachedSerializer(wrappingType);
 
+            // Opt into sync IO support until we can work out an alternative https://github.com/aspnet/AspNetCore/issues/6397
+            var syncIOFeature = context.HttpContext.Features.Get<Http.Features.IHttpBodyControlFeature>();
+            if (syncIOFeature != null)
+            {
+                syncIOFeature.AllowSynchronousIO = true;
+            }
+
             using (var textWriter = context.WriterFactory(context.HttpContext.Response.Body, writerSettings.Encoding))
             {
                 using (var xmlWriter = CreateXmlWriter(context, textWriter, writerSettings))

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
@@ -105,6 +105,13 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 response.StatusCode = result.StatusCode.Value;
             }
 
+            // Opt into sync IO support until we can work out an alternative https://github.com/aspnet/AspNetCore/issues/6397
+            var syncIOFeature = context.HttpContext.Features.Get<Http.Features.IHttpBodyControlFeature>();
+            if (syncIOFeature != null)
+            {
+                syncIOFeature.AllowSynchronousIO = true;
+            }
+
             using (var writer = new HttpResponseStreamWriter(response.Body, resolvedContentTypeEncoding))
             {
                 var viewContext = new ViewContext(

--- a/src/Mvc/test/WebSites/FormatterWebSite/StringInputFormatter.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/StringInputFormatter.cs
@@ -20,13 +20,13 @@ namespace FormatterWebSite
             SupportedEncodings.Add(Encoding.Unicode);
         }
 
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding effectiveEncoding)
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding effectiveEncoding)
         {
             var request = context.HttpContext.Request;
             using (var reader = new StreamReader(request.Body, effectiveEncoding))
             {
-                var stringContent = reader.ReadToEnd();
-                return InputFormatterResult.SuccessAsync(stringContent);
+                var stringContent = await reader.ReadToEndAsync();
+                return await InputFormatterResult.SuccessAsync(stringContent);
             }
         }
     }

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -136,9 +136,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         /// <summary>
         /// Gets or sets a value that controls whether synchronous IO is allowed for the HttpContext.Request.Body and HttpContext.Response.Body.
-        /// The default is `true`.
+        /// The default is `false`.
         /// </summary>
-        public bool AllowSynchronousIO { get; set; } = true;
+        public bool AllowSynchronousIO { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value that controls how http.sys reacts when rejecting requests due to throttling conditions - like when the request

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -50,14 +50,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         [ConditionalFact]
         public async Task Https_EchoHelloWorld_Success()
         {
-            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
             {
-                string input = new StreamReader(httpContext.Request.Body).ReadToEnd();
+                var input = await new StreamReader(httpContext.Request.Body).ReadToEndAsync();
                 Assert.Equal("Hello World", input);
-                byte[] body = Encoding.UTF8.GetBytes("Hello World");
+                var body = Encoding.UTF8.GetBytes("Hello World");
                 httpContext.Response.ContentLength = body.Length;
-                httpContext.Response.Body.Write(body, 0, body.Length);
-                return Task.FromResult(0);
+                await httpContext.Response.Body.WriteAsync(body, 0, body.Length);
             }))
             {
                 string response = await SendRequestAsync(address, "Hello World");

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/RequestBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/RequestBodyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,25 +17,25 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
     public class RequestBodyTests
     {
         [ConditionalFact]
-        public async Task RequestBody_SyncReadEnabledByDefault_ThrowsWhenDisabled()
+        public async Task RequestBody_SyncReadDisabledByDefault_WorksWhenEnabled()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
                 Task<string> responseTask = SendRequestAsync(address, "Hello World");
 
-                Assert.True(server.Options.AllowSynchronousIO);
+                Assert.False(server.Options.AllowSynchronousIO);
 
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[100];
+                Assert.Throws<InvalidOperationException>(() => context.Request.Body.Read(input, 0, input.Length));
+
+                context.AllowSynchronousIO = true;
 
                 Assert.True(context.AllowSynchronousIO);
                 var read = context.Request.Body.Read(input, 0, input.Length);
                 context.Response.ContentLength = read;
                 context.Response.Body.Write(input, 0, read);
-
-                context.AllowSynchronousIO = false;
-                Assert.Throws<InvalidOperationException>(() => context.Request.Body.Read(input, 0, input.Length));
 
                 string response = await responseTask;
                 Assert.Equal("Hello World", response);

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -320,7 +320,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         IEnumerator IEnumerable.GetEnumerator() => FastEnumerable().GetEnumerator();
 
-        bool IHttpBodyControlFeature.AllowSynchronousIO { get; set; } = true;
+        bool IHttpBodyControlFeature.AllowSynchronousIO { get; set; }
 
         void IHttpBufferingFeature.DisableRequestBuffering()
         {

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -11,9 +11,9 @@ namespace Microsoft.AspNetCore.Builder
         /// Gets or sets a value that controls whether synchronous IO is allowed for the <see cref="HttpContext.Request"/> and <see cref="HttpContext.Response"/>
         /// </summary>
         /// <remarks>
-        /// Defaults to true.
+        /// Defaults to false.
         /// </remarks>
-        public bool AllowSynchronousIO { get; set; } = true;
+        public bool AllowSynchronousIO { get; set; } = false;
 
         /// <summary>
         /// If true the server should set HttpContext.User. If false the server will only provide an

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ConnectionIdFeatureTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ConnectionIdFeatureTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -11,44 +10,22 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {
     [SkipIfHostableWebCoreNotAvailable]
     [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, "https://github.com/aspnet/IISIntegration/issues/866")]
-    public class HttpBodyControlFeatureTests : StrictTestServerTests
+    public class ConnectionIdFeatureTests : StrictTestServerTests
     {
         [ConditionalFact]
-        public async Task ThrowsOnSyncReadOrWrite()
+        public async Task ProvidesConnectionId()
         {
-            Exception writeException = null;
-            Exception readException = null;
-            using (var testServer = await TestServer.Create(
-                ctx => {
-                    var bodyControl = ctx.Features.Get<IHttpBodyControlFeature>();
-                    bodyControl.AllowSynchronousIO = false;
-
-                    try
-                    {
-                        ctx.Response.Body.Write(new byte[10]);
-                    }
-                    catch (Exception ex)
-                    {
-                        writeException = ex;
-                    }
-
-                    try
-                    {
-                        ctx.Request.Body.Read(new byte[10]);
-                    }
-                    catch (Exception ex)
-                    {
-                        readException = ex;
-                    }
-
-                    return Task.CompletedTask;
-                }, LoggerFactory))
+            string connectionId = null;
+            using (var testServer = await TestServer.Create(ctx => {
+                var connectionIdFeature = ctx.Features.Get<IHttpConnectionFeature>();
+                connectionId = connectionIdFeature.ConnectionId;
+                return Task.CompletedTask;
+            }, LoggerFactory))
             {
                 await testServer.HttpClient.GetStringAsync("/");
             }
 
-            Assert.IsType<InvalidOperationException>(readException);
-            Assert.IsType<InvalidOperationException>(writeException);
+            Assert.NotNull(connectionId);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -50,9 +50,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// Gets or sets a value that controls whether synchronous IO is allowed for the <see cref="HttpContext.Request"/> and <see cref="HttpContext.Response"/>
         /// </summary>
         /// <remarks>
-        /// Defaults to true.
+        /// Defaults to false.
         /// </remarks>
-        public bool AllowSynchronousIO { get; set; } = true;
+        public bool AllowSynchronousIO { get; set; } = false;
 
         /// <summary>
         /// Enables the Listen options callback to resolve and use services registered by the application during startup.

--- a/src/Servers/Kestrel/Core/test/KestrelServerOptionsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerOptionsTests.cs
@@ -23,11 +23,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void AllowSynchronousIODefaultsToTrue()
+        public void AllowSynchronousIODefaultsToFalse()
         {
             var options = new KestrelServerOptions();
 
-            Assert.True(options.AllowSynchronousIO);
+            Assert.False(options.AllowSynchronousIO);
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     await writer.WriteLineAsync("New protocol data");
                     await writer.FlushAsync();
+                    await writer.DisposeAsync();
                 }
 
                 upgrade.TrySetResult(true);
@@ -79,6 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         Assert.Equal(send, line);
                         await writer.WriteLineAsync(recv);
                         await writer.FlushAsync();
+                        await writer.DisposeAsync();
                     }
 
                     upgrade.TrySetResult(true);


### PR DESCRIPTION
 #4774 #5874
I had to bump IIS's dependencies to get the response compression fix. This will go away when I can rebase on the refs changes.

Let's see how many upstream tests fail...

Blocked by MVC #6397.