### PR TITLE
Fix non-parameter route constraints not called with endpoint routing for 2.2

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -27,6 +27,7 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.2' ">
     <PackagesInPatch>
+      @aspnet/signalr;
       Microsoft.AspNetCore.AspNetCoreModuleV2;
       Microsoft.AspNetCore.Authentication.Google;
       Microsoft.AspNetCore.Http;

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -27,10 +27,10 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.2' ">
     <PackagesInPatch>
-      @aspnet/signalr;
       Microsoft.AspNetCore.AspNetCoreModuleV2;
       Microsoft.AspNetCore.Authentication.Google;
       Microsoft.AspNetCore.Http;
+      Microsoft.AspNetCore.Mvc.Core;
       Microsoft.AspNetCore.Server.IIS;
       java:signalr;
     </PackagesInPatch>

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTestsBase.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTestsBase.cs
@@ -27,6 +27,32 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         public HttpClient Client { get; }
 
         [Fact]
+        public async Task ConventionalRoutedAction_RouteHasNonParameterConstraint_RouteConstraintRun_Allowed()
+        {
+            // Arrange & Act
+            var response = await Client.GetAsync("http://localhost/NonParameterConstraintRoute/NonParameterConstraint/Index?allowed=true");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("NonParameterConstraint", result.Controller);
+            Assert.Equal("Index", result.Action);
+        }
+
+        [Fact]
+        public async Task ConventionalRoutedAction_RouteHasNonParameterConstraint_RouteConstraintRun_Denied()
+        {
+            // Arrange & Act
+            var response = await Client.GetAsync("http://localhost/NonParameterConstraintRoute/NonParameterConstraint/Index?allowed=false");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
         public async Task ConventionalRoutedAction_RouteContainsPage_RouteNotMatched()
         {
             // Arrange & Act

--- a/src/Mvc/test/WebSites/RoutingWebSite/Controllers/NonParameterConstraintController.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Controllers/NonParameterConstraintController.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace RoutingWebSite
+{
+    public class NonParameterConstraintController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public NonParameterConstraintController(TestResponseGenerator generator)
+        {
+            _generator = generator;
+        }
+
+        public IActionResult Index()
+        {
+            return _generator.Generate("/NonParameterConstraintRoute/NonParameterConstraint/Index");
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/QueryStringConstraint.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/QueryStringConstraint.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace RoutingWebSite
+{
+    public class QueryStringConstraint : IRouteConstraint
+    {
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
+        {
+            return httpContext.Request.Query["allowed"].ToString() == "true";
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Startup.cs
@@ -50,6 +50,12 @@ namespace RoutingWebSite
             app.UseMvc(routes =>
             {
                 routes.MapRoute(
+                    "NonParameterConstraintRoute",
+                    "NonParameterConstraintRoute/{controller}/{action}",
+                    defaults: null,
+                    constraints: new { controller = "NonParameterConstraint", nonParameter = new QueryStringConstraint() });
+
+                routes.MapRoute(
                     "DataTokensRoute",
                     "DataTokensRoute/{controller}/{action}",
                     defaults: null,

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupWith21Compat.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupWith21Compat.cs
@@ -55,6 +55,12 @@ namespace RoutingWebSite
             app.UseMvc(routes =>
             {
                 routes.MapRoute(
+                    "NonParameterConstraintRoute",
+                    "NonParameterConstraintRoute/{controller}/{action}",
+                    defaults: null,
+                    constraints: new { controller = "NonParameterConstraint", nonParameter = new QueryStringConstraint() });
+
+                routes.MapRoute(
                     "DataTokensRoute",
                     "DataTokensRoute/{controller}/{action}",
                     defaults: null,


### PR DESCRIPTION
Addresses #6544

#### Description 

Route constraints that do not have a matching parameter in the pattern are not run when matching a request with endpoint routing.

In the route below the `DomainMatchingConstraint` will not be run when matching a request because `domain` is not a route parameter.

```cs
routes.MapRoute(
    "default",
    "{controller=Home}/{action=Index}/{id?}",
    constraints: new { domain = new DomainMatchingConstraint("example.com"), });
```

#### Customer Impact

Requests will get matched to unexpected endpoints, e.g. the wrong MVC action. The only easy workaround to the issue is for the customer to disable endpoint routing.
 
#### Regression? 

This is a regression for customers who upgrade to ASP.NET Core 2.2 and set 2.2/latest compatibility in their Startup.cs.
 
#### Risk

The fix is a small change in how endpoints are built in MVC. Risk is incorrect logic or the introduction of a runtime error.