### PR TITLE
startvs.cmd - Cannot find path to dotnet exe when space in user name

### DIFF
--- a/startvs.cmd
+++ b/startvs.cmd
@@ -17,7 +17,7 @@ SET PATH=%DOTNET_ROOT%;%PATH%
 
 SET sln=%1
 
-IF NOT EXIST %DOTNET_ROOT%\dotnet.exe (
+IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
     echo .NET Core has not yet been installed. Run `build.cmd -restore` to install tools
     exit /b 1
 )


### PR DESCRIPTION
When space exists in user name .\startvs.cmd incorrecctly returns the following error: 

.NET Core has not yet been installed. Run `build.cmd -restore` to install tools

