### PR TITLE
Add routing function test with convention builder

### DIFF
--- a/src/Http/Routing/test/FunctionalTests/EndpointRoutingSampleTest.cs
+++ b/src/Http/Routing/test/FunctionalTests/EndpointRoutingSampleTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -208,6 +208,19 @@ namespace Microsoft.AspNetCore.Routing.FunctionalTests
             Assert.NotNull(response.Content);
             var actualContent = await response.Content.ReadAsStringAsync();
             Assert.Equal("Link: /WithDoubleAsteriskCatchAll/a/b%20b1/c%20c1", actualContent);
+        }
+
+        [Fact]
+        public async Task MapGet_HasConventionMetadata()
+        {
+            // Arrange & Act
+            var response = await _client.GetAsync("/convention");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var actualContent = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Has metadata", actualContent);
         }
 
         public void Dispose()

--- a/src/Http/Routing/test/testassets/RoutingWebSite/UseEndpointRoutingStartup.cs
+++ b/src/Http/Routing/test/testassets/RoutingWebSite/UseEndpointRoutingStartup.cs
@@ -70,6 +70,16 @@ namespace RoutingWebSite
                         return response.Body.WriteAsync(_plainTextPayload, 0, payloadLength);
                     });
                 routes.MapGet(
+                    "/convention",
+                    (httpContext) =>
+                    {
+                        var endpoint = httpContext.GetEndpoint();
+                        return httpContext.Response.WriteAsync((endpoint.Metadata.GetMetadata<CustomMetadata>() != null) ? "Has metadata" : "No metadata");
+                    }).Add(b =>
+                    {
+                        b.Metadata.Add(new CustomMetadata());
+                    });
+                routes.MapGet(
                     "/withconstraints/{id:endsWith(_001)}",
                     (httpContext) =>
                     {
@@ -129,6 +139,10 @@ namespace RoutingWebSite
             // Imagine some more stuff here...
 
             app.UseEndpoint();
+        }
+
+        private class CustomMetadata
+        {
         }
 
         private IEndpointConventionBuilder MapHostEndpoint(IEndpointRouteBuilder routes, params string[] hosts)


### PR DESCRIPTION
Written in a bout of paranoia that conventions on Map overloads didn't work.