### PR TITLE
Fix code-signing for xplat packages and Windows installers

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -36,6 +36,8 @@ jobs:
     agentOs: Windows
     buildScript: ./src/SiteExtensions/LoggingAggregate/build.cmd
     buildArgs: -ci -sign /p:SignType=$(_SignType)
+    installNodeJs: false
+    installJdk: false
     jobName: SiteExtensions
     jobDisplayName: "Build: Azure Logging Site Extension"
     artifacts:
@@ -58,19 +60,22 @@ jobs:
     - script: "echo ##vso[build.addbuildtag]release-candidate"
       condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsFinalBuild'], 'true'))
       displayName: 'Set CI tags'
-    # This is going to actually build x86 native assets
     # TODO: make it possible to build for one Windows architecture at a time
-    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:SignType=$(_SignType)
+    # This is going to actually build x86 native assets
+
+    # Intentionally does not code-sign because the next step will code sign the same files.
+    # Skipping signing avoids duplicate sign requests.
+    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:SignType=
       displayName: Build x64
     # Build the x86 shared framework
-    - script: ./eng/scripts/cibuild.cmd -arch x86 /t:BuildSharedFx /p:SignType=$(_SignType)
+    # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
+    - script: ./eng/scripts/cibuild.cmd -arch x86 /t:BuildSharedFx /p:SignType=$(_SignType) /p:DisableSignCheck=true
       displayName: Build x86
     # Windows installers bundle both x86 and x64 assets
-    - powershell: |
-        ./src/Installers/Windows/build.ps1 `
-          -ci `
-          '/p:SignType=$(_SignType)'
+    - powershell: ./src/Installers/Windows/build.ps1 -ci /p:SignType=$(_SignType)
       displayName: Build Installers
+    - script: ./build.cmd -ci -sign /t:SignCheck /p:SignType=$(_SignType)
+      displayName: Run signcheck
     artifacts:
     - name: Windows_Packages
       path: artifacts/packages/
@@ -90,8 +95,10 @@ jobs:
     jobName: Windows_arm_build
     jobDisplayName: "Build: Windows ARM"
     agentOs: Windows
-    buildScript: ./eng/scripts/cibuild.cmd
+    buildScript: ./eng/scripts/cibuild.cmd -NoBuildNodeJS -NoBuildJava
     buildArgs: -arch arm /p:SignType=$(_SignType)
+    installNodeJs: false
+    installJdk: false
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so builds only produce runtime packages
@@ -114,6 +121,7 @@ jobs:
     agentOs: macOs
     buildScript: ./eng/scripts/cibuild.sh
     buildArgs: --no-build-nodejs --no-build-java
+    installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
@@ -137,6 +145,7 @@ jobs:
     jobName: Linux_x64_build
     jobDisplayName: "Build: Linux x64"
     agentOs: Linux
+    installNodeJs: false
     buildSteps:
     - script: ./eng/scripts/cibuild.sh --arch x64 --no-build-nodejs --no-build-java
       displayName: Run cibuild.sh
@@ -187,6 +196,7 @@ jobs:
     agentOs: Linux
     buildScript: ./eng/scripts/cibuild.sh
     buildArgs: --arch arm --no-build-nodejs --no-build-java
+    installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
@@ -212,6 +222,7 @@ jobs:
     agentOs: Linux
     buildScript: ./eng/scripts/cibuild.sh
     buildArgs: --arch arm64 --no-build-nodejs --no-build-java
+    installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
@@ -237,6 +248,7 @@ jobs:
     agentOs: Linux
     buildScript: ./dockerbuild.sh alpine
     buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch x64 --os-name linux-musl --no-build-nodejs --no-build-java
+    installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages

--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -5,22 +5,27 @@ parameters:
 jobs:
 - template: default-build.yml
   parameters:
+    codeSign: true
     dependsOn:
     - ${{ parameters.inputName }}_build
     condition: in(variables['_SignType'], 'test', 'real')
     jobName: CodeSign_Xplat_${{ parameters.inputName }}
     jobDisplayName: "Code-sign ${{ parameters.inputName }} packages"
     agentOs: Windows
-    beforeBuild:
+    installNodeJs: false
+    installJdk: false
+    buildSteps:
     - task: DownloadBuildArtifacts@0
       displayName: Download ${{ parameters.inputName }} artifacts
       inputs:
         artifactName: ${{ parameters.inputName }}_Packages
         downloadPath: $(Build.StagingDirectory)/deps/
         itemPattern: '**/*.nupkg'
