### PR TITLE
Changed class accessibility to `public`

### DIFF
--- a/src/DefaultBuilder/src/HostFilteringStartupFilter.cs
+++ b/src/DefaultBuilder/src/HostFilteringStartupFilter.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace Microsoft.AspNetCore
 {
-    internal class HostFilteringStartupFilter : IStartupFilter
+    public class HostFilteringStartupFilter : IStartupFilter
     {
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
         {


### PR DESCRIPTION
In `CreateDefaultBuilder` method there is a line as `services.AddTransient<IStartupFilter, HostFilteringStartupFilter>();`

Due to limited accessibility of this class, it is not possible to create completely new builders based on `CreateDefaultBuilder`
