### PR TITLE
Add apng to FileExtensionContentTypeProvider.

### DIFF
--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".aif", "audio/x-aiff" },
                 { ".aifc", "audio/aiff" },
                 { ".aiff", "audio/aiff" },
+                { ".apng", "image/apng" },
                 { ".appcache", "text/cache-manifest" },
                 { ".application", "application/x-ms-application" },
                 { ".art", "image/x-jg" },


### PR DESCRIPTION
## Summary of the changes (Less than 80 chars)

 - Add apng to FileExtensionContentTypeProvider.

## Addresses #bugnumber (in this specific format)

#7101

## Reference

[APNG Specification#MIME type](https://wiki.mozilla.org/APNG_Specification#MIME_type)