### PR TITLE
Rename IHttpContextContainer to  IDefaultHttpContextContainer

### DIFF
--- a/src/Http/Http/src/DefaultHttpContextFactory.cs
+++ b/src/Http/Http/src/DefaultHttpContextFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static DefaultHttpContext CreateHttpContext(IFeatureCollection featureCollection)
         {
-            if (featureCollection is IHttpContextContainer container)
+            if (featureCollection is IDefaultHttpContextContainer container)
             {
                 return container.HttpContext;
             }

--- a/src/Http/Http/src/HttpContextFactory.cs
+++ b/src/Http/Http/src/HttpContextFactory.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static DefaultHttpContext CreateHttpContext(IFeatureCollection featureCollection)
         {
-            if (featureCollection is IHttpContextContainer container)
+            if (featureCollection is IDefaultHttpContextContainer container)
             {
                 return container.HttpContext;
             }

--- a/src/Http/Http/src/IDefaultHttpContextContainer.cs
+++ b/src/Http/Http/src/IDefaultHttpContextContainer.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Microsoft.AspNetCore.Http
 {
-    public interface IHttpContextContainer
+    public interface IDefaultHttpContextContainer
     {
         DefaultHttpContext HttpContext { get; }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public abstract partial class HttpProtocol : IHttpContextContainer, IHttpResponseControl
+    public abstract partial class HttpProtocol : IDefaultHttpContextContainer, IHttpResponseControl
     {
         private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");
         private static readonly byte[] _bytesConnectionKeepAlive = Encoding.ASCII.GetBytes("\r\nConnection: keep-alive");
@@ -274,7 +274,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected HttpResponseHeaders HttpResponseHeaders { get; } = new HttpResponseHeaders();
 
-        DefaultHttpContext IHttpContextContainer.HttpContext
+        DefaultHttpContext IDefaultHttpContextContainer.HttpContext
         {
             get
             {


### PR DESCRIPTION
- Renamed since the property has to be a DefaultHttpContext

See https://github.com/aspnet/AspNetCore/pull/6511#discussion_r253286825 for more context