### PR TITLE
Improve Components error handling

### DIFF
--- a/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyBlazorApplicationBuilder.cs
+++ b/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyBlazorApplicationBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Rendering;
 using Microsoft.AspNetCore.Components.Builder;
 
@@ -35,13 +36,13 @@ namespace Microsoft.AspNetCore.Blazor.Hosting
             Entries.Add((componentType, domElementSelector));
         }
 
-        public WebAssemblyRenderer CreateRenderer()
+        public async Task<WebAssemblyRenderer> CreateRendererAsync()
         {
             var renderer = new WebAssemblyRenderer(Services);
             for (var i = 0; i < Entries.Count; i++)
             {
-                var entry = Entries[i];
-                renderer.AddComponent(entry.componentType, entry.domElementSelector);
+                var (componentType, domElementSelector) = Entries[i];
+                await renderer.AddComponentAsync(componentType, domElementSelector);
             }
 
             return renderer;

--- a/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHost.cs
@@ -42,6 +42,11 @@ namespace Microsoft.AspNetCore.Blazor.Hosting
             JSRuntime.SetCurrentJSRuntime(_runtime);
             SetBrowserHttpMessageHandlerAsDefault();
 
+            return StartAsyncAwaited();
+        }
+
+        private async Task StartAsyncAwaited()
+        {
             var scopeFactory = Services.GetRequiredService<IServiceScopeFactory>();
             _scope = scopeFactory.CreateScope();
 
@@ -61,7 +66,7 @@ namespace Microsoft.AspNetCore.Blazor.Hosting
                 var builder = new WebAssemblyBlazorApplicationBuilder(_scope.ServiceProvider);
                 startup.Configure(builder, _scope.ServiceProvider);
 
-                _renderer = builder.CreateRenderer();
+                _renderer = await builder.CreateRendererAsync();
             }
             catch
             {
@@ -76,9 +81,6 @@ namespace Microsoft.AspNetCore.Blazor.Hosting
 
                 throw;
             }
-
-
-            return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken = default)

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// Constructs an instance of <see cref="WebAssemblyRenderer"/>.
         /// </summary>
         /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to use when initializing components.</param>
-        public WebAssemblyRenderer(IServiceProvider serviceProvider): base(serviceProvider)
+        public WebAssemblyRenderer(IServiceProvider serviceProvider) : base(serviceProvider)
         {
             // The browser renderer registers and unregisters itself with the static
             // registry. This works well with the WebAssembly runtime, and is simple for the
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 foreach (var innerException in aggregateException.Flatten().InnerExceptions)
                 {
                     Console.Error.WriteLine(innerException);
-    }
+                }
             }
             else
             {

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -1,14 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Browser;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
 using Mono.WebAssembly.Interop;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Rendering
 {
@@ -92,6 +91,25 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 // This renderer is not used for server-side Blazor.
                 throw new NotImplementedException($"{nameof(WebAssemblyRenderer)} is supported only with in-process JS runtimes.");
             }
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleException(int componentId, IComponent component, Exception exception)
+        {
+            Console.Error.WriteLine($"Unhandled exception executing component {component.GetType().FullName} ({componentId})");
+            if (exception is AggregateException aggregateException)
+            {
+                foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+                {
+                    Console.Error.WriteLine(innerException);
+    }
+            }
+            else
+            {
+                Console.Error.WriteLine(exception);
+            }
+
+            return true;
         }
     }
 }

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -37,11 +37,13 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// </summary>
         /// <typeparam name="TComponent">The type of the component.</typeparam>
         /// <param name="domElementSelector">A CSS selector that uniquely identifies a DOM element.</param>
-        public void AddComponent<TComponent>(string domElementSelector)
-            where TComponent: IComponent
-        {
-            AddComponent(typeof(TComponent), domElementSelector);
-        }
+        /// <returns>A <see cref="Task"/> that represents the asynchronous rendering of the added component.</returns>
+        /// <remarks>
+        /// Callers of this method may choose to ignore the returned <see cref="Task"/> if they do not
+        /// want to await the rendering of the added component.
+        /// </remarks>
+        public Task AddComponentAsync<TComponent>(string domElementSelector) where TComponent : IComponent
+            => AddComponentAsync(typeof(TComponent), domElementSelector);
 
         /// <summary>
         /// Associates the <see cref="IComponent"/> with the <see cref="WebAssemblyRenderer"/>,
@@ -49,7 +51,12 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// </summary>
         /// <param name="componentType">The type of the component.</param>
         /// <param name="domElementSelector">A CSS selector that uniquely identifies a DOM element.</param>
-        public async void AddComponent(Type componentType, string domElementSelector)
+        /// <returns>A <see cref="Task"/> that represents the asynchronous rendering of the added component.</returns>
+        /// <remarks>
+        /// Callers of this method may choose to ignore the returned <see cref="Task"/> if they do not
+        /// want to await the rendering of the added component.
+        /// </remarks>
+        public Task AddComponentAsync(Type componentType, string domElementSelector)
         {
             var component = InstantiateComponent(componentType);
             var componentId = AssignRootComponentId(component);
@@ -65,8 +72,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 domElementSelector,
                 componentId);
 
-            // Dispatch the rendering. In the most common cases, this will finish synchronously
-            await RenderRootComponentAsync(componentId);
+            return RenderRootComponentAsync(componentId);
         }
 
         /// <inheritdoc />

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -94,9 +94,9 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         }
 
         /// <inheritdoc />
-        protected override bool HandleException(int componentId, IComponent component, Exception exception)
+        protected override bool HandleException(Exception exception)
         {
-            Console.Error.WriteLine($"Unhandled exception executing component {component.GetType().FullName} ({componentId})");
+            Console.Error.WriteLine($"Unhandled exception rendering component:");
             if (exception is AggregateException aggregateException)
             {
                 foreach (var innerException in aggregateException.Flatten().InnerExceptions)

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// </summary>
         /// <param name="componentType">The type of the component.</param>
         /// <param name="domElementSelector">A CSS selector that uniquely identifies a DOM element.</param>
-        public void AddComponent(Type componentType, string domElementSelector)
+        public async void AddComponent(Type componentType, string domElementSelector)
         {
             var component = InstantiateComponent(componentType);
             var componentId = AssignRootComponentId(component);
@@ -65,7 +65,8 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 domElementSelector,
                 componentId);
 
-            RenderRootComponent(componentId);
+            // Dispatch the rendering. In the most common cases, this will finish synchronously
+            await RenderRootComponentAsync(componentId);
         }
 
         /// <inheritdoc />
@@ -94,7 +95,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         }
 
         /// <inheritdoc />
-        protected override bool HandleException(Exception exception)
+        protected override void HandleException(Exception exception)
         {
             Console.Error.WriteLine($"Unhandled exception rendering component:");
             if (exception is AggregateException aggregateException)
@@ -108,8 +109,6 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             {
                 Console.Error.WriteLine(exception);
             }
-
-            return true;
         }
     }
 }

--- a/src/Components/Blazor/Build/test/RazorIntegrationTestBase.cs
+++ b/src/Components/Blazor/Build/test/RazorIntegrationTestBase.cs
@@ -443,6 +443,11 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             public void AttachComponent(IComponent component)
                 => AssignRootComponentId(component);
 
