### PR TITLE
Fix SignalR daily tests

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -95,12 +95,12 @@ jobs:
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
     BuildDirectory: ${{ parameters.buildDirectory }}
+    TeamName: AspNetCore
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
     ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal')) }}:
       _SignType:
     ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
-      TeamName: AspNetCore
       _SignType: real
     ${{ insert }}: ${{ parameters.variables }}
   steps:


### PR DESCRIPTION
Ensure the TeamName variable is set. It's required for all internal builds.