### PR TITLE
Make root build.cmd build native projects by default.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -242,12 +242,13 @@ elseif ($Projects) {
 else {
     # When adding new sub-group build flags, add them to this check.
     if((-not $Native) -and (-not $Managed) -and (-not $NodeJS) -and (-not $Installers)) {
-        Write-Warning "No default group of projects was specified, so building the 'managed' subset of projects. Run ``build.cmd -help`` for more details."
+        Write-Warning "No default group of projects was specified, so building the 'managed' and 'native' subsets of projects. Run ``build.cmd -help`` for more details."
 
         # This goal of this is to pick a sensible default for `build.cmd` with zero arguments.
-        # We believe the most common thing our contributors will work on is C#, so if no other build group was picked, build the C# projects.
+        # Now that we support subfolder invokations of build.cmd, we will be pushing to have build.cmd build everything (-all) by default
 
         $Managed = $true
+        $Native = $true
     }
 
     $MSBuildArguments += "/p:BuildManaged=$Managed"


### PR DESCRIPTION
Currently build.cmd fails without building native dependencies.