### PR TITLE
Devirtualize HttpHeaders.Reset

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -111,12 +111,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _isReadOnly = true;
         }
 
-        public void Reset()
-        {
-            _isReadOnly = false;
-            ClearFast();
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         protected static StringValues AppendValue(in StringValues existing, string append)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -111,6 +111,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _isReadOnly = true;
         }
 
+        // Inline to allow ClearFast to devirtualize in caller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset()
+        {
+            _isReadOnly = false;
+            ClearFast();
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         protected static StringValues AppendValue(in StringValues existing, string append)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -13,12 +13,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     public sealed partial class HttpRequestHeaders : HttpHeaders
     {
-        public void Reset()
-        {
-            _isReadOnly = false;
-            ClearFast();
-        }
-
         private static long ParseContentLength(string value)
         {
             if (!HeaderUtilities.TryParseNonNegativeInt64(value, out var parsed))

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -11,8 +11,14 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public partial class HttpRequestHeaders : HttpHeaders
+    public sealed partial class HttpRequestHeaders : HttpHeaders
     {
+        public void Reset()
+        {
+            _isReadOnly = false;
+            ClearFast();
+        }
+
         private static long ParseContentLength(string value)
         {
             if (!HeaderUtilities.TryParseNonNegativeInt64(value, out var parsed))

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -22,12 +22,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return new Enumerator(this);
         }
 
-        public void Reset()
-        {
-            _isReadOnly = false;
-            ClearFast();
-        }
-
         protected override IEnumerator<KeyValuePair<string, StringValues>> GetEnumeratorFast()
         {
             return GetEnumerator();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -12,7 +12,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public partial class HttpResponseHeaders : HttpHeaders
+    public sealed partial class HttpResponseHeaders : HttpHeaders
     {
         private static readonly byte[] _CrLf = new[] { (byte)'\r', (byte)'\n' };
         private static readonly byte[] _colonSpace = new[] { (byte)':', (byte)' ' };
@@ -20,6 +20,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public Enumerator GetEnumerator()
         {
             return new Enumerator(this);
+        }
+
+        public void Reset()
+        {
+            _isReadOnly = false;
+            ClearFast();
         }
 
         protected override IEnumerator<KeyValuePair<string, StringValues>> GetEnumeratorFast()


### PR DESCRIPTION
Seal the internal types `HttpRequestHeaders` and `HttpResponseHeaders` which allows the virtual `ClearFast` to devirtualize.

Move the caller `Reset` to the derived types rather than the parent type `HttpHeaders` so it can see `ClearFast` is sealed (as is executing in a sealed type rather than the unsealed parent).

/cc @davidfowl @pakrym @halter73