### PR TITLE
Allow disabling shared configuration check from hosting bundle.

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
@@ -60,7 +60,7 @@
 
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
-        <Property Id="OPT_SHARED_CONFIG_CHECK"  Value="0"/>
+        <Property Id="OPT_NO_SHARED_CONFIG_CHECK"  Value="0"/>
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
         <!-- <Property Id="REINSTALLMODE" Value="emus"/> -->
 
@@ -252,7 +252,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_SHARED_CONFIG_CHECK=0</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
@@ -60,6 +60,7 @@
 
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
+        <Property Id="DISABLESHAREDCONFIGCHECK"  Value="0"/>
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
         <!-- <Property Id="REINSTALLMODE" Value="emus"/> -->
 
@@ -251,7 +252,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize"></Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">DISABLESHAREDCONFIGCHECK=0</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
@@ -252,7 +252,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0 AND NOT Installed AND NOT REMOVE</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
@@ -60,7 +60,7 @@
 
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
-        <Property Id="DISABLESHAREDCONFIGCHECK"  Value="0"/>
+        <Property Id="OPT_SHARED_CONFIG_CHECK"  Value="0"/>
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
         <!-- <Property Id="REINSTALLMODE" Value="emus"/> -->
 
@@ -252,7 +252,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">DISABLESHAREDCONFIGCHECK=0</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_SHARED_CONFIG_CHECK=0</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV1/aspnetcoremodule.wxs
@@ -252,7 +252,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0 AND NOT Installed AND NOT REMOVE</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0 AND NOT Installed AND NOT REMOVE="ALL"</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -286,7 +286,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=1</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0 AND NOT Installed AND NOT REMOVE</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -62,7 +62,7 @@
 
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
-        <Property Id="DISABLESHAREDCONFIGCHECK"  Value="0"/>
+        <Property Id="OPT_SHARED_CONFIG_CHECK"  Value="0"/>
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
         <!-- <Property Id="REINSTALLMODE" Value="emus"/> -->
 
@@ -286,7 +286,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">DISABLESHAREDCONFIGCHECK=0</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_SHARED_CONFIG_CHECK=1</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -62,7 +62,7 @@
 
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
-        <Property Id="OPT_SHARED_CONFIG_CHECK"  Value="0"/>
+        <Property Id="OPT_NO_SHARED_CONFIG_CHECK"  Value="0"/>
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
         <!-- <Property Id="REINSTALLMODE" Value="emus"/> -->
 
@@ -286,7 +286,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_SHARED_CONFIG_CHECK=1</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=1</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -62,6 +62,7 @@
 
         <Property Id="ARPCONTACT">Microsoft Corporation</Property>
         <Property Id="ARPPRODUCTICON" Value="AspNetCoreModule.ico" />
+        <Property Id="DISABLESHAREDCONFIGCHECK"  Value="0"/>
         <Icon Id="AspNetCoreModule.ico" SourceFile="..\Bitmaps\AspNetCoreModule.ico" />
         <!-- <Property Id="REINSTALLMODE" Value="emus"/> -->
 
@@ -285,7 +286,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize"></Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">DISABLESHAREDCONFIGCHECK=0</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -286,7 +286,7 @@
             <AppSearch Before="LaunchConditions" />
             <LaunchConditions After="FindRelatedProducts" />
             <MigrateFeatureStates />
-            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0 AND NOT Installed AND NOT REMOVE</Custom>
+            <Custom Action="CheckForSharedConfiguration" After="InstallInitialize">OPT_NO_SHARED_CONFIG_CHECK=0 AND NOT Installed AND NOT REMOVE="ALL"</Custom>
             <Custom Action="CA_UNLOCk_HANDLER_PROPERTY" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="CA_UNLOCk_HANDLER" After="CA_UNLOCk_HANDLER_PROPERTY"><![CDATA[(NOT PATCH)]]></Custom>
             <Custom Action="UpdateDynamicCompression" After="InstallFiles"><![CDATA[(NOT PATCH)]]></Custom>

--- a/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
     <Fragment>
-        <Variable Name="DISABLESHAREDCONFIGCHECK" Value="0" bal:Overridable="yes" />
-
         <PackageGroup Id="PG_ANCM">
             <RollbackBoundary Id="RB_ANCM" />
 

--- a/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
@@ -10,7 +10,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
+                <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModule_x64" SourceFile="$(var.BinPath)aspnetcoremodule_x64_en.msi"
@@ -19,7 +19,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
+                <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModuleV2_x86" SourceFile="$(var.BinPath)aspnetcoremodule_x86_en_v2.msi"
@@ -28,7 +28,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
+                <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModuleV2_x64" SourceFile="$(var.BinPath)aspnetcoremodule_x64_en_v2.msi"
@@ -37,7 +37,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
+                <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
         </PackageGroup>
 

--- a/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
     <Fragment>