+            protected override void HandleException(Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
             {
                 LatestBatchReferenceFrames = renderBatch.ReferenceFrames.ToArray();

--- a/src/Components/Browser.JS/src/package-lock.json
+++ b/src/Components/Browser.JS/src/package-lock.json
@@ -1936,7 +1936,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2039,7 +2040,8 @@
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Components/Browser.JS/src/package-lock.json
+++ b/src/Components/Browser.JS/src/package-lock.json
@@ -1546,14 +1546,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1573,14 +1571,12 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1697,8 +1693,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1724,7 +1719,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1732,14 +1726,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1758,7 +1750,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1936,8 +1927,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2040,8 +2030,7 @@
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/Components/Browser/src/RendererRegistryEventDispatcher.cs
+++ b/src/Components/Browser/src/RendererRegistryEventDispatcher.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
-using System;
 
 namespace Microsoft.AspNetCore.Components.Browser
 {
@@ -16,12 +17,13 @@ namespace Microsoft.AspNetCore.Components.Browser
         /// For framework use only.
         /// </summary>
         [JSInvokable(nameof(DispatchEvent))]
-        public static void DispatchEvent(
+        public static Task DispatchEvent(
             BrowserEventDescriptor eventDescriptor, string eventArgsJson)
         {
             var eventArgs = ParseEventArgsJson(eventDescriptor.EventArgsType, eventArgsJson);
             var renderer = RendererRegistry.Current.Find(eventDescriptor.BrowserRendererId);
-            renderer.DispatchEvent(
+
+            return renderer.DispatchEventAsync(
                 eventDescriptor.ComponentId,
                 eventDescriptor.EventHandlerId,
                 eventArgs);

--- a/src/Components/Components/perf/RenderTreeDiffBuilderBenchmark.cs
+++ b/src/Components/Components/perf/RenderTreeDiffBuilderBenchmark.cs
@@ -91,6 +91,11 @@ namespace Microsoft.AspNetCore.Components.Performance
             {
             }
 
+            protected override void HandleException(Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => Task.CompletedTask;
         }

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Components
 
         private readonly RenderFragment _renderFragment;
         private RenderHandle _renderHandle;
-        private bool _hasCalledInit;
+        private bool _initialized;
         private bool _hasNeverRendered = true;
         private bool _hasPendingQueuedRender;
 
@@ -177,155 +177,75 @@ namespace Microsoft.AspNetCore.Components
         public virtual Task SetParametersAsync(ParameterCollection parameters)
         {
             parameters.SetParameterProperties(this);
-            if (!_hasCalledInit)
+            if (!_initialized)
             {
-                return RunInitAndSetParameters();
+                _initialized = true;
+
+                return RunInitAndSetParametersAsync();
             }
             else
             {
-                OnParametersSet();
-                // If you override OnInitAsync or OnParametersSetAsync and return a noncompleted task,
-                // then by default we automatically re-render once each of those tasks completes.
-                var isAsync = false;
-                Task parametersTask = null;
-                (isAsync, parametersTask) = ProcessLifeCycletask(OnParametersSetAsync());
-                StateHasChanged();
-                // We call StateHasChanged here so that we render after OnParametersSet and after the
-                // synchronous part of OnParametersSetAsync has run, and in case there is async work
-                // we trigger another render.
-                if (isAsync)
-                {
-                    return parametersTask;
-                }
-
-                return Task.CompletedTask;
+                return SetParametersAsyncCore();
             }
         }
 
-        private async Task RunInitAndSetParameters()
+        private async Task RunInitAndSetParametersAsync()
         {
-            _hasCalledInit = true;
-            var initIsAsync = false;
-
             OnInit();
-            Task initTask = null;
-            (initIsAsync, initTask) = ProcessLifeCycletask(OnInitAsync());
-            if (initIsAsync)
+            var task = OnInitAsync();
+
+            if (task.Status != TaskStatus.RanToCompletion && task.Status != TaskStatus.Canceled)
             {
                 // Call state has changed here so that we render after the sync part of OnInitAsync has run
                 // and wait for it to finish before we continue. If no async work has been done yet, we want
                 // to defer calling StateHasChanged up until the first bit of async code happens or until
-                // the end.
+                // the end. Additionally, we want to avoid calling StateHasChanged if no
+                // async work is to be performed.
                 StateHasChanged();
-                await initTask;
+
+                await ProcessLifecycleTaskAsync(task);
             }
 
-            OnParametersSet();
-            Task parametersTask = null;
-            var setParametersIsAsync = false;
-            (setParametersIsAsync, parametersTask) = ProcessLifeCycletask(OnParametersSetAsync());
-            // We always call StateHasChanged here as we want to trigger a rerender after OnParametersSet and
-            // the synchronous part of OnParametersSetAsync has run, triggering another re-render in case there
-            // is additional async work.
-            StateHasChanged();
-            if (setParametersIsAsync)
-            {
-                await parametersTask;
-            }
+            await SetParametersAsyncCore();
         }
 
-        private (bool isAsync, Task asyncTask) ProcessLifeCycletask(Task task)
+        private Task SetParametersAsyncCore()
         {
-            if (task == null)
-            {
-                throw new ArgumentNullException(nameof(task));
-            }
+            OnParametersSet();
+            var task = OnParametersSetAsync();
+            // If no aync work is to be performed, i.e. the task has already ran to completion
+            // or was canceled by the time we got to inspect it, avoid going async and re-invoking
+            // StateHasChanged at the culmination of the async work.
+            var shouldAwaitTask = task.Status != TaskStatus.RanToCompletion &&
+                task.Status != TaskStatus.Canceled;
 
-            switch (task.Status)
-            {
-                // If it's already completed synchronously, no need to await and no
-                // need to issue a further render (we already rerender synchronously).
-                // Just need to make sure we propagate any errors.
-                case TaskStatus.RanToCompletion:
-                case TaskStatus.Canceled:
-                    return (false, null);
-                case TaskStatus.Faulted:
-                    HandleException(task.Exception);
-                    return (false, null);
-                // For incomplete tasks, automatically re-render on successful completion
-                default:
-                    return (true, ReRenderAsyncTask(task));
-            }
+            // We always call StateHasChanged here as we want to trigger a rerender after OnParametersSet and
+            // the synchronous part of OnParametersSetAsync has run.
+            StateHasChanged();
+
+            return shouldAwaitTask ?
+                ProcessLifecycleTaskAsync(task) :
+                Task.CompletedTask;
         }
 
-        private async Task ReRenderAsyncTask(Task task)
+        private async Task ProcessLifecycleTaskAsync(Task task)
         {
             try
             {
                 await task;
-                StateHasChanged();
             }
-            catch (Exception ex)
+            catch when (task.IsCanceled)
             {
-                // Either the task failed, or it was cancelled, or StateHasChanged threw.
-                // We want to report task failure or StateHasChanged exceptions only.
-                if (!task.IsCanceled)
-                {
-                    HandleException(ex);
-                }
+                // Ignore task cancelation but don't bother issuing a state change.
+                return;
             }
+
+            StateHasChanged();
         }
 
-        private async void ContinueAfterLifecycleTask(Task task)
+        async Task IHandleEvent.HandleEventAsync(EventHandlerInvoker binding, UIEventArgs args)
         {
-            switch (task == null ? TaskStatus.RanToCompletion : task.Status)
-            {
-                // If it's already completed synchronously, no need to await and no
-                // need to issue a further render (we already rerender synchronously).
-                // Just need to make sure we propagate any errors.
-                case TaskStatus.RanToCompletion:
-                case TaskStatus.Canceled:
-                    break;
-                case TaskStatus.Faulted:
-                    HandleException(task.Exception);
-                    break;
-
-                // For incomplete tasks, automatically re-render on successful completion
-                default:
-                    try
-                    {
-                        await task;
-                        StateHasChanged();
-                    }
-                    catch (Exception ex)
-                    {
-                        // Either the task failed, or it was cancelled, or StateHasChanged threw.
-                        // We want to report task failure or StateHasChanged exceptions only.
-                        if (!task.IsCanceled)
-                        {
-                            HandleException(ex);
-                        }
-                    }
-
-                    break;
-            }
-        }
-
-        private static void HandleException(Exception ex)
-        {
-            if (ex is AggregateException && ex.InnerException != null)
-            {
-                ex = ex.InnerException; // It's more useful
-            }
-
-            // TODO: Need better global exception handling
-            Console.Error.WriteLine($"[{ex.GetType().FullName}] {ex.Message}\n{ex.StackTrace}");
-        }
-
-        void IHandleEvent.HandleEvent(EventHandlerInvoker binding, UIEventArgs args)
-        {
-            var task = binding.Invoke(args);
-            ContinueAfterLifecycleTask(task);
+            await binding.Invoke(args);
 
             // After each event, we synchronously re-render (unless !ShouldRender())
             // This just saves the developer the trouble of putting "StateHasChanged();"
@@ -333,32 +253,17 @@ namespace Microsoft.AspNetCore.Components
             StateHasChanged();
         }
 
-        void IHandleAfterRender.OnAfterRender()
+        Task IHandleAfterRender.OnAfterRenderAsync()
         {
             OnAfterRender();
 
-            var onAfterRenderTask = OnAfterRenderAsync();
-            if (onAfterRenderTask != null && onAfterRenderTask.Status != TaskStatus.RanToCompletion)
-            {
-                // Note that we don't call StateHasChanged to trigger a render after
-                // handling this, because that would be an infinite loop. The only
-                // reason we have OnAfterRenderAsync is so that the developer doesn't
-                // have to use "async void" and do their own exception handling in
-                // the case where they want to start an async task.
-                var taskWithHandledException = HandleAfterRenderException(onAfterRenderTask);
-            }
-        }
+            return OnAfterRenderAsync();
 
-        private async Task HandleAfterRenderException(Task parentTask)
-        {
-            try
-            {
-                await parentTask;
-            }
-            catch (Exception e)
-            {
-                HandleException(e);
-            }
+            // Note that we don't call StateHasChanged to trigger a render after
+            // handling this, because that would be an infinite loop. The only
+            // reason we have OnAfterRenderAsync is so that the developer doesn't
+            // have to use "async void" and do their own exception handling in
+            // the case where they want to start an async task.
         }
     }
 }

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -210,6 +210,9 @@ namespace Microsoft.AspNetCore.Components
                 catch when (task.IsCanceled)
                 {
                     // Ignore exceptions from task cancelletions.
+                    // Awaiting a canceled task may produce either an OperationCanceledException (if produced as a consequence of 
+                    // CancellationToken.ThrowIfCancellationRequested()) or a TaskCanceledException (produced as a consequence of awaiting Task.FromCanceled). 
+                    // It's much easier to check the state of the Task (i.e. Task.IsCanceled) rather than catch two distinct exceptions.
                 }
 
                 // Don't call StateHasChanged here. CallOnParametersSetAsync should handle that for us.

--- a/src/Components/Components/src/IHandleAfterRender.cs
+++ b/src/Components/Components/src/IHandleAfterRender.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Components
 {
@@ -11,6 +13,7 @@ namespace Microsoft.AspNetCore.Components
         /// <summary>
         /// Notifies the component that it has been rendered.
         /// </summary>
-        void OnAfterRender();
+        /// <returns>A <see cref="Task"/> that represents the asynchronous event handling operation.</returns>
+        Task OnAfterRenderAsync();
     }
 }

--- a/src/Components/Components/src/IHandleEvent.cs
+++ b/src/Components/Components/src/IHandleEvent.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Components
 {
@@ -13,6 +15,7 @@ namespace Microsoft.AspNetCore.Components
         /// </summary>
         /// <param name="binding">The event binding.</param>
         /// <param name="args">Arguments for the event handler.</param>
-        void HandleEvent(EventHandlerInvoker binding, UIEventArgs args);
+        /// <returns>A <see cref="Task"/> that represents the asynchronous event handling operation.</returns>
+        Task HandleEventAsync(EventHandlerInvoker binding, UIEventArgs args);
     }
 }

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 parameters = parameters.WithCascadingParameters(_cascadingParameters);
             }
 
-            _renderer.AddToPendingTasks(ComponentId, Component, Component.SetParametersAsync(parameters));
+            _renderer.AddToPendingTasks(Component.SetParametersAsync(parameters));
         }
 
         public void NotifyCascadingValueChanged()
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 : ParameterCollection.Empty;
             var allParams = directParams.WithCascadingParameters(_cascadingParameters);
             var task = Component.SetParametersAsync(allParams);
