### PR TITLE
Only sign DynamicLibrary cpp projects

### DIFF
--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(MSBuildProjectDirectory)\$(OutDir)$(TargetName)$(TargetExt)" Authenticode="Microsoft400" />
+    <FilesToSign Include="$(MSBuildProjectDirectory)\$(OutDir)$(TargetName)$(TargetExt)" Condition="'$(ConfigurationType)' == 'DynamicLibrary'" Authenticode="Microsoft400" />
   </ItemGroup>
 
   <Import Project="MicroBuild.Plugin.props" Condition="'$(MicroBuildSentinelFile)' == ''" />


### PR DESCRIPTION
Signtool fails on `.lib`