### PR TITLE
Temporary workaround for incorrect Blazor CLI package metadata generation

### DIFF
--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -21,4 +21,26 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
   </ItemGroup>
+
+  <!--
+    Temporarily use hand-authored .nuspec file until we can use <FrameworkReference>
+    The hand-authored .nuspec file is to ensure it *doesn't* reference the shared
+    framework packages that aren't actually shipping as packages. We can remove this
+    once the nuspec generation accounts for <FrameworkReference>.
+  -->
+  <Target Name="PrepareNuSpecProperties" BeforeTargets="_IntermediatePack">
+    <PropertyGroup>
+      <NuspecFile>Microsoft.AspNetCore.Blazor.Cli.nuspec</NuspecFile>
+      <NuspecProperties>
+        outdir=$(OutDir);
+        componentsrootdir=..\..\..\;
+        blazorversion=$(PackageVersion);
+        aspnetcoreversion=$(ComponentsPackageVersion);
+        repositorycommit=$(RepositoryCommit);</NuspecProperties>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Also temporarily override RuntimeFramework manually with hardcoded version until we can use <FrameworkReference> -->
+      <RuntimeFramework Include="Microsoft.AspNetCore.App" Version="3.0.0-preview-19064-0344" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -36,11 +36,14 @@
         componentsrootdir=..\..\..\;
         blazorversion=$(PackageVersion);
         aspnetcoreversion=$(ComponentsPackageVersion);
+        sharedfxversion=$(SharedFxVersion);
         repositorycommit=$(RepositoryCommit);</NuspecProperties>
     </PropertyGroup>
-    <ItemGroup>
-      <!-- Also temporarily override RuntimeFramework manually until we can use <FrameworkReference> -->
-      <RuntimeFramework Include="Microsoft.AspNetCore.App" Version="$(SharedFxVersion)" />
-    </ItemGroup>
+    <!-- Also temporarily generate the runtimeconfig.json manually until we can use <FrameworkReference> -->
+    <Sdk_GenerateFileFromTemplate
+      TemplateFile="temporaryruntimeconfig.json"
+      Properties="$(NuspecProperties)"
+      OutputPath="$(OutDir)temporaryruntimeconfig.out.json">
+    </Sdk_GenerateFileFromTemplate>
   </Target>
 </Project>

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -39,8 +39,8 @@
         repositorycommit=$(RepositoryCommit);</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-      <!-- Also temporarily override RuntimeFramework manually with hardcoded version until we can use <FrameworkReference> -->
-      <RuntimeFramework Include="Microsoft.AspNetCore.App" Version="3.0.0-preview-19064-0344" />
+      <!-- Also temporarily override RuntimeFramework manually until we can use <FrameworkReference> -->
+      <RuntimeFramework Include="Microsoft.AspNetCore.App" Version="$(ComponentsPackageVersion)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -40,7 +40,7 @@
     </PropertyGroup>
     <ItemGroup>
       <!-- Also temporarily override RuntimeFramework manually until we can use <FrameworkReference> -->
-      <RuntimeFramework Include="Microsoft.AspNetCore.App" Version="$(ComponentsPackageVersion)" />
+      <RuntimeFramework Include="Microsoft.AspNetCore.App" Version="$(SharedFxVersion)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.nuspec
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.AspNetCore.Blazor.Cli</id>
+    <version>$blazorversion$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt</licenseUrl>
+    <projectUrl>https://asp.net/</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Development server for use when building Blazor applications.
+
+This package was built from the source code at https://github.com/aspnet/AspNetCore/tree/$repositorycommit$</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>aspnetcore components</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/aspnet/AspNetCore" commit="$repositorycommit$" />
+    <dependencies>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="Microsoft.AspNetCore.Blazor.Server" version="$blazorversion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Components.Server" version="$aspnetcoreversion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.SpaServices.Extensions" version="$aspnetcoreversion$" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$outdir$dotnet-blazor.runtimeconfig.json" target="lib\netcoreapp3.0\dotnet-blazor.runtimeconfig.json" />
+    <file src="$outdir$dotnet-blazor.dll" target="lib\netcoreapp3.0\dotnet-blazor.dll" />
+    <file src="$componentsrootdir$THIRD-PARTY-NOTICES.txt" target=".\THIRD-PARTY-NOTICES.txt" />
+  </files>
+</package>

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.nuspec
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.nuspec
@@ -25,7 +25,7 @@ This package was built from the source code at https://github.com/aspnet/AspNetC
     </dependencies>
   </metadata>
   <files>
-    <file src="$outdir$dotnet-blazor.runtimeconfig.json" target="lib\netcoreapp3.0\dotnet-blazor.runtimeconfig.json" />
+    <file src="$outdir$temporaryruntimeconfig.out.json" target="lib\netcoreapp3.0\dotnet-blazor.runtimeconfig.json" />
     <file src="$outdir$dotnet-blazor.dll" target="lib\netcoreapp3.0\dotnet-blazor.dll" />
     <file src="$componentsrootdir$THIRD-PARTY-NOTICES.txt" target=".\THIRD-PARTY-NOTICES.txt" />
   </files>

--- a/src/Components/Blazor/Cli/src/temporaryruntimeconfig.json
+++ b/src/Components/Blazor/Cli/src/temporaryruntimeconfig.json
@@ -1,0 +1,9 @@
+{
+  "runtimeOptions": {
+    "tfm": "netcoreapp3.0",
+    "framework": {
+      "name": "Microsoft.AspNetCore.App",
+      "version": "${sharedfxversion}"
+    }
+  }
+}


### PR DESCRIPTION
This is to fix `blazor serve`.

The problem was that previously we relied on referencing parts of ASP.NET Core runtime as packages, but since it will ship as shared framework only, we can no longer do that. We now need to use `<FrameworkReference>` to reference ASP.NET Core, but the build system doesn't yet support that for this kind of package.

@natemcmaster is working on adding `<FrameworkReference>` support, so this PR is intended as a *very temporary* workaround to unlock verification that the rest works end-to-end.