### PR TITLE
Lock when removing disconnect handler

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/DisconnectHandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/DisconnectHandler.cpp
@@ -53,5 +53,6 @@ void DisconnectHandler::SetHandler(std::unique_ptr<IREQUEST_HANDLER, IREQUEST_HA
 
 void DisconnectHandler::RemoveHandler() noexcept
 {
+    SRWExclusiveLock lock(m_handlerLock);
     m_pHandler = nullptr;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/requesthandler.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/requesthandler.h
@@ -24,6 +24,8 @@ public:
     VOID
     ReferenceRequestHandler() noexcept override
     {
+        DBG_ASSERT(m_cRefs != 0);
+
         InterlockedIncrement(&m_cRefs);
     }
 


### PR DESCRIPTION
While looking into https://github.com/aspnet/AspNetCore-Internal/issues/1551 I was able to force an AV caused by unsynchronized `m_pHandler` access in `RemoveHandler` method.

May fix the failing test too.