### PR TITLE
Hoist method attributes from the request delegate as metadata.

### DIFF
--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
@@ -21,7 +22,6 @@ namespace Microsoft.AspNetCore.Builder
         private static readonly string[] PutVerb = new[] { "PUT" };
         private static readonly string[] DeleteVerb = new[] { "DELETE" };
 
-        #region MapVerbs
         /// <summary>
         /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP GET requests
         /// for the specified pattern.
@@ -227,9 +227,7 @@ namespace Microsoft.AspNetCore.Builder
 
             return Map(builder, pattern, displayName ?? $"{pattern} HTTP: {string.Join(", ", httpMethods)}", requestDelegate, metadata: resolvedMetadata.ToArray());
         }
-        #endregion
 
-        #region Map
         /// <summary>
         /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
         /// for the specified pattern.
@@ -323,14 +321,23 @@ namespace Microsoft.AspNetCore.Builder
             var routeEndpointBuilder = new RouteEndpointBuilder(
                 requestDelegate,
                 pattern,
-                defaultOrder);
-            routeEndpointBuilder.DisplayName = displayName;
+                defaultOrder)
+            {
+                DisplayName = displayName
+            };
+
             if (metadata != null)
             {
                 foreach (var item in metadata)
                 {
                     routeEndpointBuilder.Metadata.Add(item);
                 }
+            }
+
+            // Add delegate attributes as metadata
+            foreach (var attribute in requestDelegate.Method.GetCustomAttributes())
+            {
+                routeEndpointBuilder.Metadata.Add(attribute);
             }
 
             var modelEndpointDataSource = builder.DataSources.OfType<ModelEndpointDataSource>().FirstOrDefault();
@@ -343,6 +350,5 @@ namespace Microsoft.AspNetCore.Builder
 
             return modelEndpointDataSource.AddEndpointBuilder(routeEndpointBuilder);
         }
-        #endregion
     }
 }

--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -326,18 +326,18 @@ namespace Microsoft.AspNetCore.Builder
                 DisplayName = displayName
             };
 
+            // Add delegate attributes as metadata
+            foreach (var attribute in requestDelegate.Method.GetCustomAttributes())
+            {
+                routeEndpointBuilder.Metadata.Add(attribute);
+            }
+
             if (metadata != null)
             {
                 foreach (var item in metadata)
                 {
                     routeEndpointBuilder.Metadata.Add(item);
                 }
-            }
-
-            // Add delegate attributes as metadata
-            foreach (var attribute in requestDelegate.Method.GetCustomAttributes())
-            {
-                routeEndpointBuilder.Metadata.Add(attribute);
             }
 
             var modelEndpointDataSource = builder.DataSources.OfType<ModelEndpointDataSource>().FirstOrDefault();

--- a/src/Http/Routing/test/UnitTests/Builder/MapEndpointEndpointDataSourceBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/MapEndpointEndpointDataSourceBuilderExtensionsTest.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Xunit;
 
@@ -96,6 +94,36 @@ namespace Microsoft.AspNetCore.Builder
             Assert.Equal("Display name!", endpointBuilder1.DisplayName);
             Assert.Equal("/", endpointBuilder1.RoutePattern.RawText);
             Assert.Equal(metadata, Assert.Single(endpointBuilder1.Metadata));
+        }
+
+        [Fact]
+        public void MapEndpoint_AttributesCollectedAsMetadata()
+        {
+            // Arrange
+            var builder = new DefaultEndpointRouteBuilder();
+
+            // Act
+            var endpointBuilder = builder.Map(RoutePatternFactory.Parse("/"), "Display name!", Handle);
+
+            // Assert
+            var endpointBuilder1 = GetRouteEndpointBuilder(builder);
+            Assert.Equal("Display name!", endpointBuilder1.DisplayName);
+            Assert.Equal("/", endpointBuilder1.RoutePattern.RawText);
+            Assert.Equal(2, endpointBuilder1.Metadata.Count);
+            Assert.IsType<Attribute1>(endpointBuilder1.Metadata[0]);
+            Assert.IsType<Attribute2>(endpointBuilder1.Metadata[1]);
+        }
+
+        [Attribute1]
+        [Attribute2]
+        private static Task Handle(HttpContext context) => Task.CompletedTask;
+
+        private class Attribute1 : Attribute
+        {
+        }
+
+        private class Attribute2 : Attribute
+        {
         }
     }
 }

