### PR TITLE
Reenable application initialization module tests

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -182,13 +182,12 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         private string GetOriginalPath()
         {
-
             var rawUrlInBytes = GetRawUrlInBytes();
 
-            // On Windows 2012 applicationInitialization request might not have pRawUrl set, fallback to coocked url
+            // Pre Windows 10 RS2 applicationInitialization request might not have pRawUrl set, fallback to cocked url
             if (rawUrlInBytes == null)
             {
-                return GetCookedUrl().GetFullUrl();
+                return GetCookedUrl().GetAbsPath();
             }
 
             // ApplicationInitialization request might have trailing \0 character included in the length

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -182,9 +182,17 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         private string GetOriginalPath()
         {
-            // applicationInitialization request might have trailing \0 character included in the length
-            // check and skip it
+
             var rawUrlInBytes = GetRawUrlInBytes();
+
+            // On Windows 2012 applicationInitialization request might not have pRawUrl set, fallback to coocked url
+            if (rawUrlInBytes == null)
+            {
+                return GetCookedUrl().GetFullUrl();
+            }
+
+            // ApplicationInitialization request might have trailing \0 character included in the length
+            // check and skip it
             if (rawUrlInBytes.Length > 0 && rawUrlInBytes[rawUrlInBytes.Length - 1] == 0)
             {
                 var newRawUrlInBytes = new byte[rawUrlInBytes.Length - 1];

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/Helpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/Helpers.cs
@@ -128,6 +128,11 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             return response;
         }
 
+        public static Task Retry(Func<Task> func, TimeSpan maxTime)
+        {
+            return Retry(func, (int)(maxTime.TotalMilliseconds / 200), 200);
+        }
+
         public static async Task Retry(Func<Task> func, int attempts, int msDelay)
         {
             var exceptions = new List<Exception>();

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
@@ -26,7 +26,7 @@ namespace IIS.FunctionalTests
             _fixture = fixture;
         }
 
-        [ConditionalTheory(Skip="https://github.com/aspnet/AspNetCore/issues/6752")]
+        [ConditionalTheory]
         [RequiresIIS(IISCapability.ApplicationInitialization)]
         [InlineData(HostingModel.InProcess)]
         [InlineData(HostingModel.OutOfProcess)]
@@ -42,13 +42,13 @@ namespace IIS.FunctionalTests
 
                 var result = await DeployAsync(baseDeploymentParameters);
 
-                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), 10, 200);
+                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
                 StopServer();
                 EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result));
             }
         }
 
-        [ConditionalTheory(Skip="https://github.com/aspnet/AspNetCore/issues/6752")]
+        [ConditionalTheory]
         [RequiresIIS(IISCapability.ApplicationInitialization)]
         [InlineData(HostingModel.InProcess)]
         [InlineData(HostingModel.OutOfProcess)]
@@ -70,7 +70,7 @@ namespace IIS.FunctionalTests
 
                 var result = await DeployAsync(baseDeploymentParameters);
 
-                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), 10, 200);
+                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
                 StopServer();
                 EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result));
             }

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
@@ -50,6 +50,7 @@ namespace IIS.FunctionalTests
 
         [ConditionalTheory]
         [RequiresIIS(IISCapability.ApplicationInitialization)]
+        [RequiresNewHandler]
         [InlineData(HostingModel.InProcess)]
         [InlineData(HostingModel.OutOfProcess)]
         public async Task ApplicationInitializationPageIsRequested(HostingModel hostingModel)

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -101,7 +101,7 @@ namespace TestSite
                 .ConfigureLogging((_, factory) =>
                 {
                     factory.AddConsole();
-                    factory.AddFilter("Console", level => level >= LogLevel.Information);
+                    factory.AddFilter("Console", level => level >= LogLevel.Trace);
                 })
                 .UseIIS()
                 .UseStartup<Startup>()

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -101,7 +101,7 @@ namespace TestSite
                 .ConfigureLogging((_, factory) =>
                 {
                     factory.AddConsole();
-                    factory.AddFilter("Console", level => level >= LogLevel.Trace);
+                    factory.AddFilter("Console", level => level >= LogLevel.Information);
                 })
                 .UseIIS()
                 .UseStartup<Startup>()

--- a/src/Shared/HttpSys/NativeInterop/CookedUrl.cs
+++ b/src/Shared/HttpSys/NativeInterop/CookedUrl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.AspNetCore.HttpSys.Internal
 {
     // Note this type should only be used while the request buffer remains pinned
-    internal class CookedUrl
+    internal readonly struct CookedUrl
     {
         private readonly HttpApiTypes.HTTP_COOKED_URL _nativeCookedUrl;
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/6752
Fixes: https://github.com/aspnet/AspNetCore/issues/6075

They just needed more time to start.
