### PR TITLE
Shrink ParseRequestLine inner loop

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -73,16 +73,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private unsafe void ParseRequestLine(TRequestHandler handler, byte* data, int length)
         {
             // Get Method and set the offset
-            var method = HttpUtilities.GetKnownMethod(data, length, out var offset);
+            var method = HttpUtilities.GetKnownMethod(data, length, out var pathStartOffset);
 
             Span<byte> customMethod = default;
             if (method == HttpMethod.Custom)
             {
-                customMethod = GetUnknownMethod(data, length, out offset);
+                customMethod = GetUnknownMethod(data, length, out pathStartOffset);
             }
 
+            // Use a new offset var as pathStartOffset needs to be on stack
+            // as its passed by reference above so can't be in register.
             // Skip space
-            offset++;
+            var offset = pathStartOffset + 1;
             if (offset >= length)
             {
                 // Start of path not found


### PR DESCRIPTION
`pathStart == -1` and `RejectRequestLine` calls are unnecessary as they can be checked and called outside loop.

Removes 4 branches and 3 method calls from inside the path `for` loop, and puts the `offset` variable in a register

```diff
                Method |     Mean |        Op/s |
 --------------------- |---------:|------------:|
- PlaintextTechEmpower | 338.1 ns | 2,957,510.7 |
+ PlaintextTechEmpower | 328.4 ns | 3,045,455.2 |
-           LiveAspNet | 578.0 ns | 1,729,970.8 |
+           LiveAspNet | 572.8 ns | 1,745,677.2 |
-              Unicode | 792.0 ns | 1,262,606.8 |
+              Unicode | 735.9 ns | 1,358,882.0 |
```

```diff
; Assembly listing for method HttpParser`1:ParseRequestLine(struct,long,int):this

-; Total bytes of code 1003, prolog size 62 for method HttpParser`1:ParseRequestLine(struct,long,int):this
+; Total bytes of code 881, prolog size 65 for method HttpParser`1:ParseRequestLine(struct,long,int):this
```

/cc @davidfowl  @pakrym @halter73 @JamesNK 