-            _renderer.AddToPendingTasks(ComponentId, Component, task);
+            _renderer.AddToPendingTasks(task);
         }
 
         private bool AddCascadingParameterSubscriptions()

--- a/src/Components/Components/src/Rendering/HtmlRenderer.cs
+++ b/src/Components/Components/src/Rendering/HtmlRenderer.cs
@@ -44,28 +44,6 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// Renders a component into a sequence of <see cref="string"/> fragments that represent the textual representation
         /// of the HTML produced by the component.
         /// </summary>
-        /// <typeparam name="TComponent">The type of the <see cref="IComponent"/>.</typeparam>
-        /// <param name="initialParameters">A <see cref="ParameterCollection"/> with the initial parameters to render the component.</param>
-        /// <returns>A sequence of <see cref="string"/> fragments that represent the HTML text of the component.</returns>
-        public IEnumerable<string> RenderComponent<TComponent>(ParameterCollection initialParameters) where TComponent : IComponent
-        {
-            return RenderComponent(typeof(TComponent), initialParameters);
-        }
-
-        /// <summary>
-        /// Renders a component into a sequence of <see cref="string"/> fragments that represent the textual representation
-        /// of the HTML produced by the component.
-        /// </summary>
-        /// <param name="componentType">The type of the <see cref="IComponent"/>.</param>
-        /// <param name="initialParameters">A <see cref="ParameterCollection"/> with the initial parameters to render the component.</param>
-        /// <returns>A sequence of <see cref="string"/> fragments that represent the HTML text of the component.</returns>
-        private IEnumerable<string> RenderComponent(Type componentType, ParameterCollection initialParameters)
-            => RenderComponentAsync(componentType, initialParameters).GetAwaiter().GetResult();
-
-        /// <summary>
-        /// Renders a component into a sequence of <see cref="string"/> fragments that represent the textual representation
-        /// of the HTML produced by the component.
-        /// </summary>
         /// <param name="componentType">The type of the <see cref="IComponent"/>.</param>
         /// <param name="initialParameters">A <see cref="ParameterCollection"/> with the initial parameters to render the component.</param>
         /// <returns>A <see cref="Task"/> that on completion returns a sequence of <see cref="string"/> fragments that represent the HTML text of the component.</returns>

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 {
                 await pendingWork;
         }
-                catch when (!pendingWork.IsCanceled || HandleException(componentState.ComponentId, componentState.Component, pendingWork.Exception))
+                catch when (pendingWork.IsCanceled || HandleException(componentState.ComponentId, componentState.Component, pendingWork.Exception))
                 {
                     // await will unwrap an AggregateException and return exactly one inner exception.
                     // We'll do our best to handle all inner exception instances.

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -468,8 +468,8 @@ namespace Microsoft.AspNetCore.Components.Rendering
                         }
                     }
 
-                    // Either the Task is incomplete or is faulted.
-                    // In either case, queue up the task and we can inspect it later.
+                    // The Task is incomplete.
+                    // Queue up the task and we can inspect it later.
                     batch = batch ?? new List<Task>();
                     batch.Add(task);
                 }

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// <param name="eventHandlerId">The <see cref="RenderTreeFrame.AttributeEventHandlerId"/> value from the original event attribute.</param>
         /// <param name="eventArgs">Arguments to be passed to the event handler.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous execution operation.</returns>
-        public async Task DispatchEventAsync(int componentId, int eventHandlerId, UIEventArgs eventArgs)
+        public Task DispatchEventAsync(int componentId, int eventHandlerId, UIEventArgs eventArgs)
         {
             EnsureSynchronizationContext();
 
@@ -224,17 +224,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 {
                     _isBatchInProgress = true;
                     task = componentState.DispatchEventAsync(binding, eventArgs);
-                    await task;
-                }
-                catch (Exception ex) when (!task.IsCanceled)
-                {
-                    HandleException(ex);
                 }
                 finally
                 {
                     _isBatchInProgress = false;
                     ProcessRenderQueue();
                 }
+
+                return GetErrorHandledTask(task);
             }
             else
             {

--- a/src/Components/Components/test/ComponentBaseTest.cs
+++ b/src/Components/Components/test/ComponentBaseTest.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void RendersAfterParametersSetAsyncTaskIsCompleted()
+        public async Task RendersAfterParametersSetAsyncTaskIsCompleted()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var componentId = renderer.AssignRootComponentId(component);
-            renderer.RenderRootComponent(componentId);
+            var renderTask = renderer.RenderRootComponentAsync(componentId);
 
             // Assert
             Assert.Single(renderer.Batches);
@@ -170,10 +170,12 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Component should be rendered again
             Assert.Equal(2, renderer.Batches.Count);
+
+            await renderTask;
         }
 
         [Fact]
-        public void RendersAfterParametersSetAndInitAsyncTasksAreCompleted()
+        public async Task RendersAfterParametersSetAndInitAsyncTasksAreCompleted()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -189,7 +191,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var componentId = renderer.AssignRootComponentId(component);
-            renderer.RenderRootComponent(componentId);
+            var renderTask = renderer.RenderRootComponentAsync(componentId);
 
             // Assert
             Assert.Single(renderer.Batches);
@@ -210,10 +212,12 @@ namespace Microsoft.AspNetCore.Components.Test
             // Component should be rendered again
             // after the async part of onparameterssetasync completes
             Assert.Equal(4, renderer.Batches.Count);
+
+            await renderTask;
         }
 
         [Fact]
-        public void DoesNotRenderAfterOnInitAsyncTaskIsCancelled()
+        public async Task DoesNotRenderAfterOnInitAsyncTaskIsCancelled()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -223,7 +227,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var componentId = renderer.AssignRootComponentId(component);
-            renderer.RenderRootComponent(componentId);
+            var renderTask = renderer.RenderRootComponentAsync(componentId);
 
             // Assert
             Assert.Single(renderer.Batches);
@@ -235,6 +239,8 @@ namespace Microsoft.AspNetCore.Components.Test
             // Component should only be rendered again due to
             // the call to StateHasChanged after SetParametersAsync
             Assert.Equal(2, renderer.Batches.Count);
+
+            await renderTask;
         }
 
         [Fact]
@@ -262,7 +268,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void DoesNotRenderAfterOnParametersSetAsyncTaskIsCanceled()
+        public async Task DoesNotRenderAfterOnParametersSetAsyncTaskIsCanceled()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -272,7 +278,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var componentId = renderer.AssignRootComponentId(component);
-            renderer.RenderRootComponent(componentId);
+            var renderTask = renderer.RenderRootComponentAsync(componentId);
 
             // Assert
             Assert.Single(renderer.Batches);
@@ -283,6 +289,8 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Component should not be rendered again
             Assert.Single(renderer.Batches);
+
+            await renderTask;
         }
 
         [Fact]

--- a/src/Components/Components/test/ComponentBaseTest.cs
+++ b/src/Components/Components/test/ComponentBaseTest.cs
@@ -168,10 +168,10 @@ namespace Microsoft.AspNetCore.Components.Test
             component.Counter = 2;
             parametersSetTask.SetResult(true);
 
+            await renderTask;
+
             // Component should be rendered again
             Assert.Equal(2, renderer.Batches.Count);
-
-            await renderTask;
         }
 
         [Fact]
@@ -194,26 +194,25 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderTask = renderer.RenderRootComponentAsync(componentId);
 
             // Assert
+            // A rendering should have happened after the synchronous execution of Init
             Assert.Single(renderer.Batches);
 
             // Completes task started by OnInitAsync
             component.Counter = 2;
             initTask.SetResult(true);
 
-            // Component should be rendered again 2 times
-            // after on init async
-            // after set parameters
-            Assert.Equal(3, renderer.Batches.Count);
+            // Component should be rendered once, after set parameters
+            Assert.Equal(2, renderer.Batches.Count);
 
             // Completes task started by OnParametersSetAsync
             component.Counter = 3;
             parametersSetTask.SetResult(false);
 
+            await renderTask;
+
             // Component should be rendered again
             // after the async part of onparameterssetasync completes
-            Assert.Equal(4, renderer.Batches.Count);
-
-            await renderTask;
+            Assert.Equal(3, renderer.Batches.Count);
         }
 
         [Fact]
@@ -230,17 +229,18 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderTask = renderer.RenderRootComponentAsync(componentId);
 
             // Assert
+            Assert.False(renderTask.IsCompleted);
             Assert.Single(renderer.Batches);
 
             // Cancel task started by OnInitAsync
             component.Counter = 2;
             initTask.SetCanceled();
 
+            await renderTask;
+
             // Component should only be rendered again due to
             // the call to StateHasChanged after SetParametersAsync
             Assert.Equal(2, renderer.Batches.Count);
-
-            await renderTask;
         }
 
         [Fact]
@@ -287,10 +287,11 @@ namespace Microsoft.AspNetCore.Components.Test
             component.Counter = 2;
             onParametersSetTask.SetCanceled();
 
