### PR TITLE
No need to register .wasm media type since ASP.NET Core 2.2. Fixes #5666

### DIFF
--- a/src/Components/src/Microsoft.AspNetCore.Components.Server/Builder/BlazorApplicationBuilderExtensions.cs
+++ b/src/Components/src/Microsoft.AspNetCore.Components.Server/Builder/BlazorApplicationBuilderExtensions.cs
@@ -160,7 +160,6 @@ namespace Microsoft.AspNetCore.Builder
         {
             var result = new FileExtensionContentTypeProvider();
             AddMapping(result, ".dll", MediaTypeNames.Application.Octet);
-            AddMapping(result, ".wasm", WasmMediaTypeNames.Application.Wasm);
 
             if (enableDebugging)
             {


### PR DESCRIPTION
Previously we had a "duplicate key" error caused by this line. The previous effort to fix it (only register if it's not yet registered) did appear to work, but since 2.2 there's never any case where we need to register it ourselves, so this line is entirely redundant.