### PR TITLE
Fix build.cmd/sh for src/Mvc

### DIFF
--- a/src/Mvc/build.cmd
+++ b/src/Mvc/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
-SET RepoRoot="%~dp0..\.."
-%RepoRoot%\build.cmd -All -RepoRoot %~dp0 %*
+SET RepoRoot=%~dp0..\..
+%RepoRoot%\build.cmd -projects %~dp0\**\*.*proj %*

--- a/src/Mvc/build.sh
+++ b/src/Mvc/build.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 repo_root="$DIR/../.."
-"$repo_root/build.sh" -All -RepoRoot "$DIR" "$@"
+"$repo_root/build.sh" --projects "$DIR/**/*.*proj" "$@"


### PR DESCRIPTION
Follow-up to https://github.com/aspnet/AspNetCore/pull/6091. These scripts weren't updated to use the new parameters and are busted.
