### PR TITLE
[2.1] Fix for shared framework assembly version mismatches

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -103,7 +103,7 @@
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <DevDependency_MicrosoftDotNetBuildTasksFeedPackageVersion>2.1.0-prerelease-02430-04</DevDependency_MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <DevDependency_MicrosoftExtensionsDependencyModelPackageVersion>2.0.0</DevDependency_MicrosoftExtensionsDependencyModelPackageVersion>
+    <DevDependency_MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</DevDependency_MicrosoftExtensionsDependencyModelPackageVersion>
     <DevDependency_WindowsAzureStoragePackageVersion>8.7.0</DevDependency_WindowsAzureStoragePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.1.0</GoogleProtobufPackageVersion>

--- a/test/SharedFx.UnitTests/SharedFxTests.cs
+++ b/test/SharedFx.UnitTests/SharedFxTests.cs
@@ -47,6 +47,28 @@ namespace Microsoft.AspNetCore
             Assert.NotNull(depsFile["compilationOptions"]);
             Assert.Empty(depsFile["compilationOptions"]);
             Assert.NotEmpty(depsFile["runtimes"][config.RuntimeIdentifier]);
+
+            var targetLibraries = depsFile["targets"][target];
+            Assert.All(targetLibraries, libEntry =>
+            {
+                var lib = Assert.IsType<JProperty>(libEntry);
+                if (lib.Value["runtime"] == null)
+                {
+                    return;
+                }
+
+                Assert.All(lib.Value["runtime"], item =>
+                {
+                    var obj = Assert.IsType<JProperty>(item);
+                    var assemblyVersion = obj.Value["assemblyVersion"];
+                    Assert.NotNull(assemblyVersion);
+                    Assert.NotEmpty(assemblyVersion.Value<string>());
+
+                    var fileVersion = obj.Value["fileVersion"];
+                    Assert.NotNull(fileVersion);
+                    Assert.NotEmpty(fileVersion.Value<string>());
+                });
+            });
         }
 
         [Theory]


### PR DESCRIPTION
### Description

The ASP.NET Core shared framework's metadata (.deps.json) files in 2.1.7 and 2.2.1 are missing version metadata, which means corehost cannot correctly pick the highest assembly version. It instead defaults to versions in the application base directory. This scenario happens when users have a PackageReference which overrides the shared framework.

The version metadata is missing because of changes in Microsoft.Extensions.DependencyModel between 2.0 and 2.1. The 2.0 version does not support the assembly/file version metadata. Our build tools must use least 2.1.

Between 2.1.6 and 2.1.7, we switched the build to use MSBuild.exe ("full" MSBuild) instead of `dotnet msbuild` ("core" MSBuild). MSBuild has different assembly loaders behaviors in core vs full. By switching MSBuild types, we were also unintentionally switching the version of Microsoft.Extensions.DependencyModel.dll that was being used by our build task from 2.1 back down to 2.0.

 The reason we didn't discover this in earlier 2.1.x patches is that building on msbuild core automatically upgraded our build tasks to Microsoft.Extensions.DependencyModel.dll, Version=2.1.0.0. This happens because of differences in the way .NET Core and MSBuild handles assemblies with the same ID and different versions, and differences in the layout of MSBuild and the .NET Core CLI. 
 
 In the end, this happened because we didn't have test coverage. MSBuild and custom tasks burned us again, but we should have had unit tests all along, which would have uncovered this regression as soon as we switched to msbuild.exe. 

### Customer Impact
Customers with applications that have an incorrect combination of PackageReference's will crash with `FileNotFoundException` due to assembly mismatches. This crash may happen early during app startup, or later when new code paths are exercised for the first time, leading to an error in the assembly loader.

Customers can workaround this with either workaround mentioned in #3503. Both workarounds are not easy to find on your own and are not obvious to users.

### Regression?
Yes. We fixed this in 2.1.5 and regressed this in 2.2.1 and 2.1.7.

### Risk
Low.

cc @Eilon @muratg 