### PR TITLE
Add missed reference to Razor SDK in Mvc test website

### DIFF
--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
@@ -520,7 +520,7 @@ Hello from /Pages/Shared/";
             Assert.Contains("Name is required", response);
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/6122")]
+        [Fact]
         public async Task PagesFromClassLibraries_CanBeServed()
         {
             // Act

--- a/src/Mvc/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
+++ b/src/Mvc/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
+    <Reference Include="Microsoft.NET.Sdk.Razor" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #6122 

I must have accidentally nuked this reference when merging back from 2.2. Adding it back fixes the test.