### PR TITLE
Fix versioning of logging site extension

### DIFF
--- a/.azure/pipelines/site-extensions.yml
+++ b/.azure/pipelines/site-extensions.yml
@@ -2,11 +2,6 @@ trigger:
   branches:
     include:
     - master
-  paths:
-    include:
-    - src/SiteExtensions
-
-name: $(Date:yyMMdd)-$(Rev:rr)
 
 phases:
 - phase: SiteExtensions


### PR DESCRIPTION
Remove `name` to revert to default version format and build on all changes.