### PR TITLE
Allow disabling the site extension projects

### DIFF
--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -7,7 +7,6 @@
     <BuildSharedFxDependsOn Condition="'$(TestOnly)' != 'true'">$(BuildSharedFxDependsOn);CodeSign</BuildSharedFxDependsOn>
     <RedistNetCorePath>$(IntermediateDir)ar\$(SharedFxRid)\</RedistNetCorePath>
     <GetArtifactInfoDependsOn>$(GetArtifactInfo);GetFxProjectArtifactInfo</GetArtifactInfoDependsOn>
-    <BuildSiteExtensions Condition="'$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86'">true</BuildSiteExtensions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -17,7 +17,7 @@ This can be done once #4246 is complete, and done in conjunction with converting
 
   <ItemGroup>
     <!-- Packages that go to nuget.org -->
-    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="ship" Condition=" '$(BuildSiteExtension)' == 'true' " />
+    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="ship" Condition=" '$(BuildSiteExtensions)' == 'true' " />
     <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Category="ship" />
@@ -27,7 +27,7 @@ This can be done once #4246 is complete, and done in conjunction with converting
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Twitter" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.WsFederation" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(BuildSiteExtension)' == 'true' " />
+    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(BuildSiteExtensions)' == 'true' " />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor.Cli" Category="ship" />

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -17,7 +17,7 @@ This can be done once #4246 is complete, and done in conjunction with converting
 
   <ItemGroup>
     <!-- Packages that go to nuget.org -->
-    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="ship" Condition=" '$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86' " />
+    <PackageArtifact Include="AspNetCoreRuntime.3.0.$(SharedFxArchitecture)" Category="ship" Condition=" '$(BuildSiteExtension)' == 'true' " />
     <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Category="ship" />
@@ -27,7 +27,7 @@ This can be done once #4246 is complete, and done in conjunction with converting
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Twitter" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.WsFederation" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86' " />
+    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(BuildSiteExtension)' == 'true' " />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor.Cli" Category="ship" />

--- a/build/repo.props
+++ b/build/repo.props
@@ -7,6 +7,7 @@
     <DisableDefaultTargets>true</DisableDefaultTargets>
     <DisableDefaultItems>true</DisableDefaultItems>
     <BuildSolutions>false</BuildSolutions>
+    <BuildSiteExtensions Condition="'$(SharedFxRid)' == 'win-x64' OR '$(SharedFxRid)' == 'win-x86'">true</BuildSiteExtensions>
 
     <OverridePackageOutputPath>false</OverridePackageOutputPath>
 


### PR DESCRIPTION
We need to set /p:BuildSiteExtensions=false on CI while we investigate and find a workaround for race conditions in `dotnet store` and NuGet pack. https://github.com/NuGet/Home/issues/7653