### PR TITLE
Add more timeouts to Http2TestBase

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -648,7 +648,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         protected static async Task FlushAsync(PipeWriter writableBuffer)
         {
-            await writableBuffer.FlushAsync();
+            await writableBuffer.FlushAsync().AsTask().DefaultTimeout();
         }
 
         protected Task SendPreambleAsync() => SendAsync(new ArraySegment<byte>(Http2Connection.ClientPreface));
@@ -1161,7 +1161,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Contains(expectedErrorMessage, expected => message.Exception.Message.Contains(expected));
             }
 
-            await _connectionTask;
+            await _connectionTask.DefaultTimeout();
             _pair.Application.Output.Complete();
         }
 


### PR DESCRIPTION
There are some Kestrel HTTP/2 tests that are hanging. The hangs should be fixed once we take a runtime that includes dotnet/corefx#34014. In the meantime, this PR makes the hanging tests fail after a 30 second timeout.

Addresses aspnet/AspNetCore-Internal#1529
