### PR TITLE
Fix ArgumentException from duplicate key

### DIFF
--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -1,13 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Primitives;
 
@@ -269,12 +266,21 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         private Endpoint CreateRejectionEndpoint(IEnumerable<string> httpMethods)
         {
+            const string AllowHeaderName = "Allow";
             var allow = string.Join(", ", httpMethods);
+
             return new Endpoint(
                 (context) =>
                 {
                     context.Response.StatusCode = 405;
-                    context.Response.Headers.Add("Allow", allow);
+
+                    // Prevent ArgumentException from duplicate key if header already added, such as when the
+                    // request is re-executed by an error handler (see https://github.com/aspnet/AspNetCore/issues/6415)
+                    if (!context.Response.Headers.ContainsKey(AllowHeaderName))
+                    {
+                        context.Response.Headers.Add(AllowHeaderName, allow);
+                    }
+
                     return Task.CompletedTask;
                 },
                 EndpointMetadataCollection.Empty,

--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -266,9 +266,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         private Endpoint CreateRejectionEndpoint(IEnumerable<string> httpMethods)
         {
-            const string AllowHeaderName = "Allow";
             var allow = string.Join(", ", httpMethods);
-
             return new Endpoint(
                 (context) =>
                 {
@@ -276,10 +274,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
                     // Prevent ArgumentException from duplicate key if header already added, such as when the
                     // request is re-executed by an error handler (see https://github.com/aspnet/AspNetCore/issues/6415)
-                    if (!context.Response.Headers.ContainsKey(AllowHeaderName))
-                    {
-                        context.Response.Headers.Add(AllowHeaderName, allow);
-                    }
+                    context.Response.Headers["Allow"] = allow;
 
                     return Task.CompletedTask;
                 },

--- a/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyIntegrationTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyIntegrationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -286,6 +286,36 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             // Assert
             MatcherAssert.AssertMatch(context, httpContext, endpoint2, ignoreValues: true);
+        }
+
+        [Fact] // See https://github.com/aspnet/AspNetCore/issues/6415
+        public async Task NotMatch_HttpMethod_Returns405Endpoint_ReExecute()
+        {
+            // Arrange
+            var endpoint1 = CreateEndpoint("/hello", httpMethods: new string[] { "GET", "PUT" });
+            var endpoint2 = CreateEndpoint("/hello", httpMethods: new string[] { "DELETE" });
+
+            var matcher = CreateMatcher(endpoint1, endpoint2);
+            var (httpContext, context) = CreateContext("/hello", "POST");
+
+            // Act
+            await matcher.MatchAsync(httpContext, context);
+
+            // Assert
+            Assert.NotSame(endpoint1, context.Endpoint);
+            Assert.NotSame(endpoint2, context.Endpoint);
+
+            Assert.Same(HttpMethodMatcherPolicy.Http405EndpointDisplayName, context.Endpoint.DisplayName);
+
+            // Invoke the endpoint
+            await context.Endpoint.RequestDelegate(httpContext);
+            Assert.Equal(405, httpContext.Response.StatusCode);
+            Assert.Equal("DELETE, GET, PUT", httpContext.Response.Headers["Allow"]);
+
+            // Invoke the endpoint again to verify headers not duplicated
+            await context.Endpoint.RequestDelegate(httpContext);
+            Assert.Equal(405, httpContext.Response.StatusCode);
+            Assert.Equal("DELETE, GET, PUT", httpContext.Response.Headers["Allow"]);
         }
 
         private static Matcher CreateMatcher(params RouteEndpoint[] endpoints)


### PR DESCRIPTION
Fix `ArgumentException` if the matcher runs twice (e.g. on error re-execute).

Addresses #6415
