### PR TITLE
Fix Angular SPA Template compiler bug

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/Util/EventedStreamReader.cs
+++ b/src/Middleware/SpaServices.Extensions/src/Util/EventedStreamReader.cs
@@ -83,6 +83,12 @@ namespace Microsoft.AspNetCore.NodeServices.Util
                 var chunkLength = await _streamReader.ReadAsync(buf, 0, buf.Length);
                 if (chunkLength == 0)
                 {
+                    if (_linesBuffer.Length > 0)
+                    {
+                        OnCompleteLine(_linesBuffer.ToString());
+                        _linesBuffer.Clear();
+                    }
+
                     OnClosed();
                     break;
                 }


### PR DESCRIPTION
@SteveSandersonMS 
… 

Summary of the changes (Less than 80 chars)
 - Make StreamReader send last line's contents to listener (otherwise AngularCliBuilder doesn't know when build:ssr is complete)

Addresses #6306
