### PR TITLE
Blazor 0.8.0 fixes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -144,7 +144,7 @@
     <SystemIdentityModelTokensJwtPackageVersion>5.3.0</SystemIdentityModelTokensJwtPackageVersion>
     <WindowsAzureStoragePackageVersion>8.1.4</WindowsAzureStoragePackageVersion>
     <!-- Dependencies for Blazor. -->
-    <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.8.0-preview-20190125.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
+    <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.8.0-preview-20190204.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- When updating this, ensure you also update src/Components/Browser.JS/src/package.json to reference the corresponding version of @dotnet/jsinterop -->
     <MonoWebAssemblyInteropPackageVersion>0.8.0-preview1-20181126.4</MonoWebAssemblyInteropPackageVersion>
     <!-- Packages from 2.1/2.2 branches used for site extension build -->

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/Shared/SurveyPrompt.cshtml
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/Shared/SurveyPrompt.cshtml
@@ -4,7 +4,7 @@
 
     <span class="text-nowrap">
         Please take our
-        <a target="_blank" class="font-weight-bold" href="https://go.microsoft.com/fwlink/?linkid=2041371">brief survey</a>
+        <a target="_blank" class="font-weight-bold" href="https://go.microsoft.com/fwlink/?linkid=2069004">brief survey</a>
     </span>
     and tell us what you think.
 </div>

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Server" Version="$(TemplateComponentsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(TemplateComponentsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
@@ -13,7 +13,7 @@ namespace BlazorHosted_CSharp.Server
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc().AddNewtonsoftJson();
             services.AddResponseCompression();
         }
 

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/Shared/SurveyPrompt.cshtml
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/Shared/SurveyPrompt.cshtml
@@ -4,7 +4,7 @@
 
     <span class="text-nowrap">
         Please take our
-        <a target="_blank" class="font-weight-bold" href="https://go.microsoft.com/fwlink/?linkid=2041371">brief survey</a>
+        <a target="_blank" class="font-weight-bold" href="https://go.microsoft.com/fwlink/?linkid=2069004">brief survey</a>
     </span>
     and tell us what you think.
 </div>


### PR DESCRIPTION
This PR contains three fixes that are about to be shipped in Blazor 0.8.0. They are already in `stevesa/release-blazor-0.8.0`, but they need to go in `master` too, because these ones are meant to be permanent.