### PR TITLE
SpaServices.Extensions: add optional port parameter

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
@@ -41,17 +41,20 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
             // or the specified port is still free (unused).
             var shouldStartServer = !spaPort.HasValue || TcpPortFinder.TestPortAvailability(spaPort.Value);
 
-            Task<int> portTask;
+            Task<AngularCliServerInfo> angularCliServerInfoTask;
             if (shouldStartServer)
             {
                 // Start Angular CLI and attach to middleware pipeline
                 var appBuilder = spaBuilder.ApplicationBuilder;
                 var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-                var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
+                angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
             }
             else
             {
-                portTask = Task.FromResult(spaPort.Value);
+                angularCliServerInfoTask = Task.FromResult(new AngularCliServerInfo
+                {
+                    Port = spaPort.Value
+                });
             }
 
             // Everything we proxy is hardcoded to target http://localhost because:

--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
@@ -23,7 +23,8 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
 
         public static void Attach(
             ISpaBuilder spaBuilder,
-            string npmScriptName)
+            string npmScriptName,
+            int? spaPort)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
             if (string.IsNullOrEmpty(sourcePath))
@@ -36,10 +37,22 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 throw new ArgumentException("Cannot be null or empty", nameof(npmScriptName));
             }
 
-            // Start Angular CLI and attach to middleware pipeline
-            var appBuilder = spaBuilder.ApplicationBuilder;
-            var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
+            // We have to start the server by ourself if there wasn't any port specified
+            // or the specified port is still free (unused).
+            var shouldStartServer = !spaPort.HasValue || TcpPortFinder.TestPortAvailability(spaPort.Value);
+
+            Task<int> portTask;
+            if (shouldStartServer)
+            {
+                // Start Angular CLI and attach to middleware pipeline
+                var appBuilder = spaBuilder.ApplicationBuilder;
+                var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
+                var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
+            }
+            else
+            {
+                portTask = Task.FromResult(spaPort.Value);
+            }
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote

--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 throw new ArgumentNullException(nameof(spaBuilder));
             }
 
-            ReactDevelopmentServerMiddlewareOptions devServerOptions;
+            var devServerOptions = new AngularCliMiddlewareOptions();
             configure(devServerOptions);
 
             var spaOptions = spaBuilder.Options;

--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
@@ -46,15 +46,15 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 throw new ArgumentNullException(nameof(spaBuilder));
             }
 
-            var devServerOptions = new AngularCliMiddlewareOptions();
-            configure(devServerOptions);
-
             var spaOptions = spaBuilder.Options;
 
             if (string.IsNullOrEmpty(spaOptions.SourcePath))
             {
                 throw new InvalidOperationException($"To use {nameof(UseAngularCliServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
+
+            var devServerOptions = new AngularCliMiddlewareOptions();
+            configure(devServerOptions);
 
             if(string.IsNullOrEmpty(devServerOptions.npmScript))
             {

--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareOptions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareOptions.cs
@@ -4,16 +4,16 @@
 namespace Microsoft.AspNetCore.SpaServices.AngularCli
 {
     /// <summary>
-    /// Describes options for starting the create-react-app server
+    /// Describes options for starting the Angular CLI process
     /// </summary>
     public class AngularCliMiddlewareOptions
     {
         /// <summary>
-        /// The name of the script in your package.json file that launches the create-react-app server.
+        /// The name of the script in your package.json file that launches the Angular CLI process.
         /// </summary>
         public string npmScript;
         /// <summary>
-        /// Port the create-react-app server should use, if it is not already running.
+        /// Port the Angular CLI process should use, if it is not already running.
         /// </summary>
         public int? spaPort;
     }

--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareOptions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.SpaServices.AngularCli
+{
+    /// <summary>
+    /// Describes options for starting the create-react-app server
+    /// </summary>
+    public class AngularCliMiddlewareOptions
+    {
+        /// <summary>
+        /// The name of the script in your package.json file that launches the create-react-app server.
+        /// </summary>
+        public string npmScript;
+        /// <summary>
+        /// Port the create-react-app server should use, if it is not already running.
+        /// </summary>
+        public int? spaPort;
+    }
+}

--- a/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 // Start create-react-app and attach to middleware pipeline
                 var appBuilder = spaBuilder.ApplicationBuilder;
                 var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-                var portTask = StartCreateReactAppServerAsync(sourcePath, npmScriptName, logger);
+                portTask = StartCreateReactAppServerAsync(sourcePath, npmScriptName, logger);
             }
             else
             {

--- a/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
@@ -48,15 +48,15 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 throw new ArgumentNullException(nameof(spaBuilder));
             }
 
-            var devServerOptions = new ReactDevelopmentServerMiddlewareOptions();
-            configure(devServerOptions);
-
             var spaOptions = spaBuilder.Options;
 
             if (string.IsNullOrEmpty(spaOptions.SourcePath))
             {
                 throw new InvalidOperationException($"To use {nameof(UseReactDevelopmentServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
+
+            var devServerOptions = new ReactDevelopmentServerMiddlewareOptions();
+            configure(devServerOptions);
 
             if(string.IsNullOrEmpty(devServerOptions.npmScript))
             {

--- a/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 throw new ArgumentNullException(nameof(spaBuilder));
             }
 
-            ReactDevelopmentServerMiddlewareOptions devServerOptions;
+            var devServerOptions = new ReactDevelopmentServerMiddlewareOptions();
             configure(devServerOptions);
 
             var spaOptions = spaBuilder.Options;

--- a/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareOptions.cs
+++ b/src/Middleware/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
+{
+    /// <summary>
+    /// Describes options for starting the create-react-app server
+    /// </summary>
+    public class ReactDevelopmentServerMiddlewareOptions
+    {
+        /// <summary>
+        /// The name of the script in your package.json file that launches the create-react-app server.
+        /// </summary>
+        public string npmScript;
+        /// <summary>
+        /// Port the create-react-app server should use, if it is not already running.
+        /// </summary>
+        public int? spaPort;
+    }
+}

--- a/src/Middleware/SpaServices.Extensions/src/Util/TcpPortFinder.cs
+++ b/src/Middleware/SpaServices.Extensions/src/Util/TcpPortFinder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace Microsoft.AspNetCore.SpaServices.Util
@@ -20,6 +21,20 @@ namespace Microsoft.AspNetCore.SpaServices.Util
             {
                 listener.Stop();
             }
+        }
+
+        public static bool TestPortAvailability(int port)
+        {
+            var ipProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var ipEndPoints = ipProperties.GetActiveTcpListeners();
+            foreach (var endPoint in ipEndPoints)
+            {
+                if (endPoint.Port == port)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Adds an option to specify the port being used by `UseReactDevelopmentServer` or `UseAngularCliServer`.
(converted from [JavaScriptServices/1775](https://github.com/aspnet/JavaScriptServices/pull/1775) )
Addresses #5252
