### PR TITLE
Use the WebSocket factory method instead of WebSocketProtocol

### DIFF
--- a/src/Middleware/WebSockets/samples/EchoApp/Startup.cs
+++ b/src/Middleware/WebSockets/samples/EchoApp/Startup.cs
@@ -51,9 +51,9 @@ namespace EchoApp
         private async Task Echo(HttpContext context, WebSocket webSocket, ILogger logger)
         {
             var buffer = new byte[1024 * 4];
-            var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-            LogFrame(logger, result, buffer);
-            while (!result.CloseStatus.HasValue)
+            var result = await webSocket.ReceiveAsync(buffer.AsMemory(), CancellationToken.None);
+            LogFrame(logger, webSocket, result, buffer);
+            while (result.MessageType != WebSocketMessageType.Close)
             {
                 // If the client send "ServerClose", then they want a server-originated close to occur
                 string content = "<<binary>>";
@@ -75,19 +75,19 @@ namespace EchoApp
                 await webSocket.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, CancellationToken.None);
                 logger.LogDebug($"Sent Frame {result.MessageType}: Len={result.Count}, Fin={result.EndOfMessage}: {content}");
 
-                result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                LogFrame(logger, result, buffer);
+                result = await webSocket.ReceiveAsync(buffer.AsMemory(), CancellationToken.None);
+                LogFrame(logger, webSocket, result, buffer);
             }
-            await webSocket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None);
+            await webSocket.CloseAsync(webSocket.CloseStatus.Value, webSocket.CloseStatusDescription, CancellationToken.None);
         }
 
-        private void LogFrame(ILogger logger, WebSocketReceiveResult frame, byte[] buffer)
+        private void LogFrame(ILogger logger, WebSocket webSocket, ValueWebSocketReceiveResult frame, byte[] buffer)
         {
-            var close = frame.CloseStatus != null;
+            var close = frame.MessageType == WebSocketMessageType.Close;
             string message;
             if (close)
             {
-                message = $"Close: {frame.CloseStatus.Value} {frame.CloseStatusDescription}";
+                message = $"Close: {webSocket.CloseStatus.Value} {webSocket.CloseStatusDescription}";
             }
             else
             {

--- a/src/Middleware/WebSockets/src/Microsoft.AspNetCore.WebSockets.csproj
+++ b/src/Middleware/WebSockets/src/Microsoft.AspNetCore.WebSockets.csproj
@@ -13,7 +13,6 @@
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="System.Net.WebSockets.WebSocketProtocol" />
   </ItemGroup>
 
 </Project>

--- a/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
+++ b/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.WebSockets
 
                 Stream opaqueTransport = await _upgradeFeature.UpgradeAsync(); // Sets status code to 101
 
-                return WebSocketProtocol.CreateFromStream(opaqueTransport, isServer: true, subProtocol: subProtocol, keepAliveInterval: keepAliveInterval);
+                return WebSocket.CreateFromStream(opaqueTransport, isServer: true, subProtocol: subProtocol, keepAliveInterval: keepAliveInterval);
             }
         }
     }

--- a/src/Middleware/WebSockets/test/UnitTests/WebSocketPair.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/WebSocketPair.cs
@@ -28,8 +28,8 @@ namespace Microsoft.AspNetCore.WebSockets.Test
             return new WebSocketPair(
                 serverStream,
                 clientStream,
-                clientSocket: WebSocketProtocol.CreateFromStream(clientStream, isServer: false, subProtocol: null, keepAliveInterval: TimeSpan.FromMinutes(2)),
-                serverSocket: WebSocketProtocol.CreateFromStream(serverStream, isServer: true, subProtocol: null, keepAliveInterval: TimeSpan.FromMinutes(2)));
+                clientSocket: WebSocket.CreateFromStream(clientStream, isServer: false, subProtocol: null, keepAliveInterval: TimeSpan.FromMinutes(2)),
+                serverSocket: WebSocket.CreateFromStream(serverStream, isServer: true, subProtocol: null, keepAliveInterval: TimeSpan.FromMinutes(2)));
         }
     }
 }


### PR DESCRIPTION
- WebSocketProtocol.CreateFromStream makes the netstandard ManagedWebSocket which uses the inefficient versions of Stream overloads.
- Updated the samples to use the new Memory<byte> overloads.
- Also removed dependency on `System.Net.WebSockets.WebSocketProtocol` since we're netcoreapp3.0 only.

See https://github.com/dotnet/corefx/issues/29951