### PR TITLE
Block generic host Startup.ConfigureServices that return IServiceProvider 

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -232,6 +232,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 {
                     throw new NotSupportedException($"{typeof(IStartup)} isn't supported");
                 }
+                if (StartupLoader.HasConfigureServicesIServiceProviderDelegate(startupType, context.HostingEnvironment.EnvironmentName))
+                {
+                    throw new NotSupportedException($"ConfigureServices returning an {typeof(IServiceProvider)} isn't supported.");
+                }
 
                 instance = ActivatorUtilities.CreateInstance(new HostServiceProvider(webHostBuilderContext), startupType);
                 context.Properties[_startupKey] = instance;

--- a/src/Hosting/Hosting/src/Internal/StartupLoader.cs
+++ b/src/Hosting/Hosting/src/Internal/StartupLoader.cs
@@ -279,6 +279,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             return new ConfigureContainerBuilder(configureMethod);
         }
 
+        internal static bool HasConfigureServicesIServiceProviderDelegate(Type startupType, string environmentName)
+        {
+            return null != FindMethod(startupType, "Configure{0}Services", environmentName, typeof(IServiceProvider), required: false);
+        }
+
         internal static ConfigureServicesBuilder FindConfigureServicesDelegate(Type startupType, string environmentName)
         {
             var servicesMethod = FindMethod(startupType, "Configure{0}Services", environmentName, typeof(IServiceProvider), required: false)

--- a/src/Hosting/Hosting/test/Fakes/StartupWithBuiltConfigureServices.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupWithBuiltConfigureServices.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting.Fakes
 {
-    public class StartupWithNullConfigureServices
+    public class StartupWithBuiltConfigureServices
     {
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {

--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -889,6 +889,22 @@ namespace Microsoft.AspNetCore.Hosting
             Assert.Equal("Building this implementation of IWebHostBuilder is not supported.", exception.Message);
         }
 
+        [Fact]
+        public void GenericWebHostDoesNotSupportBuildingInConfigureServices()
+        {
+            var hostBuilder = new HostBuilder()
+                   .ConfigureWebHost(builder =>
+                   {
+                       builder.UseStartup<StartupWithBuiltConfigureServices>();
+                   });
+            var exception = Assert.Throws<NotSupportedException>(() =>
+            {
+                hostBuilder.Build();
+            });
+
+            Assert.Equal($"ConfigureServices returning an {typeof(IServiceProvider)} isn't supported.", exception.Message);
+        }
+
         [Theory]
         [MemberData(nameof(DefaultWebHostBuildersWithConfig))]
         public void Build_HostingStartupAssemblyCanBeExcluded(IWebHostBuilder builder)


### PR DESCRIPTION
#5149 `IServiceProvider ConfigureServices(IServiceCollection services)` is one of the patterns not supported by the generic web host as it needs to compose on a single container. Adding an error for discoverability.

@muratg this is a low risk merge.
