### PR TITLE
Added OnPrepareResponse to the WebpackDevMiddleware

### DIFF
--- a/src/Middleware/SpaServices/src/Webpack/ConditionalProxyMiddleware.cs
+++ b/src/Middleware/SpaServices/src/Webpack/ConditionalProxyMiddleware.cs
@@ -103,6 +103,8 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
                 // SendAsync removes chunking from the response. This removes the header so it doesn't expect a chunked response.
                 context.Response.Headers.Remove("transfer-encoding");
 
+                _options.OnPrepareResponse?.Invoke(context);
+
                 using (var responseStream = await responseMessage.Content.ReadAsStreamAsync())
                 {
                     try

--- a/src/Middleware/SpaServices/src/Webpack/ConditionalProxyMiddlewareOptions.cs
+++ b/src/Middleware/SpaServices/src/Webpack/ConditionalProxyMiddlewareOptions.cs
@@ -1,20 +1,23 @@
 using System;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.SpaServices.Webpack
 {
     internal class ConditionalProxyMiddlewareOptions
     {
-        public ConditionalProxyMiddlewareOptions(string scheme, string host, string port, TimeSpan requestTimeout)
+        public ConditionalProxyMiddlewareOptions(string scheme, string host, string port, TimeSpan requestTimeout, Action<HttpContext> onPrepareResponse = null)
         {
             Scheme = scheme;
             Host = host;
             Port = port;
             RequestTimeout = requestTimeout;
+            OnPrepareResponse = onPrepareResponse;
         }
 
         public string Scheme { get; }
         public string Host { get; }
         public string Port { get; }
         public TimeSpan RequestTimeout { get; }
+        public Action<HttpContext> OnPrepareResponse { get; set; }
     }
 }

--- a/src/Middleware/SpaServices/src/Webpack/WebpackDevMiddlewareOptions.cs
+++ b/src/Middleware/SpaServices/src/Webpack/WebpackDevMiddlewareOptions.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.SpaServices.Webpack
 {
@@ -30,10 +33,10 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
         /// </summary>
         public bool ReactHotModuleReplacement { get; set; }
 
-        /// <summary> 
+        /// <summary>
         /// Specifies additional options to be passed to the Webpack Hot Middleware client, if used.
-        /// </summary> 
-        public IDictionary<string, string> HotModuleReplacementClientOptions { get; set; } 
+        /// </summary>
+        public IDictionary<string, string> HotModuleReplacementClientOptions { get; set; }
 
         /// <summary>
         /// Specifies the Webpack configuration file to be used. If not set, defaults to 'webpack.config.js'.
@@ -57,5 +60,11 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
         /// configuration is exported as a function.
         /// </summary>
         public object EnvParam { get; set; }
+
+        /// <summary>
+        /// Specifies an action to be executed on the contex just before the response starts to be generated.
+        /// This allows an extension point to modify the response, for example adding headers.
+        /// </summary>
+        [JsonIgnore]public Action<HttpContext> OnPrepareResponse { get; set; }
     }
 }


### PR DESCRIPTION
**NOTE:** this is a port of this other pull request (https://github.com/aspnet/JavaScriptServices/pull/1777) to the current aspnet repo

WebpackDevMiddleware doesn't allow to add heades to the generated response while using HMR. In certain scenario (using workbox for PWA) it is necessary to add headers to the returned swerviceworker file to broad the scope of the service worker and keep the solution clean.
While this is possible in production mode using the StaticFileMiddleware, this is not possible in development because of the "proxied" way the WebpackDevMiddleware works.
To keep consistency with the static file middleware which provide a OnPrepareResponse extension point i've implemented a similar mechanism for the webpack dev middleware which could be usefull also in other scenario, not only for my particular workbox integration needs.

In my scenario it can be used this way:

`
app.UseWebpackDevMiddleware(new WebpackDevMiddlewareOptions { HotModuleReplacement = true, OnPrepareResponse = (c)=> { c.Response.HttpContext.Response.Headers["Service-Worker-Allowed"] = "/"; } });
`

if no OnPrepareResponse option is provided, everything work as usual

Implementation Question:
i've implemented in the simplest way but i've noticed that the class WebpackDevMiddlewareOptions is at one point serialized in devServerOptions (Webpack\WebpackDevMiddleware.cs+92) and passed to the createWebpackDevServer trough the node script using the node service.

Because this OnPrepareResponse action cannot be useful in the node's script context i've added the attribute [JsonIgnore] but i have the doubt that passing additional configuration option in the WebpackDevMiddlewareOptions is not the intended way to use it, even if it s very handy to have it in this way. Please let me know if this WebpackDevMiddlewareOptions class must remain pure with only the argument that have to be passed to node, or if it ok to have all the config option here and maybe using JsonIgnore or copy only the relevant part when passing it as argument to node.

Thanks,
Mosè
