### PR TITLE
Add longer timeout for dotnet-watch test

### DIFF
--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -20,7 +20,7 @@
         <AdditionalProperties>
           RepositoryToBuild=%(RepositoryBuildOrder.Identity);
           BuildRepositoryRoot=$([MSBuild]::NormalizeDirectory(%(RepositoryBuildOrder.RootPath)));
-          SkipTests=%(RepositoryBuildOrder.SkipTest)
+          SkipTests=%(RepositoryBuildOrder.SkipTests)
         </AdditionalProperties>
       </BatchedRepository>
     </ItemGroup>
@@ -58,7 +58,7 @@
       Targets="_TestRepository"
       Properties="BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
       ContinueOnError="true"
-      Condition=" %(_BatchedTestRepo.SkipTests) != 'true' ">
+      Condition=" @(_BatchedTestRepo.SkipTests) != 'true' ">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoTestResults" />
     </MSBuild>
 

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -14,7 +14,7 @@
       <RepositoryBuildOrder Condition="'%(RootPath)' == ''">
         <RootPath>$(SubmoduleRoot)%(Identity)\</RootPath>
       </RepositoryBuildOrder>
-      <BatchedRepository Include="$(MSBuildProjectFullPath)">
+      <BatchedRepository Include="$(MSBuildProjectFullPath)" Condition=" %(RepositoryBuildOrder.SkipTest) == 'true' ">
         <BuildGroup>%(RepositoryBuildOrder.Order)</BuildGroup>
         <Repository>%(RepositoryBuildOrder.Identity)</Repository>
         <AdditionalProperties>

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -14,12 +14,13 @@
       <RepositoryBuildOrder Condition="'%(RootPath)' == ''">
         <RootPath>$(SubmoduleRoot)%(Identity)\</RootPath>
       </RepositoryBuildOrder>
-      <BatchedRepository Include="$(MSBuildProjectFullPath)" Condition=" %(RepositoryBuildOrder.SkipTest) != 'true' ">
+      <BatchedRepository Include="$(MSBuildProjectFullPath)">
         <BuildGroup>%(RepositoryBuildOrder.Order)</BuildGroup>
         <Repository>%(RepositoryBuildOrder.Identity)</Repository>
         <AdditionalProperties>
           RepositoryToBuild=%(RepositoryBuildOrder.Identity);
-          BuildRepositoryRoot=$([MSBuild]::NormalizeDirectory(%(RepositoryBuildOrder.RootPath)))
+          BuildRepositoryRoot=$([MSBuild]::NormalizeDirectory(%(RepositoryBuildOrder.RootPath)));
+          SkipTests=%(RepositoryBuildOrder.SkipTest)
         </AdditionalProperties>
       </BatchedRepository>
     </ItemGroup>
@@ -56,7 +57,8 @@
       StopOnFirstFailure="false"
       Targets="_TestRepository"
       Properties="BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
-      ContinueOnError="true">
+      ContinueOnError="true"
+      Condition=" %(_BatchedTestRepo.SkipTests) != 'true' ">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoTestResults" />
     </MSBuild>
 

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -58,7 +58,7 @@
       Targets="_TestRepository"
       Properties="BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
       ContinueOnError="true"
-      Condition=" @(_BatchedTestRepo.SkipTests) != 'true' ">
+      Condition=" '%(_BatchedTestRepo.SkipTests)' != 'true' ">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoTestResults" />
     </MSBuild>
 

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -58,7 +58,7 @@
       Targets="_TestRepository"
       Properties="BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
       ContinueOnError="true"
-      Condition=" '%(_BatchedTestRepo.SkipTests)' != 'true' ">
+      Condition=" '@(_BatchedTestRepo.SkipTests)' != 'true' ">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoTestResults" />
     </MSBuild>
 

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -14,7 +14,7 @@
       <RepositoryBuildOrder Condition="'%(RootPath)' == ''">
         <RootPath>$(SubmoduleRoot)%(Identity)\</RootPath>
       </RepositoryBuildOrder>
-      <BatchedRepository Include="$(MSBuildProjectFullPath)" Condition=" %(RepositoryBuildOrder.SkipTest) == 'true' ">
+      <BatchedRepository Include="$(MSBuildProjectFullPath)" Condition=" %(RepositoryBuildOrder.SkipTest) != 'true' ">
         <BuildGroup>%(RepositoryBuildOrder.Order)</BuildGroup>
         <Repository>%(RepositoryBuildOrder.Identity)</Repository>
         <AdditionalProperties>

--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -57,8 +57,7 @@
       StopOnFirstFailure="false"
       Targets="_TestRepository"
       Properties="BuildNumber=$(BuildNumber);IsFinalBuild=$(IsFinalBuild);Configuration=$(Configuration);_NoBuildRepos=$(_NoBuildRepos)"
-      ContinueOnError="true"
-      Condition=" '@(_BatchedTestRepo.SkipTests)' != 'true' ">
+      ContinueOnError="true">
       <Output TaskParameter="TargetOutputs" ItemName="_RepoTestResults" />
     </MSBuild>
 
@@ -173,7 +172,7 @@
 
     <Message Text="============ Testing $(RepositoryToBuild) ============" Importance="High" />
 