+            await renderTask;
+
             // Component should not be rendered again
             Assert.Single(renderer.Batches);
 
-            await renderTask;
         }
 
         [Fact]

--- a/src/Components/Components/test/RenderTreeBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeBuilderTest.cs
@@ -1061,6 +1061,9 @@ namespace Microsoft.AspNetCore.Components.Test
             {
             }
 
+            protected override void HandleException(Exception exception)
+                => throw new NotImplementedException();
+
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -1,14 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Components.RenderTree;
-using Microsoft.AspNetCore.Components.Test.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Test.Helpers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Components.Test
@@ -1530,6 +1529,9 @@ namespace Microsoft.AspNetCore.Components.Test
             public FakeRenderer() : base(new TestServiceProvider(), new RendererSynchronizationContext())
             {
             }
+
+            protected override void HandleException(Exception exception)
+                => throw new NotImplementedException();
 
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => Task.CompletedTask;

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -1498,7 +1498,7 @@ namespace Microsoft.AspNetCore.Components.Test
                 },
                 [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
                 {
-                    [0] = CreateRenderFactory(new[] { 1, 2 }),
+                    [0] = CreateRenderFactory(new[] { 1, 2, }),
                     [1] = CreateRenderFactory(Array.Empty<int>()),
                     [2] = CreateRenderFactory(Array.Empty<int>()),
                 },

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -1691,6 +1691,9 @@ namespace Microsoft.AspNetCore.Components.Test
             public new int AssignRootComponentId(IComponent component)
                 => base.AssignRootComponentId(component);
 
+            protected override void HandleException(Exception exception)
+                => throw new NotImplementedException();
+
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => Task.CompletedTask;
         }

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -1473,6 +1473,40 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
+        public async Task ExceptionsReturnedUsingTaskFromExceptionCanBeHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception = new InvalidTimeZoneException();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = () => Task.FromException<(int, NestedAsyncComponent.EventType)>(exception),
+                        },
+                    }
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
+            Assert.Equal(new[] { exception }, renderer.HandledExceptions);
+            await renderTask;
+        }
+
+        [Fact]
         public async Task ExceptionsThrownAsynchronouslyCanBeHandled()
         {
             // Arrange
@@ -1565,7 +1599,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task ExceptionsThrownFromHandleAfter_AreHandled()
+        public async Task ExceptionsThrownFromHandleAfterRender_AreHandled()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
@@ -1618,7 +1652,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void SynchronousCancelledTasks_HandleAfter_Works()
+        public void SynchronousCancelledTasks_HandleAfterRender_Works()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
@@ -1653,7 +1687,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void AsynchronousCancelledTasks_HandleAfter_Works()
+        public void AsynchronousCancelledTasks_HandleAfterRender_Works()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
@@ -1688,7 +1722,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task CanceledHandleAfterTasks_AreIgnored()
+        public async Task CanceledTasksInHandleAfterRender_AreIgnored()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -175,13 +175,17 @@ namespace Microsoft.AspNetCore.Components.Test
         {
             // Arrange
             var renderer = new TestRenderer();
-            var component = new AsyncComponent(5); // Triggers n renders, the first one creating <p>n</p> and the n-1 renders asynchronously update the value.
+            var tcs = new TaskCompletionSource<int>();
+            var component = new AsyncComponent(tcs.Task, 5); // Triggers n renders, the first one creating <p>n</p> and the n-1 renders asynchronously update the value.
 
             // Act
             var componentId = renderer.AssignRootComponentId(component);
-            await renderer.InvokeAsync(() => renderer.RenderRootComponentAsync(componentId));
+            var renderTask = renderer.InvokeAsync(() => renderer.RenderRootComponentAsync(componentId));
 
             // Assert
+            Assert.False(renderTask.IsCompleted);
+            tcs.SetResult(0);
+            await renderTask;
             Assert.Equal(5, renderer.Batches.Count);
 
             // First render
@@ -442,11 +446,11 @@ namespace Microsoft.AspNetCore.Components.Test
             var task = renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
 
             // This should always be run synchronously
-            Assert.True(task.IsCompleted);
+            Assert.True(task.IsCompletedSuccessfully);
         }
 
         [Fact]
-        public async Task CanDispatchEventsToTopLevelComponents()
+        public void CanDispatchEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -469,12 +473,14 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            await renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+            var renderTask = renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Same(eventArgs, receivedArgs);
         }
 
         [Fact]
-        public async Task CanDispatchTypedEventsToTopLevelComponents()
+        public void CanDispatchTypedEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -497,12 +503,14 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIMouseEventArgs();
-            await renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+            var renderTask = renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Same(eventArgs, receivedArgs);
         }
 
         [Fact]
-        public async Task CanDispatchActionEventsToTopLevelComponents()
+        public void CanDispatchActionEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -525,12 +533,14 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIMouseEventArgs();
-            await renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+            var renderTask = renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.NotNull(receivedArgs);
         }
 
         [Fact]
-        public async Task CanDispatchEventsToNestedComponents()
+        public void CanDispatchEventsToNestedComponents()
         {
             UIEventArgs receivedArgs = null;
 
@@ -564,12 +574,14 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            await renderer.DispatchEventAsync(nestedComponentId, eventHandlerId, eventArgs);
+            var renderTask = renderer.DispatchEventAsync(nestedComponentId, eventHandlerId, eventArgs);
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Same(eventArgs, receivedArgs);
         }
 
         [Fact]
-        public async Task ThrowsIfComponentDoesNotHandleEvents()
+        public void ThrowsIfComponentDoesNotHandleEvents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -591,21 +603,27 @@ namespace Microsoft.AspNetCore.Components.Test
             var eventArgs = new UIEventArgs();
 
             // Act/Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs));
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                // Verifies that the exception is thrown synchronously.
+                _ = renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
+            });
             Assert.Equal($"The component of type {typeof(TestComponent).FullName} cannot receive " +
                 $"events because it does not implement {typeof(IHandleEvent).FullName}.", ex.Message);
         }
 
         [Fact]
-        public async Task CannotDispatchEventsToUnknownComponents()
+        public void CannotDispatchEventsToUnknownComponents()
         {
             // Arrange
             var renderer = new TestRenderer();
 
             // Act/Assert
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                renderer.DispatchEventAsync(123, 0, new UIEventArgs()));
+            Assert.Throws<ArgumentException>(() =>
+            {
+                // Intentionally written this way to verify that the exception is thrown synchronously.
+                _ = renderer.DispatchEventAsync(123, 0, new UIEventArgs());
+            });
         }
 
         [Fact]
@@ -807,7 +825,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task DisposesEventHandlersWhenAttributeValueChanged()
+        public void DisposesEventHandlersWhenAttributeValueChanged()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -824,7 +842,8 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            await renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            var renderTask = renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(1, eventCount);
 
             // Now change the attribute value
@@ -833,16 +852,21 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event, but can fire the new event
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null));
+            Assert.Throws<ArgumentException>(() =>
+            {
+                // Verifies that the exception is thrown synchronously.
+                _ = renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            });
+
             Assert.Equal(1, eventCount);
             Assert.Equal(0, newEventCount);
-            await renderer.DispatchEventAsync(componentId, origEventHandlerId + 1, args: null);
+            renderTask = renderer.DispatchEventAsync(componentId, origEventHandlerId + 1, args: null);
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(1, newEventCount);
         }
 
         [Fact]
-        public async Task DisposesEventHandlersWhenAttributeRemoved()
+        public void DisposesEventHandlersWhenAttributeRemoved()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -859,7 +883,8 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            await renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            var renderTask = renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(1, eventCount);
 
             // Now remove the event attribute
@@ -867,13 +892,16 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null));
+            Assert.Throws<ArgumentException>(() =>
+            {
+                // Verifies that the exception is thrown synchronously.
+                _ = renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            });
             Assert.Equal(1, eventCount);
         }
 
         [Fact]
-        public async Task DisposesEventHandlersWhenOwnerComponentRemoved()
+        public void DisposesEventHandlersWhenOwnerComponentRemoved()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -906,7 +934,8 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            await renderer.DispatchEventAsync(childComponentId, eventHandlerId, args: null);
+            var renderTask = renderer.DispatchEventAsync(childComponentId, eventHandlerId, args: null);
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(1, eventCount);
 
             // Now remove the EventComponent
@@ -914,13 +943,16 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                renderer.DispatchEventAsync(eventHandlerId, eventHandlerId, args: null));
+            Assert.Throws<ArgumentException>(() =>
+            {
+                // Verifies that the exception is thrown synchronously.
+                _ = renderer.DispatchEventAsync(eventHandlerId, eventHandlerId, args: null);
+            });
             Assert.Equal(1, eventCount);
         }
 
         [Fact]
-        public async Task DisposesEventHandlersWhenAncestorElementRemoved()
+        public void DisposesEventHandlersWhenAncestorElementRemoved()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -937,7 +969,8 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            await renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            var renderTask = renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(1, eventCount);
 
             // Now remove the ancestor element
@@ -945,13 +978,16 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null));
+            Assert.Throws<ArgumentException>(() =>
+            {
+                // Verifies that the exception is thrown synchronously.
+                _ = renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
+            });
             Assert.Equal(1, eventCount);
         }
 
         [Fact]
