### PR TITLE
Address flaky ANCMV1 tests

### DIFF
--- a/src/MusicStore/test/MusicStore.E2ETests/PublishAndRunTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/PublishAndRunTests.cs
@@ -18,7 +18,7 @@ namespace E2ETests
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllApplicationTypes()
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels()
                 .WithAllArchitectures();
 

--- a/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
@@ -19,7 +19,7 @@ namespace E2ETests
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllApplicationTypes()
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeploymentResult.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeploymentResult.cs
@@ -32,7 +32,24 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
         public HttpClient CreateClient(HttpMessageHandler messageHandler)
         {
-            return new HttpClient(new LoggingHandler(messageHandler, Logger))
+            if (DeploymentParameters.AncmVersion == AncmVersion.AspNetCoreModule)
+            {
+                return CreateRetryClient(messageHandler);
+            }
+            else
+            {
+                return new HttpClient(new LoggingHandler(messageHandler, Logger))
+                {
+                    BaseAddress = base.HttpClient.BaseAddress
+                };
+            }
+        }
+
+        private HttpClient CreateRetryClient(HttpMessageHandler messageHandler)
+        {
+            var loggingHandler = new LoggingHandler(messageHandler, Logger);
+            var retryHandler = new RetryHandler(loggingHandler, Logger);
+            return new HttpClient(retryHandler)
             {
                 BaseAddress = base.HttpClient.BaseAddress
             };

--- a/src/Servers/test/FunctionalTests/HelloWorldTest.cs
+++ b/src/Servers/test/FunctionalTests/HelloWorldTest.cs
@@ -23,7 +23,7 @@ namespace ServerComparison.FunctionalTests
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithApplicationTypes(ApplicationType.Portable)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels()
                 .WithAllArchitectures();
 

--- a/src/Servers/test/FunctionalTests/NtlmAuthenticationTest.cs
+++ b/src/Servers/test/FunctionalTests/NtlmAuthenticationTest.cs
@@ -23,7 +23,7 @@ namespace ServerComparison.FunctionalTests
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]

--- a/src/Servers/test/FunctionalTests/ResponseCompressionTests.cs
+++ b/src/Servers/test/FunctionalTests/ResponseCompressionTests.cs
@@ -34,7 +34,7 @@ namespace ServerComparison.FunctionalTests
         public static TestMatrix NoCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */  ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -47,7 +47,7 @@ namespace ServerComparison.FunctionalTests
         public static TestMatrix HostCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress /*, ServerType.Nginx https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ )
                 .WithTfms(Tfm.NetCoreApp30)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -60,7 +60,7 @@ namespace ServerComparison.FunctionalTests
         public static TestMatrix AppCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys) // No pass-through compression for nginx
                 .WithTfms(Tfm.NetCoreApp30)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -73,7 +73,7 @@ namespace ServerComparison.FunctionalTests
         public static TestMatrix HostAndAppCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]

--- a/src/Servers/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/test/FunctionalTests/ResponseTests.cs
@@ -27,7 +27,7 @@ namespace ServerComparison.FunctionalTests
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(/* ServerType.IISExpress, https://github.com/aspnet/AspNetCore/issues/6168, */ ServerType.Kestrel, /* ServerType.Nginx, https://github.com/aspnet/AspNetCore-Internal/issues/1525 */ ServerType.HttpSys)
                 .WithTfms(Tfm.NetCoreApp30)
-                .WithAllAncmVersions()
+                .WithAncmVersions(AncmVersion.AspNetCoreModuleV2)
                 .WithAllHostingModels();
 
         [ConditionalTheory]


### PR DESCRIPTION
- Only run ANCM V1 test in the IIS subfolder
- Add retry client when using ANCM V1
