### PR TITLE
Reuse the stack for OnCompleted and OnStarting calls

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -589,11 +589,5 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   </data>
   <data name="Http2ErrorStreamAborted" xml:space="preserve">
     <value>A frame of type {frameType} was received after stream {streamId} was reset or aborted.</value>
-  </data>
-  <data name="OnCompletedNotSupported" xml:space="preserve">
-    <value>OnCompleted cannot be registered during a call to OnCompleted.</value>
-  </data>
-  <data name="OnStartingNotSupported" xml:space="preserve">
-    <value>OnStarting cannot be registered during a call to OnStarting.</value>
   </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -590,4 +590,10 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2ErrorStreamAborted" xml:space="preserve">
     <value>A frame of type {frameType} was received after stream {streamId} was reset or aborted.</value>
   </data>
+  <data name="OnCompletedNotSupported" xml:space="preserve">
+    <value>OnCompleted cannot be registered during a call to OnCompleted.</value>
+  </data>
+  <data name="OnStartingNotSupported" xml:space="preserve">
+    <value>OnStarting cannot be registered during a call to OnStarting.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -681,7 +681,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 onStarting = _onStarting;
             }
 
-            if (onStarting?.Count == 0)
+            if (onStarting == null || onStarting.Count == 0)
             {
                 return Task.CompletedTask;
             }
@@ -742,7 +742,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 onCompleted = _onCompleted;
             }
 
-            if (onCompleted?.Count == 0)
+            if (onCompleted == null || onCompleted.Count == 0)
             {
                 return Task.CompletedTask;
             }

--- a/src/Servers/Kestrel/Core/src/Properties/CoreStrings.Designer.cs
+++ b/src/Servers/Kestrel/Core/src/Properties/CoreStrings.Designer.cs
@@ -2212,34 +2212,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatHttp2ErrorStreamAborted(object frameType, object streamId)
             => string.Format(CultureInfo.CurrentCulture, GetString("Http2ErrorStreamAborted", "frameType", "streamId"), frameType, streamId);
 
-        /// <summary>
-        /// OnCompleted cannot be registered during a call to OnCompleted.
-        /// </summary>
-        internal static string OnCompletedNotSupported
-        {
-            get => GetString("OnCompletedNotSupported");
-        }
-
-        /// <summary>
-        /// OnCompleted cannot be registered during a call to OnCompleted.
-        /// </summary>
-        internal static string FormatOnCompletedNotSupported()
-            => GetString("OnCompletedNotSupported");
-
-        /// <summary>
-        /// OnStarting cannot be registered during a call to OnStarting.
-        /// </summary>
-        internal static string OnStartingNotSupported
-        {
-            get => GetString("OnStartingNotSupported");
-        }
-
-        /// <summary>
-        /// OnStarting cannot be registered during a call to OnStarting.
-        /// </summary>
-        internal static string FormatOnStartingNotSupported()
-            => GetString("OnStartingNotSupported");
-
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Servers/Kestrel/Core/src/Properties/CoreStrings.Designer.cs
+++ b/src/Servers/Kestrel/Core/src/Properties/CoreStrings.Designer.cs
@@ -2212,6 +2212,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatHttp2ErrorStreamAborted(object frameType, object streamId)
             => string.Format(CultureInfo.CurrentCulture, GetString("Http2ErrorStreamAborted", "frameType", "streamId"), frameType, streamId);
 
