### PR TITLE
Prevent blocking threads

### DIFF
--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 var testUrlWithPort = $"{testUrl}:{(testPort == 0 ? host.GetPort() : testPort)}";
 
@@ -309,6 +309,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // Compare the response with Uri.ToString(), rather than testUrl directly.
                 // Required to handle IPv6 addresses with zone index, like "fe80::3%1"
                 Assert.Equal(new Uri(testUrlWithPort).ToString(), response);
+
+                await host.StopAsync();
             }
         }
 
@@ -348,7 +350,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 foreach (var testUrl in testUrls.Select(testUrl => $"{testUrl}:{(testPort == 0 ? host.GetPort() : testPort)}"))
                 {
@@ -358,6 +360,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     // Required to handle IPv6 addresses with zone index, like "fe80::3%1"
                     Assert.Equal(new Uri(testUrl).ToString(), response);
                 }
+
+                await host.StopAsync();
             }
         }
 
@@ -389,7 +393,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 foreach (var testUrl in testUrls.Select(testUrl => $"{testUrl}:{(testPort == 0 ? host.GetPort() : testPort)}"))
                 {
@@ -399,6 +403,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     // Required to handle IPv6 addresses with zone index, like "fe80::3%1"
                     Assert.Equal(new Uri(testUrl).ToString(), response);
                 }
+
+                await host.StopAsync();
             }
         }
 
@@ -468,7 +474,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 Assert.Equal(5000, host.GetPort());
 
@@ -485,6 +491,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     Assert.Equal(new Uri(address).ToString(), await HttpClientSlim.GetStringAsync(address, validateCertificate: false));
                 }
+
+                await host.StopAsync();
             }
         }
 
@@ -555,7 +563,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 var port = host.GetPort();
 
@@ -571,6 +579,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     log.Message, StringComparison.Ordinal));
 
                 Assert.Equal(new Uri(useUrlsAddressWithPort).ToString(), await HttpClientSlim.GetStringAsync(useUrlsAddressWithPort));
+
+                await host.StopAsync();
             }
         }
 
@@ -594,7 +604,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 var port = host.GetPort();
 
@@ -610,6 +620,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     log.Message, StringComparison.Ordinal));
 
                 Assert.Equal(new Uri(endPointAddress).ToString(), await HttpClientSlim.GetStringAsync(endPointAddress, validateCertificate: false));
+                await host.StopAsync();
             }
         }
 
@@ -630,7 +641,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 var port = host.GetPort();
 
@@ -641,6 +652,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 Assert.Equal(serverAddresses.First(), endPointAddress);
 
                 Assert.Equal(new Uri(endPointAddress).ToString(), await HttpClientSlim.GetStringAsync(endPointAddress, validateCertificate: false));
+
+                await host.StopAsync();
             }
         }
 
@@ -709,9 +722,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 Assert.Equal(endPointAddress, await HttpClientSlim.GetStringAsync(endPointAddress));
+
+                await host.StopAsync();
             }
 
             hostBuilder = TransportSelector.GetWebHostBuilder()
@@ -723,9 +738,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 Assert.Equal(endPointAddress, await HttpClientSlim.GetStringAsync(endPointAddress));
+
+                await host.StopAsync();
             }
         }
 
@@ -748,10 +765,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 Assert.Equal(ipv4endPointAddress, await HttpClientSlim.GetStringAsync(ipv4endPointAddress));
                 Assert.Equal(ipv6endPointAddress, await HttpClientSlim.GetStringAsync(ipv6endPointAddress));
+
+                await host.StopAsync();
             }
 
             hostBuilder = TransportSelector.GetWebHostBuilder()
@@ -764,10 +783,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 Assert.Equal(ipv4endPointAddress, await HttpClientSlim.GetStringAsync(ipv4endPointAddress));
                 Assert.Equal(ipv6endPointAddress, await HttpClientSlim.GetStringAsync(ipv6endPointAddress));
