### PR TITLE
Use ref extensions as ref extensions

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7784,7 +7784,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 17, 14));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7810,7 +7810,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 31, 8));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7831,7 +7831,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 133, 16));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7857,7 +7857,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 350, 10));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7871,7 +7871,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if ((tempBits & -9223372036854775808L) != 0)
                 {
                     output.Write(new ReadOnlySpan<byte>(_headerBytes, 592, 18));
-                    PipelineExtensions.WriteNumeric(ref output, (ulong)ContentLength.Value);
+                    output.WriteNumeric((ulong)ContentLength.Value);
 
                     if((tempBits & ~-9223372036854775808L) == 0)
                     {
@@ -7889,7 +7889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 0, 17));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7910,7 +7910,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 39, 14));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7931,7 +7931,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 53, 10));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7952,7 +7952,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 63, 11));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7978,7 +7978,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 74, 21));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -7999,7 +7999,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 95, 11));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8020,7 +8020,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 106, 7));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8041,7 +8041,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 113, 11));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8062,7 +8062,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 124, 9));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8083,7 +8083,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 149, 20));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8104,7 +8104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 169, 20));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8125,7 +8125,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 189, 20));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8146,7 +8146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 209, 15));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8167,7 +8167,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 224, 17));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8188,7 +8188,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 241, 11));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8209,7 +8209,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 252, 17));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8230,7 +8230,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 269, 17));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8251,7 +8251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 286, 7));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8272,7 +8272,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 293, 8));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8293,7 +8293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 301, 12));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8314,7 +8314,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 313, 22));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8335,7 +8335,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 335, 15));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8356,7 +8356,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 360, 14));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8377,7 +8377,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 374, 8));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8398,7 +8398,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 382, 20));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8419,7 +8419,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 402, 36));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8440,7 +8440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 438, 32));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8461,7 +8461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 470, 32));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8482,7 +8482,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 502, 31));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8503,7 +8503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 533, 33));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }
@@ -8524,7 +8524,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, 566, 26));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }
                         }
                     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -39,9 +39,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if (value != null)
                         {
                             buffer.Write(_CrLf);
-                            PipelineExtensions.WriteAsciiNoValidation(ref buffer, kv.Key);
+                            buffer.WriteAsciiNoValidation(kv.Key);
                             buffer.Write(_colonSpace);
-                            PipelineExtensions.WriteAsciiNoValidation(ref buffer, value);
+                            buffer.WriteAsciiNoValidation(value);
                         }
                     }
                 }

--- a/src/Servers/Kestrel/tools/CodeGenerator/KnownHeaders.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/KnownHeaders.cs
@@ -582,7 +582,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             if (value != null)
                             {{
                                 output.Write(new ReadOnlySpan<byte>(_headerBytes, {header.BytesOffset}, {header.BytesCount}));
-                                PipelineExtensions.WriteAsciiNoValidation(ref output, value);
+                                output.WriteAsciiNoValidation(value);
                             }}
                         }}
                     }}
@@ -596,7 +596,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if ((tempBits & {1L << 63}L) != 0)
                 {{
                     output.Write(new ReadOnlySpan<byte>(_headerBytes, {loop.Headers.First(x => x.Identifier == "ContentLength").BytesOffset}, {loop.Headers.First(x => x.Identifier == "ContentLength").BytesCount}));
-                    PipelineExtensions.WriteNumeric(ref output, (ulong)ContentLength.Value);
+                    output.WriteNumeric((ulong)ContentLength.Value);
 
                     if((tempBits & ~{1L << 63}L) == 0)
                     {{


### PR DESCRIPTION
C# now allows struct ref extension methods to be used as such, so clean up the call sites.