### PR TITLE
Add support for suspending ANCM startup

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -146,6 +146,13 @@ APPLICATION_INFO::TryCreateApplication(IHttpContext& pHttpContext, const ShimOpt
         }
         else
         {
+            auto const suspendedEventName = startupEvent.value() + L"_suspended";
+
+            HandleWrapper<NullHandleTraits> suspendedEventHandle = OpenEvent(EVENT_MODIFY_STATE, false, suspendedEventName.c_str());
+            if (suspendedEventHandle != nullptr)
+            {
+                LOG_LAST_ERROR_IF(!SetEvent(suspendedEventHandle));
+            }
             LOG_LAST_ERROR_IF(WaitForSingleObject(eventHandle, INFINITE) != WAIT_OBJECT_0);
         }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -133,6 +133,23 @@ APPLICATION_INFO::CreateApplication(IHttpContext& pHttpContext)
 HRESULT
 APPLICATION_INFO::TryCreateApplication(IHttpContext& pHttpContext, const ShimOptions& options)
 {
+    const auto startupEvent = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_STARTUP_SUSPEND_EVENT");
+    if (startupEvent.has_value())
+    {
+        LOG_INFOF(L"Startup suspend event %ls", startupEvent.value().c_str());
+
+        HandleWrapper<NullHandleTraits> eventHandle = OpenEvent(SYNCHRONIZE, false, startupEvent.value().c_str());
+
+        if (eventHandle == nullptr)
+        {
+            LOG_INFOF(L"Unable to open startup suspend event");
+        }
+        else
+        {
+            LOG_LAST_ERROR_IF(WaitForSingleObject(eventHandle, INFINITE) != WAIT_OBJECT_0);
+        }
+
+    }
     RETURN_IF_FAILED(m_handlerResolver.GetApplicationFactory(*pHttpContext.GetApplication(), m_pApplicationFactory, options));
     LOG_INFO(L"Creating handler application");
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -533,7 +533,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             var eventPrefix = deploymentParameters.ServerType == ServerType.IISExpress ? "" : "Global\\";
 
             var startWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "ANCM_TestEvent");
-            var suspendedWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "Global\\ANCM_TestEvent_suspended");
+            var suspendedWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "ANCM_TestEvent_suspended");
 
             var deploymentResult = await DeployAsync(deploymentParameters);
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -530,8 +530,10 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             deploymentParameters.ApplicationType = ApplicationType.Standalone;
             deploymentParameters.EnvironmentVariables["ASPNETCORE_STARTUP_SUSPEND_EVENT"] = "ANCM_TestEvent";
 
-            var startWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, "Global\\ANCM_TestEvent");
-            var suspendedWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, "Global\\ANCM_TestEvent_suspended");
+            var eventPrefix = deploymentParameters.ServerType == ServerType.IISExpress ? "" : "Global\\";
+
+            var startWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "ANCM_TestEvent");
+            var suspendedWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "Global\\ANCM_TestEvent_suspended");
 
             var deploymentResult = await DeployAsync(deploymentParameters);
 


### PR DESCRIPTION
Uses the `ASPNETCORE_STARTUP_SUSPEND_EVENT` environment variable to get an event name.

Fixes: https://github.com/aspnet/AspNetCore/issues/6972
