### PR TITLE
Fix  StartupTests.StartsWithDotnetInstallLocation

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -259,14 +259,26 @@ HostFxrResolver::GetAbsolutePathToDotnet(
     }
 
     auto isWow64Process = Environment::IsRunning64BitProcess();
-    const auto platform = isWow64Process? L"x64" : L"x86";
+    const auto platform = isWow64Process ? L"x64" : L"x86";
+
+    DWORD flags = 0;
+    std::wstring regKeySubSection;
+
+    if (isWow64Process)
+    {
+        regKeySubSection = std::wstring(L"SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk";
+    }
+    else
+    {
+        regKeySubSection = std::wstring(L"SOFTWARE\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk";
+        flags = RRF_SUBKEY_WOW6432KEY;
+    }
 
     const auto installationLocation = RegistryKey::TryGetString(
         HKEY_LOCAL_MACHINE,
-        L"SOFTWARE",
-        std::wstring(L"\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk",
+        regKeySubSection,
         L"InstallLocation",
-        isWow64Process);
+        flags);
 
     if (installationLocation.has_value())
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -259,18 +259,17 @@ HostFxrResolver::GetAbsolutePathToDotnet(
     }
 
     auto isWow64Process = Environment::IsRunning64BitProcess();
-    const auto platform = isWow64Process ? L"x64" : L"x86";
 
     DWORD flags = 0;
     std::wstring regKeySubSection;
 
     if (isWow64Process)
     {
-        regKeySubSection = std::wstring(L"SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk";
+        regKeySubSection = L"SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\x64\\sdk";
     }
     else
     {
-        regKeySubSection = std::wstring(L"SOFTWARE\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk";
+        regKeySubSection = L"SOFTWARE\\dotnet\\Setup\\InstalledVersions\\x86\\sdk";
         flags = RRF_SUBKEY_WOW6432KEY;
     }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -263,8 +263,10 @@ HostFxrResolver::GetAbsolutePathToDotnet(
 
     const auto installationLocation = RegistryKey::TryGetString(
         HKEY_LOCAL_MACHINE,
-        std::wstring(L"SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk",
-        L"InstallLocation");
+        L"SOFTWARE",
+        std::wstring(L"\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk",
+        L"InstallLocation",
+        isWow64Process);
 
     if (installationLocation.has_value())
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -260,7 +260,6 @@ HostFxrResolver::GetAbsolutePathToDotnet(
 
     auto isWow64Process = Environment::IsRunning64BitProcess();
 
-    DWORD flags = 0;
     std::wstring regKeySubSection;
 
     if (isWow64Process)
@@ -270,14 +269,12 @@ HostFxrResolver::GetAbsolutePathToDotnet(
     else
     {
         regKeySubSection = L"SOFTWARE\\dotnet\\Setup\\InstalledVersions\\x86\\sdk";
-        flags = RRF_SUBKEY_WOW6432KEY;
     }
 
     const auto installationLocation = RegistryKey::TryGetString(
         HKEY_LOCAL_MACHINE,
         regKeySubSection,
-        L"InstallLocation",
-        flags);
+        L"InstallLocation");
 
     if (installationLocation.has_value())
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -263,9 +263,8 @@ HostFxrResolver::GetAbsolutePathToDotnet(
 
     const auto installationLocation = RegistryKey::TryGetString(
         HKEY_LOCAL_MACHINE,
-        std::wstring(L"SOFTWARE\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk",
-        L"InstallLocation",
-        RRF_SUBKEY_WOW6432KEY);
+        std::wstring(L"SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\") + platform + L"\\sdk",
+        L"InstallLocation");
 
     if (installationLocation.has_value())
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
@@ -16,11 +16,11 @@ std::optional<DWORD> RegistryKey::TryGetDWORD(HKEY section, const std::wstring& 
     return dwData;
 }
 
-std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags)
+std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName)
 {
     DWORD cbData;
 
-    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData)))
+    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ, nullptr, nullptr, &cbData)))
     {
         return std::nullopt;
     }
@@ -28,7 +28,7 @@ std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::w
     std::wstring data;
     data.resize(cbData / sizeof(wchar_t));
 
-    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData)))
+    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ, nullptr, data.data(), &cbData)))
     {
         return std::nullopt;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
@@ -16,23 +16,11 @@ std::optional<DWORD> RegistryKey::TryGetDWORD(HKEY section, const std::wstring& 
     return dwData;
 }
 
-std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::wstring& subSectionPrefix, const std::wstring& subSectionSuffix, const std::wstring& valueName, bool isWow64Process)
+std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags)
 {
     DWORD cbData;
-    std::wstring regKeySubSection;
-    DWORD flags = 0;
 
-    if (isWow64Process)
-    {
-        regKeySubSection = subSectionPrefix + L"\\WOW6432Node" + subSectionSuffix;
-    }
-    else
-    {
-        regKeySubSection = subSectionPrefix + subSectionSuffix;
-        flags = RRF_SUBKEY_WOW6432KEY;
-    }
-
-    if (!CheckReturnValue(RegGetValue(section, regKeySubSection.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData)))
+    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData)))
     {
         return std::nullopt;
     }