-    <Exec Condition="'$(SkipTestsDueToMissingSharedFx)' != 'true' "
+    <Exec Condition="'$(SkipTestsDueToMissingSharedFx)' != 'true' AND '$(SkipTests)' != 'true'"
       Command="./$(_BuildScriptToExecute) -Path $(BuildRepositoryRoot) $(BuildArguments)"
       IgnoreStandardErrorWarningFormat="true"
       WorkingDirectory="$(RepositoryRoot)"
@@ -184,7 +183,7 @@
     <CallTarget Targets="_RestoreOriginalRepoLockFile" />
 
     <ItemGroup>
-      <RepositoryTestResult Update="$(RepositoryToBuild)" Success="true" Condition="'$(TestExitCode)' == '0' OR '$(SkipTestsDueToMissingSharedFx)' == 'true' " />
+      <RepositoryTestResult Update="$(RepositoryToBuild)" Success="true" Condition="'$(TestExitCode)' == '0' OR '$(SkipTestsDueToMissingSharedFx)' == 'true' OR '$(SkipTests)' == 'true' " />
     </ItemGroup>
 
     <Message Text="============ Done testing $(RepositoryToBuild) ============" Importance="High" />

--- a/build/buildorder.props
+++ b/build/buildorder.props
@@ -7,7 +7,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <RepositoryBuildOrder Include="EntityFrameworkCore" Order="8" SkipTest="true" />
+    <RepositoryBuildOrder Include="EntityFrameworkCore" Order="8" SkipTests="true" />
     <RepositoryBuildOrder Include="Templating" Order="17" RootPath="$(RepositoryRoot)src\Templating\" />
   </ItemGroup>
 </Project>

--- a/build/buildorder.props
+++ b/build/buildorder.props
@@ -7,7 +7,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <RepositoryBuildOrder Include="EntityFrameworkCore" Order="8" />
+    <RepositoryBuildOrder Include="EntityFrameworkCore" Order="8" SkipTest="true" />
     <RepositoryBuildOrder Include="Templating" Order="17" RootPath="$(RepositoryRoot)src\Templating\" />
   </ItemGroup>
 </Project>

--- a/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
+++ b/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
@@ -100,15 +100,6 @@ namespace Microsoft.DotNet.Watcher.Internal
             return process;
         }
 
-        private static async Task ConsumeStreamAsync(StreamReader reader, Action<string> consume)
-        {
-            string line;
-            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
-            {
-                consume?.Invoke(line);
-            }
-        }
-
         private class ProcessState : IDisposable
         {
             private readonly IReporter _reporter;

--- a/src/Tools/dotnet-watch/test/DotNetWatcherTests.cs
+++ b/src/Tools/dotnet-watch/test/DotNetWatcherTests.cs
@@ -49,19 +49,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
                 await _app.IsWaitingForFileChange();
 
-                try
-                {
-                    File.SetLastWriteTime(source, DateTime.Now);
-                    await _app.HasRestarted();
-                }
-                catch (Exception ex)
-                {
-                    _logger.WriteLine("Retrying. First attempt to restart app failed: " + ex.Message);
-
-                    // retry
-                    File.SetLastWriteTime(source, DateTime.Now);
-                    await _app.HasRestarted();
-                }
+                File.SetLastWriteTime(source, DateTime.Now);
+                await _app.HasRestarted(TimeSpan.FromMinutes(1));
             }
         }
 

--- a/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
+++ b/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
@@ -278,7 +278,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
             _tempDir.Create();
             return await filesetFactory
                 .CreateAsync(CancellationToken.None)
-                .TimeoutAfter(TimeSpan.FromSeconds(30));
+                .TimeoutAfter(TimeSpan.FromSeconds(60));
         }
 
         public void Dispose()

--- a/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
+++ b/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
@@ -278,7 +278,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
             _tempDir.Create();
             return await filesetFactory
                 .CreateAsync(CancellationToken.None)
-                .TimeoutAfter(TimeSpan.FromSeconds(60));
+                .TimeoutAfter(TimeSpan.FromSeconds(30));
         }
 
         public void Dispose()

--- a/src/Tools/dotnet-watch/test/Properties/AssemblyInfo.cs
+++ b/src/Tools/dotnet-watch/test/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Tools/dotnet-watch/test/Scenario/WatchableApp.cs
+++ b/src/Tools/dotnet-watch/test/Scenario/WatchableApp.cs
@@ -42,7 +42,10 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public string SourceDirectory { get; }
 
         public Task HasRestarted()
-            => Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
+            => HasRestarted(DefaultMessageTimeOut);
+
+        public Task HasRestarted(TimeSpan timeout)
+            => Process.GetOutputLineAsync(StartedMessage, timeout);
 
         public async Task HasExited()
         {
@@ -50,9 +53,9 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             await Process.GetOutputLineStartsWithAsync(WatchExitedMessage, DefaultMessageTimeOut);
         }
 
-        public async Task IsWaitingForFileChange()
+        public Task IsWaitingForFileChange()
         {
-            await Process.GetOutputLineStartsWithAsync(WaitingForFileChangeMessage, DefaultMessageTimeOut);
+            return Process.GetOutputLineStartsWithAsync(WaitingForFileChangeMessage, DefaultMessageTimeOut);
         }
 
         public bool UsePollingWatcher { get; set; }


### PR DESCRIPTION
@muratg Test only change.

Also, realized the retry doesn't work for this test because the DOTNET_WATCH_ITERATION count can increase twice if it retries.

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1696