### PR TITLE
Reduce HTTP/2 allocations

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
@@ -17,7 +18,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
-    public partial class Http2Stream : HttpProtocol
+    public abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem
     {
         private readonly Http2StreamContext _context;
         private readonly Http2OutputProducer _http2Output;
@@ -498,6 +499,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 return (oldCompletionState, _completionState);
             }
         }
+
+        /// <summary>
+        /// Used to kick off the request processing loop by derived classes.
+        /// </summary>
+        public abstract void Execute();
 
         [Flags]
         private enum StreamCompletionFlags

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Hosting.Server;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
+{
+    public class Http2Stream<TContext> : Http2Stream
+    {
+        private readonly IHttpApplication<TContext> _application;
+
+        public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context) : base(context)
+        {
+            _application = application;
+        }
+
+        public override void Execute()
+        {
+            // REVIEW: Should we store this in a field for easy debugging?
+            _ = ProcessRequestsAsync(_application);
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _http1Connection.Reset();
             _collection = _http1Connection;
 
-            var http2Stream = new Http2Stream(context);
+            var http2Stream = new TestHttp2Stream(context);
             http2Stream.Reset();
             _http2Collection = http2Stream;
         }
@@ -220,5 +220,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         private Http1Connection CreateHttp1Connection() => new TestHttp1Connection(_httpConnectionContext);
+
+        private class TestHttp2Stream : Http2Stream
+        {
+            public TestHttp2Stream(Http2StreamContext context) : base(context)
+            {
+            }
+
+            public override void Execute()
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
- Remove per request allocations on the thread pool by implementing IThreadPoolWorkItem on Http2Stream
- Made generic version of Http2Stream to store the IHttpApplication instead of using a tuple

cc @benaadams 

PS: I can't run much locally, so the CI will tell me if it doesn't work 😄 