### PR TITLE
Only publish artifacts on successful builds (unless specified otherwise)

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -73,6 +73,7 @@ jobs:
       path: artifacts/installers/
     - name: Windows_Logs
       path: artifacts/logs/
+      publishOnError: true
 
 # Build Windows ARM
 - template: jobs/default-build.yml
@@ -98,6 +99,7 @@ jobs:
       path: artifacts/installers/
     - name: Windows_arm_Logs
       path: artifacts/logs/
+      publishOnError: true
 
 # Build MacOS
 - template: jobs/default-build.yml
@@ -111,7 +113,8 @@ jobs:
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
-    - script: find artifacts/packages/ -type f -not -name 'runtime.*' -delete
+    - script: if [ -d 'artifacts/packages' ]; then find artifacts/packages/ -type f -not -name 'runtime.*' -delete; fi
+      condition: always()
     artifacts:
     - name: MacOS_x64_Packages
       path: artifacts/packages/
@@ -121,6 +124,7 @@ jobs:
       path: artifacts/installers/
     - name: MacOS_x64_Logs
       path: artifacts/logs/
+      publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
     inputName: MacOS_x64
@@ -160,7 +164,8 @@ jobs:
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
-    - script: find artifacts/packages/ -type f -not -name 'runtime.*' -delete
+    - script: if [ -d 'artifacts/packages' ]; then find artifacts/packages/ -type f -not -name 'runtime.*' -delete; fi
+      condition: always()
     artifacts:
     - name: Linux_x64_Packages
       path: artifacts/packages/
@@ -170,6 +175,7 @@ jobs:
       path: artifacts/installers/
     - name: Linux_x64_Logs
       path: artifacts/logs/
+      publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
     inputName: Linux_x64
@@ -186,7 +192,8 @@ jobs:
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
-    - script: find artifacts/packages/ -type f -not -name 'runtime.*' -delete
+    - script: if [ -d 'artifacts/packages' ]; then find artifacts/packages/ -type f -not -name 'runtime.*' -delete; fi
+      condition: always()
     artifacts:
     - name: Linux_arm_Packages
       path: artifacts/packages/
@@ -196,6 +203,7 @@ jobs:
       path: artifacts/installers/
     - name: Linux_arm_Logs
       path: artifacts/logs/
+      publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
     inputName: Linux_arm
@@ -212,7 +220,8 @@ jobs:
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
-    - script: find artifacts/packages/ -type f -not -name 'runtime.*' -delete
+    - script: if [ -d 'artifacts/packages' ]; then find artifacts/packages/ -type f -not -name 'runtime.*' -delete; fi
+      condition: always()
     artifacts:
     - name: Linux_arm64_Packages
       path: artifacts/packages/
@@ -222,6 +231,7 @@ jobs:
       path: artifacts/installers/
     - name: Linux_arm64_Logs
       path: artifacts/logs/
+      publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
     inputName: Linux_arm64
@@ -238,7 +248,8 @@ jobs:
     afterBuild:
     # Remove packages that are not rid-specific.
     # TODO add a flag so macOS/Linux builds only produce runtime packages
-    - script: find artifacts/packages/ -type f -not -name 'runtime.*' -delete
+    - script: if [ -d 'artifacts/packages' ]; then find artifacts/packages/ -type f -not -name 'runtime.*' -delete; fi
+      condition: always()
     artifacts:
     - name: Linux_musl_x64_Packages
       path: artifacts/packages/
@@ -248,6 +259,7 @@ jobs:
       path: artifacts/installers/
     - name: Linux_musl_x64_Logs
       path: artifacts/logs/
+      publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
     inputName: Linux_musl_x64

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -44,9 +44,6 @@ jobs:
     - script: "echo ##vso[build.addbuildtag]release-candidate"
       condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsFinalBuild'], 'true'))
       displayName: 'Set CI tags'
-    # TODO: make it possible to build for one Windows architecture at a time
-    # This is going to actually build x86 native assets
-
     # !!! NOTE !!! Some of these steps have disabled code signing.
     # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
     # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
@@ -54,17 +51,22 @@ jobs:
 
     - script: ./eng/scripts/cibuild.cmd -arch x64 /p:DisableCodeSigning=true
       displayName: Build x64
