### PR TITLE
wip: Disable test assembly parallelization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -95,6 +95,9 @@
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('Tests')) OR $(MSBuildProjectName.EndsWith('.Test'))">true</IsTestProject>
     <IsTestAssetProject Condition="$(RepoRelativeProjectDir.Contains('testassets'))">true</IsTestAssetProject>
     <IsSampleProject Condition="$(RepoRelativeProjectDir.Contains('sample'))">true</IsSampleProject>
+    
+    <!-- This disables test assembly parallelization by default by putting each test assembly in a unique group -->
+    <TestGroupName>$(MSBuildProjectName)</TestGroupName>
   </PropertyGroup>
 
   <Import Project="eng\Dependencies.props" />


### PR DESCRIPTION
Attempt to resolve https://github.com/aspnet/AspNetCore-internal/issues/1531

We suspect tests hang indefinitely due to resource constraints. 