### PR TITLE
Fix signing for 2.2 site extensions

### DIFF
--- a/.azure/pipelines/site-extensions.yml
+++ b/.azure/pipelines/site-extensions.yml
@@ -29,7 +29,7 @@ phases:
     inputs:
       signType: $(_SignType)
       zipSources: false
-  - script: src/SiteExtensions/build.cmd -ci
+  - script: src/SiteExtensions/LoggingAggregate/build.cmd -ci
     displayName: Run src/SiteExtensions/LoggingAggregate/build.cmd
   - task: PublishBuildArtifacts@1
     displayName: Upload artifacts

--- a/build/CodeSign.props
+++ b/build/CodeSign.props
@@ -125,6 +125,14 @@
 
     <!-- This files should already be signed already by a different leg of the build. They have to be listed again here because we recreate a redistributable which binaries built in other repos. -->
     <FilesToExcludeFromSigning Include="libuv.dll" />
+
+    <!-- EF powershell scripts -->
+    <FilesToExcludeFromSigning Include="EntityFrameworkCore.PowerShell2.psd1" />
+    <FilesToExcludeFromSigning Include="EntityFrameworkCore.PowerShell2.psm1" />
+    <FilesToExcludeFromSigning Include="EntityFrameworkCore.psd1" />
+    <FilesToExcludeFromSigning Include="EntityFrameworkCore.psm1" />
+    <FilesToExcludeFromSigning Include="init.ps1" />
+    <FilesToExcludeFromSigning Include="install.ps1" />
   </ItemGroup>
 
 </Project>

--- a/build/CodeSign.props
+++ b/build/CodeSign.props
@@ -125,14 +125,6 @@
 
     <!-- This files should already be signed already by a different leg of the build. They have to be listed again here because we recreate a redistributable which binaries built in other repos. -->
     <FilesToExcludeFromSigning Include="libuv.dll" />
-
-    <!-- EF powershell scripts -->
-    <FilesToExcludeFromSigning Include="EntityFrameworkCore.PowerShell2.psd1" />
-    <FilesToExcludeFromSigning Include="EntityFrameworkCore.PowerShell2.psm1" />
-    <FilesToExcludeFromSigning Include="EntityFrameworkCore.psd1" />
-    <FilesToExcludeFromSigning Include="EntityFrameworkCore.psm1" />
-    <FilesToExcludeFromSigning Include="init.ps1" />
-    <FilesToExcludeFromSigning Include="install.ps1" />
   </ItemGroup>
 
 </Project>

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnitTestFxProject>$(RepositoryRoot)src\Framework\Framework.UnitTests\Framework.UnitTests.csproj</UnitTestFxProject>
     <UnitTestFxProject>$([MSBuild]::NormalizePath($(UnitTestFxProject)))</UnitTestFxProject>
-    <CodeSignDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(CodeSignDependsOn);GetSharedFxFilesToSign</CodeSignDependsOn>
+    <CodeSignDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(CodeSignDependsOn);GetSharedFxFilesToSign;</CodeSignDependsOn>
     <BuildSharedFxDependsOn>_BuildSharedFxProjects;TestSharedFx</BuildSharedFxDependsOn>
     <BuildSharedFxDependsOn Condition="'$(TestOnly)' != 'true'">$(BuildSharedFxDependsOn);CodeSign</BuildSharedFxDependsOn>
     <RedistNetCorePath>$(IntermediateDir)ar\$(SharedFxRid)\</RedistNetCorePath>
@@ -16,6 +16,8 @@
     <FxProjectToBuild Condition=" '$(BuildRuntimeArchive)' != 'false' " Include="$(RepositoryRoot)src\Installers\Archive\*.*proj" />
     <FxProjectToBuild Condition=" '$(SharedFxRid)' == 'linux-x64' AND '$(LinuxInstallerType)' == 'deb' " Include="$(RepositoryRoot)src\Installers\Debian\*.*proj" />
     <FxProjectToBuild Condition=" '$(SharedFxRid)' == 'linux-x64' AND '$(LinuxInstallerType)' == 'rpm' " Include="$(RepositoryRoot)src\Installers\Rpm\*.*proj" />
+
+    <FxProjectToBuild Condition=" '$(BuildSiteExtensions)' == 'true' " Include="$(RepositoryRoot)src\SiteExtensions\LoggingBranch\LoggingBranch.csproj" />
   </ItemGroup>
 
   <Target Name="BuildSharedFx" DependsOnTargets="$(BuildSharedFxDependsOn)" />
@@ -30,6 +32,7 @@
       <FilesToSign Include="$(BuildDir)runtime.$(SharedFxRid).Microsoft.AspNetCore.All.$(PackageVersion).nupkg" Certificate="$(PackageSigningCertName)" />
       <FilesToSign Include="$(BuildDir)runtime.$(SharedFxRid).Microsoft.AspNetCore.App.$(PackageVersion).symbols.nupkg" Certificate="$(PackageSigningCertName)" />
       <FilesToSign Include="$(BuildDir)runtime.$(SharedFxRid).Microsoft.AspNetCore.All.$(PackageVersion).symbols.nupkg" Certificate="$(PackageSigningCertName)" />
