### PR TITLE
Avoid double compression when reposnse ContentEncoding header already exists

### DIFF
--- a/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
+++ b/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
@@ -142,6 +142,10 @@ namespace Microsoft.AspNetCore.ResponseCompression
 
         private async void InternalWriteAsync(byte[] buffer, int offset, int count, AsyncCallback callback, TaskCompletionSource<object> tcs)
         {
+            // Avoid to compress responses with any ContentEncoding header.
+            if (_context.Response.Headers.ContainsKey(HeaderNames.ContentEncoding))
+                _compressionChecked = true;
+
             try
             {
                 await WriteAsync(buffer, offset, count);


### PR DESCRIPTION
Avoid double compression when response already has ContentEncoding header.

Addresses #5160 
