### PR TITLE
Make GetMemory use MaxBufferSize for MemoryPool

### DIFF
--- a/src/Http/Http/src/StreamPipeWriter.cs
+++ b/src/Http/Http/src/StreamPipeWriter.cs
@@ -279,7 +279,7 @@ namespace System.IO.Pipelines
 
             // Get a new buffer using the minimum segment size, unless the size hint is larger than a single segment.
             // Also, the size cannot be larger than the MaxBufferSize of the MemoryPool
-            _currentSegmentOwner = _pool.Rent(Math.Min(Math.Max(_minimumSegmentSize, sizeHint), _pool.MaxBufferSize));
+            _currentSegmentOwner = _pool.Rent(Math.Clamp(sizeHint, _minimumSegmentSize, _pool.MaxBufferSize));
             _currentSegment = _currentSegmentOwner.Memory;
             _position = 0;
         }

--- a/src/Http/Http/src/StreamPipeWriter.cs
+++ b/src/Http/Http/src/StreamPipeWriter.cs
@@ -278,7 +278,8 @@ namespace System.IO.Pipelines
             }
 
             // Get a new buffer using the minimum segment size, unless the size hint is larger than a single segment.
-            _currentSegmentOwner = _pool.Rent(Math.Max(_minimumSegmentSize, sizeHint));
+            // Also, the size cannot be larger than the MaxBufferSize of the MemoryPool
+            _currentSegmentOwner = _pool.Rent(Math.Min(Math.Max(_minimumSegmentSize, sizeHint), _pool.MaxBufferSize));
             _currentSegment = _currentSegmentOwner.Memory;
             _position = 0;
         }

--- a/src/Http/Http/test/PipeWriterTests.cs
+++ b/src/Http/Http/test/PipeWriterTests.cs
@@ -89,10 +89,12 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(memory, secondMemory);
         }
 
-        [Fact]
-        public void GetSpanWithZeroSizeHintReturnsMaxBufferSizeOfPool()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2048)]
+        public void GetSpanWithZeroSizeHintReturnsMaxBufferSizeOfPool(int sizeHint)
         {
-            var span = Writer.GetSpan(0);
+            var span = Writer.GetSpan(sizeHint);
 
             Assert.Equal(4096, span.Length);
         }

--- a/src/Http/Http/test/PipeWriterTests.cs
+++ b/src/Http/Http/test/PipeWriterTests.cs
@@ -90,13 +90,11 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void CanGetNewSpanWhenNoAdvanceWhenSizeTooLarge()
+        public void GetSpanWithZeroSizeHintReturnsMaxBufferSizeOfPool()
         {
             var span = Writer.GetSpan(0);
 
-            var secondSpan = Writer.GetSpan(10000);
-
-            Assert.False(span.SequenceEqual(secondSpan));
+            Assert.Equal(4096, span.Length);
         }
 
         [Fact]

--- a/src/Http/Http/test/StreamPipeWriterTests.cs
+++ b/src/Http/Http/test/StreamPipeWriterTests.cs
@@ -32,6 +32,7 @@ namespace System.IO.Pipelines.Tests
         [InlineData(8000, 8000)]
         public async Task CanAdvanceWithPartialConsumptionOfFirstSegment(int firstWriteLength, int secondWriteLength)
         {
+            Writer = new StreamPipeWriter(MemoryStream, MinimumSegmentSize, new TestMemoryPool(maxBufferSize: 20000));
             await Writer.WriteAsync(Encoding.ASCII.GetBytes("a"));
 
             var expectedLength = firstWriteLength + secondWriteLength + 1;

--- a/src/Http/Http/test/TestMemoryPool.cs
+++ b/src/Http/Http/test/TestMemoryPool.cs
@@ -14,12 +14,14 @@ namespace System.IO.Pipelines.Tests
     public class TestMemoryPool : MemoryPool<byte>
     {
         private MemoryPool<byte> _pool;
-
+        private int _maxBufferSize;
         private bool _disposed;
         private int _rentCount;
-        public TestMemoryPool()
+
+        public TestMemoryPool(int maxBufferSize = 4096)
         {
             _pool = new CustomMemoryPool<byte>();
+            _maxBufferSize = maxBufferSize;
         }
 
         public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
@@ -39,7 +41,7 @@ namespace System.IO.Pipelines.Tests
             _disposed = true;
         }
 
-        public override int MaxBufferSize => 4096;
+        public override int MaxBufferSize => _maxBufferSize;
 
         internal void CheckDisposed()
         {


### PR DESCRIPTION
Another issue with StreamPipeWriter found by https://github.com/aspnet/AspNetCore/pull/7110