+    # TODO: make it possible to build for one Windows architecture at a time
+    # This is going to actually build x86 native assets. See https://github.com/aspnet/AspNetCore/issues/7196
 
     # Build the x86 shared framework
     # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
     - script: ./eng/scripts/cibuild.cmd -arch x86 /t:BuildSharedFx /p:DisableCodeSigning=true
       displayName: Build x86
+
     # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
     - script: ./build.cmd -ci -sign -forceCoreMsbuild /p:DisableCodeSigning=true -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
       displayName: Build SiteExtension
+
     # Windows installers bundle both x86 and x64 assets
     - powershell: ./src/Installers/Windows/build.ps1 -ci /p:SignType=$(_SignType)
       displayName: Build Installers
+
     # This runs code-signing on all outputs as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
     # consider running code-signing inline with the other previous steps.
     - script: ./build.cmd -ci -sign /t:CodeSign /t:SignCheck /p:SignType=$(_SignType)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -47,21 +47,28 @@ jobs:
     # TODO: make it possible to build for one Windows architecture at a time
     # This is going to actually build x86 native assets
 
-    # Intentionally does not code-sign because the next step will code sign the same files.
-    # Skipping signing avoids duplicate sign requests.
-    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:SignType=
+    # !!! NOTE !!! Some of these steps have disabled code signing.
+    # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
+    # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
+    # The sign settings have been configured to
+
+    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:DisableCodeSigning=true
       displayName: Build x64
+
     # Build the x86 shared framework
     # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
-    - script: ./eng/scripts/cibuild.cmd -arch x86 /t:BuildSharedFx /p:SignType=$(_SignType) /p:DisableSignCheck=true
+    - script: ./eng/scripts/cibuild.cmd -arch x86 /t:BuildSharedFx /p:DisableCodeSigning=true
       displayName: Build x86
+    # This is in a separate build step which is forced to run on dotnet core to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
+    - script: ./eng/scripts/cibuild.cmd /p:DisableCodeSigning=true -forceCoreMsbuild -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+      displayName: Build SiteExtension
     # Windows installers bundle both x86 and x64 assets
     - powershell: ./src/Installers/Windows/build.ps1 -ci /p:SignType=$(_SignType)
       displayName: Build Installers
-    - powershell: ./build.ps1 -ci -sign -forceCoreMsbuild -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
-      displayName: Build SiteExtension
-    - script: ./build.cmd -ci -sign /t:SignCheck /p:SignType=$(_SignType)
-      displayName: Run signcheck
+    # This runs code-signing on all outputs as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
+    # consider running code-signing inline with the other previous steps.
+    - script: ./build.cmd -ci -sign /t:CodeSign /t:SignCheck /p:SignType=$(_SignType)
+      displayName: Code sign packages
     artifacts:
     - name: Windows_Packages
       path: artifacts/packages/

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -59,8 +59,8 @@ jobs:
     # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
     - script: ./eng/scripts/cibuild.cmd -arch x86 /t:BuildSharedFx /p:DisableCodeSigning=true
       displayName: Build x86
-    # This is in a separate build step which is forced to run on dotnet core to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
-    - script: ./eng/scripts/cibuild.cmd /p:DisableCodeSigning=true -forceCoreMsbuild -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+    # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
+    - script: ./build.cmd -ci -sign -forceCoreMsbuild /p:DisableCodeSigning=true -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
       displayName: Build SiteExtension
     # Windows installers bundle both x86 and x64 assets
     - powershell: ./src/Installers/Windows/build.ps1 -ci /p:SignType=$(_SignType)

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -160,7 +160,7 @@ jobs:
   - ${{ each artifact in parameters.artifacts }}:
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts from ${{ artifact.path }}
-      condition: or(eq(variables['system.pullrequest.isfork'], false), eq('${{ artifact.includeForks }}', 'true'))
+      condition: and(or(succeeded(), eq('${{ artifact.publishOnError }}', 'true')), or(eq(variables['system.pullrequest.isfork'], false), eq('${{ artifact.includeForks }}', 'true')))
       continueOnError: true
       inputs:
         ${{ if eq(parameters.buildDirectory, '') }}:


### PR DESCRIPTION
This resolves an error that happened in this build: https://dev.azure.com/dnceng/internal/_build/results?buildId=85382

The build failed in Linux_x64 due to network timeout from Docker, but the Linux_x64_Packages artifact was published anyways without running the afterBuild step that filters out duplicate packages. As a result, the deployment had duplicate copies of Microsoft.AspNetCore.App (one from the Linux build, the other from the Windows build).