### PR TITLE
Improve the error experience in Startup

### DIFF
--- a/src/Hosting/Hosting/src/Internal/ConfigureServicesBuilder.cs
+++ b/src/Hosting/Hosting/src/Internal/ConfigureServicesBuilder.cs
@@ -43,13 +43,36 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 throw new InvalidOperationException("The ConfigureServices method must either be parameterless or take only one parameter of type IServiceCollection.");
             }
 
-            var arguments = new object[MethodInfo.GetParameters().Length];
+            // Create a delegate for the known types so that we can avoid target invocation exceptions
+            if (MethodInfo.ReturnType == typeof(IServiceProvider))
+            {
+                if (parameters.Length == 0)
+                {
+                    return MethodInfo.CreateDelegate<Func<IServiceProvider>>(instance).Invoke();
+                }
+
+                return MethodInfo.CreateDelegate<Func<IServiceCollection, IServiceProvider>>(instance).Invoke(services);
+            }
+            else if (MethodInfo.ReturnType == typeof(void))
+            {
+                if (parameters.Length == 0)
+                {
+                    MethodInfo.CreateDelegate<Action>(instance).Invoke();
+                    return null;
+                }
+
+                MethodInfo.CreateDelegate<Action<IServiceCollection>>(instance).Invoke(services);
+                return null;
+            }
+
+            var arguments = new object[parameters.Length];
 
             if (parameters.Length > 0)
             {
                 arguments[0] = services;
             }
 
+            // Not sure what this return type would have been but, just delegate to a late bound invoke
             return MethodInfo.Invoke(instance, arguments) as IServiceProvider;
         }
     }

--- a/src/Hosting/Hosting/src/Internal/MethodInfoExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/MethodInfoExtensions.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    internal static class MethodInfoExtensions
+    {
+        public static TDelegate CreateDelegate<TDelegate>(this MethodInfo methodInfo, object target)
+        {
+            if (methodInfo.IsStatic)
+            {
+                return (TDelegate)(object)methodInfo.CreateDelegate(typeof(TDelegate));
+            }
+
+            return (TDelegate)(object)methodInfo.CreateDelegate(typeof(TDelegate), target);
+        }
+    }
+}

--- a/src/Hosting/Hosting/src/Startup/ConventionBasedStartup.cs
+++ b/src/Hosting/Hosting/src/Startup/ConventionBasedStartup.cs
@@ -18,39 +18,15 @@ namespace Microsoft.AspNetCore.Hosting
         {
             _methods = methods;
         }
-        
+
         public void Configure(IApplicationBuilder app)
         {
-            try
-            {
-                _methods.ConfigureDelegate(app);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TargetInvocationException)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                }
-
-                throw;
-            }
+            _methods.ConfigureDelegate(app);
         }
 
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
-            try
-            {
-                return _methods.ConfigureServicesDelegate(services);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TargetInvocationException)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                }
-
-                throw;
-            }
+            return _methods.ConfigureServicesDelegate(services);
         }
     }
 }

--- a/src/Hosting/Hosting/test/StartupManagerTests.cs
+++ b/src/Hosting/Hosting/test/StartupManagerTests.cs
@@ -499,8 +499,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
 
-            var ex = Assert.Throws<TargetInvocationException>(() => startup.ConfigureDelegate(app));
-            Assert.IsAssignableFrom<InvalidOperationException>(ex.InnerException);
+            var ex = Assert.Throws<InvalidOperationException>(() => startup.ConfigureDelegate(app));
         }
 
         [Fact]


### PR DESCRIPTION
- When using reflection to invoke the Configure and ConfigureServices, the exception assistant doesn't properly show the exception even when it happens in user code. Even throw we try to re-throw the TargetInvocationException, it doesn't work super well as the callstack is deep in ExceptonDispatchInfo.Throw.
- Instead, we create a delegate that calls into both Configure and ConfigureServices to avoid using reflection.

Here's what this looks like in VS with an exception today:

![image](https://user-images.githubusercontent.com/95136/52189437-8397b200-27ed-11e9-8686-ae3f2a1ae1b0.png)

```
   at WebApplication93.Startup.Configure(IApplicationBuilder app, IHostingEnvironment env) in C:\Users\david\source\repos\WebApplication93\WebApplication93\Startup.cs:line 24
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Hosting.ConventionBasedStartup.Configure(IApplicationBuilder app)
   at Microsoft.AspNetCore.HostFilteringStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder app)
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.BuildApplication()
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.StartAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Hosting.WebHostExtensions.RunAsync(IWebHost host, CancellationToken token, String shutdownMessage)
   at Microsoft.AspNetCore.Hosting.WebHostExtensions.RunAsync(IWebHost host, CancellationToken token)
   at Microsoft.AspNetCore.Hosting.WebHostExtensions.Run(IWebHost host)
   at WebApplication93.Program.Main(String[] args) in C:\Users\david\source\repos\WebApplication93\WebApplication93\Program.cs:line 21
```

After this change:

![image](https://user-images.githubusercontent.com/95136/52189498-b93c9b00-27ed-11e9-9126-36904b1d395c.png)

PS: It turns out since Configure is called on an async code path, this doesn't help for exceptions throw there. ConfigureServices works great though.
