### PR TITLE
Revert "Revert "Put Razor.Design.Test and Razor.Language.Test in a different test group (#6725)" (#6753)"

### DIFF
--- a/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
+++ b/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
@@ -13,6 +13,7 @@
     <!-- Copy references locally so that we can use them in the test. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <BuildVariablesGeneratedFile>$(MSBuildProjectDirectory)\obj\BuildVariables.generated.cs</BuildVariablesGeneratedFile>
+    <TestGroupName>RazorTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/Razor.Language/test/Microsoft.AspNetCore.Razor.Language.Test.csproj
+++ b/src/Razor/Razor.Language/test/Microsoft.AspNetCore.Razor.Language.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
+    <TestGroupName>RazorTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Possible fix to https://github.com/aspnet/AspNetCore-Internal/issues/1645

Test indicates that we're exhausting the maximum available file descriptors. Moving it out in to a separate test group would give it more breathing space