### PR TITLE
Specify correct global.json path for Razor.Design tests

### DIFF
--- a/src/Razor/Razor.Design/test/IntegrationTests/IntegrationTests/ProjectDirectory.cs
+++ b/src/Razor/Razor.Design/test/IntegrationTests/IntegrationTests/ProjectDirectory.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 CopyGlobalJson(solutionRoot, destinationPath);
 
                 return new ProjectDirectory(
-                    destinationPath, 
+                    destinationPath,
                     directoryPath,
                     newProjectFilePath);
             }
@@ -128,7 +128,8 @@ $@"<Project>
 
             void CopyGlobalJson(string solutionRoot, string projectRoot)
             {
-                var srcGlobalJson = Path.Combine(solutionRoot, "global.json");
+                var repoRoot = Path.Combine(solutionRoot, "..", "..");
+                var srcGlobalJson = Path.Combine(repoRoot, "global.json");
                 if (!File.Exists(srcGlobalJson))
                 {
                     throw new InvalidOperationException("global.json at the root of the repository could not be found. Run './build /t:Noop' at the repository root and re-run these tests.");


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1533

Since the individual src folders don't contain global.json anymore, this needs to be updated. I wasn't seeing this locally at first because I had a global.json lying around from before. I started seeing this error after I `git clean`ed