### PR TITLE
Fix failing Razor file comparison tests

### DIFF
--- a/src/Razor/Razor.Design/test/IntegrationTests/IntegrationTests/RazorCompileIntegrationTest.cs
+++ b/src/Razor/Razor.Design/test/IntegrationTests/IntegrationTests/RazorCompileIntegrationTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -41,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.BuildPassed(result);
 
-            // Everything we do should noop - including building the app. 
+            // Everything we do should noop - including building the app.
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.dll");
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.pdb");
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.Views.dll");
@@ -49,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         }
 
         [Fact]
-        [InitializeTestProject("SimpleMvc")] 
+        [InitializeTestProject("SimpleMvc")]
         public async Task RazorCompile_EmbedRazorGenerateSources_EmbedsCshtmlFiles()
         {
             var result = await DotnetMSBuild("RazorCompile", "/p:EmbedRazorGenerateSources=true");
@@ -63,16 +64,16 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.Equal(new string[]
             {
-                "/Views/_ViewImports.cshtml",
-                "/Views/_ViewStart.cshtml",
                 "/Views/Home/About.cshtml",
                 "/Views/Home/Contact.cshtml",
                 "/Views/Home/Index.cshtml",
+                "/Views/Shared/Error.cshtml",
                 "/Views/Shared/_Layout.cshtml",
                 "/Views/Shared/_ValidationScriptsPartial.cshtml",
-                "/Views/Shared/Error.cshtml",
+                "/Views/_ViewImports.cshtml",
+                "/Views/_ViewStart.cshtml",
             },
-            resources.OrderBy(r => r));
+            resources.OrderBy(r => r, StringComparer.Ordinal));
         }
 
         [Fact]
@@ -90,16 +91,16 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.Equal(new string[]
             {
-                "/Views/_ViewImports.cshtml",
-                "/Views/_ViewStart.cshtml",
                 "/Views/Home/About.cshtml",
                 "/Views/Home/Contact.cshtml",
                 "/Views/Home/Index.cshtml",
+                "/Views/Shared/Error.cshtml",
                 "/Views/Shared/_Layout.cshtml",
                 "/Views/Shared/_ValidationScriptsPartial.cshtml",
-                "/Views/Shared/Error.cshtml",
+                "/Views/_ViewImports.cshtml",
+                "/Views/_ViewStart.cshtml",
             },
-            resources.OrderBy(r => r));
+            resources.OrderBy(r => r, StringComparer.Ordinal));
         }
 
         private Assembly LoadAssemblyFromBytes(params string[] paths)