-    buildScript: eng\tools\XplatPackageSigner\sign-packages.cmd $(Build.StagingDirectory)\deps\${{ parameters.inputName }}Packages\
+    - task: MSBuild@1
+      displayName: Code-sign .nupkg files
+      inputs:
+        solution: eng\tools\XplatPackageSigner\XplatPackageSigner.proj
+        msbuildArguments: /p:SignType=$(_SignType) /p:DirectoryToSign=$(Build.StagingDirectory)\deps\${{ parameters.inputName }}_Packages\
     artifacts:
     - name: ${{ parameters.inputName }}_Packages_Signed
-      path: $(Build.StagingDirectory)\deps\${{ parameters.inputName }}Packages\
-    - name: ${{ parameters.inputName }}_Logs
-      path: artifacts/logs/
+      path: $(Build.StagingDirectory)\deps\${{ parameters.inputName }}_Packages\

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -62,6 +62,8 @@ parameters:
   artifacts:  []
   buildDirectory: ''
   buildScript: ''
+  installNodeJs: true
+  installJdk: true
 
 jobs:
 - job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
@@ -111,11 +113,12 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - task: NodeTool@0
-    displayName: Install Node 10.x
-    inputs:
-      versionSpec: 10.x
-  - ${{ if eq(parameters.agentOs, 'Windows') }}:
+  - ${{ if eq(parameters.installNodeJs, 'true') }}:
+    - task: NodeTool@0
+      displayName: Install Node 10.x
+      inputs:
+        versionSpec: 10.x
+  - ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:
     - powershell: ./eng/scripts/InstallJdk.ps1 '11.0.1'
       displayName: Install JDK 11
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,6 +53,8 @@
     <SignAssembly>true</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <PlatformName Condition=" '$(PlatformName)' == '' ">$(Platform)</PlatformName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
@@ -107,12 +109,13 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OutputInRepoRoot)' == 'true' ">
-    <BaseOutputPath>$(RepositoryRoot)bin\$(Configuration)\$(MSBuildProjectName)\</BaseOutputPath>
-    <OutputPath>$(BaseOutputPath)</OutputPath>
+    <BaseOutputPath>$(RepositoryRoot)bin\$(MSBuildProjectName)\</BaseOutputPath>
+    <OutputPath Condition=" '$(PlatformName)' == 'AnyCPU' ">$(BaseOutputPath)$(Configuration)\</OutputPath>
+    <OutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+
     <BaseIntermediateOutputPath>$(RepositoryRoot)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <OutputPath Condition=" '$(AppendPlatformToOutputPath)' == 'true' AND '$(Platform)' != '' AND '$(Platform)' != 'AnyCPU' ">$(OutputPath)$(Platform)\</OutputPath>
-    <IntermediateOutputPath Condition=" '$(AppendPlatformToOutputPath)' == 'true' AND '$(Platform)' != '' AND '$(Platform)' != 'AnyCPU' ">$(IntermediateOutputPath)$(Platform)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
 
   <!-- Defines project type conventions. -->

--- a/eng/targets/Wix.Common.targets
+++ b/eng/targets/Wix.Common.targets
@@ -31,7 +31,6 @@
     <Culture Condition=" '$(Culture)' == '' ">en-US</Culture>
     <Cultures Condition=" '$(Cultures)' == '' ">$(Culture)</Cultures>
     <InstallerPlatform>$(Platform)</InstallerPlatform>
-    <PlatformName Condition=" '$(PlatformName)' == '' ">$(Platform)</PlatformName>
     <OutDir Condition=" '$(OutDir)' == '' ">$(OutputPath)</OutDir>
     <DefineConstants>$(DefineConstants);BinPath=$(OutputPath)$(Culture)\</DefineConstants>
     <DefineConstants>$(WixVariables);$(DefineConstants)</DefineConstants>

--- a/eng/tools/XplatPackageSigner/XplatPackageSigner.proj
+++ b/eng/tools/XplatPackageSigner/XplatPackageSigner.proj
@@ -5,7 +5,7 @@
   Note: because Authenticode signing of .dll's is not something Linux and macOS can verify anyways, this signing
   process only code-signs the .nupkg itself, not the contents.
 -->
-<Project DefaultTargets="AfterBuild" InitialTargets="CheckForRequiredProperties">
+<Project DefaultTargets="Build" InitialTargets="CheckForRequiredProperties">
   <PropertyGroup>
     <SignType>$([MSBuild]::ValueOrDefault($(SignType),'real'))</SignType>
   </PropertyGroup>
@@ -14,14 +14,14 @@
   <Import Project="..\..\targets\MicroBuild.Plugin.props" Condition="'$(MicroBuildSentinelFile)' == ''" />
   <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.props" Condition=" '$(MicroBuildPluginDirectory)' != ''" />
 
