### PR TITLE
Fail `ComplexTypeModelBinder` after `CanCreateModel(...)` in some cases

### DIFF
--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // If CanCreateModel could not find data for non-greedy properties, failures indicate greedy binders were
             // unsuccessful. For example, user may submit file attachments [0].File and [1].File but not [2].File for
             // a collection of a complex type containing an IFormFile property. In that case, we have exhausted the
-            // attached files and checking for [2].File would be pointless. (And, if it had a point, would we stop
+            // attached files and checking for [3].File is likely be pointless. (And, if it had a point, would we stop
             // after 10 failures, 100, or more -- all adding redundant errors to ModelState?) Inform higher-level
             // binders of the failure.
             //

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
@@ -599,8 +599,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // Arrange
             var bindingContext = CreateContext(GetMetadataForType(typeof(Person)), new Person());
             var originalModel = bindingContext.Model;
+            var binders = bindingContext.ModelMetadata.Properties.ToDictionary(
+                keySelector: item => item,
+                elementSelector: item => (IModelBinder)null);
 
-            var binder = new Mock<TestableComplexTypeModelBinder>() { CallBase = true };
+            var binder = new Mock<TestableComplexTypeModelBinder>(binders) { CallBase = true };
             binder
                 .Setup(b => b.CreateModelPublic(It.IsAny<ModelBindingContext>()))
                 .Verifiable();
@@ -618,8 +621,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             // Arrange
             var bindingContext = CreateContext(GetMetadataForType(typeof(Person)), model: null);
+            var binders = bindingContext.ModelMetadata.Properties.ToDictionary(
+                keySelector: item => item,
+                elementSelector: item => (IModelBinder)null);
 
-            var testableBinder = new Mock<TestableComplexTypeModelBinder> { CallBase = true };
+            var testableBinder = new Mock<TestableComplexTypeModelBinder>(binders) { CallBase = true };
             testableBinder
                 .Setup(o => o.CreateModelPublic(bindingContext))
                 .Returns(new Person())

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,7 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
         private class Address
         {
             [FromHeader(Name = "Header")]
-            [Required]
+            [BindRequired]
             public string Street { get; set; }
         }
 
@@ -33,6 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
         public async Task BindPropertyFromHeader_NoData_UsesFullPathAsKeyForModelStateErrors()
         {
             // Arrange
+            var expected = "A value for the 'Header' parameter or property was not provided.";
             var parameter = new ParameterDescriptor()
             {
                 Name = "Parameter1",
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var key = Assert.Single(modelState.Keys);
             Assert.Equal("CustomParameter.Address.Header", key);
             var error = Assert.Single(modelState[key].Errors);
-            Assert.Equal(ValidationAttributeUtil.GetRequiredErrorMessage("Street"), error.ErrorMessage);
+            Assert.Equal(expected, error.ErrorMessage);
         }
 
         [Fact]
@@ -277,7 +277,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 ParameterType = modelType
             };
 
-            Action<HttpRequest> action = r => r.Headers.Add("CustomParameter", new[] { expectedAttemptedValue });
+            void action(HttpRequest r) => r.Headers.Add("CustomParameter", new[] { expectedAttemptedValue });
             var testContext = GetModelBindingTestContext(action);
             var parameterBinder = ModelBindingTestHelper.GetParameterBinder(testContext.HttpContext.RequestServices);
 


### PR DESCRIPTION
- #4802
- also reduces the impact of incorrect metadata as in #4939 and #6616