### PR TITLE
Replace JObject with JsonDocument in Authentication

### DIFF
--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Facebook/TestFacebookEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Facebook/TestFacebookEvents.cs
@@ -21,7 +21,7 @@ namespace MusicStore.Mocks.Facebook
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value == "Id", "");
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst("urn:facebook:link")?.Value == "https://www.facebook.com/myLink", "");
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.Name)?.Value == "AspnetvnextTest AspnetvnextTest", "");
-                Helpers.ThrowIfConditionFailed(() => context.User.SelectToken("id").ToString() == context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value, "");
+                Helpers.ThrowIfConditionFailed(() => context.User.GetString("id") == context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value, "");
                 Helpers.ThrowIfConditionFailed(() => context.ExpiresIn.Value == TimeSpan.FromSeconds(100), "");
                 Helpers.ThrowIfConditionFailed(() => context.AccessToken == "ValidAccessToken", "");
                 context.Principal.Identities.First().AddClaim(new Claim("ManageStore", "false"));

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Google/TestGoogleEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Google/TestGoogleEvents.cs
@@ -23,7 +23,6 @@ namespace MusicStore.Mocks.Google
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.Surname)?.Value == "AspnetvnextTest", "FamilyName is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.Name)?.Value == "AspnetvnextTest AspnetvnextTest", "Name is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.ExpiresIn.Value == TimeSpan.FromSeconds(1200), "ExpiresIn is not valid");
-                Helpers.ThrowIfConditionFailed(() => context.User != null, "User object is not valid");
                 context.Principal.Identities.First().AddClaim(new Claim("ManageStore", "false"));
             }
 

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/TestMicrosoftAccountEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/TestMicrosoftAccountEvents.cs
@@ -23,8 +23,7 @@ namespace MusicStore.Mocks.MicrosoftAccount
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value == "fccf9a24999f4f4f", "Id is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.Name)?.Value == "AspnetvnextTest AspnetvnextTest", "Name is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.ExpiresIn.Value == TimeSpan.FromSeconds(3600), "ExpiresIn is not valid");
-                Helpers.ThrowIfConditionFailed(() => context.User != null, "User object is not valid");
-                Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value == context.User.SelectToken("id").ToString(), "User id is not valid");
+                Helpers.ThrowIfConditionFailed(() => context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value == context.User.GetString("id"), "User id is not valid");
                 context.Principal.Identities.First().AddClaim(new Claim("ManageStore", "false"));
             }
 

--- a/src/Security/Authentication/.gitignore
+++ b/src/Security/Authentication/.gitignore
@@ -1,0 +1,2 @@
+#launchSettings.json files are required for the auth samples. The ports must not change.
+!launchSettings.json

--- a/src/Security/Authentication/Cookies/samples/CookieSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/Cookies/samples/CookieSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:1780/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "CookieSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:1782/"
+    }
+  }
+}

--- a/src/Security/Authentication/Cookies/samples/CookieSessionSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/Cookies/samples/CookieSessionSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:1771/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "CookieSessionSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:1776/"
+    }
+  }
+}

--- a/src/Security/Authentication/Core/src/JsonDocumentAuthExtensions.cs
+++ b/src/Security/Authentication/Core/src/JsonDocumentAuthExtensions.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    public static class JsonDocumentAuthExtensions
+    {
+        public static string GetString(this JsonDocument document, string key) =>
+            document.RootElement.TryGetProperty(key, out var property)
+                ? property.ToString() : null;
+    }
+}

--- a/src/Security/Authentication/Core/src/JsonDocumentAuthExtensions.cs
+++ b/src/Security/Authentication/Core/src/JsonDocumentAuthExtensions.cs
@@ -7,9 +7,6 @@ namespace Microsoft.AspNetCore.Authentication
 {
     public static class JsonDocumentAuthExtensions
     {
-        public static string GetString(this JsonDocument document, string key) =>
-            document.RootElement.GetString(key);
-
         public static string GetString(this JsonElement element, string key) =>
             element.TryGetProperty(key, out var property)
                 ? property.ToString() : null;

--- a/src/Security/Authentication/Core/src/JsonDocumentAuthExtensions.cs
+++ b/src/Security/Authentication/Core/src/JsonDocumentAuthExtensions.cs
@@ -8,7 +8,10 @@ namespace Microsoft.AspNetCore.Authentication
     public static class JsonDocumentAuthExtensions
     {
         public static string GetString(this JsonDocument document, string key) =>
-            document.RootElement.TryGetProperty(key, out var property)
+            document.RootElement.GetString(key);
+
+        public static string GetString(this JsonElement element, string key) =>
+            element.TryGetProperty(key, out var property)
                 ? property.ToString() : null;
     }
 }

--- a/src/Security/Authentication/Facebook/src/FacebookHandler.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 
             using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
             {
-                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
+                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
                 context.RunClaimActions();
                 await Events.CreatingTicket(context);
                 return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);

--- a/src/Security/Authentication/Google/src/GoogleHandler.cs
+++ b/src/Security/Authentication/Google/src/GoogleHandler.cs
@@ -39,8 +39,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
 
             using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
             {
-
-                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
+                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
                 context.RunClaimActions();
                 await Events.CreatingTicket(context);
                 return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "https://localhost:44318/",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SocialSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:44318/"
+    }
+  }
+}

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
@@ -104,18 +104,11 @@ namespace JwtBearerSample
                     {
                         response.ContentType = "application/json";
                         response.Headers[HeaderNames.CacheControl] = "no-cache";
-                        await SerializeAsync(Todos, response.Body);
+                        Serialize(Todos, response.BodyPipe);
+                        await response.BodyPipe.FlushAsync();
                     }
                 });
             });