+
+                await host.StopAsync();
             }
         }
 
@@ -775,7 +796,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("http1", HttpProtocols.Http1)]
         [InlineData("http2", HttpProtocols.Http2)]
         [InlineData("http1AndHttp2", HttpProtocols.Http1AndHttp2)]
-        public void EndpointDefaultsConfig_CanSetProtocolForUrlsConfig(string input, HttpProtocols expected)
+        public async Task EndpointDefaultsConfig_CanSetProtocolForUrlsConfig(string input, HttpProtocols expected)
         {
             KestrelServerOptions capturedOptions = null;
             var hostBuilder = TransportSelector.GetWebHostBuilder()
@@ -795,9 +816,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
                 Assert.Single(capturedOptions.ListenOptions);
                 Assert.Equal(expected, capturedOptions.ListenOptions[0].Protocols);
+                await host.StopAsync();
             }
         }
 

--- a/src/Servers/Kestrel/test/FunctionalTests/ConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ConnectionAdapterTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         }
                     });
                 }
+                await server.StopAsync();
             }
         }
 

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
@@ -63,6 +63,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
             {
                 var result = await Client.GetStringAsync($"https://localhost:{server.Port}/");
                 Assert.Equal("hello world HTTP/2", result);
+
+                await server.StopAsync();
             }
         }
 
@@ -89,6 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
             {
                 var result = await Client.GetStringAsync($"https://localhost:{server.Port}/");
                 Assert.Equal("hello world HTTP/2", result);
+                await server.StopAsync();
             }
         }
     }

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = builder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -123,6 +123,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         await AssertStreamContains(stream, $"bytesRead: {contentLength}");
                     }
                 }
+
+                await host.StopAsync();
             }
         }
 
@@ -157,13 +159,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             using (var host = builder.Build())
             using (var client = new HttpClient())
             {
-                host.Start();
+                await host.StartAsync();
 
                 client.DefaultRequestHeaders.Connection.Clear();
                 client.DefaultRequestHeaders.Connection.Add("close");
 
                 var response = await client.GetAsync($"http://127.0.0.1:{host.GetPort()}/");
                 response.EnsureSuccessStatusCode();
+
+                await host.StopAsync();
             }
         }
 
@@ -210,6 +214,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         "",
                         "");
                 }
+                await server.StopAsync();
             }
         }
 
@@ -220,7 +225,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var connectionReset = new SemaphoreSlim(0);
             var loggedHigherThanDebug = false;
 
-            TestSink.MessageLogged += context => {
+            TestSink.MessageLogged += context =>
+            {
                 if (context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets")
@@ -258,6 +264,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // is still in flight when the connection is aborted, leading to the reset never being received
                 // and therefore not logged.
                 Assert.True(await connectionReset.WaitAsync(TestConstants.DefaultTimeout));
+
+                await server.StopAsync();
             }
 
             Assert.False(loggedHigherThanDebug);
@@ -269,7 +277,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var connectionReset = new SemaphoreSlim(0);
             var loggedHigherThanDebug = false;
 
-            TestSink.MessageLogged += context => {
+            TestSink.MessageLogged += context =>
+            {
                 if (context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets")
@@ -316,6 +325,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // is still in flight when the connection is aborted, leading to the reset never being received
                 // and therefore not logged.
                 Assert.True(await connectionReset.WaitAsync(TestConstants.DefaultTimeout));
+                await server.StopAsync();
             }
 
             Assert.False(loggedHigherThanDebug);
@@ -329,7 +339,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var connectionClosing = new SemaphoreSlim(0);
             var loggedHigherThanDebug = false;
 
-            TestSink.MessageLogged += context => {
+            TestSink.MessageLogged += context =>
+            {
                 if (context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets")
@@ -371,6 +382,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // and therefore not logged.
                 Assert.True(await connectionReset.WaitAsync(TestConstants.DefaultTimeout), "Connection reset event should have been logged");
                 connectionClosing.Release();
+                await server.StopAsync();
             }
 
             Assert.False(loggedHigherThanDebug, "Logged event should not have been higher than debug.");
@@ -407,7 +419,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = builder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -421,6 +433,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 Assert.True(await appDone.WaitAsync(_semaphoreWaitTimeout));
                 Assert.True(expectedExceptionThrown);
+
+                await host.StopAsync();
             }
         }
 
@@ -444,7 +458,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = builder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -454,11 +468,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     socket.Shutdown(SocketShutdown.Send);
                     await requestAborted.WaitAsync().DefaultTimeout();
                 }
+
+                await host.StopAsync();
             }
         }
 
         [Fact]
-        public void AbortingTheConnectionSendsFIN()
+        public async Task AbortingTheConnectionSendsFIN()
         {
             var builder = TransportSelector.GetWebHostBuilder()
                 .UseKestrel()
@@ -472,7 +488,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = builder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -481,6 +497,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     int result = socket.Receive(new byte[32]);
                     Assert.Equal(0, result);
                 }
+
+                await host.StopAsync();
             }
         }
 