+      <FilesToSign Include="$(BuildDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(SharedFxArchitecture).$(PackageVersion).nupkg" Condition=" '$(BuildSiteExtensions)' == 'true' " Certificate="$(PackageSigningCertName)" />
     </ItemGroup>
 
     <!-- These files should already be signed by the .NET Core team. They have to be listed again here because we recreate a redistributable which includes the Microsoft.NETCore.App runtime. -->
@@ -39,28 +42,6 @@
       <FilesToExcludeFromSigning Include="$(RedistNetCorePath)dotnet.exe" />
     </ItemGroup>
 
-  </Target>
-
-  <Target Name="BuildSiteExtension" DependsOnTargets="BuildSharedFx" Condition="'$(BuildSiteExtension)' == 'true'" >
-    <PropertyGroup>
-      <AzureIntegrationProjProperties>
-        AspNetUniverseBuildOffline=true;
-        DotNetRestoreSourcePropsPath=$(GeneratedRestoreSourcesPropsPath);
-        DotNetPackageVersionPropsPath=$(GeneratedPackageVersionPropsPath);
-        BuildNumber=$(BuildNumber);
-        Configuration=$(Configuration);
-        IsFinalBuild=$(IsFinalBuild);
-      </AzureIntegrationProjProperties>
-    </PropertyGroup>
-
-    <!-- Pack logging site extension -->
-    <MSBuild Projects="$(RepositoryRoot)\src\SiteExtensions\LoggingBranch\LoggingBranch.csproj" Targets="Restore;Pack" Properties="$(AzureIntegrationProjProperties);PackageOutputPath=$(BuildDir)" />
-  </Target>
-
-  <Target Name="GetSiteExtensionArtifactInfo" Condition="'$(BuildSiteExtension)' == 'true'" >
-    <MSBuild Projects="$(RepositoryRoot)\src\SiteExtensions\LoggingBranch\LoggingBranch.csproj" Targets="GetArtifactInfo" Properties="PackageOutputPath=$(BuildDir);BuildNumber=$(BuildNumber);DesignTimeBuild=true;IsFinalBuild=$(IsFinalBuild)">
-      <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
-    </MSBuild>
   </Target>
 
   <Target Name="_BuildSharedFxProjects" DependsOnTargets="GeneratePropsFiles;ResolveCommitHash">

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -44,7 +44,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.2.2" Category="noship" Condition="'$(BuildSiteExtension)' == 'true'" />
+    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(SharedFxArchitecture)" Category="noship" Condition=" '$(BuildSiteExtensions)' == 'true' " />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Connections.Abstractions" Category="ship" />

--- a/build/repo.props
+++ b/build/repo.props
@@ -18,8 +18,8 @@
     <SignCheckExclusionsFile>$(RepositoryRoot)eng\signcheck.exclusions.txt</SignCheckExclusionsFile>
     <SharedSourcesFolder>$(RepositoryRoot)src\Shared\</SharedSourcesFolder>
     <SharedFxArchitecture Condition="'$(SharedFxArchitecture)' == ''">$(SharedFxRid.Substring($([MSBuild]::Add($(SharedFxRid.LastIndexOf('-')), 1))))</SharedFxArchitecture>
-    <BuildSiteExtension>true</BuildSiteExtension>
-    <BuildSiteExtension Condition="'$(BuildSiteExtension)' == 'true' AND '$(OS)' != 'Windows_NT'">false</BuildSiteExtension>
+    <BuildSiteExtensions>true</BuildSiteExtensions>
+    <BuildSiteExtensions Condition="'$(BuildSiteExtensions)' == 'true' AND '$(OS)' != 'Windows_NT'">false</BuildSiteExtensions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -21,7 +21,7 @@
     <CompileDependsOn>$(CompileDependsOn);BuildProjects;PackSharedSources</CompileDependsOn>
     <CompileDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(CompileDependsOn);PackProjects;BuildRepositories;BuildSharedFx</CompileDependsOn>
     <PackageDependsOn Condition=" '$(_ProjectsOnly)' == 'true'">$(PackageDependsOn);PackProjects</PackageDependsOn>
-    <PackageDependsOn Condition="'$(TestOnly)' != 'true' AND '$(_ProjectsOnly)' != 'true'">$(PackageDependsOn);BuildSiteExtension;CheckExpectedPackagesExist</PackageDependsOn>
+    <PackageDependsOn Condition="'$(TestOnly)' != 'true' AND '$(_ProjectsOnly)' != 'true'">$(PackageDependsOn);CheckExpectedPackagesExist</PackageDependsOn>
     <PackageDependsOn Condition="'$(TestOnly)' != 'true'">$(PackageDependsOn);CodeSign</PackageDependsOn>
     <TestDependsOn>$(TestDependsOn);TestProjects</TestDependsOn>
     <TestDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(TestDependsOn);_TestRepositories</TestDependsOn>
