### PR TITLE
Re-enable h2spec tests with more diagnostics

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -23,7 +23,7 @@ namespace Interop.FunctionalTests
         SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support")]
     public class H2SpecTests : LoggedTest
     {
-        [ConditionalTheory(Skip = "Skipped while debugging https://github.com/aspnet/AspNetCore-Internal/issues/1720")]
+        [ConditionalTheory]
         [MemberData(nameof(H2SpecTestCases))]
         public async Task RunIndividualTestCase(H2SpecTestCase testCase)
         {


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-internal/issues/1720 These tests were timing out or hanging. I've added more diagnostics to see if we can figure out why. I won't merge yet, I'll run them in a loop on this PR until we can get more info.