@@ -516,6 +534,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                     await connectionClosedTcs.Task.DefaultTimeout();
                 }
+                await server.StopAsync();
             }
         }
 
@@ -552,6 +571,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         "",
                         "");
                 }
+                await server.StopAsync();
             }
         }
 
@@ -593,6 +613,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         // isn't guaranteed but not unexpected.
                     }
                 }
+                await server.StopAsync();
             }
         }
 
@@ -673,6 +694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         "");
                     await connection.WaitForConnectionClose();
                 }
+                await server.StopAsync();
             }
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await readTcs.Task);
@@ -698,7 +720,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var serverClosedConnection = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            TestSink.MessageLogged += context => {
+            TestSink.MessageLogged += context =>
+            {
                 if (context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" &&
                     context.LoggerName != "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets")
                 {
@@ -760,6 +783,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 clientClosedConnection.SetResult(null);
 
                 await appFuncCompleted.Task.DefaultTimeout();
+                await server.StopAsync();
             }
 
             mockKestrelTrace.Verify(t => t.ConnectionStop(It.IsAny<string>()), Times.Once());
@@ -783,7 +807,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 try
                 {
-                    await context.Request.Body.CopyToAsync(Stream.Null);;
+                    await context.Request.Body.CopyToAsync(Stream.Null); ;
                 }
                 catch (Exception ex)
                 {
@@ -812,6 +836,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 }
 
                 await Assert.ThrowsAnyAsync<IOException>(() => readTcs.Task).DefaultTimeout();
+                await server.StopAsync();
             }
 
             mockKestrelTrace.Verify(t => t.ConnectionStop(It.IsAny<string>()), Times.Once());
@@ -841,7 +866,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             using (var host = builder.Build())
             using (var client = new HttpClient())
             {
-                host.Start();
+                await host.StartAsync();
 
                 var response = await client.GetAsync($"http://{requestAddress}:{host.GetPort()}/");
                 response.EnsureSuccessStatusCode();
@@ -852,6 +877,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var facts = JsonConvert.DeserializeObject<JObject>(connectionFacts);
                 Assert.Equal(expectAddress, facts["RemoteIPAddress"].Value<string>());
                 Assert.NotEmpty(facts["RemotePort"].Value<string>());
+
+                await host.StopAsync();
             }
         }
 

--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 using (var client = new HttpClient())
                 {
@@ -91,6 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         count = await responseBody.ReadAsync(bytes, 0, bytes.Length);
                     }
                 }
+                await host.StopAsync();
             }
         }
 
@@ -113,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var host = hostBuilder.Build())
             {
-                host.Start();
+                await host.StartAsync();
 
                 using (var client = new HttpClient())
                 {
@@ -132,6 +133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         Assert.Equal(headers.GetValues(headerName).Single(), expectedValue);
                     }
                 }
