### PR TITLE
Put Razor.Design.Test and Razor.Language.Test in a different test group

### DIFF
--- a/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
+++ b/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
@@ -13,6 +13,7 @@
     <!-- Copy references locally so that we can use them in the test. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <BuildVariablesGeneratedFile>$(MSBuildProjectDirectory)\obj\BuildVariables.generated.cs</BuildVariablesGeneratedFile>
+    <TestGroupName>RazorTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/Razor.Language/test/Microsoft.AspNetCore.Razor.Language.Test.csproj
+++ b/src/Razor/Razor.Language/test/Microsoft.AspNetCore.Razor.Language.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
+    <TestGroupName>RazorTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We have had a lot of test failures in Ubuntu which involve file descriptors. This started happening right after we mondoized these repos.