### PR TITLE
Update build tools and exclude symbols.nupkg files from signcheck

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -273,6 +273,7 @@ $MSBuildArguments += "/p:_RunSign=$Sign"
 Import-Module -Force -Scope Local (Join-Path $korebuildPath 'KoreBuild.psd1')
 
 try {
+    $RepoRoot = Resolve-Path $RepoRoot
     Set-KoreBuildSettings -ToolsSource $ToolsSource -DotNetHome $DotNetHome -RepoPath $RepoRoot -ConfigFile $ConfigFile -CI:$CI
     if ($ForceCoreMsbuild) {
         $global:KoreBuildSettings.MSBuildType = 'core'

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -106,7 +106,7 @@
     <Message Text="============ Building $(RepositoryToBuild) ============" Importance="High" />
 
     <Exec
-      Command="./$(_BuildScriptToExecute) -RepoRoot $(BuildRepositoryRoot) $(BuildArguments)"
+      Command="./$(_BuildScriptToExecute) -RepoRoot $(BuildRepositoryRoot.TrimEnd('\').TrimEnd('/')) $(BuildArguments)"
       IgnoreStandardErrorWarningFormat="true"
       WorkingDirectory="$(RepositoryRoot)"
       IgnoreExitCode="true"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -110,7 +110,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Build tool dependencies">
     <InternalAspNetCoreSdkPackageVersion>$(KoreBuildVersion)</InternalAspNetCoreSdkPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">3.0.0-build-20190118.4</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">3.0.0-build-20190122.3</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageVersion>1.0.0-alpha-004</MicrosoftNETFrameworkReferenceAssembliesPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
   </PropertyGroup>

--- a/eng/signcheck.exclusions.txt
+++ b/eng/signcheck.exclusions.txt
@@ -4,3 +4,4 @@ content/*.js;Microsoft.DotNet.Web.ProjectTemplates.*.nupkg; Exclude JavaScript f
 Templates/*.js;Microsoft.VisualStudio.Web.CodeGenerators.Mvc.*.nupkg; Exclude JavaScript files from codesigning in code generators
 *.js;signalr-*-javadoc.jar; Exclude JavaScript files in the generated javadocs
 *.binlog; Exclude msbuild log files
+*.symbols.nupkg; Exclude NuGet symbols packages. These are not shipped to customers and should not be code signed.

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "version": "3.0.100-preview-009750"
   },
   "msbuild-sdks": {
-    "Internal.AspNetCore.Sdk": "3.0.0-build-20190118.4"
+    "Internal.AspNetCore.Sdk": "3.0.0-build-20190122.3"
   }
 }

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:3.0.0-build-20190118.4
-commithash:dc060235e4056a2a5ec0141fa89da9e490544268
+version:3.0.0-build-20190122.3
+commithash:43e5fa8e3d8b192e573c3c14ae39b43e1d05cd5e


### PR DESCRIPTION
Updates to a build tools version which should fix https://github.com/aspnet/AspNetCore-Internal/issues/1694.

Also, exclude .symbols.nupkg files from signcheck. These are not shipped to customers and do not need to be signed. We can save time and bandwidth by not code-signing these. After this merges, I will re-enable signcheck on CI.