--- a/src/Http/Routing/test/UnitTests/Builder/MapEndpointEndpointDataSourceBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/MapEndpointEndpointDataSourceBuilderExtensionsTest.cs
@@ -114,6 +114,25 @@ namespace Microsoft.AspNetCore.Builder
             Assert.IsType<Attribute2>(endpointBuilder1.Metadata[1]);
         }
 
+        [Fact]
+        public void MapEndpoint_ExplicitMetadataAddedAfterAttributeMetadata()
+        {
+            // Arrange
+            var builder = new DefaultEndpointRouteBuilder();
+
+            // Act
+            var endpointBuilder = builder.Map(RoutePatternFactory.Parse("/"), "Display name!", Handle, new Metadata());
+
+            // Assert
+            var endpointBuilder1 = GetRouteEndpointBuilder(builder);
+            Assert.Equal("Display name!", endpointBuilder1.DisplayName);
+            Assert.Equal("/", endpointBuilder1.RoutePattern.RawText);
+            Assert.Equal(3, endpointBuilder1.Metadata.Count);
+            Assert.IsType<Attribute1>(endpointBuilder1.Metadata[0]);
+            Assert.IsType<Attribute2>(endpointBuilder1.Metadata[1]);
+            Assert.IsType<Metadata>(endpointBuilder1.Metadata[2]);
+        }
+
         [Attribute1]
         [Attribute2]
         private static Task Handle(HttpContext context) => Task.CompletedTask;
@@ -124,6 +143,11 @@ namespace Microsoft.AspNetCore.Builder
 
         private class Attribute2 : Attribute
         {
+        }
+
+        private class Metadata
+        {
+
         }
     }
 }


### PR DESCRIPTION
- This should allow a more declarative approach to declaring endpoint metadata using the default methods.
- Removed the regions because I was offended :trollface: 

Here's an example of using the Authorize attribute (it's a shame local functions don't support attributes yet):

```C#
using System.Security.Claims;
using System.Threading.Tasks;
using Microsoft.AspNetCore.Authentication;
using Microsoft.AspNetCore.Authorization;
using Microsoft.AspNetCore.Builder;
using Microsoft.AspNetCore.Hosting;
using Microsoft.AspNetCore.Http;
using Microsoft.AspNetCore.Routing;
using Microsoft.Extensions.DependencyInjection;

namespace WebApplication66
{
    public class Startup
    {
        public void ConfigureServices(IServiceCollection services)
        {
            services.AddAuthentication("Cookies")
                    .AddCookie();

            services.AddAuthorization();

            services.AddAuthorizationPolicyEvaluator();
        }

        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
        {
            if (env.IsDevelopment())
            {
                app.UseDeveloperExceptionPage();
            }

            app.UseAuthentication();

            app.UseRouting(routes =>
            {
                routes.MapGet("/", Hello);
                routes.MapGet("/account/login", Login);
                routes.MapGet("/account/logout", Logout);
            });

            app.UseAuthorization();
        }

        [Authorize]
        async Task Hello(HttpContext context)
        {
            await context.Response.WriteAsync($"Hello {context.User.Identity.Name}");
        }

        async Task Login(HttpContext context)
        {
            var claims = new[] {
                        new Claim(ClaimTypes.NameIdentifier, "id"),
                        new Claim(ClaimTypes.Name, "David")
                    };

            var identity = new ClaimsIdentity(claims, "Cookies");
            var user = new ClaimsPrincipal(identity);
            await context.SignInAsync(user);
        }

        async Task Logout(HttpContext context)
        {
            await context.SignOutAsync();
        }
    }
}
```