-  <PropertyGroup>
-    <OutDir>$(RepositoryRoot)bin\$(MSBuildProjectName)\</OutDir>
+  <PropertyGroup Condition="'$(DirectoryToSign)' != ''">
+    <OutDir>$([MSBuild]::NormalizeDirectory($(DirectoryToSign)))</OutDir>
     <IntermediateOutputPath>$(RepositoryRoot)obj\$(MSBuildProjectName)\</IntermediateOutputPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DirectoryToSign)' != ''">
-    <SymbolsPackages Include="$([MSBuild]::NormalizeDirectory($(DirectoryToSign)))**\*.symbols.nupkg" />
-    <FilesToSign Include="$([MSBuild]::NormalizeDirectory($(DirectoryToSign)))**\*.nupkg">
+  <ItemGroup Condition="'$(OutDir)' != ''">
+    <SymbolsPackages Include="$(OutDir)**\*.symbols.nupkg" />
+    <FilesToSign Include="$(OutDir)**\*.nupkg">
       <Authenticode>NuGet</Authenticode>
     </FilesToSign>
   </ItemGroup>
@@ -33,5 +33,6 @@
 
   <!-- MicroBuild code-signing chains onto this target. -->
   <Target Name="AfterBuild" />
+  <Target Name="Build" DependsOnTargets="AfterBuild" />
   <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.targets" Condition=" '$(MicroBuildPluginDirectory)' != ''" />
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
@@ -16,8 +16,6 @@
     <IisOobWinSdkVersion Condition="'$(IisOobWinSdkVersion)' == ''">10.0.17134.0</IisOobWinSdkVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(IisOobWinSdkVersion)</WindowsTargetPlatformVersion>
     <CharacterSet>Unicode</CharacterSet>
-    <OutDir>bin\$(Configuration)\$(PlatformShortname)\</OutDir>
-    <IntDir>obj\$(Configuration)\$(PlatformShortname)\</IntDir>
   </PropertyGroup>
 
   <!--

--- a/src/Installers/Windows/Directory.Build.props
+++ b/src/Installers/Windows/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputInRepoRoot>true</OutputInRepoRoot>
-    <AppendPlatformToOutputPath>true</AppendPlatformToOutputPath>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />

--- a/src/Installers/Windows/SharedFrameworkLib/SharedFrameworkLib.wixproj
+++ b/src/Installers/Windows/SharedFrameworkLib/SharedFrameworkLib.wixproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Name>AspNetCoreSharedFrameworkLib$(Platform)</Name>
     <!-- Use the internal installer name because .wixlib files are only produced so we can hand them off to the dotnet/cli repo. -->
-    <OutputName>$(InternalInstallerBaseName)-$(PackageVersion)-$(TargetRuntimeIdentifier)</OutputName>
+    <OutputName>$(InternalInstallerBaseName)-$(PackageVersion)-win-$(Platform)</OutputName>
     <!-- This is still marked as a 'product' because is needs to copied to artifact outputs. -->
     <IsProductInstaller>true</IsProductInstaller>
     <OutputType>Library</OutputType>

--- a/src/Installers/Windows/build.ps1
+++ b/src/Installers/Windows/build.ps1
@@ -5,7 +5,9 @@ param(
     [Alias("x86")]
     [string]$sharedfx86harvestroot,
     [Alias("x64")]
-    [string]$sharedfx64harvestroot
+    [string]$sharedfx64harvestroot,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$AdditionalArgs
 )
 
 $ErrorActionPreference = 'Stop'
@@ -37,7 +39,8 @@ try {
             -sign `
             -BuildInstallers `
             "-bl:$repoRoot/artifacts/logs/installers.msbuild.binlog" `
-            @msbuildargs
+            @msbuildargs `
+            @AdditionalArgs
 }
 finally {
     Pop-Location

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -19,7 +19,7 @@
     <Content Include="applicationHost.xdt" />
     <Content Include="scmApplicationHost.xdt" />
     <Content Include="install.cmd" />
-    <Content Include="$(RepositoryRoot)bin\$(Configuration)\Microsoft.Web.Xdt.Extensions\net461\Microsoft.Web.Xdt.Extensions.dll" PackagePath="content" />
+    <Content Include="$(RepositoryRoot)bin\Microsoft.Web.Xdt.Extensions\$(Configuration)\net461\Microsoft.Web.Xdt.Extensions.dll" PackagePath="content" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ran this internally - https://dev.azure.com/dnceng/internal/_build/results?buildId=85126

Resolves https://github.com/aspnet/AspNetCore-Internal/issues/1750

Incidentally, this was also the last piece required to make the full build chain of AspNetCore work in AzDo, so this resolves https://github.com/aspnet/AspNetCore-Internal/issues/876, too.