-        }
-
-        private async Task SerializeAsync(IList<Todo> todos, Stream stream)
-        {
-            var pipe = new StreamPipeWriter(stream);
-            Serialize(todos, pipe);
-            await pipe.FlushAsync();
-            pipe.Complete();
         }
 
         private void Serialize(IList<Todo> todos, IBufferWriter<byte> output)

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
@@ -96,9 +96,12 @@ namespace JwtBearerSample
                     {
                         var reader = new StreamReader(context.Request.Body);
                         var body = await reader.ReadToEndAsync();
-                        var obj = JsonDocument.Parse(body).RootElement;
-                        var todo = new Todo() { Description = obj.GetProperty("Description").ToString(), Owner = context.User.Identity.Name };
-                        Todos.Add(todo);
+                        using (var json = JsonDocument.Parse(body))
+                        {
+                            var obj = json.RootElement;
+                            var todo = new Todo() { Description = obj.GetProperty("Description").GetString(), Owner = context.User.Identity.Name };
+                            Todos.Add(todo);
+                        }
                     }
                     else
                     {

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 
             using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
             {
-                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
+                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
                 context.RunClaimActions();
                 await Events.CreatingTicket(context);
                 return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
@@ -5,11 +5,11 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 {
@@ -30,13 +30,13 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
                 throw new HttpRequestException($"An error occurred when retrieving Microsoft user information ({response.StatusCode}). Please check if the authentication information is correct and the corresponding Microsoft Account API is enabled.");
             }
 
-            var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
-
-            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
-            context.RunClaimActions();
-
-            await Events.CreatingTicket(context);
-            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
+            {
+                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
+                context.RunClaimActions();
+                await Events.CreatingTicket(context);
+                return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+            }
         }
     }
 }

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountOptions.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountOptions.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 {
@@ -29,7 +27,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             ClaimActions.MapJsonKey(ClaimTypes.Name, "displayName");
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "givenName");
             ClaimActions.MapJsonKey(ClaimTypes.Surname, "surname");
-            ClaimActions.MapCustomJson(ClaimTypes.Email, user => user.Value<string>("mail") ?? user.Value<string>("userPrincipalName"));
+            ClaimActions.MapCustomJson(ClaimTypes.Email, user => user.GetString("mail") ?? user.GetString("userPrincipalName"));
         }
     }
 }

--- a/src/Security/Authentication/OAuth/src/ClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/ClaimAction.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
 {
@@ -37,6 +37,6 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <param name="userData">The source data to examine. This value may be null.</param>
         /// <param name="identity">The identity to add Claims to.</param>
         /// <param name="issuer">The value to use for Claim.Issuer when creating a Claim.</param>
-        public abstract void Run(JObject userData, ClaimsIdentity identity, string issuer);
+        public abstract void Run(JsonDocument userData, ClaimsIdentity identity, string issuer);
     }
 }

--- a/src/Security/Authentication/OAuth/src/ClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/ClaimAction.cs
@@ -37,6 +37,6 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <param name="userData">The source data to examine. This value may be null.</param>
         /// <param name="identity">The identity to add Claims to.</param>
         /// <param name="issuer">The value to use for Claim.Issuer when creating a Claim.</param>
-        public abstract void Run(JsonDocument userData, ClaimsIdentity identity, string issuer);
+        public abstract void Run(JsonElement userData, ClaimsIdentity identity, string issuer);
     }
 }

--- a/src/Security/Authentication/OAuth/src/ClaimActionCollectionMapExtensions.cs
+++ b/src/Security/Authentication/OAuth/src/ClaimActionCollectionMapExtensions.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="collection"></param>
         /// <param name="claimType">The value to use for Claim.Type when creating a Claim.</param>
         /// <param name="resolver">The Func that will be called to select value from the given json user data.</param>
-        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, Func<JObject, string> resolver)
+        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, Func<JsonDocument, string> resolver)
         {
             collection.MapCustomJson(claimType, ClaimValueTypes.String, resolver);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="claimType">The value to use for Claim.Type when creating a Claim.</param>
         /// <param name="valueType">The value to use for Claim.ValueType when creating a Claim.</param>
         /// <param name="resolver">The Func that will be called to select value from the given json user data.</param>
-        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, string valueType, Func<JObject, string> resolver)
+        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, string valueType, Func<JsonDocument, string> resolver)
         {
             collection.Add(new CustomJsonClaimAction(claimType, valueType, resolver));
         }

--- a/src/Security/Authentication/OAuth/src/ClaimActionCollectionMapExtensions.cs
+++ b/src/Security/Authentication/OAuth/src/ClaimActionCollectionMapExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="collection"></param>
         /// <param name="claimType">The value to use for Claim.Type when creating a Claim.</param>
         /// <param name="resolver">The Func that will be called to select value from the given json user data.</param>
-        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, Func<JsonDocument, string> resolver)
+        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, Func<JsonElement, string> resolver)
         {
             collection.MapCustomJson(claimType, ClaimValueTypes.String, resolver);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="claimType">The value to use for Claim.Type when creating a Claim.</param>
         /// <param name="valueType">The value to use for Claim.ValueType when creating a Claim.</param>
         /// <param name="resolver">The Func that will be called to select value from the given json user data.</param>
-        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, string valueType, Func<JsonDocument, string> resolver)
+        public static void MapCustomJson(this ClaimActionCollection collection, string claimType, string valueType, Func<JsonElement, string> resolver)
         {
             collection.Add(new CustomJsonClaimAction(claimType, valueType, resolver));
         }