+        /// <summary>
+        /// OnCompleted cannot be registered during a call to OnCompleted.
+        /// </summary>
+        internal static string OnCompletedNotSupported
+        {
+            get => GetString("OnCompletedNotSupported");
+        }
+
+        /// <summary>
+        /// OnCompleted cannot be registered during a call to OnCompleted.
+        /// </summary>
+        internal static string FormatOnCompletedNotSupported()
+            => GetString("OnCompletedNotSupported");
+
+        /// <summary>
+        /// OnStarting cannot be registered during a call to OnStarting.
+        /// </summary>
+        internal static string OnStartingNotSupported
+        {
+            get => GetString("OnStartingNotSupported");
+        }
+
+        /// <summary>
+        /// OnStarting cannot be registered during a call to OnStarting.
+        /// </summary>
+        internal static string FormatOnStartingNotSupported()
+            => GetString("OnStartingNotSupported");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -2002,6 +2002,98 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        public async Task OnStartingThrowsInsideOnStartingCallbacksRunsInline()
+        {
+            var testContext = new TestServiceContext(LoggerFactory);
+            var callbacks = 0;
+
+            using (var server = new TestServer(async httpContext =>
+            {
+                var response = httpContext.Response;
+                response.OnStarting(state1 =>
+                {
+                    callbacks++;
+                    response.OnStarting(state2 =>
+                    {
+                        callbacks++;
+                        return Task.CompletedTask;
+                    },
+                    null);
+
+                    return Task.CompletedTask;
+
+                }, null);
+
+                response.Headers["Content-Length"] = new[] { "11" };
+
+                await response.Body.WriteAsync(Encoding.ASCII.GetBytes("Hello World"), 0, 11);
+            }, testContext))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "Host:",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        $"Date: {testContext.DateHeaderValue}",
+                        "");
+                }
+
+                Assert.Equal(2, callbacks);
+
+                await server.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task OnCompletedThrowsInsideOnCompletedCallbackRunsInline()
+        {
+            var testContext = new TestServiceContext(LoggerFactory);
+            var callbacks = 0;
+            using (var server = new TestServer(async httpContext =>
+            {
+                var response = httpContext.Response;
+                response.OnCompleted(state1 =>
+                {
+                    callbacks++;
+                    response.OnCompleted(state2 =>
+                    {
+                        callbacks++;
+                        return Task.CompletedTask;
+                    },
+                    null);
+
+                    return Task.CompletedTask;
+
+                }, null);
+
+                response.Headers["Content-Length"] = new[] { "11" };
+
+                await response.Body.WriteAsync(Encoding.ASCII.GetBytes("Hello World"), 0, 11);
+            }, testContext))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "Host:",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        $"Date: {testContext.DateHeaderValue}",
+                        "");
+                }
+
+                Assert.Equal(2, callbacks);
+                await server.StopAsync();
+            }
+        }
+
+        [Fact]
         public async Task ThrowingInOnCompletedIsLogged()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -2002,7 +2002,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task OnStartingThrowsInsideOnStartingCallbacksRunsInline()
+        public async Task OnStartingThrowsInsideOnStartingCallbacksRuns()
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var callbacks = 0;
@@ -2049,7 +2049,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task OnCompletedThrowsInsideOnCompletedCallbackRunsInline()
+        public async Task OnCompletedThrowsInsideOnCompletedCallbackRuns()
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var callbacks = 0;


### PR DESCRIPTION
- Reviewing profiles for MVC and other things that use RegisterForDispose, this shows up as a significant amount of allocations.

PS: I'm not sure why OnStarting has a lock, when can you ever have overlapping calls to it?

```C#
using System;
using System.Text;
using Microsoft.AspNetCore.Builder;
using Microsoft.AspNetCore.Hosting;
using Microsoft.Extensions.DependencyInjection;

namespace WebApplication62
{
    public class Startup
    {
        public void ConfigureServices(IServiceCollection services)
        {
        }

        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
        {
            if (env.IsDevelopment())
            {
                app.UseDeveloperExceptionPage();
            }

            app.Run(async context =>
            {
                int encoded = Encoding.UTF8.GetBytes("Hello World".AsSpan(), context.Response.BodyPipe.GetSpan());
                context.Response.BodyPipe.Advance(encoded);
                await context.Response.BodyPipe.FlushAsync();
            });
        }
    }
}
```

Before
![image](https://user-images.githubusercontent.com/95136/51375614-2f859180-1abb-11e9-9691-634cb010683e.png)

After
![image](https://user-images.githubusercontent.com/95136/51375593-272d5680-1abb-11e9-9550-3e3dca9f6f61.png)

Will throughput tests to see if they are any regressions