-        public async Task AllRendersTriggeredSynchronouslyDuringEventHandlerAreHandledAsSingleBatch()
+        public void AllRendersTriggeredSynchronouslyDuringEventHandlerAreHandledAsSingleBatch()
         {
             // Arrange: A root component with a child whose event handler explicitly queues
             // a re-render of both the root component and the child
@@ -985,9 +1021,10 @@ namespace Microsoft.AspNetCore.Components.Test
             Assert.Single(renderer.Batches);
 
             // Act
-            await renderer.DispatchEventAsync(childComponentId, origEventHandlerId, args: null);
+            var renderTask = renderer.DispatchEventAsync(childComponentId, origEventHandlerId, args: null);
 
             // Assert
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(2, renderer.Batches.Count);
             var batch = renderer.Batches.Last();
             Assert.Collection(batch.DiffsInOrder,
@@ -1136,7 +1173,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task QueuedRenderIsSkippedIfComponentWasAlreadyDisposedInSameBatch()
+        public void QueuedRenderIsSkippedIfComponentWasAlreadyDisposedInSameBatch()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -1175,9 +1212,10 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             // The fact that there's no error here is the main thing we're testing
-            await renderer.DispatchEventAsync(childComponentId, origEventHandlerId, args: null);
+            var renderTask = renderer.DispatchEventAsync(childComponentId, origEventHandlerId, args: null);
 
             // Assert: correct render result
+            Assert.True(renderTask.IsCompletedSuccessfully);
             var newBatch = renderer.Batches.Skip(1).Single();
             Assert.Equal(1, newBatch.DisposedComponentIDs.Count);
             Assert.Equal(1, newBatch.DiffsByComponentId.Count);
@@ -1190,7 +1228,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task CanCombineBindAndConditionalAttribute()
+        public void CanCombineBindAndConditionalAttribute()
         {
             // This test represents https://github.com/aspnet/Blazor/issues/624
 
@@ -1206,7 +1244,9 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act: Toggle the checkbox
             var eventArgs = new UIChangeEventArgs { Value = true };
-            await renderer.DispatchEventAsync(componentId, checkboxChangeEventHandlerId, eventArgs);
+            var renderTask =  renderer.DispatchEventAsync(componentId, checkboxChangeEventHandlerId, eventArgs);
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
             var latestBatch = renderer.Batches.Last();
             var latestDiff = latestBatch.DiffsInOrder.Single();
             var referenceFrames = latestBatch.ReferenceFrames;
@@ -1441,7 +1481,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task ExceptionsThrownSynchronouslyCanBeHandled()
+        public void ExceptionsThrownSynchronouslyCanBeHandled()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
@@ -1450,7 +1490,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert
             var componentId = renderer.AssignRootComponentId(component);
-            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
             {
                 [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
                 {
@@ -1469,11 +1509,12 @@ namespace Microsoft.AspNetCore.Components.Test
                 },
             }));
 
+            Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(new[] { exception }, renderer.HandledExceptions);
         }
 
         [Fact]
-        public async Task ExceptionsReturnedUsingTaskFromExceptionCanBeHandled()
+        public void ExceptionsReturnedUsingTaskFromExceptionCanBeHandled()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
@@ -1503,7 +1544,6 @@ namespace Microsoft.AspNetCore.Components.Test
 
             Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Equal(new[] { exception }, renderer.HandledExceptions);
-            await renderTask;
         }
 
         [Fact]
@@ -1512,11 +1552,12 @@ namespace Microsoft.AspNetCore.Components.Test
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
             var component = new NestedAsyncComponent();
+            var tcs = new TaskCompletionSource<int>();
             var exception = new InvalidTimeZoneException();
 
             // Act/Assert
             var componentId = renderer.AssignRootComponentId(component);
-            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
             {
                 [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
                 {
@@ -1527,7 +1568,7 @@ namespace Microsoft.AspNetCore.Components.Test
                             Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
                             EventAction = async () =>
                             {
-                                await Task.Yield();
+                                await tcs.Task;
                                 throw exception;
                             }
                         },
@@ -1539,21 +1580,25 @@ namespace Microsoft.AspNetCore.Components.Test
                 },
             }));
 
+            Assert.False(renderTask.IsCompleted);
+            tcs.SetResult(0);
+            await renderTask;
             Assert.Same(exception, Assert.Single(renderer.HandledExceptions).GetBaseException());
         }
 
         [Fact]
-        public async Task ExceptionsThrownFromMultipleComponentsCanBeHandled()
+        public async Task ExceptionsThrownAsynchronouslyFromMultipleComponentsCanBeHandled()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
             var component = new NestedAsyncComponent();
             var exception1 = new InvalidTimeZoneException();
             var exception2 = new UriFormatException();
+            var tcs = new TaskCompletionSource<int>();
 
             // Act/Assert
             var componentId = renderer.AssignRootComponentId(component);
-            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
             {
                 [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
                 {
@@ -1565,7 +1610,7 @@ namespace Microsoft.AspNetCore.Components.Test
                             Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
                             EventAction = async () =>
                             {
-                                await Task.Yield();
+                                await tcs.Task;
                                 throw exception1;
                             }
                         },
@@ -1577,7 +1622,7 @@ namespace Microsoft.AspNetCore.Components.Test
                             Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
                             EventAction = async () =>
                             {
-                                await Task.Yield();
+                                await tcs.Task;
                                 throw exception2;
                             }
                         },
@@ -1591,11 +1636,67 @@ namespace Microsoft.AspNetCore.Components.Test
                 },
             }));
 
-            var exception = Assert.Single(renderer.HandledExceptions);
-            var aggregateException = Assert.IsType<AggregateException>(exception);
-            Assert.Equal(2, aggregateException.InnerExceptions.Count);
-            Assert.Contains(exception1, aggregateException.InnerExceptions);
-            Assert.Contains(exception2, aggregateException.InnerExceptions);
+            Assert.False(renderTask.IsCompleted);
+            tcs.SetResult(0);
+
+            await renderTask;
+            Assert.Equal(2, renderer.HandledExceptions.Count);
+            Assert.Contains(exception1, renderer.HandledExceptions);
+            Assert.Contains(exception2, renderer.HandledExceptions);
+        }
+
+        [Fact]
+        public void ExceptionsThrownSynchronouslyFromMultipleComponentsCanBeHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception1 = new InvalidTimeZoneException();
+            var exception2 = new UriFormatException();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = Array.Empty<NestedAsyncComponent.ExecutionAction>(),
+                    [1] = new List<NestedAsyncComponent.ExecutionAction>
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = () =>
+                            {
+                                throw exception1;
+                            }
+                        },
+                    },
+                    [2] = new List<NestedAsyncComponent.ExecutionAction>
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = () =>
+                            {
+                                throw exception2;
+                            }
+                        },
+                    },
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(new[] { 1, 2, }),
+                    [1] = CreateRenderFactory(Array.Empty<int>()),
+                    [2] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
+
+            Assert.Equal(2, renderer.HandledExceptions.Count);
+            Assert.Contains(exception1, renderer.HandledExceptions);
+            Assert.Contains(exception2, renderer.HandledExceptions);
         }
 
         [Fact]
@@ -1610,7 +1711,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert
             var componentId = renderer.AssignRootComponentId(component);
-            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
             {
                 [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
                 {
@@ -1645,6 +1746,8 @@ namespace Microsoft.AspNetCore.Components.Test
                     [1] = CreateRenderFactory(Array.Empty<int>()),
                 },
             }));
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
 
             // OnAfterRenderAsync happens in the background. Make it more predictable, by gating it until we're ready to capture exceptions.
             await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
@@ -2158,10 +2261,13 @@ namespace Microsoft.AspNetCore.Components.Test
         {
             private RenderHandle _renderHandler;
 
-            public AsyncComponent(int number)
+            public AsyncComponent(Task taskToAwait, int number)
             {
+                _taskToAwait = taskToAwait;
                 Number = number;
             }
+
+            private readonly Task _taskToAwait;
 
             public int Number { get; set; }
 
@@ -2178,7 +2284,7 @@ namespace Microsoft.AspNetCore.Components.Test
                     n = Number;
                     _renderHandler.Render(CreateFragment);
                     Number--;
-                    await Task.Yield();
+                    await _taskToAwait;
                 };
 
                 // Cheap closure

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Test.Helpers;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
@@ -195,7 +196,7 @@ namespace Microsoft.AspNetCore.Components.Test
             AssertFrame.Text(create.ReferenceFrames[1], "5");
 
             // Second render
-            for (int i = 1; i < 5; i++)
+            for (var i = 1; i < 5; i++)
             {
 
                 var update = renderer.Batches[i];
@@ -414,7 +415,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void CanDispatchEventsToTopLevelComponents()
+        public async Task CanDispatchEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -437,12 +438,12 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            await renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
             Assert.Same(eventArgs, receivedArgs);
         }
 
         [Fact]
-        public void CanDispatchTypedEventsToTopLevelComponents()
+        public async Task CanDispatchTypedEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -465,12 +466,12 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIMouseEventArgs();
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            await renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
             Assert.Same(eventArgs, receivedArgs);
         }
 
         [Fact]
-        public void CanDispatchActionEventsToTopLevelComponents()
+        public async Task CanDispatchActionEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -493,12 +494,12 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIMouseEventArgs();
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            await renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs);
             Assert.NotNull(receivedArgs);
         }
 
         [Fact]
-        public void CanDispatchEventsToNestedComponents()
+        public async Task CanDispatchEventsToNestedComponents()
         {
             UIEventArgs receivedArgs = null;
 
@@ -532,12 +533,12 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            renderer.DispatchEvent(nestedComponentId, eventHandlerId, eventArgs);
+            await renderer.DispatchEventAsync(nestedComponentId, eventHandlerId, eventArgs);
             Assert.Same(eventArgs, receivedArgs);
         }
 
         [Fact]
