### PR TITLE
Reference InprocessTestSite in CreateDefaultBuilderApp and Disable Failing Tests

### DIFF
--- a/src/DefaultBuilder/testassets/CreateDefaultBuilderApp/CreateDefaultBuilderApp.csproj
+++ b/src/DefaultBuilder/testassets/CreateDefaultBuilderApp/CreateDefaultBuilderApp.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId>aspnetcore-CreateDefaultBuilder-20170424224131</UserSecretsId>
+    <InProcessTestSite>true</InProcessTestSite>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Http/test/StreamPipeReaderTests.cs
+++ b/src/Http/Http/test/StreamPipeReaderTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Http.Tests
             Assert.NotEqual(readResult, readResult2);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/4621")]
         public async Task ReadCanBeCancelledViaProvidedCancellationToken()
         {
             var pipeReader = new StreamPipeReader(new HangingStream());

--- a/src/MusicStore/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
@@ -17,7 +17,7 @@ namespace E2ETests
     public class NtlmAuthenticationTests : LoggedTest
     {
         public static TestMatrix TestVariants
-            => TestMatrix.ForServers(ServerType.IISExpress, ServerType.HttpSys)
+            => TestMatrix.ForServers(/*ServerType.IISExpress https://github.com/aspnet/AspNetCore/issues/6170*/ ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllApplicationTypes()
                 .WithAllArchitectures();

--- a/src/MusicStore/test/MusicStore.E2ETests/OpenIdConnectTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/OpenIdConnectTests.cs
@@ -14,7 +14,7 @@ namespace E2ETests
     public class OpenIdConnectTests : LoggedTest
     {
         public static TestMatrix TestVariants
-            => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel)
+            => TestMatrix.ForServers(/* ServerType.IISExpress https://github.com/aspnet/AspNetCore/issues/6170 */ ServerType.Kestrel)
                 .WithTfms(Tfm.NetCoreApp30);
 
         [ConditionalTheory]

--- a/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
@@ -16,24 +16,14 @@ namespace E2ETests
     public class SmokeTests : LoggedTest
     {
         public static TestMatrix TestVariants
-            => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys)
+            => TestMatrix.ForServers(/* ServerType.IISExpress, https://github.com/aspnet/AspNetCore/issues/6170*/ ServerType.Kestrel, ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllApplicationTypes()
                 .WithAllAncmVersions()
                 .WithAllHostingModels();
 
-        // ANCM In-process cannot run on netcoreapp2.1 and below
-        public static TestMatrix TestVariantsWithoutInproc
-            => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp30)
-                .WithAllApplicationTypes()
-                .WithAllAncmVersions()
-                .WithHostingModels(HostingModel.OutOfProcess)
-                .WithAllArchitectures();
-
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
-        [MemberData(nameof(TestVariantsWithoutInproc))]
         public async Task Smoke_Tests(TestVariant variant)
         {
             var testName = $"SmokeTestSuite_{variant}";

--- a/src/Servers/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/test/FunctionalTests/ResponseTests.cs
@@ -25,7 +25,7 @@ namespace ServerComparison.FunctionalTests
         }
 
         public static TestMatrix TestVariants
-            => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
+            => TestMatrix.ForServers(/* ServerType.IISExpress, https://github.com/aspnet/AspNetCore/issues/6168 */, ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllAncmVersions()
                 .WithAllHostingModels();

--- a/src/Servers/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/test/FunctionalTests/ResponseTests.cs
@@ -25,7 +25,7 @@ namespace ServerComparison.FunctionalTests
         }
 
         public static TestMatrix TestVariants
-            => TestMatrix.ForServers(/* ServerType.IISExpress, https://github.com/aspnet/AspNetCore/issues/6168 */, ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
+            => TestMatrix.ForServers(/* ServerType.IISExpress, https://github.com/aspnet/AspNetCore/issues/6168, */ ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllAncmVersions()
                 .WithAllHostingModels();


### PR DESCRIPTION
Apparently the RunIISExpressInProcess test wasn't fixed before 😢 . This should resolve it.