+        <Variable Name="DISABLESHAREDCONFIGCHECK" Value="0" bal:Overridable="yes" />
+
         <PackageGroup Id="PG_ANCM">
             <RollbackBoundary Id="RB_ANCM" />
 
@@ -9,28 +11,36 @@
                         Compressed="yes"
                         Vital="yes"
                         Visible="no"
-                        InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)" />
+                        InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)">
+                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+            </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModule_x64" SourceFile="$(var.BinPath)aspnetcoremodule_x64_en.msi"
                         Name="aspnetcoremodule_x64_en.msi"
                         Compressed="yes"
                         Vital="yes"
                         Visible="no"
-                        InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)" />
+                        InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)">
+                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+            </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModuleV2_x86" SourceFile="$(var.BinPath)aspnetcoremodule_x86_en_v2.msi"
                         Name="aspnetcoremodule_x86_en_v2.msi"
                         Compressed="yes"
                         Vital="yes"
                         Visible="no"
-                        InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)" />
+                        InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)">
+                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+            </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModuleV2_x64" SourceFile="$(var.BinPath)aspnetcoremodule_x64_en_v2.msi"
                         Name="aspnetcoremodule_x64_en_v2.msi"
                         Compressed="yes"
                         Vital="yes"
                         Visible="no"
-                        InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)" />
+                        InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)">
+                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+            </MsiPackage>
         </PackageGroup>
 
         <util:RegistrySearch Id="IISCoreWebEngineInstalledSearch_x86"

--- a/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
@@ -10,7 +10,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModule_x64" SourceFile="$(var.BinPath)aspnetcoremodule_x64_en.msi"
@@ -19,7 +19,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModuleV2_x86" SourceFile="$(var.BinPath)aspnetcoremodule_x86_en_v2.msi"
@@ -28,7 +28,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
             <MsiPackage Id="AspNetCoreModuleV2_x64" SourceFile="$(var.BinPath)aspnetcoremodule_x64_en_v2.msi"
@@ -37,7 +37,7 @@
                         Vital="yes"
                         Visible="no"
                         InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM)">
-                <MsiProperty Name="DISABLESHAREDCONFIGCHECK" Value="[DISABLESHAREDCONFIGCHECK]" />
+                <MsiProperty Name="OPT_SHARED_CONFIG_CHECK" Value="[OPT_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
         </PackageGroup>
 

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -24,7 +24,7 @@
         <Variable Name="OPT_NO_SHAREDFX" Value="0" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_RUNTIME" Value="0" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_X86" Value="0" bal:Overridable="yes"/>
-        <Variable Name="OPT_SHARED_CONFIG_CHECK" Value="0" bal:Overridable="yes" />
+        <Variable Name="OPT_NO_SHARED_CONFIG_CHECK" Value="0" bal:Overridable="yes" />
 
         <!-- These variables control the state of conditional UI text elements.
              They are disabled by default and enabled based on whether or not we detect that IIS is installed -->

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -24,8 +24,9 @@
         <Variable Name="OPT_NO_SHAREDFX" Value="0" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_RUNTIME" Value="0" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_X86" Value="0" bal:Overridable="yes"/>
+        <Variable Name="DISABLESHAREDCONFIGCHECK" Value="0" bal:Overridable="yes" />
 
-        <!-- These variables control the state of conditional UI text elements. 
+        <!-- These variables control the state of conditional UI text elements.
              They are disabled by default and enabled based on whether or not we detect that IIS is installed -->
         <Variable Name="InstallResetIISState" Value="disable"/>
         <Variable Name="InstallNoIISState" Value="disable"/>

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -24,7 +24,7 @@
         <Variable Name="OPT_NO_SHAREDFX" Value="0" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_RUNTIME" Value="0" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_X86" Value="0" bal:Overridable="yes"/>
-        <Variable Name="DISABLESHAREDCONFIGCHECK" Value="0" bal:Overridable="yes" />
+        <Variable Name="OPT_SHARED_CONFIG_CHECK" Value="0" bal:Overridable="yes" />
 
         <!-- These variables control the state of conditional UI text elements.
              They are disabled by default and enabled based on whether or not we detect that IIS is installed -->


### PR DESCRIPTION
Issue: https://github.com/aspnet/AspNetCore/issues/4451

### Description

When installing the 2.2 Windows Hosting Bundle, today, we block the use of shared applicationHost.config redirection. This was a change made in the time period between 2.2-preview3 and 2.2. However, some customers relied on this behavior when installing the hosting bundle to update a shared configuration file on the same machine. More importantly, there was no way to disable the check in the new hosting bundle. 

The fix is to allow users to specify the parameter "OPT_NO_SHARED_CONFIG_CHECK" to disable the shared configuration check. 

Usage:
```
dotnet-hosting-2.2.x.exe OPT_NO_SHARED_CONFIG_CHECK=1
```

### Regression?

Regression from 2.1 hosting bundle.

## Risk

Very low. Default scenario are still the same and this only skips a check for shared configuration.
