### PR TITLE
Reduce allocations

### DIFF
--- a/src/Servers/IIS/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
@@ -547,7 +547,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             }
             catch (Exception ex)
             {
-               _logger.LogError(0, ex, $"Unexpected exception in {nameof(IISHttpServer)}.{nameof(HandleRequest)}.");
+               _logger.LogError(0, ex, $"Unexpected exception in {nameof(IISHttpContext)}.{nameof(HandleRequest)}.");
             }
             finally
             {

--- a/src/Servers/IIS/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/src/Microsoft.AspNetCore.Server.IIS/Core/IISHttpContext.cs
@@ -25,7 +25,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.IIS.Core
 {
-    internal abstract partial class IISHttpContext : NativeRequestContext, IDisposable
+    internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPoolWorkItem, IDisposable
     {
         private const int MinAllocBufferSize = 2048;
         private const int PauseWriterThreshold = 65536;
@@ -530,6 +530,41 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 }
             }
             return null;
+        }
+
+        // Invoked by the thread pool
+        public void Execute()
+        {
+            _ = HandleRequest();
+        }
+
+        private async Task HandleRequest()
+        {
+            bool successfulRequest = false;
+            try
+            {
+                successfulRequest = await ProcessRequestAsync();
+            }
+            catch (Exception ex)
+            {
+               _logger.LogError(0, ex, $"Unexpected exception in {nameof(IISHttpServer)}.{nameof(HandleRequest)}.");
+            }
+            finally
+            {
+                // Post completion after completing the request to resume the state machine
+                PostCompletion(ConvertRequestCompletionResults(successfulRequest));
+
+                Server.DecrementRequests();
+
+                // Dispose the context
+                Dispose();
+            }
+        }
+
+        private static NativeMethods.REQUEST_NOTIFICATION_STATUS ConvertRequestCompletionResults(bool success)
+        {
+            return success ? NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_CONTINUE
+                           : NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_FINISH_REQUEST;
         }
     }
 }

--- a/src/Servers/IIS/src/Microsoft.AspNetCore.Server.IIS/Core/IO/AsyncIOOperation.cs
+++ b/src/Servers/IIS/src/Microsoft.AspNetCore.Server.IIS/Core/IO/AsyncIOOperation.cs
@@ -151,10 +151,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
             {
                 if (Continuation != null)
                 {
-                    // TODO: use generic overload when code moved to be netcoreapp only
-                    var continuation = Continuation;
-                    var state = State;
-                    ThreadPool.QueueUserWorkItem(_ => continuation(state));
+                    ThreadPool.UnsafeQueueUserWorkItem(Continuation, State, preferLocal: false);
                 }
             }
         }


### PR DESCRIPTION
- Remove per request allocations by implementing IThreadPoolWorkItem on the IISHttpContext.
- Removed per operation allocations by using UnsafeQueueUserWorkItem in AsyncIOOperation.
- This should also reduce overhead by removing non-essential ExecutionContext propagation logic

The per IO operation allocation should be removed completely by this optimization https://github.com/dotnet/coreclr/commit/e7ead79fedc52e17f2cf9befd5c0f5091d70f909#diff-b9b22fdb097c803c0ca6fa45655b24f7

Fixes #4229