### PR TITLE
Revert signtool to older version that doesn't lock the .nupkg file

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -110,7 +110,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Build tool dependencies">
     <InternalAspNetCoreSdkPackageVersion>$(KoreBuildVersion)</InternalAspNetCoreSdkPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">3.0.0-build-20190118.1</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">3.0.0-build-20190118.3</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageVersion>1.0.0-alpha-004</MicrosoftNETFrameworkReferenceAssembliesPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "version": "3.0.100-preview-009750"
   },
   "msbuild-sdks": {
-    "Internal.AspNetCore.Sdk": "3.0.0-build-20190118.1"
+    "Internal.AspNetCore.Sdk": "3.0.0-build-20190118.3"
   }
 }

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:3.0.0-build-20190118.1
-commithash:bddfbe9c6512fd9235665b04f39679ff80371a1b
+version:3.0.0-build-20190118.3
+commithash:27bad0e40ebbb1b8f1d4b7143edc600974fbe3db


### PR DESCRIPTION
Workaround for https://github.com/dotnet/arcade/issues/1839