### PR TITLE
Move PipeAdapters to System.IO.Pipelines namespace.

### DIFF
--- a/src/Http/Http/perf/StreamPipeReaderBenchmark.cs
+++ b/src/Http/Http/perf/StreamPipeReaderBenchmark.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO.Pipelines;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Http/Http/perf/StreamPipeReaderBenchmark.cs
+++ b/src/Http/Http/perf/StreamPipeReaderBenchmark.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO.Pipelines;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Http/Http/perf/StreamPipeWriterBenchmark.cs
+++ b/src/Http/Http/perf/StreamPipeWriterBenchmark.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.IO.Pipelines;
 using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;

--- a/src/Http/Http/perf/StreamPipeWriterBenchmark.cs
+++ b/src/Http/Http/perf/StreamPipeWriterBenchmark.cs
@@ -1,8 +1,7 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using System.IO.Pipelines;
 using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;

--- a/src/Http/Http/src/StreamPipeReader.cs
+++ b/src/Http/Http/src/StreamPipeReader.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.AspNetCore.Http
+namespace System.IO.Pipelines
 {
     /// <summary>
     /// Implements PipeReader using an underlying stream.

--- a/src/Http/Http/src/StreamPipeReaderOptions.cs
+++ b/src/Http/Http/src/StreamPipeReaderOptions.cs
@@ -1,9 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.AspNetCore.Http
+namespace System.IO.Pipelines
 {
     public class StreamPipeReaderOptions
     {

--- a/src/Http/Http/src/StreamPipeWriter.cs
+++ b/src/Http/Http/src/StreamPipeWriter.cs
@@ -12,10 +12,10 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.AspNetCore.Http
+namespace System.IO.Pipelines
 {
     /// <summary>
-    /// Implements PipeWriter using a underlying stream. 
+    /// Implements PipeWriter using a underlying stream.
     /// </summary>
     public class StreamPipeWriter : PipeWriter, IDisposable
     {
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        /// Creates a new StreamPipeWrapper 
+        /// Creates a new StreamPipeWrapper
         /// </summary>
         /// <param name="writingStream">The stream to write to</param>
         public StreamPipeWriter(Stream writingStream) : this(writingStream, 4096)

--- a/src/Http/Http/src/ThrowHelper.cs
+++ b/src/Http/Http/src/ThrowHelper.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.AspNetCore.Http
+namespace System.IO.Pipelines
 {
     internal static class ThrowHelper
     {

--- a/src/Http/Http/test/DefaultHttpContextTests.cs
+++ b/src/Http/Http/test/DefaultHttpContextTests.cs
@@ -9,10 +9,11 @@ using System.Reflection;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Http
+namespace System.IO.Pipelines.Tests
 {
     public class DefaultHttpContextTests
     {

--- a/src/Http/Http/test/FlushResultCancellationTests.cs
+++ b/src/Http/Http/test/FlushResultCancellationTests.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public class FlushResultCancellationTests : PipeTest
     {

--- a/src/Http/Http/test/PipeTest.cs
+++ b/src/Http/Http/test/PipeTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using System.IO.Pipelines;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public abstract class PipeTest : IDisposable
     {

--- a/src/Http/Http/test/PipeWriterTests.cs
+++ b/src/Http/Http/test/PipeWriterTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public class PipeWriterTests : PipeTest
     {

--- a/src/Http/Http/test/ReadAsyncCancellationTests.cs
+++ b/src/Http/Http/test/ReadAsyncCancellationTests.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public class ReadAsyncCancellationTests : PipeTest
     {

--- a/src/Http/Http/test/StreamPipeReaderTests.cs
+++ b/src/Http/Http/test/StreamPipeReaderTests.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public partial class StreamPipeReaderTests : PipeTest
     {

--- a/src/Http/Http/test/StreamPipeWriterTests.cs
+++ b/src/Http/Http/test/StreamPipeWriterTests.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public class StreamPipeWriterTests : PipeTest
     {

--- a/src/Http/Http/test/TestMemoryPool.cs
+++ b/src/Http/Http/test/TestMemoryPool.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 
-namespace Microsoft.AspNetCore.Http.Tests
+namespace System.IO.Pipelines.Tests
 {
     public class TestMemoryPool : MemoryPool<byte>
     {

--- a/src/Http/HttpAbstractions.sln
+++ b/src/Http/HttpAbstractions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28407.52
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Authentication.Abstractions", "Authentication.Abstractions", "{587C3D55-6092-4B86-99F5-E9772C9C1ADB}"
 EndProject
@@ -109,9 +109,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DC519C5E-CA6E-48CA-BF35-B46305B83013}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server.IISIntegration", "..\Servers\IIS\src\Microsoft.AspNetCore.Server.IISIntegration\Microsoft.AspNetCore.Server.IISIntegration.csproj", "{DF1EF1B6-9795-4957-979C-F62F58F91743}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.HttpOverrides", "..\Middleware\HttpOverrides\src\Microsoft.AspNetCore.HttpOverrides.csproj", "{611794D2-EF3A-422A-A077-23E61C7ADE49}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server.IISIntegration", "..\Servers\IIS\IISIntegration\src\Microsoft.AspNetCore.Server.IISIntegration.csproj", "{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -579,18 +579,6 @@ Global
 		{1909E2E3-D435-47AA-B2AB-D6EC58BEDC0D}.Release|x64.Build.0 = Release|Any CPU
 		{1909E2E3-D435-47AA-B2AB-D6EC58BEDC0D}.Release|x86.ActiveCfg = Release|Any CPU
 		{1909E2E3-D435-47AA-B2AB-D6EC58BEDC0D}.Release|x86.Build.0 = Release|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Debug|x64.Build.0 = Debug|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Debug|x86.Build.0 = Debug|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Release|x64.ActiveCfg = Release|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Release|x64.Build.0 = Release|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Release|x86.ActiveCfg = Release|Any CPU
-		{DF1EF1B6-9795-4957-979C-F62F58F91743}.Release|x86.Build.0 = Release|Any CPU
 		{611794D2-EF3A-422A-A077-23E61C7ADE49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{611794D2-EF3A-422A-A077-23E61C7ADE49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{611794D2-EF3A-422A-A077-23E61C7ADE49}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -603,6 +591,18 @@ Global
 		{611794D2-EF3A-422A-A077-23E61C7ADE49}.Release|x64.Build.0 = Release|Any CPU
 		{611794D2-EF3A-422A-A077-23E61C7ADE49}.Release|x86.ActiveCfg = Release|Any CPU
 		{611794D2-EF3A-422A-A077-23E61C7ADE49}.Release|x86.Build.0 = Release|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Debug|x86.Build.0 = Debug|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Release|x64.ActiveCfg = Release|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Release|x64.Build.0 = Release|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Release|x86.ActiveCfg = Release|Any CPU
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -649,8 +649,8 @@ Global
 		{EEA036BB-E6B8-4D01-907B-D4B34B4368DB} = {793FFE24-138A-4C3D-81AB-18D625E36230}
 		{1909E2E3-D435-47AA-B2AB-D6EC58BEDC0D} = {793FFE24-138A-4C3D-81AB-18D625E36230}
 		{DC519C5E-CA6E-48CA-BF35-B46305B83013} = {14A7B3DE-46C8-4245-B0BD-9AFF3795C163}
-		{DF1EF1B6-9795-4957-979C-F62F58F91743} = {793FFE24-138A-4C3D-81AB-18D625E36230}
 		{611794D2-EF3A-422A-A077-23E61C7ADE49} = {793FFE24-138A-4C3D-81AB-18D625E36230}
+		{1062FCDE-E145-40EC-B175-FDBCAA0C59A0} = {793FFE24-138A-4C3D-81AB-18D625E36230}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85B5E151-2E9D-419C-83DD-0DDCF446C83A}


### PR DESCRIPTION
We have to move the StreamPipeAdapters outside of M.A.Http because of a circular dependency. 
