### PR TITLE
React to JwtBearer removal from Microsoft.AspNetCore.App

### DIFF
--- a/src/Mvc/benchmarkapps/BasicApi/BasicApi.csproj
+++ b/src/Mvc/benchmarkapps/BasicApi/BasicApi.csproj
@@ -11,39 +11,34 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(BenchmarksOnlyNpgsqlEntityFrameworkCorePostgreSQLPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
-    <PackageReference Include="MySqlConnector" Version="$(BenchmarksOnlyMySqlConnectorPackageVersion)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(BenchmarksOnlyPomeloEntityFrameworkCoreMySqlPackageVersion)" />
-
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion)" />
+    <PackageReference Include="MySqlConnector" Version="$(BenchmarksOnlyMySqlConnectorPackageVersion)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(BenchmarksOnlyNpgsqlEntityFrameworkCorePostgreSQLPackageVersion)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(BenchmarksOnlyPomeloEntityFrameworkCoreMySqlPackageVersion)" />
   </ItemGroup>
 
-  <!-- These references are used when running locally -->
+  <!-- These references are used when building locally or on CI. -->
   <ItemGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <Reference Include="Microsoft.AspNetCore.Authentication" />
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
-
-    <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
   </ItemGroup>
 
-  <!--
-    These references are used when running on the Benchmarks Server.
-    Use All meta-package and not App to include Microsoft.EntityFrameworkCore.Sqlite.
-  -->
+  <!-- These references are used when building on the Benchmarks Server. -->
   <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
     <KnownFrameworkReference
       Update="Microsoft.AspNetCore.App"
       DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
       LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
       TargetingPackVersion="$(MicrosoftAspNetCoreAppPackageVersion)" />
+
+    <!-- Special-case the JwtBearer package because assembly no longer ships in Microsoft.AspNetCore.App. -->
+    <!-- Cannot use <Reference> because it's unsupported when building an isolated project. -->
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(BenchmarksAspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicApiTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicApiTest.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -57,9 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        // Tests are conditional to avoid occasional CI failures on Windows 8 and Windows 2012 under full framework.
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR, SkipReason = "See aspnet/Identity#1630")]
+        [Fact]
         public async Task Token_WithKnownUser_ReturnsOkAndToken()
         {
             // Arrange & Act
@@ -84,8 +81,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR, SkipReason = "See aspnet/Identity#1630")]
+        [Theory]
         [InlineData("reader@example.com")]
         [InlineData("writer@example.com")]
         public async Task FindByStatus_WithToken_ReturnsOkAndPet(string username)
@@ -112,8 +108,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.NotEmpty(json);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR, SkipReason = "See aspnet/Identity#1630")]
+        [Fact]
         public async Task FindById_WithInvalidPetId_ReturnsNotFound()
         {
             // Arrange & Act 1
@@ -133,8 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR, SkipReason = "See aspnet/Identity#1630")]
+        [Fact]
         public async Task FindById_WithValidPetId_ReturnsOkAndPet()
         {
             // Arrange & Act 1
@@ -159,8 +153,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.NotEmpty(json);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR, SkipReason = "See aspnet/Identity#1630")]
+        [Fact]
         public async Task AddPet_WithInsufficientClaims_ReturnsForbidden()
         {
             // Arrange & Act 1
@@ -192,8 +185,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR, SkipReason = "See aspnet/Identity#1630")]
+        [Fact]
         public async Task AddPet_WithValidClaims_ReturnsCreated()
         {
             // Arrange & Act 1


### PR DESCRIPTION
- also revert "Work around `CryptographicException`s thrown in some full framework test runs"
  - no longer support .NET Framework

nits:
- remove NET461 special case
- remove reference to transitive Mvc.Core dependency