--- a/src/Security/Authentication/OAuth/src/CustomJsonClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/CustomJsonClaimAction.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Claims;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
 {
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <param name="claimType">The value to use for Claim.Type when creating a Claim.</param>
         /// <param name="valueType">The value to use for Claim.ValueType when creating a Claim.</param>
         /// <param name="resolver">The Func that will be called to select value from the given json user data.</param>
-        public CustomJsonClaimAction(string claimType, string valueType, Func<JObject, string> resolver)
+        public CustomJsonClaimAction(string claimType, string valueType, Func<JsonDocument, string> resolver)
             : base(claimType, valueType)
         {
             Resolver = resolver;
@@ -27,10 +27,10 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <summary>
         /// The Func that will be called to select value from the given json user data.
         /// </summary>
-        public Func<JObject, string> Resolver { get; }
+        public Func<JsonDocument, string> Resolver { get; }
 
         /// <inheritdoc />
-        public override void Run(JObject userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
         {
             if (userData == null)
             {

--- a/src/Security/Authentication/OAuth/src/CustomJsonClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/CustomJsonClaimAction.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <param name="claimType">The value to use for Claim.Type when creating a Claim.</param>
         /// <param name="valueType">The value to use for Claim.ValueType when creating a Claim.</param>
         /// <param name="resolver">The Func that will be called to select value from the given json user data.</param>
-        public CustomJsonClaimAction(string claimType, string valueType, Func<JsonDocument, string> resolver)
+        public CustomJsonClaimAction(string claimType, string valueType, Func<JsonElement, string> resolver)
             : base(claimType, valueType)
         {
             Resolver = resolver;
@@ -27,15 +27,11 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <summary>
         /// The Func that will be called to select value from the given json user data.
         /// </summary>
-        public Func<JsonDocument, string> Resolver { get; }
+        public Func<JsonElement, string> Resolver { get; }
 
         /// <inheritdoc />
-        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
         {
-            if (userData == null)
-            {
-                return;
-            }
             var value = Resolver(userData);
             if (!string.IsNullOrEmpty(value))
             {

--- a/src/Security/Authentication/OAuth/src/DeleteClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/DeleteClaimAction.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
 using System.Security.Claims;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
 {
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         }
 
         /// <inheritdoc />
-        public override void Run(JObject userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
         {
             foreach (var claim in identity.FindAll(ClaimType).ToList())
             {

--- a/src/Security/Authentication/OAuth/src/DeleteClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/DeleteClaimAction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         }
 
         /// <inheritdoc />
-        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
         {
             foreach (var claim in identity.FindAll(ClaimType).ToList())
             {

--- a/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
+++ b/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
@@ -25,27 +25,6 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         /// <param name="options">The options used by the authentication middleware.</param>
         /// <param name="backchannel">The HTTP client used by the authentication middleware</param>
         /// <param name="tokens">The tokens returned from the token endpoint.</param>
-        public OAuthCreatingTicketContext(
-            ClaimsPrincipal principal,
-            AuthenticationProperties properties,
-            HttpContext context,
-            AuthenticationScheme scheme,
-            OAuthOptions options,
-            HttpClient backchannel,
-            OAuthTokenResponse tokens)
-            : this(principal, properties, context, scheme, options, backchannel, tokens, user: JsonDocument.Parse("{}"))
-        { }
-
-        /// <summary>
-        /// Initializes a new <see cref="OAuthCreatingTicketContext"/>.
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/>.</param>
-        /// <param name="properties">The <see cref="AuthenticationProperties"/>.</param>
-        /// <param name="context">The HTTP environment.</param>
-        /// <param name="scheme">The authentication scheme.</param>
-        /// <param name="options">The options used by the authentication middleware.</param>
-        /// <param name="backchannel">The HTTP client used by the authentication middleware</param>
-        /// <param name="tokens">The tokens returned from the token endpoint.</param>
         /// <param name="user">The JSON-serialized user.</param>
         public OAuthCreatingTicketContext(
             ClaimsPrincipal principal,

--- a/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
+++ b/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             OAuthOptions options,
             HttpClient backchannel,
             OAuthTokenResponse tokens)
-            : this(principal, properties, context, scheme, options, backchannel, tokens, user: JsonDocument.Parse(string.Empty))
+            : this(principal, properties, context, scheme, options, backchannel, tokens, user: JsonDocument.Parse("{}"))
         { }
 
         /// <summary>

--- a/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
+++ b/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             OAuthOptions options,
             HttpClient backchannel,
             OAuthTokenResponse tokens,
-            JsonDocument user)
+            JsonElement user)
             : base(context, scheme, options)
         {
             if (backchannel == null)
@@ -47,11 +47,6 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                 throw new ArgumentNullException(nameof(tokens));
             }
 
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
             TokenResponse = tokens;
             Backchannel = backchannel;
             User = user;
@@ -61,9 +56,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
         /// <summary>
         /// Gets the JSON-serialized user or an empty
-        /// <see cref="JsonDocument"/> if it is not available.
+        /// <see cref="JsonElement"/> if it is not available.
         /// </summary>
-        public JsonDocument User { get; }
+        public JsonElement User { get; }
 
         /// <summary>
         /// Gets the token response returned by the authentication service.
@@ -115,13 +110,8 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
         public void RunClaimActions() => RunClaimActions(User);
 
-        public void RunClaimActions(JsonDocument userData)
+        public void RunClaimActions(JsonElement userData)
         {
-            if (userData == null)
-            {
-                throw new ArgumentNullException(nameof(userData));
-            }
-
             foreach (var action in Options.ClaimActions)
             {
                 action.Run(userData, Identity, Options.ClaimsIssuer ?? Scheme.Name);

--- a/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
+++ b/src/Security/Authentication/OAuth/src/Events/OAuthCreatingTicketContext.cs
@@ -5,8 +5,8 @@ using System;
 using System.Globalization;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth
 {
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             OAuthOptions options,
             HttpClient backchannel,
             OAuthTokenResponse tokens)
-            : this(principal, properties, context, scheme, options, backchannel, tokens, user: new JObject())
+            : this(principal, properties, context, scheme, options, backchannel, tokens, user: JsonDocument.Parse(string.Empty))
         { }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             OAuthOptions options,
             HttpClient backchannel,
             OAuthTokenResponse tokens,
-            JObject user)
+            JsonDocument user)
             : base(context, scheme, options)
         {
             if (backchannel == null)
@@ -82,9 +82,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
         /// <summary>
         /// Gets the JSON-serialized user or an empty
-        /// <see cref="JObject"/> if it is not available.
+        /// <see cref="JsonDocument"/> if it is not available.
         /// </summary>
-        public JObject User { get; }
+        public JsonDocument User { get; }
 
         /// <summary>
         /// Gets the token response returned by the authentication service.
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
         public void RunClaimActions() => RunClaimActions(User);
 
-        public void RunClaimActions(JObject userData)
+        public void RunClaimActions(JsonDocument userData)
         {
             if (userData == null)
             {

--- a/src/Security/Authentication/OAuth/src/JsonKeyClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/JsonKeyClaimAction.cs
@@ -30,9 +30,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         public string JsonKey { get; }
 
         /// <inheritdoc />
-        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
         {
-            if (userData == null || !userData.RootElement.TryGetProperty(JsonKey, out var value))
+            if (!userData.TryGetProperty(JsonKey, out var value))
             {
                 return;
             }

--- a/src/Security/Authentication/OAuth/src/JsonSubKeyClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/JsonSubKeyClaimAction.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         public string SubKey { get; }
 
         /// <inheritdoc />
-        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
         {
             var value = GetValue(userData, JsonKey, SubKey);
             if (!string.IsNullOrEmpty(value))
@@ -42,9 +42,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         }
 
         // Get the given subProperty from a property.
-        private static string GetValue(JsonDocument userData, string propertyName, string subProperty)
+        private static string GetValue(JsonElement userData, string propertyName, string subProperty)
         {
-            if (userData != null && userData.RootElement.TryGetProperty(propertyName, out var value)
+            if (userData.TryGetProperty(propertyName, out var value)
                 && value.Type == JsonValueType.Object && value.TryGetProperty(subProperty, out value))
             {
                 return value.ToString();

--- a/src/Security/Authentication/OAuth/src/JsonSubKeyClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/JsonSubKeyClaimAction.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json.Linq;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
 {
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         public string SubKey { get; }
 
         /// <inheritdoc />
-        public override void Run(JObject userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
         {
             var value = GetValue(userData, JsonKey, SubKey);
             if (!string.IsNullOrEmpty(value))
@@ -42,15 +42,12 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         }
 
         // Get the given subProperty from a property.
-        private static string GetValue(JObject userData, string propertyName, string subProperty)
+        private static string GetValue(JsonDocument userData, string propertyName, string subProperty)
         {
-            if (userData != null && userData.TryGetValue(propertyName, out var value))
+            if (userData != null && userData.RootElement.TryGetProperty(propertyName, out var value)
+                && value.Type == JsonValueType.Object && value.TryGetProperty(subProperty, out value))
             {
-                var subObject = JObject.Parse(value.ToString());
-                if (subObject != null && subObject.TryGetValue(subProperty, out value))
-                {
-                    return value.ToString();
-                }
+                return value.ToString();
             }
             return null;
         }

--- a/src/Security/Authentication/OAuth/src/MapAllClaimsAction.cs
+++ b/src/Security/Authentication/OAuth/src/MapAllClaimsAction.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         {
             foreach (var pair in userData.EnumerateObject())
             {
-                var claimValue = userData.GetString(pair.Name);
+                var claimValue = pair.Value.ToString();
 
                 // Avoid adding a claim if there's a duplicate name and value. This often happens in OIDC when claims are
                 // retrieved both from the id_token and from the user-info endpoint.

--- a/src/Security/Authentication/OAuth/src/MapAllClaimsAction.cs
+++ b/src/Security/Authentication/OAuth/src/MapAllClaimsAction.cs
@@ -17,13 +17,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         {
         }
 
-        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
         {
-            if (userData == null)
-            {
-                return;
-            }
-            foreach (var pair in userData.RootElement.EnumerateObject())
+            foreach (var pair in userData.EnumerateObject())
             {
                 var claimValue = userData.GetString(pair.Name);
 

--- a/src/Security/Authentication/OAuth/src/Microsoft.AspNetCore.Authentication.OAuth.csproj
+++ b/src/Security/Authentication/OAuth/src/Microsoft.AspNetCore.Authentication.OAuth.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ASP.NET Core middleware that enables an application to support any standard OAuth 2.0 authentication workflow.</Description>
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication" />
-    <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         {
             using (var user = JsonDocument.Parse("{}"))
             {
-                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, user);
+                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, user.RootElement);
                 await Events.CreatingTicket(context);
                 return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
             }

--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -199,9 +199,12 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
         protected virtual async Task<AuthenticationTicket> CreateTicketAsync(ClaimsIdentity identity, AuthenticationProperties properties, OAuthTokenResponse tokens)
         {
-            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens);
-            await Events.CreatingTicket(context);
-            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+            using (var user = JsonDocument.Parse("{}"))
+            {
+                var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, user);
+                await Events.CreatingTicket(context);
+                return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+            }
         }
 
         protected override async Task HandleChallengeAsync(AuthenticationProperties properties)

--- a/src/Security/Authentication/OAuth/src/OAuthTokenResponse.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthTokenResponse.cs
@@ -2,19 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth
 {
-    public class OAuthTokenResponse
+    public class OAuthTokenResponse : IDisposable
     {
-        private OAuthTokenResponse(JObject response)
+        private OAuthTokenResponse(JsonDocument response)
         {
             Response = response;
-            AccessToken = response.Value<string>("access_token");
-            TokenType = response.Value<string>("token_type");
-            RefreshToken = response.Value<string>("refresh_token");
-            ExpiresIn = response.Value<string>("expires_in");
+            AccessToken = response.GetString("access_token");
+            TokenType = response.GetString("token_type");
+            RefreshToken = response.GetString("refresh_token");
+            ExpiresIn = response.GetString("expires_in");
         }
 
         private OAuthTokenResponse(Exception error)
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             Error = error;
         }
 
-        public static OAuthTokenResponse Success(JObject response)
+        public static OAuthTokenResponse Success(JsonDocument response)
         {
             return new OAuthTokenResponse(response);
         }
@@ -32,7 +32,12 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             return new OAuthTokenResponse(error);
         }
 
-        public JObject Response { get; set; }
+        public void Dispose()
+        {
+            Response?.Dispose();
+        }
+
+        public JsonDocument Response { get; set; }
         public string AccessToken { get; set; }
         public string TokenType { get; set; }
         public string RefreshToken { get; set; }

--- a/src/Security/Authentication/OAuth/src/OAuthTokenResponse.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthTokenResponse.cs
@@ -11,10 +11,11 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         private OAuthTokenResponse(JsonDocument response)
         {
             Response = response;
-            AccessToken = response.GetString("access_token");
-            TokenType = response.GetString("token_type");
-            RefreshToken = response.GetString("refresh_token");
-            ExpiresIn = response.GetString("expires_in");
+            var root = response.RootElement;
+            AccessToken = root.GetString("access_token");
+            TokenType = root.GetString("token_type");
+            RefreshToken = root.GetString("refresh_token");
+            ExpiresIn = root.GetString("expires_in");
         }
 
         private OAuthTokenResponse(Exception error)

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "https://localhost:44318/",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SocialSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:44318/"
+    }
+  }
+}

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "https://localhost:44318/",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SocialSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:44318/"
+    }
+  }
+}

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -211,8 +211,8 @@ namespace OpenIdConnectSample
                     using (var payload = JsonDocument.Parse(await tokenResponse.Content.ReadAsStringAsync()))
                     {
                         // Persist the new acess token
-                        props.UpdateTokenValue("access_token", payload.GetString("access_token"));
-                        props.UpdateTokenValue("refresh_token", payload.GetString("refresh_token"));
+                        props.UpdateTokenValue("access_token", payload.RootElement.GetString("access_token"));
+                        props.UpdateTokenValue("refresh_token", payload.RootElement.GetString("refresh_token"));
                         if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
                         {
                             var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -210,7 +210,6 @@ namespace OpenIdConnectSample
 
                     using (var payload = JsonDocument.Parse(await tokenResponse.Content.ReadAsStringAsync()))
                     {
-
                         // Persist the new acess token
                         props.UpdateTokenValue("access_token", payload.GetString("access_token"));
                         props.UpdateTokenValue("refresh_token", payload.GetString("refresh_token"));

--- a/src/Security/Authentication/OpenIdConnect/src/Events/UserInformationReceivedContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/UserInformationReceivedContext.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 {
@@ -16,6 +16,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 
-        public JObject User { get; set; }
+        public JsonDocument User { get; set; }
     }
 }

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -712,10 +712,13 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 }
                 else
                 {
-                    var identity = (ClaimsIdentity)user.Identity;
-                    foreach (var action in Options.ClaimActions)
+                    using (var payload = JsonDocument.Parse("{}"))
                     {
-                        action.Run(null, identity, ClaimsIssuer);
+                        var identity = (ClaimsIdentity)user.Identity;
+                        foreach (var action in Options.ClaimActions)
+                        {
+                            action.Run(payload.RootElement, identity, ClaimsIssuer);
+                        }
                     }
                 }
 
@@ -890,7 +893,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
                     foreach (var action in Options.ClaimActions)
                     {
-                        action.Run(user, identity, ClaimsIssuer);
+                        action.Run(user.RootElement, identity, ClaimsIssuer);
                     }
                 }
             }

--- a/src/Security/Authentication/OpenIdConnect/src/UniqueJsonKeyClaimAction.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/UniqueJsonKeyClaimAction.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.Claims
 {
@@ -27,9 +27,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.Claims
         }
 
         /// <inheritdoc />
-        public override void Run(JObject userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
         {
-            var value = userData?.Value<string>(JsonKey);
+            var value = userData?.GetString(JsonKey);
             if (string.IsNullOrEmpty(value))
             {
                 // Not found

--- a/src/Security/Authentication/OpenIdConnect/src/UniqueJsonKeyClaimAction.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/UniqueJsonKeyClaimAction.cs
@@ -27,9 +27,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.Claims
         }
 
         /// <inheritdoc />
-        public override void Run(JsonDocument userData, ClaimsIdentity identity, string issuer)
+        public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
         {
-            var value = userData?.GetString(JsonKey);
+            var value = userData.GetString(JsonKey);
             if (string.IsNullOrEmpty(value))
             {
                 // Not found

--- a/src/Security/Authentication/Twitter/src/TwitterCreatingTicketContext.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterCreatingTicketContext.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Twitter
 {
@@ -36,14 +35,14 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             string screenName,
             string accessToken,
             string accessTokenSecret,
-            JObject user)
+            JsonDocument user)
             : base(context, scheme, options)
         {
             UserId = userId;
             ScreenName = screenName;
             AccessToken = accessToken;
             AccessTokenSecret = accessTokenSecret;
-            User = user ?? new JObject();
+            User = user ?? JsonDocument.Parse(string.Empty);
             Principal = principal;
             Properties = properties;
         }
@@ -70,8 +69,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
         /// <summary>
         /// Gets the JSON-serialized user or an empty
-        /// <see cref="JObject"/> if it is not available.
+        /// <see cref="JsonDocument"/> if it is not available.
         /// </summary>
-        public JObject User { get; }
+        public JsonDocument User { get; }
     }
 }

--- a/src/Security/Authentication/Twitter/src/TwitterCreatingTicketContext.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterCreatingTicketContext.cs
@@ -35,14 +35,14 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             string screenName,
             string accessToken,
             string accessTokenSecret,
-            JsonDocument user)
+            JsonElement user)
             : base(context, scheme, options)
         {
             UserId = userId;
             ScreenName = screenName;
             AccessToken = accessToken;
             AccessTokenSecret = accessTokenSecret;
-            User = user ?? JsonDocument.Parse("{}");
+            User = user;
             Principal = principal;
             Properties = properties;
         }
@@ -69,8 +69,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
         /// <summary>
         /// Gets the JSON-serialized user or an empty
-        /// <see cref="JsonDocument"/> if it is not available.
+        /// <see cref="JsonElement"/> if it is not available.
         /// </summary>
-        public JsonDocument User { get; }
+        public JsonElement User { get; }
     }
 }

--- a/src/Security/Authentication/Twitter/src/TwitterCreatingTicketContext.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterCreatingTicketContext.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             ScreenName = screenName;
             AccessToken = accessToken;
             AccessTokenSecret = accessTokenSecret;
-            User = user ?? JsonDocument.Parse(string.Empty);
+            User = user ?? JsonDocument.Parse("{}");
             Principal = principal;
             Properties = properties;
         }

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -9,13 +9,13 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Twitter
 {
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             },
             ClaimsIssuer);
 
-            JObject user = null;
+            JsonDocument user = null;
             if (Options.RetrieveUserDetails)
             {
                 user = await RetrieveUserDetailsAsync(accessToken, identity);
@@ -113,11 +113,13 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 });
             }
 
-            return HandleRequestResult.Success(await CreateTicketAsync(identity, properties, accessToken, user));
+            var ticket = await CreateTicketAsync(identity, properties, accessToken, user);
+            user?.Dispose();
+            return HandleRequestResult.Success(ticket);
         }
 
         protected virtual async Task<AuthenticationTicket> CreateTicketAsync(
-            ClaimsIdentity identity, AuthenticationProperties properties, AccessToken token, JObject user)
+            ClaimsIdentity identity, AuthenticationProperties properties, AccessToken token, JsonDocument user)
         {
             foreach (var action in Options.ClaimActions)
             {
@@ -275,7 +277,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         }
 
         // https://dev.twitter.com/rest/reference/get/account/verify_credentials
-        private async Task<JObject> RetrieveUserDetailsAsync(AccessToken accessToken, ClaimsIdentity identity)
+        private async Task<JsonDocument> RetrieveUserDetailsAsync(AccessToken accessToken, ClaimsIdentity identity)
         {
             Logger.RetrieveUserDetails();
 
@@ -288,7 +290,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             }
             var responseText = await response.Content.ReadAsStringAsync();
 
-            var result = JObject.Parse(responseText);
+            var result = JsonDocument.Parse(responseText);
 
             return result;
         }

--- a/src/Security/Authentication/WsFederation/samples/WsFedSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/WsFederation/samples/WsFedSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "https://localhost:44318/",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SocialSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:44318/"
+    }
+  }
+}

--- a/src/Security/Authentication/samples/SocialSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/samples/SocialSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "https://localhost:44318/",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SocialSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:44318/"
+    }
+  }
+}

