### PR TITLE
Move identity functional test to their own group

### DIFF
--- a/src/Identity/test/Identity.FunctionalTests/Microsoft.AspNetCore.Identity.FunctionalTests.csproj
+++ b/src/Identity/test/Identity.FunctionalTests/Microsoft.AspNetCore.Identity.FunctionalTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TestGroupName>Identity.FunctionalTest</TestGroupName>
     <PlatformTarget Condition=" '$(TargetFramework)' == 'netcoreapp2.1' "></PlatformTarget>
 
     <!-- These tests are completely busted in Azure Pipelines due to OutOfMemoryExceptions caused by https://github.com/aspnet/Extensions/issues/844 -->


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1656

Somehow moving these tests to their own group resolves the binding error. There's no logical explanation for this.

@muratg this is a test only change for 2.1.