### PR TITLE
Ensure Identity.Views.{V3, V4}.dll are the AllItemsFullPathWithTarget…

### DIFF
--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -118,10 +118,11 @@
     Name="_GetRazorDlls" BeforeTargets="GetCopyToOutputDirectoryItems">
 
     <ItemGroup>
-      <_AllItemsFullPathWithTargetPath Include="$(MSBuildThisFileDirectory)$(IntermediateOutputPath)%(UIFrameworkVersionMoniker.Identity)\$(TargetName).Views.%(UIFrameworkVersionMoniker.Identity).*" />
+      <_GeneratedRazorViews Include="$(TargetDir)$(TargetName).Views.%(UIFrameworkVersionMoniker.Identity).dll" />
+      <_GeneratedRazorViews Include="$(TargetDir)$(TargetName).Views.%(UIFrameworkVersionMoniker.Identity).pdb" />
 
-      <AllItemsFullPathWithTargetPath Include="%(_AllItemsFullPathWithTargetPath.FullPath)">
-        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      <AllItemsFullPathWithTargetPath Include="%(_GeneratedRazorViews.FullPath)">
+        <TargetPath>%(FileName)%(Extension)</TargetPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </AllItemsFullPathWithTargetPath>
     </ItemGroup>
@@ -143,8 +144,8 @@
 
   <Target Name="VerifyBuildOutputs" AfterTargets="BuildRazorViews">
     <ItemGroup>
-      <ExpectedOutputFile Include="$(OutputPath)Microsoft.AspNetCore.Identity.UI.Views.V3.dll" />
-      <ExpectedOutputFile Include="$(OutputPath)Microsoft.AspNetCore.Identity.UI.Views.V4.dll" />
+      <ExpectedOutputFile Include="$(TargetDir)Microsoft.AspNetCore.Identity.UI.Views.V3.dll" />
+      <ExpectedOutputFile Include="$(TargetDir)Microsoft.AspNetCore.Identity.UI.Views.V4.dll" />
     </ItemGroup>
 
     <Error Text="Unable to find precompiled view file %(ExpectedOutputFile.Identity)"

--- a/src/Identity/test/Identity.FunctionalTests/Microsoft.AspNetCore.Identity.FunctionalTests.csproj
+++ b/src/Identity/test/Identity.FunctionalTests/Microsoft.AspNetCore.Identity.FunctionalTests.csproj
@@ -24,24 +24,4 @@
   </ItemGroup>
 
   <Import Project="$(MvcTestingTargets)" Condition="'$(MvcTestingTargets)' != ''" />
-
-  <Target Name="CopyViews" AfterTargets="Build" Condition="$(TargetFramework) != ''">
-    <ItemGroup>
-      <_IdentityUIViewsAssemblies Include="$(MSBuildThisFileDirectory)..\..\UI\src\bin\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Identity.UI.Views.*.dll" />
-    </ItemGroup>
-    <Copy
-      SourceFiles="@(_IdentityUIViewsAssemblies)"
-      DestinationFolder="$(OutputPath)" />
-  </Target>
-
-  <Target Name="VerifyBuildOutputs" AfterTargets="Build" Condition="$(TargetFramework) != ''">
-    <ItemGroup>
-      <ExpectedOutputFile Include="$(OutputPath)Microsoft.AspNetCore.Identity.UI.Views.V3.dll" />
-      <ExpectedOutputFile Include="$(OutputPath)Microsoft.AspNetCore.Identity.UI.Views.V4.dll" />
-    </ItemGroup>
-
-    <Error Text="Unable to find precompiled view file %(ExpectedOutputFile.Identity)"
-           Condition="!Exists('%(ExpectedOutputFile.Identity)')" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
…Path group so they get copied across ProjectReferences

Fix https://github.com/aspnet/AspNetCore-Internal/issues/1612.