### PR TITLE
Add JQueryQueryStringValueProviderFactory in default MVC options

### DIFF
--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -75,6 +75,7 @@ namespace Microsoft.AspNetCore.Mvc
             options.ValueProviderFactories.Add(new RouteValueProviderFactory());
             options.ValueProviderFactories.Add(new QueryStringValueProviderFactory());
             options.ValueProviderFactories.Add(new JQueryFormValueProviderFactory());
+			options.ValueProviderFactories.Add(new JQueryQueryStringValueProviderFactory());
 
             // Set up metadata providers
             ConfigureAdditionalModelMetadataDetailsProviders(options.ModelMetadataDetailsProviders);

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/JQueryValueProvider.cs
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/JQueryValueProvider.cs
@@ -84,6 +84,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(key));
             }
 
+            if (key.Length == 0)
+            {
+                // Top level parameters will fall back to an empty prefix when the parameter name does not
+                // appear in any value provider. This would result in the parameter binding to a query string
+                // parameter with a empty key (e.g. /User?=test) which isn't a scenario we want to support.
+                // Return a "None" result in this event.
+                return ValueProviderResult.None;
+            }
+
             if (_values.TryGetValue(key, out var values) && values.Count > 0)
             {
                 return new ValueProviderResult(values, Culture);

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
@@ -82,7 +82,8 @@ namespace Microsoft.AspNetCore.Mvc
                 provider => Assert.IsType<FormValueProviderFactory>(provider),
                 provider => Assert.IsType<RouteValueProviderFactory>(provider),
                 provider => Assert.IsType<QueryStringValueProviderFactory>(provider),
-                provider => Assert.IsType<JQueryFormValueProviderFactory>(provider));
+                provider => Assert.IsType<JQueryFormValueProviderFactory>(provider),
+				provider => Assert.IsType<JQueryQueryStringValueProviderFactory>(provider));
         }
 
         [Fact]


### PR DESCRIPTION
 `JQueryQueryStringValueProviderFactory` is not in the default MVC options, which results in query strings of format `model[property]` to not bind to models.

As the `JQueryFormValueProviderFactory` is added by default, I think the `JQueryQueryStringValueProviderFactory` should also be added by default, for consistency.

Addresses #6106
