### PR TITLE
Strong-name the dotnet-blazor CLI tool. Fixes #1501

### DIFF
--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -1,8 +1,3 @@
 <!-- Use this file to workaround issues. List the issue tracking the item to fix so we can remove the workaround when the issue is resolved. -->
 <Project>
-
-  <!-- Workaround https://github.com/aspnet/AspNetCore-Internal/issues/1501. dotnet-blazor.dll isn't strong-named signed. -->
-  <ItemGroup>
-    <FileNamesToSign Include="dotnet-blazor.dll" CertificateName="Microsoft400" />
-  </ItemGroup>
 </Project>

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -7,11 +7,6 @@
     <PackageId>Microsoft.AspNetCore.Blazor.Cli</PackageId>
     <IsShippingPackage>true</IsShippingPackage>
     <StartupObject>Microsoft.AspNetCore.Blazor.Cli.Program</StartupObject>
-    <!--
-      Disabled because E2ETest.csproj needs to WebDriver which is not strong named signed, and InternalsVisibleTo must specify a strong-name token.
-      See also eng/Workarounds.targets.
-    -->
-    <SignAssembly>false</SignAssembly>
     <Description>Development server for use when building Blazor applications.</Description>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>

--- a/src/Components/Blazor/Cli/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Blazor/Cli/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Microsoft.AspNetCore.Components.E2ETests")]

--- a/src/Components/Blazor/Cli/src/Server/Program.cs
+++ b/src/Components/Blazor/Cli/src/Server/Program.cs
@@ -6,9 +6,19 @@ using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.AspNetCore.Blazor.Cli.Server
 {
-    internal class Program
+    // This project is a CLI tool, so we don't expect anyone to reference it
+    // as a runtime library. As such we consider it reasonable to mark the
+    // following method as public purely so the E2E tests project can invoke it.
+
+    /// <summary>
+    /// Intended for framework test use only.
+    /// </summary>
+    public class Program
     {
-        internal static IWebHost BuildWebHost(string[] args) =>
+        /// <summary>
+        /// Intended for framework test use only.
+        /// </summary>
+        public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseConfiguration(new ConfigurationBuilder()
                     .AddCommandLine(args)


### PR DESCRIPTION
Since `dotnet-blazor` is a CLI tool, we don't expect anyone to be referencing it as a runtime library. As such it looks reasonable to mark the entrypoint as `public` so the E2E test can use it.