### PR TITLE
Lock-free IOQueue

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/IOQueue.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/IOQueue.cs
@@ -10,23 +10,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
     public class IOQueue : PipeScheduler, IThreadPoolWorkItem
     {
-        private readonly object _workSync = new object();
         private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
-        private bool _doingWork;
+        private int _doingWork;
 
         public override void Schedule(Action<object> action, object state)
         {
-            var work = new Work(action, state);
+            _workItems.Enqueue(new Work(action, state));
 
-            _workItems.Enqueue(work);
-
-            lock (_workSync)
+            // Set working if it wasn't (via atomic Interlocked).
+            if (Interlocked.CompareExchange(ref _doingWork, 1, 0) == 0)
             {
-                if (!_doingWork)
-                {
-                    System.Threading.ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
-                    _doingWork = true;
-                }
+                // Wasn't working, schedule.
+                System.Threading.ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
             }
         }
 
@@ -39,14 +34,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                     item.Callback(item.State);
                 }
 
-                lock (_workSync)
+                // All work done.
+
+                // Set _doingWork (0 == false) prior to checking IsEmpty to catch any missed work in interim.
+                // This doesn't need to be volatile due to the following barrier (i.e. it is volatile).
+                _doingWork = 0;
+
+                // Ensure _doingWork is written before IsEmpty is read.
+                // As they are two different memory locations, we insert a barrier to guarantee ordering.
+                Thread.MemoryBarrier();
+
+                // Check if there is work to do
+                if (_workItems.IsEmpty)
                 {
-                    if (_workItems.IsEmpty)
-                    {
-                        _doingWork = false;
-                        return;
-                    }
+                    // Nothing to do, exit.
+                    break;
                 }