@@ -40,7 +28,7 @@ std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::w
     std::wstring data;
     data.resize(cbData / sizeof(wchar_t));
 
-    if (!CheckReturnValue(RegGetValue(section, regKeySubSection.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData)))
+    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData)))
     {
         return std::nullopt;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
@@ -20,7 +20,7 @@ std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::w
 {
     DWORD cbData;
 
-    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData) != NO_ERROR))
+    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData)))
     {
         return std::nullopt;
     }
@@ -28,7 +28,7 @@ std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::w
     std::wstring data;
     data.resize(cbData / sizeof(wchar_t));
 
-    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData) != NO_ERROR))
+    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData)))
     {
         return std::nullopt;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.cpp
@@ -16,11 +16,23 @@ std::optional<DWORD> RegistryKey::TryGetDWORD(HKEY section, const std::wstring& 
     return dwData;
 }
 
-std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags)
+std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::wstring& subSectionPrefix, const std::wstring& subSectionSuffix, const std::wstring& valueName, bool isWow64Process)
 {
     DWORD cbData;
+    std::wstring regKeySubSection;
+    DWORD flags = 0;
 
-    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData)))
+    if (isWow64Process)
+    {
+        regKeySubSection = subSectionPrefix + L"\\WOW6432Node" + subSectionSuffix;
+    }
+    else
+    {
+        regKeySubSection = subSectionPrefix + subSectionSuffix;
+        flags = RRF_SUBKEY_WOW6432KEY;
+    }
+
+    if (!CheckReturnValue(RegGetValue(section, regKeySubSection.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, nullptr, &cbData)))
     {
         return std::nullopt;
     }
@@ -28,7 +40,7 @@ std::optional<std::wstring> RegistryKey::TryGetString(HKEY section, const std::w
     std::wstring data;
     data.resize(cbData / sizeof(wchar_t));
 
-    if (!CheckReturnValue(RegGetValue(section, subSectionName.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData)))
+    if (!CheckReturnValue(RegGetValue(section, regKeySubSection.c_str(), valueName.c_str(), RRF_RT_REG_SZ | flags, nullptr, data.data(), &cbData)))
     {
         return std::nullopt;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.h
@@ -13,7 +13,7 @@ public:
     std::optional<DWORD> TryGetDWORD(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags = 0);
 
     static
-    std::optional<std::wstring> TryGetString(HKEY section, const std::wstring& subSectionPrefix, const std::wstring& subSectionSuffix, const std::wstring& valueName, bool isWow64Process);
+    std::optional<std::wstring> TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags = 0);
 
 private:
     static

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.h
@@ -13,7 +13,7 @@ public:
     std::optional<DWORD> TryGetDWORD(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags = 0);
 
     static
-    std::optional<std::wstring> TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags = 0);
+    std::optional<std::wstring> TryGetString(HKEY section, const std::wstring& subSectionPrefix, const std::wstring& subSectionSuffix, const std::wstring& valueName, bool isWow64Process);
 
 private:
     static

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RegistryKey.h
@@ -13,7 +13,7 @@ public:
     std::optional<DWORD> TryGetDWORD(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags = 0);
 
     static
-    std::optional<std::wstring> TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName, DWORD flags = 0);
+    std::optional<std::wstring> TryGetString(HKEY section, const std::wstring& subSectionName, const std::wstring& valueName);
 
 private:
     static


### PR DESCRIPTION
The reg key flag RRF_SUBKEY_WOW6432KEY doesn't evaluate to WOW6432Node on Win8 and below. Therefore we need to insert it ourselves.

StartsWithDotnetInstallLocation is failing on CI currently.