### PR TITLE
Move Kestrel Sockets tests to their own group

### DIFF
--- a/src/Servers/Kestrel/test/Sockets.FunctionalTests/Sockets.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Sockets.FunctionalTests/Sockets.FunctionalTests.csproj
@@ -5,6 +5,7 @@
     <DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(DefineConstants);MACOS</DefineConstants>
     <DefineConstants>$(DefineConstants);SOCKETS</DefineConstants>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TestGroupName>Sockets.FunctionalTest</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We'll see if this works around the Kestrel binding issues like it did for Identity.
https://github.com/aspnet/AspNetCore/pull/6865