### PR TITLE
Move dotnet watch to a seperate test group

### DIFF
--- a/src/Tools/dotnet-watch/test/dotnet-watch.Tests.csproj
+++ b/src/Tools/dotnet-watch/test/dotnet-watch.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Microsoft.DotNet.Watcher.Tools.Tests</AssemblyName>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestProjects\**\*</DefaultItemExcludes>
+    <TestGroupName>DotNetWatcherToolsTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It seems we are hitting inotify watches limit. Try running dotnet-watch tests separately.

```
Process exited 13519
Process exited 13519 with code 0
12/21/18 3:51:16 PM: process start: '/mnt/work/e37dd45d8cd1eaf4/.dotnet/dotnet /mnt/work/e37dd45d8cd1eaf4/bin/dotnet-watch.Tests/Release/netcoreapp2.1/tool/dotnet-watch.dll run --'
Waiting for output line [msg == 'Started']. Will wait for 120 sec.
12/21/18 3:51:19 PM: post: 'watch : The file watcher observing '/mnt/work/e37dd45d8cd1eaf4/bin/dotnet-watch.Tests/Release/netcoreapp2.1/tmp/vqov5hfj.mjj/AppWithDeps/' encountered an error: The configured user limit (8192) on the number of inotify watches has been reached.'
12/21/18 3:51:19 PM: recv: 'watch : The file watcher observing '/mnt/work/e37dd45d8cd1eaf4/bin/dotnet-watch.Tests/Release/netcoreapp2.1/tmp/vqov5hfj.mjj/AppWithDeps/' encountered an error: The configured user limit (8192) on the number of inotify watches has been reached.'
12/21/18 3:51:19 PM: post: 'watch : The file watcher observing '/mnt/work/e37dd45d8cd1eaf4/bin/dotnet-watch.Tests/Release/netcoreapp2.1/tmp/vqov5hfj.mjj/Dependency/' encountered an error: The configured user limit (8192) on the number of inotify watches has been reached.'
12/21/18 3:51:19 PM: recv: 'watch : The file watcher observing '/mnt/work/e37dd45d8cd1eaf4/bin/dotnet-watch.Tests/Release/netcoreapp2.1/tmp/vqov5hfj.mjj/Dependency/' encountered an error: The configured user limit (8192) on the number of inotify watches has been reached.'
12/21/18 3:51:19 PM: post: 'watch : Started'
12/21/18 3:51:19 PM: recv: 'watch : Started'
12/21/18 3:51:25 PM: post: 'Started'
12/21/18 3:51:25 PM: recv: 'Started'
12/21/18 3:51:25 PM: post: 'PID = 14884'
Waiting for output line [msg == 'Started']. Will wait for 30 sec.
12/21/18 3:51:25 PM: recv: 'PID = 14884'
Disposing WatchableApp
```