### PR TITLE
Reduce number of SauceLabs browsers to 3

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/scripts/karma.sauce.conf.js
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/karma.sauce.conf.js
@@ -27,11 +27,11 @@ try {
         },
 
         // Mozilla Firefox Latest, any OS
-        sl_firefox: {
-            base: "SauceLabs",
-            browserName: "firefox",
-            version: "latest",
-        },
+        // sl_firefox: {
+        //     base: "SauceLabs",
+        //     browserName: "firefox",
+        //     version: "latest",
+        // },
     }
 
     // Legacy Browsers
@@ -68,8 +68,8 @@ try {
 
     var customLaunchers = {
         ...evergreenBrowsers,
-        ...legacyBrowsers,
-        ...mobileBrowsers,
+        // ...legacyBrowsers,
+        // ...mobileBrowsers,
     };
 
     module.exports = createKarmaConfig({


### PR DESCRIPTION
Looked into retries but it doesn't seem like there is a nice way to do that. I can explore that more though. 
I was to see if this configuration stabilizes our daily tests. If so we can spit groups of browsers into different build tasks. 