-        public void ThrowsIfComponentDoesNotHandleEvents()
+        public async Task ThrowsIfComponentDoesNotHandleEvents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -559,19 +560,21 @@ namespace Microsoft.AspNetCore.Components.Test
             var eventArgs = new UIEventArgs();
 
             // Act/Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => renderer.DispatchEvent(componentId, eventHandlerId, eventArgs));
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                renderer.DispatchEventAsync(componentId, eventHandlerId, eventArgs));
             Assert.Equal($"The component of type {typeof(TestComponent).FullName} cannot receive " +
                 $"events because it does not implement {typeof(IHandleEvent).FullName}.", ex.Message);
         }
 
         [Fact]
-        public void CannotDispatchEventsToUnknownComponents()
+        public async Task CannotDispatchEventsToUnknownComponents()
         {
             // Arrange
             var renderer = new TestRenderer();
 
             // Act/Assert
-            Assert.Throws<ArgumentException>(() => renderer.DispatchEvent(123, 0, new UIEventArgs()));
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                renderer.DispatchEventAsync(123, 0, new UIEventArgs()));
         }
 
         [Fact]
@@ -773,7 +776,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void DisposesEventHandlersWhenAttributeValueChanged()
+        public async Task DisposesEventHandlersWhenAttributeValueChanged()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -790,7 +793,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+            await renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now change the attribute value
@@ -799,15 +802,16 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event, but can fire the new event
-            Assert.Throws<ArgumentException>(() => renderer.DispatchEvent(componentId, origEventHandlerId, args: null));
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null));
             Assert.Equal(1, eventCount);
             Assert.Equal(0, newEventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId + 1, args: null);
+            await renderer.DispatchEventAsync(componentId, origEventHandlerId + 1, args: null);
             Assert.Equal(1, newEventCount);
         }
 
         [Fact]
-        public void DisposesEventHandlersWhenAttributeRemoved()
+        public async Task DisposesEventHandlersWhenAttributeRemoved()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -824,7 +828,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+            await renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now remove the event attribute
@@ -832,12 +836,13 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event
-            Assert.Throws<ArgumentException>(() => renderer.DispatchEvent(componentId, origEventHandlerId, args: null));
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null));
             Assert.Equal(1, eventCount);
         }
 
         [Fact]
-        public void DisposesEventHandlersWhenOwnerComponentRemoved()
+        public async Task DisposesEventHandlersWhenOwnerComponentRemoved()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -870,7 +875,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(childComponentId, eventHandlerId, args: null);
+            await renderer.DispatchEventAsync(childComponentId, eventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now remove the EventComponent
@@ -878,12 +883,13 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event
-            Assert.Throws<ArgumentException>(() => renderer.DispatchEvent(eventHandlerId, eventHandlerId, args: null));
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                renderer.DispatchEventAsync(eventHandlerId, eventHandlerId, args: null));
             Assert.Equal(1, eventCount);
         }
 
         [Fact]
-        public void DisposesEventHandlersWhenAncestorElementRemoved()
+        public async Task DisposesEventHandlersWhenAncestorElementRemoved()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -900,7 +906,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+            await renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now remove the ancestor element
@@ -908,12 +914,13 @@ namespace Microsoft.AspNetCore.Components.Test
             component.TriggerRender();
 
             // Act/Assert 2: Can no longer fire the original event
-            Assert.Throws<ArgumentException>(() => renderer.DispatchEvent(componentId, origEventHandlerId, args: null));
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                renderer.DispatchEventAsync(componentId, origEventHandlerId, args: null));
             Assert.Equal(1, eventCount);
         }
 
         [Fact]
-        public void AllRendersTriggeredSynchronouslyDuringEventHandlerAreHandledAsSingleBatch()
+        public async Task AllRendersTriggeredSynchronouslyDuringEventHandlerAreHandledAsSingleBatch()
         {
             // Arrange: A root component with a child whose event handler explicitly queues
             // a re-render of both the root component and the child
@@ -947,7 +954,7 @@ namespace Microsoft.AspNetCore.Components.Test
             Assert.Single(renderer.Batches);
 
             // Act
-            renderer.DispatchEvent(childComponentId, origEventHandlerId, args: null);
+            await renderer.DispatchEventAsync(childComponentId, origEventHandlerId, args: null);
 
             // Assert
             Assert.Equal(2, renderer.Batches.Count);
@@ -1098,7 +1105,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void QueuedRenderIsSkippedIfComponentWasAlreadyDisposedInSameBatch()
+        public async Task QueuedRenderIsSkippedIfComponentWasAlreadyDisposedInSameBatch()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -1137,7 +1144,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             // The fact that there's no error here is the main thing we're testing
-            renderer.DispatchEvent(childComponentId, origEventHandlerId, args: null);
+            await renderer.DispatchEventAsync(childComponentId, origEventHandlerId, args: null);
 
             // Assert: correct render result
             var newBatch = renderer.Batches.Skip(1).Single();
@@ -1152,7 +1159,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void CanCombineBindAndConditionalAttribute()
+        public async Task CanCombineBindAndConditionalAttribute()
         {
             // This test represents https://github.com/aspnet/Blazor/issues/624
 
@@ -1168,7 +1175,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act: Toggle the checkbox
             var eventArgs = new UIChangeEventArgs { Value = true };
-            renderer.DispatchEvent(componentId, checkboxChangeEventHandlerId, eventArgs);
+            await renderer.DispatchEventAsync(componentId, checkboxChangeEventHandlerId, eventArgs);
             var latestBatch = renderer.Batches.Last();
             var latestDiff = latestBatch.DiffsInOrder.Single();
             var referenceFrames = latestBatch.ReferenceFrames;
@@ -1349,26 +1356,258 @@ namespace Microsoft.AspNetCore.Components.Test
             // Act/Assert 1: Event can be fired for the first time
             var render1TCS = new TaskCompletionSource<object>();
             renderer.NextUpdateDisplayReturnTask = render1TCS.Task;
-            renderer.DispatchEvent(componentId, eventHandlerId, new UIEventArgs());
+            await renderer.DispatchEventAsync(componentId, eventHandlerId, new UIEventArgs());
             Assert.Equal(1, numEventsFired);
 
             // Act/Assert 2: *Same* event handler ID can be reused prior to completion of
             // preceding UI update
             var render2TCS = new TaskCompletionSource<object>();
             renderer.NextUpdateDisplayReturnTask = render2TCS.Task;
-            renderer.DispatchEvent(componentId, eventHandlerId, new UIEventArgs());
+            await renderer.DispatchEventAsync(componentId, eventHandlerId, new UIEventArgs());
             Assert.Equal(2, numEventsFired);
 
             // Act/Assert 3: After we complete the first UI update in which a given
             // event handler ID is disposed, we can no longer reuse that event handler ID
             render1TCS.SetResult(null);
             await Task.Delay(500); // From here we can't see when the async disposal is completed. Just give it plenty of time (Task.Yield isn't enough).
-            var ex = Assert.Throws<ArgumentException>(() =>
-            {
-                renderer.DispatchEvent(componentId, eventHandlerId, new UIEventArgs());
-            });
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+                renderer.DispatchEventAsync(componentId, eventHandlerId, new UIEventArgs()));
             Assert.Equal($"There is no event handler with ID {eventHandlerId}", ex.Message);
             Assert.Equal(2, numEventsFired);
+        }
+
+        [Fact]
+        public async Task ExceptionsThrownSynchronouslyCanBeHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception = new InvalidTimeZoneException();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = () => throw exception,
+                        },
+                    }
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            Assert.Collection(renderer.HandledExceptions,
+                tuple =>
+                {
+                    Assert.Equal(componentId, tuple.componentId);
+                    Assert.Same(exception, tuple.exception);
+                });
+        }
+
+        [Fact]
+        public async Task ExceptionsThrownAsynchronouslyCanBeHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception = new InvalidTimeZoneException();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = async () =>
+                            {
+                                await Task.Yield();
+                                throw exception;
+                            }
+                        },
+                    }
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            Assert.Collection(renderer.HandledExceptions,
+                tuple =>
+                {
+                    Assert.Equal(componentId, tuple.componentId);
+                    // EventAction may finish synchronously. Call GetBaseException to account for the absence of an AggregateExcepiton.
+                    Assert.Same(exception, tuple.exception.GetBaseException());
+                });
+        }
+
+        [Fact]
+        public async Task ExceptionsThrownFromMultipleComponentsCanBeHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception1 = new InvalidTimeZoneException();
+            var exception2 = new UriFormatException();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = Array.Empty<NestedAsyncComponent.ExecutionAction>(),
+                    [1] = new List<NestedAsyncComponent.ExecutionAction>
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = async () =>
+                            {
+                                await Task.Yield();
+                                throw exception1;
+                            }
+                        },
+                    },
+                    [2] = new List<NestedAsyncComponent.ExecutionAction>
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnInitAsyncAsync,
+                            EventAction = async () =>
+                            {
+                                await Task.Yield();
+                                throw exception2;
+                            }
+                        },
+                    },
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(new[] { 1, 2 }),
+                    [1] = CreateRenderFactory(Array.Empty<int>()),
+                    [2] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            var result = Assert.Single(renderer.HandledExceptions);
+            Assert.Equal(componentId, result.componentId);
+            var aggregateException = Assert.IsType<AggregateException>(result.exception);
+            Assert.Equal(2, aggregateException.InnerExceptions.Count);
+            Assert.Contains(exception1, aggregateException.InnerExceptions);
+            Assert.Contains(exception2, aggregateException.InnerExceptions);
+        }
+
+        [Fact]
+        public async Task ExceptionsThrownFromHandleAfter_AreHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception = new InvalidTimeZoneException();
+
+            var taskCompletionSource = new TaskCompletionSource<int>();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            EventAction = () =>
+                            {
+                                throw exception;
+                            },
+                        }
+                    },
+                    [1] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            EventAction = async () =>
+                            {
+                                await Task.Yield();
+                                taskCompletionSource.TrySetResult(0);
+                                return (1, NestedAsyncComponent.EventType.OnAfterRenderAsync);
+                            },
+                        }
+                    }
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(new[] { 1 }),
+                    [1] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            // OnAfterRenderAsync happens in the background. Make it more predictable, by gating it until we're ready to capture exceptions.
+            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
+            Assert.Collection(renderer.HandledExceptions,
+                tuple =>
+                {
+                    Assert.Same(exception, tuple.exception.GetBaseException());
+                });
+        }
+
+        [Fact]
+        public async Task CanceledHandleAfterTasks_AreIgnored()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var taskCompletionSource = new TaskCompletionSource<int>();
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            await renderer.RenderRootComponentAsync(componentId, ParameterCollection.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            EventAction = () =>
+                            {
+                                taskCompletionSource.TrySetResult(0);
+                                cancellationTokenSource.Token.ThrowIfCancellationRequested();
+                                return default;
+                            },
+                        }
+                    },
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
+
+            Assert.Empty(renderer.HandledExceptions);
         }
 
         [Fact]
