### PR TITLE
Always copy nuget package output to build directory

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
@@ -28,12 +28,20 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
-    <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" ReferenceOutputAssembly="false" />
+    <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Private="false" />
     <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
     <Reference Include="System.Net.WebSockets.WebSocketProtocol" />
   </ItemGroup>
+
+  <Target Name="RemoveSourceOverride" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory">
+    <ItemGroup>
+      <SourceItemsToRemove Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy(%(_SourceItemsToCopyToOutputDirectory.FullPath)).Contains('IIS\AspNetCoreModule')) != 'true'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" />
+      <_SourceItemsToCopyToOutputDirectory Include="@(SourceItemsToRemove)" />
+   </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
-    <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Private="false" />
+    <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" />
     <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Logging" />

--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
-    <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" />
+    <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" ReferenceOutputAssembly="false" />
     <Reference Include="Microsoft.AspNetCore.Server.IntegrationTesting" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Logging" />

--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
@@ -38,9 +38,8 @@
 
   <Target Name="RemoveSourceOverride" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory">
     <ItemGroup>
-      <SourceItemsToRemove Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy(%(_SourceItemsToCopyToOutputDirectory.FullPath)).Contains('IIS\AspNetCoreModule')) != 'true'" />
-      <_SourceItemsToCopyToOutputDirectory Remove="@(_SourceItemsToCopyToOutputDirectory)" />
-      <_SourceItemsToCopyToOutputDirectory Include="@(SourceItemsToRemove)" />
+      <SourceItemsToRemove Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="$([System.String]::Copy(%(_SourceItemsToCopyToOutputDirectory.FullPath)).Contains('IIS\AspNetCoreModule')) == 'true'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(SourceItemsToRemove)" />
    </ItemGroup>
   </Target>
 


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore-Internal/issues/1647
There was a race between the PackageReference and https://github.com/aspnet/AspNetCore/blob/master/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj#L42 copying aspnetcore.dll to the build/publish directories, meaning half of the time it got the wrong dlls in the output. Setting CopyToOutputDirectory *should* fix this. I tested this ~5 times locally and see it working.