### PR TITLE
Temporarily disable E2E component tests

### DIFF
--- a/src/Components/build/repo.props
+++ b/src/Components/build/repo.props
@@ -27,6 +27,13 @@
     <ProjectsToPack Include="$(RepositoryRoot)blazor\src\*\*.csproj" />
   </ItemGroup>
 
+  <!--
+    Temporarily disabled until this runs on macOS
+  -->
+  <ItemGroup Condition="'$(BlazorAllTests)'!='true'">
+    <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.Components.E2ETest\Microsoft.AspNetCore.Components.E2ETest.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)" />
 


### PR DESCRIPTION
These are causing hangs and timeouts on macOS

