### PR TITLE
Move generic webhost log output, enable in templates

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
     {
         public GenericWebHostService(IOptions<GenericWebHostServiceOptions> options,
                                      IServer server,
-                                     ILogger<GenericWebHostService> logger,
+                                     ILoggerFactory loggerFactory,
                                      DiagnosticListener diagnosticListener,
                                      IHttpContextFactory httpContextFactory,
                                      IApplicationBuilderFactory applicationBuilderFactory,
@@ -37,7 +37,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             Options = options.Value;
             Server = server;
-            Logger = logger;
+            Logger = loggerFactory.CreateLogger<GenericWebHostService>();
+            LifetimeLogger = loggerFactory.CreateLogger("Microsoft.Hosting.Lifetime");
             DiagnosticListener = diagnosticListener;
             HttpContextFactory = httpContextFactory;
             ApplicationBuilderFactory = applicationBuilderFactory;
@@ -49,6 +50,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public GenericWebHostServiceOptions Options { get; }
         public IServer Server { get; }
         public ILogger<GenericWebHostService> Logger { get; }
+        // Only for high level lifetime events
+        public ILogger LifetimeLogger { get; }
         public DiagnosticListener DiagnosticListener { get; }
         public IHttpContextFactory HttpContextFactory { get; }
         public IApplicationBuilderFactory ApplicationBuilderFactory { get; }
@@ -119,7 +122,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 foreach (var address in addresses)
                 {
-                    Logger.LogInformation("Now listening on: {address}", address);
+                    LifetimeLogger.LogInformation("Now listening on: {address}", address);
                 }
             }
 

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/RazorComponentsWeb-CSharp.Server/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/RazorComponentsWeb-CSharp.Server/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
@@ -33,7 +33,8 @@
 //#endif
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
@@ -33,7 +33,8 @@
 //#endif
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
@@ -20,7 +20,8 @@
 //#endif
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/appsettings.json
+++ b/src/Templating/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore/issues/6449, combines with https://github.com/aspnet/Extensions/pull/964 to enable startup and shutdown logs in production.

Logs (without the Extensions changes):
```
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:5000
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: https://localhost:5001
info: Microsoft.Extensions.Hosting.Host[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Extensions.Hosting.Host[0]
      Hosting environment: Production
info: Microsoft.Extensions.Hosting.Host[0]
      Content root path: D:\github\AspNetCore\src\Hosting\samples\GenericWebHost\bin\Debug\netcoreapp3.0
```