--- a/src/Razor/Razor.Language/test/DefaultRazorProjectFileSystemTest.cs
+++ b/src/Razor/Razor.Language/test/DefaultRazorProjectFileSystemTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Testing;
@@ -77,29 +78,13 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Assert
             Assert.Collection(
-                items.OrderBy(f => f.FilePath),
-                item =>
-                {
-                    Assert.Equal("/_ViewImports.cshtml", item.FilePath);
-                    Assert.Equal("/", item.BasePath);
-                    Assert.Equal(Path.Combine(TestFolder, "_ViewImports.cshtml"), item.PhysicalPath);
-                    Assert.Equal("_ViewImports.cshtml", item.RelativePhysicalPath);
-
-                },
+                items.OrderBy(f => f.FilePath, StringComparer.Ordinal),
                 item =>
                 {
                     Assert.Equal("/Home.cshtml", item.FilePath);
                     Assert.Equal("/", item.BasePath);
                     Assert.Equal(Path.Combine(TestFolder, "Home.cshtml"), item.PhysicalPath);
                     Assert.Equal("Home.cshtml", item.RelativePhysicalPath);
-
-                },
-                item =>
-                {
-                    Assert.Equal("/Views/_ViewImports.cshtml", item.FilePath);
-                    Assert.Equal("/", item.BasePath);
-                    Assert.Equal(Path.Combine(TestFolder, "Views", "_ViewImports.cshtml"), item.PhysicalPath);
-                    Assert.Equal(Path.Combine("Views", "_ViewImports.cshtml"), item.RelativePhysicalPath);
 
                 },
                 item =>
@@ -111,18 +96,31 @@ namespace Microsoft.AspNetCore.Razor.Language
                 },
                 item =>
                 {
-                    Assert.Equal("/Views/Home/_ViewImports.cshtml", item.FilePath);
-                    Assert.Equal("/", item.BasePath);
-                    Assert.Equal(Path.Combine(TestFolder, "Views", "Home", "_ViewImports.cshtml"), item.PhysicalPath);
-                    Assert.Equal(Path.Combine("Views", "Home", "_ViewImports.cshtml"), item.RelativePhysicalPath);
-
-                },
-                item =>
-                {
                     Assert.Equal("/Views/Home/Index.cshtml", item.FilePath);
                     Assert.Equal("/", item.BasePath);
                     Assert.Equal(Path.Combine(TestFolder, "Views", "Home", "Index.cshtml"), item.PhysicalPath);
                     Assert.Equal(Path.Combine("Views", "Home", "Index.cshtml"), item.RelativePhysicalPath);
+                },
+                item =>
+                {
+                    Assert.Equal("/Views/Home/_ViewImports.cshtml", item.FilePath);
+                    Assert.Equal("/", item.BasePath);
+                    Assert.Equal(Path.Combine(TestFolder, "Views", "Home", "_ViewImports.cshtml"), item.PhysicalPath);
+                    Assert.Equal(Path.Combine("Views", "Home", "_ViewImports.cshtml"), item.RelativePhysicalPath);
+                },
+                item =>
+                {
+                    Assert.Equal("/Views/_ViewImports.cshtml", item.FilePath);
+                    Assert.Equal("/", item.BasePath);
+                    Assert.Equal(Path.Combine(TestFolder, "Views", "_ViewImports.cshtml"), item.PhysicalPath);
+                    Assert.Equal(Path.Combine("Views", "_ViewImports.cshtml"), item.RelativePhysicalPath);
+                },
+                 item =>
+                {
+                    Assert.Equal("/_ViewImports.cshtml", item.FilePath);
+                    Assert.Equal("/", item.BasePath);
+                    Assert.Equal(Path.Combine(TestFolder, "_ViewImports.cshtml"), item.PhysicalPath);
+                    Assert.Equal("_ViewImports.cshtml", item.RelativePhysicalPath);
                 });
         }
 
@@ -137,20 +135,20 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Assert
             Assert.Collection(
-                items.OrderBy(f => f.FilePath),
-                item =>
-                {
-                    Assert.Equal("/_ViewImports.cshtml", item.FilePath);
-                    Assert.Equal("/Views", item.BasePath);
-                    Assert.Equal(Path.Combine(TestFolder, "Views", "_ViewImports.cshtml"), item.PhysicalPath);
-                    Assert.Equal(Path.Combine("_ViewImports.cshtml"), item.RelativePhysicalPath);
-                },
+                items.OrderBy(f => f.FilePath, StringComparer.Ordinal),
                 item =>
                 {
                     Assert.Equal("/About/About.cshtml", item.FilePath);
                     Assert.Equal("/Views", item.BasePath);
                     Assert.Equal(Path.Combine(TestFolder, "Views", "About", "About.cshtml"), item.PhysicalPath);
                     Assert.Equal(Path.Combine("About", "About.cshtml"), item.RelativePhysicalPath);
+                },
+                item =>
+                {
+                    Assert.Equal("/Home/Index.cshtml", item.FilePath);
+                    Assert.Equal("/Views", item.BasePath);
+                    Assert.Equal(Path.Combine(TestFolder, "Views", "Home", "Index.cshtml"), item.PhysicalPath);
+                    Assert.Equal(Path.Combine("Home", "Index.cshtml"), item.RelativePhysicalPath);
                 },
                 item =>
                 {
@@ -161,10 +159,10 @@ namespace Microsoft.AspNetCore.Razor.Language
                 },
                 item =>
                 {
-                    Assert.Equal("/Home/Index.cshtml", item.FilePath);
+                    Assert.Equal("/_ViewImports.cshtml", item.FilePath);
                     Assert.Equal("/Views", item.BasePath);
-                    Assert.Equal(Path.Combine(TestFolder, "Views", "Home", "Index.cshtml"), item.PhysicalPath);
-                    Assert.Equal(Path.Combine("Home", "Index.cshtml"), item.RelativePhysicalPath);
+                    Assert.Equal(Path.Combine(TestFolder, "Views", "_ViewImports.cshtml"), item.PhysicalPath);
+                    Assert.Equal(Path.Combine("_ViewImports.cshtml"), item.RelativePhysicalPath);
                 });
         }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1601

It looks like `OrderBy()` is using a different default StringComparer between Windows and Linux which is why we were seeing failures only on Ubuntu CI. I've now specified the StringComparer and changed the ordering to match what is expected.