### PR TITLE
Ensure PackageArchive contains the right build of Razor.Design package

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -87,14 +87,6 @@
     <MicrosoftVisualStudioWebCodeGenerationTemplatingPackageVersion>2.1.7</MicrosoftVisualStudioWebCodeGenerationTemplatingPackageVersion>
     <MicrosoftVisualStudioWebCodeGenerationUtilsPackageVersion>2.1.7</MicrosoftVisualStudioWebCodeGenerationUtilsPackageVersion>
     <MicrosoftVisualStudioWebCodeGeneratorsMvcPackageVersion>2.1.7</MicrosoftVisualStudioWebCodeGeneratorsMvcPackageVersion>
-
-    <!-- These dependencies are required to build. The need to be used as explicit package references -->
-    <MicrosoftAspNetCoreRazorDesignPackageVersion>2.1.1</MicrosoftAspNetCoreRazorDesignPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>2.1.1</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreRazorRuntimePackageVersion>2.1.1</MicrosoftAspNetCoreRazorRuntimePackageVersion>
-    <MicrosoftAspNetCoreRazorLanguagePackageVersion>2.1.1</MicrosoftAspNetCoreRazorLanguagePackageVersion>
-    <MicrosoftCodeAnalysisRazorPackageVersion>2.1.1</MicrosoftCodeAnalysisRazorPackageVersion>
-
     <!-- These dependencies are temporary while we refactor package refs into project refs. -->
     <MicrosoftAspNetCoreAspNetCoreModulePackageVersion>2.1.1</MicrosoftAspNetCoreAspNetCoreModulePackageVersion>
     <MicrosoftAspNetCoreAspNetCoreModuleV1PackageVersion>2.1.1</MicrosoftAspNetCoreAspNetCoreModuleV1PackageVersion>

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -32,7 +32,7 @@ try {
         $slnDir = Split-Path -Parent $_
         $sln = $_
         & dotnet sln $_ list `
-            | ? { $_ -ne 'Project(s)' -and $_ -ne '----------' } `
+            | ? { $_ -like '*proj' } `
             | % {
                 $proj = Join-Path $slnDir $_
                 if (-not (Test-Path $proj)) {

--- a/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
+++ b/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
@@ -18,10 +18,9 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
-
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="$(MicrosoftAspNetCoreRazorRuntimePackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="$(MicrosoftCodeAnalysisRazorPackageVersion)" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Reference Include="Microsoft.CodeAnalysis.Razor" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp" />
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.FileProviders.Composite" />
@@ -30,24 +29,11 @@
 
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="BuiltProjectOutputGroup;DebugSymbolsProjectOutputGroup;DocumentationProjectOutputGroup">
 
-    <!-- We can uncomment the below block once https://github.com/aspnet/AspNetCore/issues/6070 is fixed. -->
-    <!--
-
-    <PropertyGroup>
-      <SrcPath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\src\</SrcPath>
-    </PropertyGroup>
-    <MSBuild Projects="$(SrcPath)Razor\Mvc.Razor.Extensions\src\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj;
-                       $(SrcPath)Razor\Razor.Runtime\src\Microsoft.AspNetCore.Razor.Runtime.csproj;
-                       $(SrcPath)Razor\CodeAnalysis.Razor\src\Microsoft.CodeAnalysis.Razor.csproj;"
-              Targets="_GetPackageVersionInfo" Properties="DesignTimeBuild=true;NoBuild=true">
-      <Output TaskParameter="TargetOutputs" ItemName="_DependencyPackageInfo" />
-    </MSBuild>
     <PropertyGroup>
       <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>@(_DependencyPackageInfo->WithMetadataValue('PackageId', 'Microsoft.AspNetCore.Mvc.Razor.Extensions')->Metadata('PackageVersion'))</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
       <MicrosoftAspNetCoreRazorRuntimePackageVersion>@(_DependencyPackageInfo->WithMetadataValue('PackageId', 'Microsoft.AspNetCore.Razor.Runtime')->Metadata('PackageVersion'))</MicrosoftAspNetCoreRazorRuntimePackageVersion>
       <MicrosoftCodeAnalysisRazorPackageVersion>@(_DependencyPackageInfo->WithMetadataValue('PackageId', 'Microsoft.CodeAnalysis.Razor')->Metadata('PackageVersion'))</MicrosoftCodeAnalysisRazorPackageVersion>
     </PropertyGroup>
-    -->
 
     <PropertyGroup>
       <!-- Make sure we create a symbols.nupkg -->

--- a/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
+++ b/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="$(MicrosoftAspNetCoreRazorRuntimePackageVersion)" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />

--- a/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
+++ b/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
@@ -20,12 +20,8 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
 
     <!-- Including these here specifically so that apps referencing the MVC package get razor compiler targets -->
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)">
-      <PrivateAssets>None</PrivateAssets>
-    </PackageReference>
+    <Reference Include="Microsoft.AspNetCore.Razor.Design" PrivateAssets="None" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" PrivateAssets="None" />
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
 

--- a/src/Mvc/samples/MvcSandbox/MvcSandbox.csproj
+++ b/src/Mvc/samples/MvcSandbox/MvcSandbox.csproj
@@ -12,8 +12,6 @@
     <Reference Include="Microsoft.AspNetCore.Mvc" />
 
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />

--- a/src/Mvc/shared/Mvc.TestCommon/Microsoft.AspNetCore.Mvc.TestCommon.csproj
+++ b/src/Mvc/shared/Mvc.TestCommon/Microsoft.AspNetCore.Mvc.TestCommon.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Html.Abstractions" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="$(MicrosoftAspNetCoreRazorRuntimePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Language" />
     <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />

--- a/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
@@ -31,6 +31,9 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Language" />
+
     <ProjectReference Include="..\WebSites\ApiExplorerWebSite\ApiExplorerWebSite.csproj" />
     <ProjectReference Include="..\WebSites\ApplicationModelWebSite\ApplicationModelWebSite.csproj" />
     <ProjectReference Include="..\WebSites\BasicWebSite\BasicWebSite.csproj" />

--- a/src/Mvc/test/WebSites/ControllersFromServicesClassLibrary/ControllersFromServicesClassLibrary.csproj
+++ b/src/Mvc/test/WebSites/ControllersFromServicesClassLibrary/ControllersFromServicesClassLibrary.csproj
@@ -8,5 +8,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Language" />
   </ItemGroup>
 </Project>

--- a/src/Mvc/test/WebSites/ControllersFromServicesWebSite/ControllersFromServicesWebSite.csproj
+++ b/src/Mvc/test/WebSites/ControllersFromServicesWebSite/ControllersFromServicesWebSite.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\ControllersFromServicesClassLibrary\ControllersFromServicesClassLibrary.csproj" />
     <Reference Include="Microsoft.AspNetCore.Mvc" />
 
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Language" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />

--- a/src/Mvc/test/WebSites/RazorBuildWebSite/RazorBuildWebSite.csproj
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite/RazorBuildWebSite.csproj
@@ -19,13 +19,6 @@
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
-
-    <!--
-      Referencing here so you can easily regenerate the C# from Razor.
-      Just do `dotnet build /t:RazorGenerate /p:TargetFramework=netcoreapp2.0` and look in obj/Debug/netcoreapp2.0/Razor
-      -->
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/test/WebSites/RazorWebSite/RazorWebSite.csproj
+++ b/src/Mvc/test/WebSites/RazorWebSite/RazorWebSite.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
 
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Language" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />


### PR DESCRIPTION
* Re-order values in build\dependencies.props to ensure Razor.Design's package version is
  overwritten.
* Convert additional package refs to project refs

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1708

