### PR TITLE
Mark Java client as Product Package

### DIFF
--- a/src/SignalR/clients/java/signalr/signalr.javaproj
+++ b/src/SignalR/clients/java/signalr/signalr.javaproj
@@ -11,6 +11,8 @@
 
     <!-- In servicing builds, this will be set to value if the Java client is not configured to be released in the currently building patch. -->
     <IsPackable>true</IsPackable>
+    
+    <IsProductPackage>true</IsProductPackage>
 
     <!-- Pass the Java Package Version down to Gradle -->
     <GradleOptions>-PpackageVersion="$(PackageVersion)"</GradleOptions>


### PR DESCRIPTION
Marking Java client as Product Package so it ends up the the artifacts directory.