### PR TITLE
Do not include prodcon build ID in version metadata

### DIFF
--- a/version.props
+++ b/version.props
@@ -40,9 +40,6 @@
     <ExperimentalPackageVersion>$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>
     <ExperimentalPackageVersion  Condition=" '$(IncludePreReleaseLabelInPackageVersion)' == 'true' ">$(ExperimentalVersionPrefix)-$(VersionSuffix)</ExperimentalPackageVersion>
 
-    <VersionMetadata Condition=" '$(DotNetProductBuildId)' != '' ">pb-$(DotNetProductBuildId)</VersionMetadata>
-    <VersionSuffix Condition=" '$(VersionMetadata)' != '' ">$(VersionSuffix)+$(VersionMetadata)</VersionSuffix>
-
     <SharedFxCliBlobChannel>release/$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</SharedFxCliBlobChannel>
 
     <!-- This is used for error checking to ensure generated code and baselines are up to date when we increment the patch. -->


### PR DESCRIPTION
This causes problems for npm pack in a prodcon build. We don't need this version metadata, so let's remove it altogether.