@@ -1572,9 +1811,10 @@ namespace Microsoft.AspNetCore.Components.Test
                 builder.AddContent(6, $"Render count: {++renderCount}");
             }
 
-            public void HandleEvent(EventHandlerInvoker binding, UIEventArgs args)
+            public Task HandleEventAsync(EventHandlerInvoker binding, UIEventArgs args)
             {
                 binding.Invoke(args);
+                return Task.CompletedTask;
             }
         }
 
@@ -1642,9 +1882,9 @@ namespace Microsoft.AspNetCore.Components.Test
                 return Task.CompletedTask;
             }
 
-            public void HandleEvent(EventHandlerInvoker binding, UIEventArgs args)
+            public async Task HandleEventAsync(EventHandlerInvoker binding, UIEventArgs args)
             {
-                var task = binding.Invoke(args);
+                await binding.Invoke(args);
                 Render();
             }
 
@@ -1687,10 +1927,11 @@ namespace Microsoft.AspNetCore.Components.Test
             public bool CheckboxEnabled;
             public string SomeStringProperty;
 
-            public void HandleEvent(EventHandlerInvoker binding, UIEventArgs args)
+            public Task HandleEventAsync(EventHandlerInvoker binding, UIEventArgs args)
             {
                 binding.Invoke(args);
                 TriggerRender();
+                return Task.CompletedTask;
             }
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -1712,9 +1953,10 @@ namespace Microsoft.AspNetCore.Components.Test
         {
             public int OnAfterRenderCallCount { get; private set; }
 
-            public void OnAfterRender()
+            public Task OnAfterRenderAsync()
             {
                 OnAfterRenderCallCount++;
+                return Task.CompletedTask;
             }
 
             Task IComponent.SetParametersAsync(ParameterCollection parameters)
@@ -1833,7 +2075,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             return component => builder =>
             {
-                int s = 0;
+                var s = 0;
                 builder.OpenElement(s++, "div");
                 builder.AddContent(s++, $"Id: {component.TestId} BuildRenderTree, {Guid.NewGuid()}");
                 foreach (var child in childrenToRender)
@@ -1852,13 +2094,6 @@ namespace Microsoft.AspNetCore.Components.Test
 
         private class NestedAsyncComponent : ComponentBase
         {
-            private RenderHandle _renderHandle;
-
-            public void Configure(RenderHandle renderHandle)
-            {
-                _renderHandle = renderHandle;
-            }
-
             [Parameter] public IDictionary<int, IList<ExecutionAction>> EventActions { get; set; }
 
             [Parameter] public IDictionary<int, Func<NestedAsyncComponent, RenderFragment>> WhatToRender { get; set; }
@@ -1924,6 +2159,15 @@ namespace Microsoft.AspNetCore.Components.Test
                 renderFactory(this)(builder);
             }
 
+            protected override async Task OnAfterRenderAsync()
+            {
+                if (TryGetEntry(EventType.OnAfterRenderAsync, out var entry))
+                {
+                    var result = await entry.EventAction();
+                    LogResult(result);
+                }
+            }
+
             private bool TryGetEntry(EventType eventType, out ExecutionAction entry)
             {
                 var entries = EventActions[TestId];
@@ -1937,7 +2181,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             private void LogResult((int, EventType) entry)
             {
-                Log.Enqueue(entry);
+                Log?.Enqueue(entry);
             }
 
             public class ExecutionAction
@@ -1977,7 +2221,8 @@ namespace Microsoft.AspNetCore.Components.Test
                 OnInitAsyncAsync,
                 OnParametersSet,
                 OnParametersSetAsyncSync,
-                OnParametersSetAsyncAsync
+                OnParametersSetAsyncAsync,
+                OnAfterRenderAsync,
             }
         }
     }

--- a/src/Components/Components/test/Rendering/HtmlRendererTests.cs
+++ b/src/Components/Components/test/Rendering/HtmlRendererTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         private static readonly Func<string, string> _encoder = (string t) => HtmlEncoder.Default.Encode(t);
 
         [Fact]
-        public void RenderComponent_CanRenderEmptyElement()
+        public void RenderComponentAsync_CanRenderEmptyElement()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -30,14 +30,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_CanRenderSimpleComponent()
+        public void RenderComponentAsync_CanRenderSimpleComponent()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -51,14 +51,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_HtmlEncodesContent()
+        public void RenderComponentAsync_HtmlEncodesContent()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
 
         [Fact]
-        public void RenderComponent_DoesNotEncodeMarkup()
+        public void RenderComponentAsync_DoesNotEncodeMarkup()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
 
         [Fact]
-        public void RenderComponent_CanRenderWithAttributes()
+        public void RenderComponentAsync_CanRenderWithAttributes()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -118,14 +118,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_HtmlEncodesAttributeValues()
+        public void RenderComponentAsync_HtmlEncodesAttributeValues()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -141,14 +141,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_CanRenderBooleanAttributes()
+        public void RenderComponentAsync_CanRenderBooleanAttributes()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -163,14 +163,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_DoesNotRenderBooleanAttributesWhenValueIsFalse()
+        public void RenderComponentAsync_DoesNotRenderBooleanAttributesWhenValueIsFalse()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -185,14 +185,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_CanRenderWithChildren()
+        public void RenderComponentAsync_CanRenderWithChildren()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -209,14 +209,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_CanRenderWithMultipleChildren()
+        public void RenderComponentAsync_CanRenderWithMultipleChildren()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -240,14 +240,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_CanRenderComponentWithChildrenComponents()
+        public void RenderComponentAsync_CanRenderComponentAsyncWithChildrenComponents()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -270,14 +270,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_ComponentReferenceNoops()
+        public void RenderComponentAsync_ComponentReferenceNoops()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -301,14 +301,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_CanPassParameters()
+        public void RenderComponentAsync_CanPassParameters()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             Action<UIChangeEventArgs> change = (UIChangeEventArgs changeArgs) => throw new InvalidOperationException();
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<ComponentWithParameters>(
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<ComponentWithParameters>(
                 new ParameterCollection(new[] {
                     RenderTreeFrame.Element(0,string.Empty),
                     RenderTreeFrame.Attribute(1,"update",change),
@@ -345,7 +345,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         }
 
         [Fact]
-        public void RenderComponent_CanRenderComponentWithRenderFragmentContent()
+        public void RenderComponentAsync_CanRenderComponentAsyncWithRenderFragmentContent()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -365,14 +365,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);
         }
 
         [Fact]
-        public void RenderComponent_ElementRefsNoops()
+        public void RenderComponentAsync_ElementRefsNoops()
         {
             // Arrange
             var dispatcher = Renderer.CreateDefaultDispatcher();
@@ -393,7 +393,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var htmlRenderer = new HtmlRenderer(serviceProvider, _encoder, dispatcher);
 
             // Act
-            var result = GetResult(dispatcher.Invoke(() => htmlRenderer.RenderComponent<TestComponent>(ParameterCollection.Empty)));
+            var result = GetResult(dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterCollection.Empty)));
 
             // Assert
             Assert.Equal(expectedHtml, result);

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 for (var i = 0; i < builder.Entries.Count; i++)
                 {
                     var (componentType, domElementSelector) = builder.Entries[i];
-                    Renderer.AddComponent(componentType, domElementSelector);
+                    await Renderer.AddComponentAsync(componentType, domElementSelector);
                 }
 
                 for (var i = 0; i < _circuitHandlers.Length; i++)

--- a/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var scope = _scopeFactory.CreateScope();
             var jsRuntime = new RemoteJSRuntime(client);
             var rendererRegistry = new RendererRegistry();
-            var synchronizationContext = new CircuitSynchronizationContext();
+            var dispatcher = Renderer.CreateDefaultDispatcher();
             var renderer = new RemoteRenderer(
                 scope.ServiceProvider,
                 rendererRegistry,

--- a/src/Components/Server/src/Circuits/RemoteRenderer.cs
+++ b/src/Components/Server/src/Circuits/RemoteRenderer.cs
@@ -61,24 +61,12 @@ namespace Microsoft.AspNetCore.Components.Browser.Rendering
         }
 
         /// <summary>
