### PR TITLE
Remove JwtBearer and OIDC authentication from the shared framework

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -23,11 +23,12 @@ This can be done once #4246 is complete, and done in conjunction with converting
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Facebook" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Google" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Twitter" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.WsFederation" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(BuildSiteExtensions)' == 'true' " />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Blazor.Cli" Category="ship" />
@@ -79,6 +80,7 @@ This can be done once #4246 is complete, and done in conjunction with converting
     <!-- Experimental packages which are not ready for production yet -->
       <PackageArtifact Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.NodeServices.Sockets" Category="noship" />
+      <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.0.$(SharedFxArchitecture)" Category="noship" Condition=" '$(BuildSiteExtensions)' == 'true' " />
 
     <!-- Packages for internal use only. -->
       <!-- These packages contain CLI tools which are bundled in the .NET Core SDK. -->
@@ -108,9 +110,7 @@ This can be done once #4246 is complete, and done in conjunction with converting
       <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="noship" />
-      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="noship" />
-      <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="noship" />
       <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="noship" />

--- a/src/Framework/Microsoft.AspNetCore.App.props
+++ b/src/Framework/Microsoft.AspNetCore.App.props
@@ -17,9 +17,7 @@
     <Dependency Include="Microsoft.AspNetCore.Authentication.Abstractions"             Version="$(MicrosoftAspNetCoreAuthenticationAbstractionsPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Authentication.Cookies"                  Version="$(MicrosoftAspNetCoreAuthenticationCookiesPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Authentication.Core"                     Version="$(MicrosoftAspNetCoreAuthenticationCorePackageVersion)" />
-    <Dependency Include="Microsoft.AspNetCore.Authentication.JwtBearer"                Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Authentication.OAuth"                    Version="$(MicrosoftAspNetCoreAuthenticationOAuthPackageVersion)" />
-    <Dependency Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"            Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Authentication"                          Version="$(MicrosoftAspNetCoreAuthenticationPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Authorization.Policy"                    Version="$(MicrosoftAspNetCoreAuthorizationPolicyPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Authorization"                           Version="$(MicrosoftAspNetCoreAuthorizationPackageVersion)" />
@@ -133,15 +131,9 @@
     <Dependency Include="Microsoft.Extensions.Options"                                 Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
     <Dependency Include="Microsoft.Extensions.Primitives"                              Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
     <Dependency Include="Microsoft.Extensions.WebEncoders"                             Version="$(MicrosoftExtensionsWebEncodersPackageVersion)" />
-    <Dependency Include="Microsoft.IdentityModel.JsonWebTokens"                        Version="$(MicrosoftIdentityModelJsonWebTokensPackageVersion)" />
-    <Dependency Include="Microsoft.IdentityModel.Logging"                              Version="$(MicrosoftIdentityModelLoggingPackageVersion)" />
-    <Dependency Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"              Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion)" />
-    <Dependency Include="Microsoft.IdentityModel.Protocols"                            Version="$(MicrosoftIdentityModelProtocolsPackageVersion)" />
-    <Dependency Include="Microsoft.IdentityModel.Tokens"                               Version="$(MicrosoftIdentityModelTokensPackageVersion)" />
     <Dependency Include="Microsoft.Net.Http.Headers"                                   Version="$(MicrosoftNetHttpHeadersPackageVersion)" />
     <Dependency Include="Newtonsoft.Json.Bson"                                         Version="$(NewtonsoftJsonBsonPackageVersion)" />
     <Dependency Include="Newtonsoft.Json"                                              Version="$(NewtonsoftJsonPackageVersion)" />
-    <Dependency Include="System.IdentityModel.Tokens.Jwt"                              Version="$(SystemIdentityModelTokensJwtPackageVersion)" />
     <Dependency Include="System.IO.Pipelines"                                          Version="$(SystemIOPipelinesPackageVersion)" />
     <Dependency Include="System.Net.WebSockets.WebSocketProtocol"                      Version="$(SystemNetWebSocketsWebSocketProtocolPackageVersion)" />
     <Dependency Include="System.Runtime.CompilerServices.Unsafe"                       Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />

--- a/src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
+++ b/src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authentication;security</PackageTags>
+    <IsProductPackage>true</IsProductPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
+++ b/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authentication;security</PackageTags>
+    <IsProductPackage>true</IsProductPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These are being pulled out of the shared framework and will ship as NuGet packages. These assemblies have a dependency on the IdentityModel APIs which do no yet fit the guidelines the shared framework.

cref https://github.com/aspnet/AspNetCore/issues/3755