### PR TITLE
Harden IISExpress shutdown code

### DIFF
--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -446,10 +446,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
         {
             internal delegate bool EnumWindowProc(IntPtr hwnd, IntPtr lParam);
             [DllImport("user32.dll")]
-            internal static extern IntPtr GetTopWindow(IntPtr hWnd);
-            [DllImport("user32.dll")]
-            internal static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
-            [DllImport("user32.dll")]
             internal static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint lpdwProcessId);
             [DllImport("user32.dll")]
             internal static extern bool PostMessage(HandleRef hWnd, uint Msg, IntPtr wParam, IntPtr lParam);

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -451,25 +452,56 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             internal static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint lpdwProcessId);
             [DllImport("user32.dll")]
             internal static extern bool PostMessage(HandleRef hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+            internal delegate bool EnumWindowProc(IntPtr hwnd, IntPtr lParam);
+            [DllImport("user32")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool EnumWindows (EnumWindowProc callback, IntPtr lParam);
+
+            [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+            internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName,int nMaxCount);
         }
 
         private void SendStopMessageToProcess(int pid)
         {
             Logger.LogInformation($"Sending shutdown request to {pid}");
-            for (var ptr = WindowsNativeMethods.GetTopWindow(IntPtr.Zero); ptr != IntPtr.Zero; ptr = WindowsNativeMethods.GetWindow(ptr, 2))
-            {
+            var found = false;
+            WindowsNativeMethods.EnumWindows ((ptr, param) => {
+
                 WindowsNativeMethods.GetWindowThreadProcessId(ptr, out var windowProcessId);
                 if (pid == windowProcessId)
                 {
+                    // 256 is the max length
+                    var className = new StringBuilder(256);
+
+                    if (WindowsNativeMethods.GetClassName(ptr, className, className.Capacity) == 0)
+                    {
+                        throw new InvalidOperationException($"Unable to get window class name: {Marshal.GetLastWin32Error()}");
+                    }
+
+                    if (!string.Equals(className.ToString(), "IISEXPRESS", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // skip windows without IISEXPRESS class
+                        return true;
+                    }
+
                     var hWnd = new HandleRef(null, ptr);
                     if (!WindowsNativeMethods.PostMessage(hWnd, 0x12, IntPtr.Zero, IntPtr.Zero))
                     {
                         throw new InvalidOperationException($"Unable to PostMessage to process {pid}. LastError: {Marshal.GetLastWin32Error()}");
                     }
-                    return;
+
+                    found = true;
+                    return false;
                 }
+
+                return true;
+            }, IntPtr.Zero);
+
+            if (!found)
+            {
+                throw new InvalidOperationException($"Unable to find main window for process {pid}");
             }
-            throw new InvalidOperationException($"Unable to find main window for process {pid}");
         }
 
         private void GracefullyShutdownProcess(Process hostProcess)

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -466,8 +466,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
         {
             Logger.LogInformation($"Sending shutdown request to {pid}");
             var found = false;
-            WindowsNativeMethods.EnumWindows ((ptr, param) => {
-
+            WindowsNativeMethods.EnumWindows((ptr, param) => {
                 WindowsNativeMethods.GetWindowThreadProcessId(ptr, out var windowProcessId);
                 if (pid == windowProcessId)
                 {

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -444,6 +444,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
         private class WindowsNativeMethods
         {
+            internal delegate bool EnumWindowProc(IntPtr hwnd, IntPtr lParam);
             [DllImport("user32.dll")]
             internal static extern IntPtr GetTopWindow(IntPtr hWnd);
             [DllImport("user32.dll")]
@@ -452,12 +453,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             internal static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint lpdwProcessId);
             [DllImport("user32.dll")]
             internal static extern bool PostMessage(HandleRef hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
-
-            internal delegate bool EnumWindowProc(IntPtr hwnd, IntPtr lParam);
-            [DllImport("user32")]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static extern bool EnumWindows (EnumWindowProc callback, IntPtr lParam);
-
+            [DllImport("user32.dll")]
+            internal static extern bool EnumWindows(EnumWindowProc callback, IntPtr lParam);
             [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
             internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName,int nMaxCount);
         }


### PR DESCRIPTION
Continuation of https://github.com/aspnet/AspNetCore/pull/6854

`EnumWindows` is more reliable than `GetWindow` and making sure we send the message to the correct window because IISExpress usually has two.