### PR TITLE
Make auth schemes const

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADDefaults.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADDefaults.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
 
 
@@ -13,29 +13,29 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         /// The scheme name for Open ID Connect when using
         /// <see cref="AzureADAuthenticationBuilderExtensions.AddAzureAD(AuthenticationBuilder, System.Action{AzureADOptions})"/>.
         /// </summary>
-        public static readonly string OpenIdScheme = "AzureADOpenID";
+        public const string OpenIdScheme = "AzureADOpenID";
 
         /// <summary>
         /// The scheme name for cookies when using
         /// <see cref="AzureADAuthenticationBuilderExtensions.AddAzureAD(AuthenticationBuilder, System.Action{AzureADOptions})"/>.
         /// </summary>
-        public static readonly string CookieScheme = "AzureADCookie";
+        public const string CookieScheme = "AzureADCookie";
 
         /// <summary>
         /// The default scheme for Azure Active Directory Bearer.
         /// </summary>
-        public static readonly string BearerAuthenticationScheme = "AzureADBearer";
+        public const string BearerAuthenticationScheme = "AzureADBearer";
 
         /// <summary>
         /// The scheme name for JWT Bearer when using
         /// <see cref="AzureADAuthenticationBuilderExtensions.AddAzureADBearer(AuthenticationBuilder, System.Action{AzureADOptions})"/>.
         /// </summary>
-        public static readonly string JwtBearerAuthenticationScheme = "AzureADJwtBearer";
+        public const string JwtBearerAuthenticationScheme = "AzureADJwtBearer";
 
         /// <summary>
         /// The default scheme for Azure Active Directory.
         /// </summary>
-        public static readonly string AuthenticationScheme = "AzureAD";
+        public const string AuthenticationScheme = "AzureAD";
 
         /// <summary>
         /// The display name for Azure Active Directory.

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CDefaults.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CDefaults.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
 
 
@@ -20,29 +20,29 @@ namespace Microsoft.AspNetCore.Authentication.AzureADB2C.UI
         /// The scheme name for Open ID Connect when using
         /// <see cref="AzureADB2CAuthenticationBuilderExtensions.AddAzureADB2C(AuthenticationBuilder, System.Action{AzureADB2COptions})"/>.
         /// </summary>
-        public static readonly string OpenIdScheme = "AzureADB2COpenID";
+        public const string OpenIdScheme = "AzureADB2COpenID";
 
         /// <summary>
         /// The scheme name for cookies when using
         /// <see cref="AzureADB2CAuthenticationBuilderExtensions.AddAzureADB2C(AuthenticationBuilder, System.Action{AzureADB2COptions})"/>.
         /// </summary>
-        public static readonly string CookieScheme = "AzureADB2CCookie";
+        public const string CookieScheme = "AzureADB2CCookie";
 
         /// <summary>
         /// The default scheme for Azure Active Directory B2C Bearer.
         /// </summary>
-        public static readonly string BearerAuthenticationScheme = "AzureADB2CBearer";
+        public const string BearerAuthenticationScheme = "AzureADB2CBearer";
 
         /// <summary>
         /// The scheme name for JWT Bearer when using
         /// <see cref="AzureADB2CAuthenticationBuilderExtensions.AddAzureADB2CBearer(AuthenticationBuilder, System.Action{AzureADB2COptions})"/>.
         /// </summary>
-        public static readonly string JwtBearerAuthenticationScheme = "AzureADB2CJwtBearer";
+        public const string JwtBearerAuthenticationScheme = "AzureADB2CJwtBearer";
 
         /// <summary>
         /// The default scheme for Azure Active Directory B2C.
         /// </summary>
-        public static readonly string AuthenticationScheme = "AzureADB2C";
+        public const string AuthenticationScheme = "AzureADB2C";
 
         /// <summary>
         /// The display name for Azure Active Directory B2C.

--- a/src/Servers/HttpSys/build.cmd
+++ b/src/Servers/HttpSys/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET RepoRoot=%~dp0..\..\..
+%RepoRoot%\build.cmd -projects %~dp0\**\*.*proj %*

--- a/src/Servers/HttpSys/src/HttpSysDefaults.cs
+++ b/src/Servers/HttpSys/src/HttpSysDefaults.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// The name of the authentication scheme used.
         /// </summary>
-        public static readonly string AuthenticationScheme = "Windows";
+        public const string AuthenticationScheme = "Windows";
     }
 }


### PR DESCRIPTION
So you can use them in the Authorize attribute. We already do this for other auth providers.
#5884 HttpSys
#6020 AzureAd