### PR TITLE
Fix HttpContext not being passed to constraints in link generation for 2.2

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -32,6 +32,7 @@ Later on, this will be checked using this condition:
       Microsoft.AspNetCore.Authentication.Google;
       Microsoft.AspNetCore.Http;
       Microsoft.AspNetCore.Mvc.Core;
+      Microsoft.AspNetCore.Routing;
       Microsoft.AspNetCore.Server.IIS;
       java:signalr;
     </PackagesInPatch>

--- a/src/Http/Routing/src/DefaultLinkGenerator.cs
+++ b/src/Http/Routing/src/DefaultLinkGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -90,6 +90,7 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             return GetPathByEndpoints(
+                httpContext,
                 endpoints,
                 values,
                 ambientValues,
@@ -112,6 +113,7 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             return GetPathByEndpoints(
+                httpContext: null,
                 endpoints,
                 values,
                 ambientValues: null,
@@ -206,7 +208,8 @@ namespace Microsoft.AspNetCore.Routing
             return endpoints;
         }
 
-        public string GetPathByEndpoints(
+        private string GetPathByEndpoints(
+            HttpContext httpContext,
             List<RouteEndpoint> endpoints,
             RouteValueDictionary values,
             RouteValueDictionary ambientValues,
@@ -218,7 +221,7 @@ namespace Microsoft.AspNetCore.Routing
             {
                 var endpoint = endpoints[i];
                 if (TryProcessTemplate(
-                    httpContext: null,
+                    httpContext: httpContext,
                     endpoint: endpoint,
                     values: values,
                     ambientValues: ambientValues,

--- a/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorTest.cs
+++ b/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -522,6 +522,42 @@ namespace Microsoft.AspNetCore.Routing
 
             // Assert
             Assert.Equal("ftp://example.com:5000/Home/Index", uri);
+        }
+
+        [Fact]
+        public void GetPathByAddress_WithHttpContext_ContextPassedToConstraint()
+        {
+            // Arrange
+            var constraint = new TestRouteConstraint();
+
+            var endpoint1 = EndpointFactory.CreateRouteEndpoint("{controller}/{action}/{id?}", policies: new { controller = constraint }, metadata: new object[] { new IntMetadata(1), });
+
+            var linkGenerator = CreateLinkGenerator(endpoint1);
+
+            var httpContext = CreateHttpContext();
+            httpContext.Request.PathBase = "/Foo";
+
+            // Act
+            var uri = linkGenerator.GetPathByAddress(
+                httpContext,
+                1,
+                values: new RouteValueDictionary(new { action = "Index", controller = "Home", }),
+                pathBase: "/");
+
+            // Assert
+            Assert.Equal("/Home/Index", uri);
+            Assert.True(constraint.HasHttpContext);
+        }
+
+        private class TestRouteConstraint : IRouteConstraint
+        {
+            public bool HasHttpContext { get; set; }
+
+            public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
+            {
+                HasHttpContext = (httpContext != null);
+                return true;
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Ports https://github.com/aspnet/AspNetCore/pull/6045 to 2.2

#### Description

Link generation has an overload to use a HttpContext during link generation. When endpoint routing is enable this method is used by `IUrlHelper`, which passes the current request's context. This issue is inside link generation the HttpContext is incorrectly not being passed to route constraints.
 
#### Customer Impact 

For customers with a route constraint that expects a HttpContext, no HttpContext could cause route constraints could produce an incorrect result, resulting in the wrong URL. Or a route constraint could null reference exception. The only simple workaround to the issue is for the customer to disable endpoint routing.
 
#### Regression? 

This is a regression for customers who upgrade to ASP.NET Core 2.2 and set 2.2/latest compatibility in their Startup.cs.
 
#### Risk

The only change is passing a value to a method that wasn't previously being passed.