-        /// Attaches a new root component to the renderer,
-        /// causing it to be displayed in the specified DOM element.
-        /// </summary>
-        /// <typeparam name="TComponent">The type of the component.</typeparam>
-        /// <param name="domElementSelector">A CSS selector that uniquely identifies a DOM element.</param>
-        public void AddComponent<TComponent>(string domElementSelector)
-            where TComponent : IComponent
-        {
-            AddComponent(typeof(TComponent), domElementSelector);
-        }
-
-        /// <summary>
         /// Associates the <see cref="IComponent"/> with the <see cref="RemoteRenderer"/>,
         /// causing it to be displayed in the specified DOM element.
         /// </summary>
         /// <param name="componentType">The type of the component.</param>
         /// <param name="domElementSelector">A CSS selector that uniquely identifies a DOM element.</param>
-        public void AddComponent(Type componentType, string domElementSelector)
+        public Task AddComponentAsync(Type componentType, string domElementSelector)
         {
             var component = InstantiateComponent(componentType);
             var componentId = AssignRootComponentId(component);
@@ -90,11 +78,11 @@ namespace Microsoft.AspNetCore.Components.Browser.Rendering
                 componentId);
             CaptureAsyncExceptions(attachComponentTask);
 
-            RenderRootComponent(componentId);
+            return RenderRootComponentAsync(componentId);
         }
 
         /// <inheritdoc />
-        protected override bool HandleException(Exception exception)
+        protected override void HandleException(Exception exception)
         {
             if (exception is AggregateException aggregateException)
             {
@@ -107,8 +95,6 @@ namespace Microsoft.AspNetCore.Components.Browser.Rendering
             {
                 _logger.UnhandledExceptionRenderingComponent(exception);
             }
-
-            return true;
         }
 
         /// <inheritdoc />

--- a/src/Components/Server/src/Circuits/RemoteRenderer.cs
+++ b/src/Components/Server/src/Circuits/RemoteRenderer.cs
@@ -94,18 +94,18 @@ namespace Microsoft.AspNetCore.Components.Browser.Rendering
         }
 
         /// <inheritdoc />
-        protected override bool HandleException(int componentId, IComponent component, Exception exception)
+        protected override bool HandleException(Exception exception)
         {
             if (exception is AggregateException aggregateException)
             {
                 foreach (var innerException in aggregateException.Flatten().InnerExceptions)
                 {
-                    _logger.UnhandledExceptionRenderingComponent(component.GetType(), componentId, innerException);
+                    _logger.UnhandledExceptionRenderingComponent(innerException);
                 }
             }
             else
             {
-                _logger.UnhandledExceptionRenderingComponent(component.GetType(), componentId, exception);
+                _logger.UnhandledExceptionRenderingComponent(exception);
             }
 
             return true;

--- a/src/Components/Server/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -93,8 +93,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddStandardRazorComponentsServices(IServiceCollection services)
         {
-            services.AddLogging();
-
             // Here we add a bunch of services that don't vary in any way based on the
             // user's configuration. So even if the user has multiple independent server-side
             // Components entrypoints, this lot is the same and repeated registrations are a no-op.

--- a/src/Components/Server/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -93,6 +93,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddStandardRazorComponentsServices(IServiceCollection services)
         {
+            services.AddLogging();
+
             // Here we add a bunch of services that don't vary in any way based on the
             // user's configuration. So even if the user has multiple independent server-side
             // Components entrypoints, this lot is the same and repeated registrations are a no-op.

--- a/src/Components/Server/src/LoggerExtensions.cs
+++ b/src/Components/Server/src/LoggerExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.Server
+{
+    internal static class LoggerExtensions
+    {
+        private static readonly Action<ILogger, string, int, string, Exception> _unhandledExceptionRenderingComponent;
+
+        static LoggerExtensions()
+        {
+            _unhandledExceptionRenderingComponent = LoggerMessage.Define<string, int, string>(
+                LogLevel.Warning,
+                new EventId(1, "ExceptionRenderingComponent"),
+                "Unhandled exception rendering component '{ComponentType}({ComponentId}): {Message}");
+        }
+
+        public static void UnhandledExceptionRenderingComponent(this ILogger logger, Type componentType, int componentId, Exception exception)
+        {
+            _unhandledExceptionRenderingComponent(
+                logger,
+                TypeNameHelper.GetTypeDisplayName(componentType),
+                componentId,
+                exception.Message,
+                exception);
+        }
+    }
+}

--- a/src/Components/Server/src/LoggerExtensions.cs
+++ b/src/Components/Server/src/LoggerExtensions.cs
@@ -2,29 +2,26 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Components.Server
 {
     internal static class LoggerExtensions
     {
-        private static readonly Action<ILogger, string, int, string, Exception> _unhandledExceptionRenderingComponent;
+        private static readonly Action<ILogger, string, Exception> _unhandledExceptionRenderingComponent;
 
         static LoggerExtensions()
         {
-            _unhandledExceptionRenderingComponent = LoggerMessage.Define<string, int, string>(
+            _unhandledExceptionRenderingComponent = LoggerMessage.Define<string>(
                 LogLevel.Warning,
                 new EventId(1, "ExceptionRenderingComponent"),
-                "Unhandled exception rendering component '{ComponentType}({ComponentId}): {Message}");
+                "Unhandled exception rendering component: {Message}");
         }
 
-        public static void UnhandledExceptionRenderingComponent(this ILogger logger, Type componentType, int componentId, Exception exception)
+        public static void UnhandledExceptionRenderingComponent(this ILogger logger, Exception exception)
         {
             _unhandledExceptionRenderingComponent(
                 logger,
-                TypeNameHelper.GetTypeDisplayName(componentType),
-                componentId,
                 exception.Message,
                 exception);
         }

--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -25,6 +25,7 @@
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.AspNetCore.SpaServices.Extensions" />
     <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildNodeJS)' != 'false'">

--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -25,7 +25,6 @@
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.AspNetCore.SpaServices.Extensions" />
     <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />
-    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildNodeJS)' != 'false'">

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.Browser;
 using Microsoft.AspNetCore.Components.Browser.Rendering;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.JSInterop;
 using Moq;
 using Xunit;
@@ -155,7 +156,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         private class TestRemoteRenderer : RemoteRenderer
         {
             public TestRemoteRenderer(IServiceProvider serviceProvider, RendererRegistry rendererRegistry, IJSRuntime jsRuntime, IClientProxy client)
-                : base(serviceProvider, rendererRegistry, jsRuntime, client, CreateDefaultDispatcher())
+                : base(serviceProvider, rendererRegistry, jsRuntime, client, CreateDefaultDispatcher(), NullLogger.Instance)
             {
             }
 

--- a/src/Components/Server/test/Circuits/RenderBatchWriterTest.cs
+++ b/src/Components/Server/test/Circuits/RenderBatchWriterTest.cs
@@ -377,6 +377,11 @@ namespace Microsoft.AspNetCore.Components.Server
             {
             }
 
+            protected override void HandleException(Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }

--- a/src/Components/Shared/test/TestRenderer.cs
+++ b/src/Components/Shared/test/TestRenderer.cs
@@ -30,16 +30,12 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
         public List<CapturedBatch> Batches { get; }
             = new List<CapturedBatch>();
 
-        public List<(int componentId, Exception exception)> HandledExceptions { get; }
-            = new List<(int, Exception)>();
+        public List<Exception> HandledExceptions { get; } = new List<Exception>();
 
         public bool ShouldHandleExceptions { get; set; }
 
         public new int AssignRootComponentId(IComponent component)
             => base.AssignRootComponentId(component);
-
-        public new void RenderRootComponent(int componentId)
-            => Invoke(() => base.RenderRootComponent(componentId));
 
         public new Task RenderRootComponentAsync(int componentId)
             => InvokeAsync(() => base.RenderRootComponentAsync(componentId));
@@ -66,14 +62,14 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
         public T InstantiateComponent<T>() where T : IComponent
             => (T)InstantiateComponent(typeof(T));
 
-        protected override bool HandleException(int componentId, IComponent component, Exception exception)
+        protected override void HandleException(Exception exception)
         {
-            if (ShouldHandleExceptions)
+            if (!ShouldHandleExceptions)
             {
-                HandledExceptions.Add((componentId, exception));
+                throw exception;
             }
 
-            return ShouldHandleExceptions;
+            HandledExceptions.Add(exception);
         }
 
         protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)

--- a/src/Components/test/E2ETest/Infrastructure/SeleniumStandaloneServer.cs
+++ b/src/Components/test/E2ETest/Infrastructure/SeleniumStandaloneServer.cs
@@ -107,14 +107,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
                     {
 
                     }
-                    await Task.Delay(1000);
-
+                    await Task.Delay(1000); 
                 }
             });
 
             try
             {
-                waitForStart.TimeoutAfter(Timeout).Wait();
+                waitForStart.TimeoutAfter(Timeout).Wait(1000);
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -23,7 +23,7 @@ namespace Interop.FunctionalTests
         SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support")]
     public class H2SpecTests : LoggedTest
     {
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/6691")]
         [MemberData(nameof(H2SpecTestCases))]
         [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7299
         public async Task RunIndividualTestCase(H2SpecTestCase testCase)


### PR DESCRIPTION
* Change event handlers IHandleEvent, IHandleAfterEvent to be async.
* Return faulted tasks to Renderer instead of handling exceptions in ComponentBase
* Use ILogger in RemoteRenderer, and log to console in WebAssemblyRenderer

Fixes https://github.com/aspnet/AspNetCore/issues/4964
