### PR TITLE
Remove copy targets from ResolveIISReferences

### DIFF
--- a/eng/targets/ResolveIisReferences.targets
+++ b/eng/targets/ResolveIisReferences.targets
@@ -19,8 +19,6 @@ with the right MSBuild incantations to get output copied to the right place.
           <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
           <!-- NativeContent is a custom type of item group which is assigned a target path after project references are resolved.  -->
           <OutputItemType>NativeContent</OutputItemType>
-          <!-- Set the copy policy. -->
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
           <!-- This instructs the ProjectRef protocol to collect symbols as well as built output -->
           <Targets>Build;BuiltProjectOutputGroup;DebugSymbolsProjectOutputGroup</Targets>
           <!-- Optimization. Native projects don't have a .NET TargetFramework -->
@@ -43,22 +41,4 @@ with the right MSBuild incantations to get output copied to the right place.
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -native` to build native projects. Run `build.cmd -managed -native` to build both C# and C++." />
   </Target>
 
-  <Target Name="_GetNativeContentCopyToOutputDirectoryItems"
-          BeforeTargets="GetCopyToOutputDirectoryItems"
-          DependsOnTargets="ResolveProjectReferences">
-
-    <ItemGroup>
-      <!-- Prepend LinkBase to output path. -->
-      <NativeContent>
-        <Link>%(LinkBase)%(FileName)%(Extension)</Link>
-        <!-- Don't put this content in a nuget package. -->
-        <Pack>false</Pack>
-      </NativeContent>
-    </ItemGroup>
-
-    <!-- Add the item to the ContentWithTargetPath group, which is then used by GetCopyToOutputDirectoryItems to copy to the correct output location. -->
-    <AssignTargetPath Files="@(NativeContent)" RootFolder="$(MSBuildProjectDirectory)">
-      <Output TaskParameter="AssignedFiles" ItemName="ContentWithTargetPath" />
-    </AssignTargetPath>
-  </Target>
 </Project>

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
@@ -30,11 +30,11 @@
   <ItemGroup Condition="'$(OS)' == 'Windows_NT' AND '$(VCTargetsPath)' != ''">
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV1\AspNetCore\AspNetCore.vcxproj" Platform="x64"/>
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="x64"/>
-    <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" HandlerPath="2.0.0" Platform="x64" />
+    <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="x64" />
 
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV1\AspNetCore\AspNetCore.vcxproj" Platform="Win32" />
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="Win32" />
-    <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" HandlerPath="2.0.0" Platform="Win32" />
+    <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="Win32" />
   </ItemGroup>
 
   <Target Name="AddRunNativeComponents" BeforeTargets="AssignTargetPaths" Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
Sever.IIS and IntegrationTesting.IIS use content items to copy DLLs so we are copying twice.