+
+                // Is work, can we set it as active again (via atomic Interlocked), prior to scheduling?
+                if (Interlocked.Exchange(ref _doingWork, 1) == 1)
+                {
+                    // Execute has been rescheduled already, exit.
+                    break;
+                }
+
+                // Is work, wasn't already scheduled so continue loop.
             }
         }
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransport.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransport.cs
@@ -19,8 +19,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
     internal sealed class SocketTransport : ITransport
     {
-        private static readonly PipeScheduler[] ThreadPoolSchedulerArray = new PipeScheduler[] { PipeScheduler.ThreadPool };
-
         private readonly MemoryPool<byte> _memoryPool;
         private readonly IEndPointInformation _endPointInformation;
         private readonly IConnectionDispatcher _dispatcher;
@@ -65,8 +63,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             }
             else
             {
-                _numSchedulers = ThreadPoolSchedulerArray.Length;
-                _schedulers = ThreadPoolSchedulerArray;
+                var directScheduler = new PipeScheduler[] { PipeScheduler.ThreadPool };
+                _numSchedulers = directScheduler.Length;
+                _schedulers = directScheduler;
             }
         }
 

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/SchedulerBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/SchedulerBenchmark.cs
@@ -1,0 +1,172 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class SchedulerBenchmark
+    {
+        private const int InnerLoopCount = 1024;
+        private const int OuterLoopCount = 64;
+        private const int OperationsPerInvoke = InnerLoopCount * OuterLoopCount;
+
+        private PipeScheduler _lockFreeQueue;
+        private PipeScheduler _lockBasedQueue;
+
+        private static Action<object> _action = (o) => { };
+
+        private static Action<int> _lockFreeAction;
+        private static Action<int> _lockBasedAction;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _lockFreeQueue = new IOQueueLockFree();
+            _lockBasedQueue = new IOQueueLockBased();
+
+            _lockFreeAction =
+                (n) =>
+                {
+                    for (var i = 0; i < InnerLoopCount; i++)
+                    {
+                        _lockFreeQueue.Schedule(_action, null);
+                    }
+                };
+
+
+            _lockBasedAction =
+                (n) =>
+                {
+                    for (var i = 0; i < InnerLoopCount; i++)
+                    {
+                        _lockBasedQueue.Schedule(_action, null);
+                    }
+                };
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke, Baseline = true)]
+        public void LockBased() => Schedule(_lockBasedAction);
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void LockFree() => Schedule(_lockFreeAction);
+
+        private void Schedule(Action<int> scheduleAction) => Parallel.For(0, OuterLoopCount, scheduleAction);
+
+        public class IOQueueLockFree : PipeScheduler, IThreadPoolWorkItem
+        {
+            private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
+            private int _doingWork;
+
+            public override void Schedule(Action<object> action, object state)
+            {
+                _workItems.Enqueue(new Work(action, state));
+
+                // Set working if it wasn't (via atomic Interlocked).
+                if (Interlocked.CompareExchange(ref _doingWork, 1, 0) == 0)
+                {
+                    // Wasn't working, schedule.
+                    System.Threading.ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+                }
+            }
+
+            void IThreadPoolWorkItem.Execute()
+            {
+                while (true)
+                {
+                    while (_workItems.TryDequeue(out Work item))
+                    {
+                        item.Callback(item.State);
+                    }
+
+                    // All work done.
+
+                    // Set _doingWork (0 == false) prior to checking IsEmpty to catch any missed work in interim.
+                    // This doesn't need to be volatile due to the following barrier (i.e. it is volatile).
+                    _doingWork = 0;
+
+                    // Ensure _doingWork is written before IsEmpty is read.
+                    // As they are two different memory locations, we insert a barrier to guarantee ordering.
+                    Thread.MemoryBarrier();
+
+                    // Check if there is work to do
+                    if (_workItems.IsEmpty)
+                    {
+                        // Nothing to do, exit.
+                        break;
+                    }
+
+                    // Is work, can we set it as active again (via atomic Interlocked), prior to scheduling?
+                    if (Interlocked.Exchange(ref _doingWork, 1) == 1)
+                    {
+                        // Execute has been rescheduled already, exit.
+                        break;
+                    }
+
+                    // Is work, wasn't already scheduled so continue loop.
+                }
+            }
+        }
+
+        public class IOQueueLockBased : PipeScheduler, IThreadPoolWorkItem
+        {
+            private readonly object _workSync = new object();
+            private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
+            private bool _doingWork;
+
+            public override void Schedule(Action<object> action, object state)
+            {
+                var work = new Work(action, state);
+
+                _workItems.Enqueue(work);
+
+                lock (_workSync)
+                {
+                    if (!_doingWork)
+                    {
+                        System.Threading.ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+                        _doingWork = true;
+                    }
+                }
+            }
+
+            void IThreadPoolWorkItem.Execute()
+            {
+                while (true)
+                {
+                    while (_workItems.TryDequeue(out Work item))
+                    {
+                        item.Callback(item.State);
+                    }
+
+                    lock (_workSync)
+                    {
+                        if (_workItems.IsEmpty)
+                        {
+                            _doingWork = false;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        private readonly struct Work
+        {
+            public readonly Action<object> Callback;
+            public readonly object State;
+
+            public Work(Action<object> callback, object state)
+            {
+                Callback = callback;
+                State = state;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Second half of https://github.com/aspnet/AspNetCore/pull/4060

The lock contention shows up on my 4 core (8-HT) machine at around 12% of `IOQueue.Schedule`

![image](https://user-images.githubusercontent.com/1142958/51032136-d4254200-1596-11e9-89d9-122e0d5f036f.png)

and is the highest source (33%) of lock connection (1.8% of run) from the traces @sebastienros sent me (from back in Nov) from the 14 core (28 Hyper-threaded cores) benchmarking machines:

![image](https://user-images.githubusercontent.com/1142958/51035650-91696700-15a2-11e9-9313-395f44a70540.png)

+59% on microbenchmark
```
           Method |      Mean |         Op/s | Scaled |  Allocated |
----------------- |----------:|-------------:|-------:|-----------:|
 LockBasedIOQueue |  38.74 ns | 25,810,514.1 |   1.00 |    1.76 KB |
  LockFreeIOQueue |  24.38 ns | 41,017,208.3 |   0.63 |    1.74 KB |
 ThreadPoolDirect | 114.95 ns |  8,699,475.6 |   2.97 | 1257.78 KB |
```

Resolves https://github.com/aspnet/AspNetCore/issues/6153

/cc @davidfowl @pakrym @halter73 