--- a/src/Security/Authentication/samples/SocialSample/Startup.cs
+++ b/src/Security/Authentication/samples/SocialSample/Startup.cs
@@ -209,7 +209,7 @@ namespace SocialSample
 
                         using (var user = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
                         {
-                            context.RunClaimActions(user);
+                            context.RunClaimActions(user.RootElement);
                         }
                     }
                 };

--- a/src/Security/Authentication/samples/SocialSample/Startup.cs
+++ b/src/Security/Authentication/samples/SocialSample/Startup.cs
@@ -337,8 +337,8 @@ namespace SocialSample
                         {
 
                             // Persist the new acess token
-                            authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
-                            refreshToken = payload.GetString("refresh_token");
+                            authProperties.UpdateTokenValue("access_token", payload.RootElement.GetString("access_token"));
+                            refreshToken = payload.RootElement.GetString("refresh_token");
                             if (!string.IsNullOrEmpty(refreshToken))
                             {
                                 authProperties.UpdateTokenValue("refresh_token", refreshToken);
@@ -372,7 +372,7 @@ namespace SocialSample
                         var refreshResponse = await options.Backchannel.GetStringAsync(options.TokenEndpoint + query);
                         using (var payload = JsonDocument.Parse(refreshResponse))
                         {
-                            authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
+                            authProperties.UpdateTokenValue("access_token", payload.RootElement.GetString("access_token"));
                             if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
                             {
                                 var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);

--- a/src/Security/Authentication/samples/SocialSample/Startup.cs
+++ b/src/Security/Authentication/samples/SocialSample/Startup.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -21,7 +22,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Linq;
 
 namespace SocialSample
 {
@@ -207,7 +207,7 @@ namespace SocialSample
                         var response = await context.Backchannel.SendAsync(request, context.HttpContext.RequestAborted);
                         response.EnsureSuccessStatusCode();
 
-                        var user = JObject.Parse(await response.Content.ReadAsStringAsync());
+                        var user = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
                         context.RunClaimActions(user);
                     }
@@ -332,16 +332,16 @@ namespace SocialSample
                         var refreshResponse = await options.Backchannel.PostAsync(options.TokenEndpoint, content, context.RequestAborted);
                         refreshResponse.EnsureSuccessStatusCode();
 
-                        var payload = JObject.Parse(await refreshResponse.Content.ReadAsStringAsync());
+                        var payload = JsonDocument.Parse(await refreshResponse.Content.ReadAsStringAsync());
 
                         // Persist the new acess token
-                        authProperties.UpdateTokenValue("access_token", payload.Value<string>("access_token"));
-                        refreshToken = payload.Value<string>("refresh_token");
+                        authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
+                        refreshToken = payload.GetString("refresh_token");
                         if (!string.IsNullOrEmpty(refreshToken))
                         {
                             authProperties.UpdateTokenValue("refresh_token", refreshToken);
                         }
-                        if (int.TryParse(payload.Value<string>("expires_in"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+                        if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
                         {
                             var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
                             authProperties.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
@@ -368,10 +368,10 @@ namespace SocialSample
                         }.ToQueryString();
 
                         var refreshResponse = await options.Backchannel.GetStringAsync(options.TokenEndpoint + query);
-                        var payload = JObject.Parse(refreshResponse);
+                        var payload = JsonDocument.Parse(refreshResponse);
 
-                        authProperties.UpdateTokenValue("access_token", payload.Value<string>("access_token"));
-                        if (int.TryParse(payload.Value<string>("expires_in"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+                        authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
+                        if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
                         {
                             var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
                             authProperties.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
@@ -485,12 +485,12 @@ namespace SocialSample
             throw new NotImplementedException(currentAuthType);
         }
 
-        private async Task PrintRefreshedTokensAsync(HttpResponse response, JObject payload, AuthenticationProperties authProperties)
+        private async Task PrintRefreshedTokensAsync(HttpResponse response, JsonDocument payload, AuthenticationProperties authProperties)
         {
             response.ContentType = "text/html";
             await response.WriteAsync("<html><body>");
             await response.WriteAsync("Refreshed.<br>");
-            await response.WriteAsync(HtmlEncoder.Default.Encode(payload.ToString()).Replace(",", ",<br>") + "<br>");
+            await response.WriteAsync(HtmlEncoder.Default.Encode(payload.RootElement.ToString()).Replace(",", ",<br>") + "<br>");
 
             await response.WriteAsync("<br>Tokens:<br>");
 

--- a/src/Security/Authentication/samples/SocialSample/Startup.cs
+++ b/src/Security/Authentication/samples/SocialSample/Startup.cs
@@ -207,9 +207,10 @@ namespace SocialSample
                         var response = await context.Backchannel.SendAsync(request, context.HttpContext.RequestAborted);
                         response.EnsureSuccessStatusCode();
 
-                        var user = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-
-                        context.RunClaimActions(user);
+                        using (var user = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
+                        {
+                            context.RunClaimActions(user);
+                        }
                     }
                 };
             });
@@ -332,24 +333,25 @@ namespace SocialSample
                         var refreshResponse = await options.Backchannel.PostAsync(options.TokenEndpoint, content, context.RequestAborted);
                         refreshResponse.EnsureSuccessStatusCode();
 
-                        var payload = JsonDocument.Parse(await refreshResponse.Content.ReadAsStringAsync());
-
-                        // Persist the new acess token
-                        authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
-                        refreshToken = payload.GetString("refresh_token");
-                        if (!string.IsNullOrEmpty(refreshToken))
+                        using (var payload = JsonDocument.Parse(await refreshResponse.Content.ReadAsStringAsync()))
                         {
-                            authProperties.UpdateTokenValue("refresh_token", refreshToken);
-                        }
-                        if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
-                        {
-                            var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
-                            authProperties.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
-                        }
-                        await context.SignInAsync(user, authProperties);
 
-                        await PrintRefreshedTokensAsync(response, payload, authProperties);
+                            // Persist the new acess token
+                            authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
+                            refreshToken = payload.GetString("refresh_token");
+                            if (!string.IsNullOrEmpty(refreshToken))
+                            {
+                                authProperties.UpdateTokenValue("refresh_token", refreshToken);
+                            }
+                            if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
+                            {
+                                var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
+                                authProperties.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
+                            }
+                            await context.SignInAsync(user, authProperties);
 
+                            await PrintRefreshedTokensAsync(response, payload, authProperties);
+                        }
                         return;
                     }
                     // https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension
@@ -368,18 +370,18 @@ namespace SocialSample
                         }.ToQueryString();
 
                         var refreshResponse = await options.Backchannel.GetStringAsync(options.TokenEndpoint + query);
-                        var payload = JsonDocument.Parse(refreshResponse);
-
-                        authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
-                        if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
+                        using (var payload = JsonDocument.Parse(refreshResponse))
                         {
-                            var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
-                            authProperties.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
+                            authProperties.UpdateTokenValue("access_token", payload.GetString("access_token"));
+                            if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
+                            {
+                                var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
+                                authProperties.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
+                            }
+                            await context.SignInAsync(user, authProperties);
+
+                            await PrintRefreshedTokensAsync(response, payload, authProperties);
                         }
-                        await context.SignInAsync(user, authProperties);
-
-                        await PrintRefreshedTokensAsync(response, payload, authProperties);
-
                         return;
                     }
 

--- a/src/Security/Authentication/samples/SocialSample/web.config
+++ b/src/Security/Authentication/samples/SocialSample/web.config
@@ -4,6 +4,8 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false">
+      <environmentVariables />
+    </aspNetCore>
   </system.webServer>
 </configuration>

--- a/src/Security/Authentication/test/ClaimActionTests.cs
+++ b/src/Security/Authentication/test/ClaimActionTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.IO;
 using System.Linq;
 using System.Security.Claims;
-using Microsoft.AspNetCore.Testing.xunit;
-using Xunit;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
-using Newtonsoft.Json.Linq;
+using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -17,10 +14,7 @@ namespace Microsoft.AspNetCore.Authentication
         [Fact]
         public void CanMapSingleValueUserDataToClaim()
         {
-            var userData = new JObject
-            {
-                ["name"] = "test"
-            };
+            var userData = JsonDocument.Parse("{ \"name\": \"test\" }");
 
             var identity = new ClaimsIdentity();
 
@@ -34,10 +28,7 @@ namespace Microsoft.AspNetCore.Authentication
         [Fact]
         public void CanMapArrayValueUserDataToClaims()
         {
-            var userData = new JObject
-            {
-                ["role"] = new JArray { "role1", "role2" }
-            };
+            var userData = JsonDocument.Parse("{ \"role\": [ \"role1\", \"role2\" ] }");
 
             var identity = new ClaimsIdentity();
 
@@ -55,11 +46,7 @@ namespace Microsoft.AspNetCore.Authentication
         [Fact]
         public void MapAllSucceeds()
         {
-            var userData = new JObject
-            {
-                ["name0"] = "value0",
-                ["name1"] = "value1",
-            };
+            var userData = JsonDocument.Parse("{ \"name0\": \"value0\", \"name1\": \"value1\" }");
 
             var identity = new ClaimsIdentity();
             var action = new MapAllClaimsAction();
@@ -74,11 +61,7 @@ namespace Microsoft.AspNetCore.Authentication
         [Fact]
         public void MapAllAllowesDulicateKeysWithUniqueValues()
         {
-            var userData = new JObject
-            {
-                ["name0"] = "value0",
-                ["name1"] = "value1",
-            };
+            var userData = JsonDocument.Parse("{ \"name0\": \"value0\", \"name1\": \"value1\" }");
 
             var identity = new ClaimsIdentity();
             identity.AddClaim(new Claim("name0", "value2"));
@@ -93,11 +76,7 @@ namespace Microsoft.AspNetCore.Authentication
         [Fact]
         public void MapAllSkipsDuplicateValues()
         {
-            var userData = new JObject
-            {
-                ["name0"] = "value0",
-                ["name1"] = "value1",
-            };
+            var userData = JsonDocument.Parse("{ \"name0\": \"value0\", \"name1\": \"value1\" }");
 
             var identity = new ClaimsIdentity();
             identity.AddClaim(new Claim("name0", "value0"));

--- a/src/Security/Authentication/test/ClaimActionTests.cs
+++ b/src/Security/Authentication/test/ClaimActionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Authentication
         [Fact]
         public void CanMapArrayValueUserDataToClaims()
         {
-            var userData = JsonDocument.Parse("{ \"role\": [ \"role1\", \"role2\" ] }");
+            var userData = JsonDocument.Parse("{ \"role\": [ \"role1\", null, \"role2\" ] }");
 
             var identity = new ClaimsIdentity();
 

--- a/src/Security/Authentication/test/ClaimActionTests.cs
+++ b/src/Security/Authentication/test/ClaimActionTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Authentication
             var identity = new ClaimsIdentity();
 
             var action = new JsonKeyClaimAction("name", "name", "name");
-            action.Run(userData, identity, "iss");
+            action.Run(userData.RootElement, identity, "iss");
 
             Assert.Equal("name", identity.FindFirst("name").Type);
             Assert.Equal("test", identity.FindFirst("name").Value);
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Authentication
             var identity = new ClaimsIdentity();
 
             var action = new JsonKeyClaimAction("role", "role", "role");
-            action.Run(userData, identity, "iss");
+            action.Run(userData.RootElement, identity, "iss");
 
             var roleClaims = identity.FindAll("role").ToList();
             Assert.Equal(2, roleClaims.Count);
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Authentication
 
             var identity = new ClaimsIdentity();
             var action = new MapAllClaimsAction();
-            action.Run(userData, identity, "iss");
+            action.Run(userData.RootElement, identity, "iss");
 
             Assert.Equal("name0", identity.FindFirst("name0").Type);
             Assert.Equal("value0", identity.FindFirst("name0").Value);
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Authentication
             identity.AddClaim(new Claim("name0", "value2"));
             identity.AddClaim(new Claim("name1", "value3"));
             var action = new MapAllClaimsAction();
-            action.Run(userData, identity, "iss");
+            action.Run(userData.RootElement, identity, "iss");
 
             Assert.Equal(2, identity.FindAll("name0").Count());
             Assert.Equal(2, identity.FindAll("name1").Count());
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Authentication
             identity.AddClaim(new Claim("name0", "value0"));
             identity.AddClaim(new Claim("name1", "value1"));
             var action = new MapAllClaimsAction();
-            action.Run(userData, identity, "iss");
+            action.Run(userData.RootElement, identity, "iss");
 
             Assert.Single(identity.FindAll("name0"));
             Assert.Single(identity.FindAll("name1"));

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Net;
@@ -325,10 +324,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                                 if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == FacebookDefaults.TokenEndpoint)
                                 {
                                     var res = new HttpResponseMessage(HttpStatusCode.OK);
-                                    var graphResponse = JsonConvert.SerializeObject(new
-                                    {
-                                        access_token = "TestAuthToken"
-                                    });
+                                    var graphResponse = "{ \"access_token\": \"TestAuthToken\" }";
                                     res.Content = new StringContent(graphResponse, Encoding.UTF8);
                                     return res;
                                 }
@@ -337,11 +333,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                                 {
                                     finalUserInfoEndpoint = req.RequestUri.ToString();
                                     var res = new HttpResponseMessage(HttpStatusCode.OK);
-                                    var graphResponse = JsonConvert.SerializeObject(new
-                                    {
-                                        id = "TestProfileId",
-                                        name = "TestName"
-                                    });
+                                    var graphResponse = "{ \"id\": \"TestProfileId\", \"name\": \"TestName\" }";
                                     res.Content = new StringContent(graphResponse, Encoding.UTF8);
                                     return res;
                                 }

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -972,7 +971,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
         private static HttpResponseMessage ReturnJsonResponse(object content, HttpStatusCode code = HttpStatusCode.OK)
         {
             var res = new HttpResponseMessage(code);
-            var text = JsonConvert.SerializeObject(content);
+            var text = Newtonsoft.Json.JsonConvert.SerializeObject(content);
             res.Content = new StringContent(text, Encoding.UTF8, "application/json");
             return res;
         }

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -703,7 +703,6 @@ namespace Microsoft.AspNetCore.Authentication.Google
                 {
                     OnCreatingTicket = context =>
                     {
-                        Assert.NotNull(context.User);
                         Assert.Equal("Test Access Token", context.AccessToken);
                         Assert.Equal("Test Refresh Token", context.RefreshToken);
                         Assert.Equal(TimeSpan.FromSeconds(3600), context.ExpiresIn);

--- a/src/Security/Authentication/test/MicrosoftAccountTests.cs
+++ b/src/Security/Authentication/test/MicrosoftAccountTests.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Net;
@@ -302,7 +301,7 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
         private static HttpResponseMessage ReturnJsonResponse(object content)
         {
             var res = new HttpResponseMessage(HttpStatusCode.OK);
-            var text = JsonConvert.SerializeObject(content);
+            var text = Newtonsoft.Json.JsonConvert.SerializeObject(content);
             res.Content = new StringContent(text, Encoding.UTF8, "application/json");
             return res;
         }


### PR DESCRIPTION
 #4260
- "Drop in" replacement with some odd gymnastics sometimes.
- It's not as breaking as I thought it might be for derived OAuth handlers. ClaimActions shield them from most of the changes. They primarily have to call Parse with the new type. @PinpointTownes 
- Users doing advanced claims mapping or inspection via events may be broken.
- Also fixed launch settings so the samples would work again.