### PR TITLE
Attempt to run Cors functional tests with watchman disabled.

### DIFF
--- a/src/Middleware/CORS/test/FunctionalTests/CorsMiddlewareFunctionalTest.cs
+++ b/src/Middleware/CORS/test/FunctionalTests/CorsMiddlewareFunctionalTest.cs
@@ -37,7 +37,7 @@ namespace FunctionalTests
                     processStartInfo = new ProcessStartInfo
                     {
                         FileName = "cmd",
-                        Arguments = "/c npm test --no-color",
+                        Arguments = "/c npm test --no-color --no-watchman",
                     };
                 }
                 else
@@ -45,7 +45,7 @@ namespace FunctionalTests
                     processStartInfo = new ProcessStartInfo
                     {
                         FileName = "npm",
-                        Arguments = "test",
+                        Arguments = "test --no-watchman",
                     };
                 }
 


### PR DESCRIPTION
According to https://github.com/facebook/jest/issues/2219, jest will
not run tests if watchman is installed. Running the tests in isolation always pass, but it's possible that something sets up watchman on our OSX CI environment as part of building.
The symptoms seem close to what's reported in the issue making it worth a try

Possible fix for https://github.com/aspnet/AspNetCore-Internal/issues/1619

