### PR TITLE
Remove JsonPatch from the shared framework

### DIFF
--- a/build/SharedFrameworkOnly.props
+++ b/build/SharedFrameworkOnly.props
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <!-- Packages to be removed from the shared framework but not done yet due to JSON.net dependency. -->
-    <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.JsonPatch" />
     <SharedFrameworkAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" />
 
     <!-- Assemblies required by components and WebAssembly -->

--- a/src/Framework/Microsoft.AspNetCore.App.props
+++ b/src/Framework/Microsoft.AspNetCore.App.props
@@ -46,7 +46,6 @@
     <Dependency Include="Microsoft.AspNetCore.HttpOverrides"                           Version="$(MicrosoftAspNetCoreHttpOverridesPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.HttpsPolicy"                             Version="$(MicrosoftAspNetCoreHttpsPolicyPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Identity"                                Version="$(MicrosoftAspNetCoreIdentityPackageVersion)" />
-    <Dependency Include="Microsoft.AspNetCore.JsonPatch"                               Version="$(MicrosoftAspNetCoreJsonPatchPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Localization.Routing"                    Version="$(MicrosoftAspNetCoreLocalizationRoutingPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Localization"                            Version="$(MicrosoftAspNetCoreLocalizationPackageVersion)" />
     <Dependency Include="Microsoft.AspNetCore.Mvc.Abstractions"                        Version="$(MicrosoftAspNetCoreMvcAbstractionsPackageVersion)" />


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/4260 and https://github.com/aspnet/AspNetCore/issues/3755

This dependency should have been removed when we did https://github.com/aspnet/AspNetCore/pull/5146, but it got missed. Per our design review, this was one of the assemblies we decided should be removed from the shared framework. Users can add this to their projects by adding a PackageReference.

cc @mkArtakMSFT @muratg we should do this for Preview 2 to front load as many breaking changes as we can.