@@ -72,7 +72,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ResolveRepoInfo" DependsOnTargets="_ResolveProjectArtifactsInfoShipped;_PrepareRepositories;GetSiteExtensionArtifactInfo">
+  <Target Name="ResolveRepoInfo" DependsOnTargets="_ResolveProjectArtifactsInfoShipped;_PrepareRepositories">
     <!-- We need to pass the NETCoreApp package versions to msbuild so that it doesn't complain about us using a different one than it was restored against.  -->
     <PropertyGroup>
       <DesignTimeBuildProps>$(BuildProperties);MicrosoftNETCoreAppPackageVersion=$(MicrosoftNETCoreAppPackageVersion);</DesignTimeBuildProps>

--- a/eng/targets/RuntimeIdentifiers.props
+++ b/eng/targets/RuntimeIdentifiers.props
@@ -6,6 +6,8 @@
     <SharedFxRid Condition=" '$(SharedFxRid)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx-x64</SharedFxRid>
     <SharedFxRid Condition=" '$(SharedFxRid)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux-x64</SharedFxRid>
 
+    <SharedFxArchitecture Condition="'$(SharedFxArchitecture)' == ''">$(SharedFxRid.Substring($([MSBuild]::Add($(SharedFxRid.LastIndexOf('-')), 1))))</SharedFxArchitecture>
+
     <!-- Defines the default RID of the platform currently running the build. -->
     <HostRid Condition=" '$(HostRid)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win-x64</HostRid>
     <HostRid Condition=" '$(HostRid)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx-x64</HostRid>

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
         "version": "2.2.102"
     },
     "msbuild-sdks": {
-        "Internal.AspNetCore.Sdk": "2.2.1-build-20190110.1"
+        "Internal.AspNetCore.Sdk": "2.2.1-build-20190116.1"
     }
 }

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
         "version": "2.2.102"
     },
     "msbuild-sdks": {
-        "Internal.AspNetCore.Sdk": "2.2.1-build-20190116.1"
+        "Internal.AspNetCore.Sdk": "2.2.1-build-20190117.2"
     }
 }

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.1-build-20190116.1
-commithash:22916e09d533fcbdf5d0c51f8a9140e8c36e7bad
+version:2.2.1-build-20190117.2
+commithash:66f8343ddf482908dd82005dd2154c9e2776e2a1

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.1-build-20190110.1
-commithash:f4ebd797fd15484869312b139fdd7e3a115d23bb
+version:2.2.1-build-20190116.1
+commithash:22916e09d533fcbdf5d0c51f8a9140e8c36e7bad

--- a/src/SiteExtensions/LoggingBranch/LoggingBranch.csproj
+++ b/src/SiteExtensions/LoggingBranch/LoggingBranch.csproj
@@ -8,9 +8,10 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>aspnet;logging;aspnetcore;AzureSiteExtension;keyvault;configuration;dataprotection</PackageTags>
     <ContentTargetFolders>content</ContentTargetFolders>
-    <PackageId>Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(TrimmedVersion)</PackageId>
+    <PackageId>Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(TrimmedVersion).$(SharedFxArchitecture)</PackageId>
     <MicrosoftAspNetCoreAppPackageVersion>$(PackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
-    <HostingStartupRuntimeFrameworkVersion>$(MicrosoftNETCoreApp21PackageVersion)</HostingStartupRuntimeFrameworkVersion>
+    <HostingStartupRuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</HostingStartupRuntimeFrameworkVersion>
+
     <TargetFramework>net461</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageType>AzureSiteExtension</PackageType>
@@ -23,11 +24,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <HostingStartupRuntimeStoreTargets Include="netcoreapp2.2" Runtime="win7-x64" />
-    <HostingStartupRuntimeStoreTargets Include="netcoreapp2.2" Runtime="win7-x86" />
+    <HostingStartupRuntimeStoreTargets Include="netcoreapp3.0" Runtime="$(SharedFxRid)" />
+
     <HostingStartupPackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(PackageVersion)" />
 
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+
+    <ProjectReference Include="..\..\Framework\Microsoft.AspNetCore.App\pkg\Microsoft.AspNetCore.App.pkgproj">
+      <Targets>Pack</Targets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
+
+     <ProjectReference Include="..\..\Framework\Microsoft.AspNetCore.App\src\Microsoft.AspNetCore.App.shfxproj">
+      <Targets>Pack</Targets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/SiteExtensions/LoggingBranch/LoggingBranch.csproj
+++ b/src/SiteExtensions/LoggingBranch/LoggingBranch.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <HostingStartupRuntimeStoreTargets Include="netcoreapp3.0" Runtime="$(SharedFxRid)" />
+    <HostingStartupRuntimeStoreTargets Include="netcoreapp2.2" Runtime="$(SharedFxRid)" />
 
     <HostingStartupPackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(PackageVersion)" />
 


### PR DESCRIPTION
2.2 build is more similar to 3.1 then 2.1 so switch it to use the same patterns as we do in 3.0.
