### PR TITLE
Remove 2.2.1 Section from PatchConfig

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -13,18 +13,6 @@ Later on, this will be checked using this condition:
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.1' ">
-    <PackagesInPatch>
-      Microsoft.AspNetCore.AspNetCoreModule;
-      Microsoft.AspNetCore.AspNetCoreModuleV2;
-      Microsoft.AspNetCore.Server.IIS;
-      Microsoft.AspNetCore.Server.IISIntegration;
-      Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
-      Microsoft.AspNetCore.WebSockets;
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore;
-    </PackagesInPatch>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.2' ">
     <PackagesInPatch>
     </PackagesInPatch>


### PR DESCRIPTION
Removing the 2.2.1 Section from the PatchConfig.props in favor of 2.2.2
