### PR TITLE
Assign FilesToSign in a target

### DIFF
--- a/build/CodeSign.props
+++ b/build/CodeSign.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
-    <FileExtensionsToSign Include=".js" Certificate="None" />
+    <FileExtensionsToSign Include=".js" CertificateName="None" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/CodeSign.props
+++ b/build/CodeSign.props
@@ -1,6 +1,11 @@
 <Project>
 
   <ItemGroup>
+    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <FileExtensionsToSign Include=".js" Certificate="None" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Third-party components which should be signed.  -->
       <!-- Microsoft.AspNetCore.App -->
       <FilesToSign Include="Newtonsoft.Json.dll"                                           Certificate="$(AssemblySigning3rdPartyCertName)" Container="Microsoft.AspNetCore.App" />

--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -6,10 +6,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <FilesToSign Include="$(MSBuildProjectDirectory)\$(OutDir)$(TargetName)$(TargetExt)" Condition="'$(ConfigurationType)' == 'DynamicLibrary'" Authenticode="Microsoft400" />
-  </ItemGroup>
-
   <Import Project="MicroBuild.Plugin.props" Condition="'$(MicroBuildSentinelFile)' == ''" />
   <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.props" Condition=" '$(MicroBuildPluginDirectory)' != ''" />
 

--- a/eng/targets/Cpp.Common.targets
+++ b/eng/targets/Cpp.Common.targets
@@ -3,7 +3,7 @@
 
   <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(DisableMicroBuild)' != 'true' AND '$(MicroBuildPluginDirectory)' != ''" />
 
-  <Target Name="GetVcxprojFilesToSign" BeforeTargets="GetSignedPackageFiles">
+  <Target Name="GetVcxprojFilesToSign" BeforeTargets="SignFiles">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)$(TargetName)$(TargetExt)" Condition="'$(ConfigurationType)' == 'DynamicLibrary'" Authenticode="Microsoft400" />
     </ItemGroup>

--- a/eng/targets/Cpp.Common.targets
+++ b/eng/targets/Cpp.Common.targets
@@ -3,6 +3,12 @@
 
   <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(DisableMicroBuild)' != 'true' AND '$(MicroBuildPluginDirectory)' != ''" />
 
+  <Target Name="GetVcxprojFilesToSign" BeforeTargets="GetSignedPackageFiles">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)$(TargetName)$(TargetExt)" Condition="'$(ConfigurationType)' == 'DynamicLibrary'" Authenticode="Microsoft400" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="Pack" />
   <Target Name="Restore" />
   <Target Name="ResolveNuGetPackageAssets" />


### PR DESCRIPTION
Assign `FilesToSign` in a target.
Exclude `.js` files from signing.