### PR TITLE
Move Kestrel.Core.Tests to their own test group

### DIFF
--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TestGroupName>Kestrel.Core.Tests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1699
Experimenting to see if this is the same issue we've been having in 2.1.

Compare to the baseline build https://dnceng.visualstudio.com/public/_build/results?buildId=77668