### PR TITLE
Revert feature that resets unspecified component parameters to default. Fixes #6864

### DIFF
--- a/src/Components/Blazor/testassets/StandaloneApp/Pages/FetchData.cshtml
+++ b/src/Components/Blazor/testassets/StandaloneApp/Pages/FetchData.cshtml
@@ -48,14 +48,14 @@ else
 
     WeatherForecast[] forecasts;
 
+    public override Task SetParametersAsync(ParameterCollection parameters)
+    {
+        StartDate = DateTime.Now;
+        return base.SetParametersAsync(parameters);
+    }
+
     protected override async Task OnParametersSetAsync()
     {
-        // If no value was given in the URL for StartDate, apply a default
-        if (StartDate == default)
-        {
-            StartDate = DateTime.Now;
-        }
-
         forecasts = await Http.GetJsonAsync<WeatherForecast[]>(
             $"sample-data/weather.json?date={StartDate.ToString("yyyy-MM-dd")}");
 

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Components feature for ASP.NET Core.</Description>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 

--- a/src/Components/Components/src/Reflection/IPropertySetter.cs
+++ b/src/Components/Components/src/Reflection/IPropertySetter.cs
@@ -6,7 +6,5 @@ namespace Microsoft.AspNetCore.Components.Reflection
     internal interface IPropertySetter
     {
         void SetValue(object target, object value);
-
-        void SetDefaultValue(object target);
     }
 }

--- a/src/Components/Components/src/Reflection/MemberAssignment.cs
+++ b/src/Components/Components/src/Reflection/MemberAssignment.cs
@@ -48,14 +48,10 @@ namespace Microsoft.AspNetCore.Components.Reflection
             {
                 _setterDelegate = (Action<TTarget, TValue>)Delegate.CreateDelegate(
                     typeof(Action<TTarget, TValue>), setMethod);
-                var propertyType = typeof(TValue);
             }
 
             public void SetValue(object target, object value)
                 => _setterDelegate((TTarget)target, (TValue)value);
-
-            public void SetDefaultValue(object target)
-                => _setterDelegate((TTarget)target, default);
         }
     }
 }

--- a/src/Components/Components/test/ParameterCollectionAssignmentExtensionsTest.cs
+++ b/src/Components/Components/test/ParameterCollectionAssignmentExtensionsTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void NoIncomingParameterMatchesDeclaredParameter_SetValuesDefault()
+        public void NoIncomingParameterMatchesDeclaredParameter_LeavesValueUnchanged()
         {
             // Arrange
             var existingObjectValue = new object();
@@ -90,9 +90,9 @@ namespace Microsoft.AspNetCore.Components.Test
             parameterCollection.SetParameterProperties(target);
 
             // Assert
-            Assert.Equal(0, target.IntProp);
-            Assert.Null(target.StringProp);
-            Assert.Null(target.ObjectPropCurrentValue);
+            Assert.Equal(456, target.IntProp);
+            Assert.Equal("Existing value", target.StringProp);
+            Assert.Same(existingObjectValue, target.ObjectPropCurrentValue);
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -221,6 +221,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             AssertHighlightedLinks("With parameters", "With more parameters");
 
             // Can remove parameters while remaining on same page
+            // WARNING: This only works because the WithParameters component overrides SetParametersAsync
+            // and explicitly resets its parameters to default when each new set of parameters arrives.
+            // Without that, the page would retain the old value.
+            // See https://github.com/aspnet/AspNetCore/issues/6864 where we reverted the logic to auto-reset.
             app.FindElement(By.LinkText("With parameters")).Click();
             WaitAssert.Equal("Your full name is Abc .", () => app.FindElement(By.Id("test-info")).Text);
             AssertHighlightedLinks("With parameters");

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithParameters.cshtml
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithParameters.cshtml
@@ -5,9 +5,15 @@
 
 @functions
 {
-    [Parameter]
-    string FirstName { get; set; }
+    [Parameter] string FirstName { get; set; }
 
-    [Parameter]
-    string LastName { get ; set; }
+    [Parameter] string LastName { get ; set; }
+
+    public override Task SetParametersAsync(ParameterCollection parameters)
+    {
+        // Manually reset parameters to defaults so we don't retain any from an earlier URL
+        FirstName = default;
+        LastName = default;
+        return base.SetParametersAsync(parameters);
+    }
 }

--- a/src/Components/test/testassets/ComponentsApp.App/Pages/FetchData.cshtml
+++ b/src/Components/test/testassets/ComponentsApp.App/Pages/FetchData.cshtml
@@ -48,14 +48,14 @@ else
 
     WeatherForecast[] forecasts;
 
+    public override Task SetParametersAsync(ParameterCollection parameters)
+    {
+        StartDate = DateTime.Now;
+        return base.SetParametersAsync(parameters);
+    }
+
     protected override async Task OnParametersSetAsync()
     {
-        // If no value was given in the URL for StartDate, apply a default
-        if (StartDate == default)
-        {
-            StartDate = DateTime.Now;
-        }
-
         forecasts = await ForecastService.GetForecastAsync(StartDate);
     }
 }


### PR DESCRIPTION
See the discussion in #6864. This fix is necessary to make the following very basic scenario work:

```csharp
[Parameter] int IncrementAmount { get; set; } = 1;
```
