### PR TITLE
Minor argument check fixes in health check builder

### DIFF
--- a/src/Middleware/HealthChecks/src/Builder/HealthCheckApplicationBuilderExtensions.cs
+++ b/src/Middleware/HealthChecks/src/Builder/HealthCheckApplicationBuilderExtensions.cs
@@ -201,6 +201,11 @@ namespace Microsoft.AspNetCore.Builder
 
             if (path == null)
             {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (port == null)
+            {
                 throw new ArgumentNullException(nameof(port));
             }
 


### PR DESCRIPTION
Fixed `nameof()` reference to be consistent with arg being checked. Added null check for port to be consistent with earlier overload.