### PR TITLE
[ApiAuthorization] Make test more reliable

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/ConfigureClientScopesTests.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/ConfigureClientScopesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -67,10 +67,10 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
 
             // Assert
             var spaClient = Assert.Single(options.Clients, c => c.ClientId == "TestSPA");
-            Assert.Equal(new[] { "openid", "profile", "ResourceAPI" }, spaClient.AllowedScopes.OrderBy(id => id).ToArray());
+            Assert.Equal(new[] { "openid", "profile", "ResourceAPI" }.OrderBy(id => id).ToArray(), spaClient.AllowedScopes.OrderBy(id => id).ToArray());
 
             var nativeApp = Assert.Single(options.Clients, c => c.ClientId == "NativeApp");
-            Assert.Equal(new[] { "offline_access", "openid", "profile", "ResourceAPI" }, nativeApp.AllowedScopes.OrderBy(id => id).ToArray());
+            Assert.Equal(new[] { "offline_access", "openid", "profile", "ResourceAPI" }.OrderBy(id => id).ToArray(), nativeApp.AllowedScopes.OrderBy(id => id).ToArray());
         }
     }
 }


### PR DESCRIPTION
Quick review? I'm just backporting the same fix I did on 3.0 see 5ff7e20c5983555422a121c8586b9ef1a108252a