+                await host.StopAsync();
             }
         }
 
@@ -175,6 +177,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 connectionClosed.SetResult(null);
 
                 await appCompleted.Task.DefaultTimeout();
+                await server.StopAsync();
             }
         }
 
@@ -238,6 +241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 // RequestAborted tripped
                 await requestAbortedWh.Task.DefaultTimeout();
+                await server.StopAsync();
             }
         }
 
@@ -328,6 +332,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 clientClosedConnection.SetResult(null);
 
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => writeTcs.Task).DefaultTimeout();
+                await server.StopAsync();
             }
 
             mockKestrelTrace.Verify(t => t.ConnectionStop(It.IsAny<string>()), Times.Once());
@@ -394,6 +399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 // On macOS, the default 5 shutdown timeout is insufficient for the write loop to complete, so give it extra time.
                 await appCompletedTcs.Task.DefaultTimeout();
+                await server.StopAsync();
             }
 
             var coreLogs = TestSink.Writes.Where(w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel");
@@ -430,6 +436,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         connection.Reset();
                     }
                 }
+                await server.StopAsync();
             }
 
             var transportLogs = TestSink.Writes.Where(w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" ||
@@ -539,6 +546,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     sw.Stop();
                     logger.LogInformation("Connection was aborted after {totalMilliseconds}ms.", sw.ElapsedMilliseconds);
                 }
+                await server.StopAsync();
             }
         }
 
@@ -629,6 +637,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         await AssertStreamAborted(connection.Stream, chunkSize * chunks);
                     }
                 }
+                await server.StopAsync();
             }
         }
 
@@ -722,6 +731,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     await Assert.ThrowsAnyAsync<OperationCanceledException>(() => copyToAsyncCts.Task).DefaultTimeout();
                     await AssertStreamAborted(connection.Stream, responseSize);
                 }
+                await server.StopAsync();
             }
         }
 
@@ -785,6 +795,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     await AssertStreamCompleted(connection.Stream, minTotalOutputSize, targetBytesPerSecond);
                     await appFuncCompleted.Task.DefaultTimeout();
                 }
+                await server.StopAsync();
             }
 
             mockKestrelTrace.Verify(t => t.ResponseMinimumDataRateNotSatisfied(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
@@ -867,6 +878,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     var targetBytesPerSecond = responseSize / 4;
                     await AssertStreamCompleted(connection.Stream, minTotalOutputSize, targetBytesPerSecond);
                 }
+                await server.StopAsync();
             }
 
             mockKestrelTrace.Verify(t => t.ResponseMinimumDataRateNotSatisfied(It.IsAny<string>(), It.IsAny<string>()), Times.Never());

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/ChromeTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/ChromeTests.cs
@@ -100,6 +100,8 @@ namespace Interop.FunctionalTests
                 var chromeOutput = RunHeadlessChrome($"https://localhost:{host.GetPort()}/{requestSuffix}");
 
                 AssertExpectedResponseOrShowDebugInstructions(expectedResponse, chromeOutput);
+
+                await host.StopAsync();
             }
         }
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -47,6 +47,8 @@ namespace Interop.FunctionalTests
                 await host.StartAsync();
 
                 H2SpecCommands.RunTest(testCase.Id, host.GetPort(), testCase.Https, Logger);
+
+                await host.StopAsync();
             }
         }
 

--- a/src/Servers/Kestrel/test/Libuv.FunctionalTests/ListenHandleTests.cs
+++ b/src/Servers/Kestrel/test/Libuv.FunctionalTests/ListenHandleTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         "",
                         "");
                 }
+                await server.StopAsync();
             }
         }
     }


### PR DESCRIPTION
- Call StopAsync and StartAsync on the Host and TestServer in more places

I realized that `TestServer.Start` might also be problematic in tests that don't run with the in memory server.