### PR TITLE
Use SetPlatform in native project references

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CustomAction\aspnetcoreCA.vcxproj">
       <Name>aspnetcoreCA</Name>
+      <SetPlatform Condition="'$(Platform)' == 'x86'">Platform=Win32</SetPlatform>
       <Project>{7c27e72f-54d0-4820-8cfa-5e4be640974b}</Project>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CustomAction\aspnetcoreCA.vcxproj">
       <Name>aspnetcoreCA</Name>
+      <SetPlatform Condition="'$(Platform)' == 'x86'">Platform=Win32</SetPlatform>
       <Project>{7c27e72f-54d0-4820-8cfa-5e4be640974b}</Project>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
@@ -62,7 +62,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SetPlatform>Platform=Win32</SetPlatform>
     </ProjectReference>
-    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="Win32">
+    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj">
       <Name>AspNetCoreV2Handler</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
@@ -40,30 +40,34 @@
   </PropertyGroup>
 
  <ItemGroup>
-    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj"  Platform="x64">
+    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj">
       <Name>AspNetCoreV2WoW64</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SetPlatform>Platform=x64</SetPlatform>
     </ProjectReference>
-    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="x64">
+    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj">
       <Name>AspNetCoreV2HandlerWoW64</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SetPlatform>Platform=x64</SetPlatform>
     </ProjectReference>
 
-    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj"  Platform="Win32">
+    <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj">
       <Name>AspNetCoreV2</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SetPlatform>Platform=Win32</SetPlatform>
     </ProjectReference>
     <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="Win32">
       <Name>AspNetCoreV2Handler</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SetPlatform>Platform=Win32</SetPlatform>
     </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
May fix https://github.com/aspnet/AspNetCore/issues/7250 

We were double building native projects in x86 and win32 platforms