### PR TITLE
Use Win32 as native platform

### DIFF
--- a/eng/targets/ResolveIisReferences.targets
+++ b/eng/targets/ResolveIisReferences.targets
@@ -46,7 +46,7 @@ with the right MSBuild incantations to get output copied to the right place.
 
         <ProjectReference Include="@(NativeProjectReference)">
           <!-- Set the arch-->
-          <SetPlatform>Platform=x86</SetPlatform>
+          <SetPlatform>Platform=Win32</SetPlatform>
           <!-- The base path for the output. -->
           <LinkBase>x86\%(HandlerPath)\</LinkBase>
           <!-- This reference assembly doesn't need -->

--- a/src/Servers/IIS/AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2.pkgproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2.pkgproj
@@ -19,8 +19,8 @@
     <Content Include="..\AspNetCore\bin\$(Configuration)\x64\aspnetcorev2.dll" PackagePath="contentFiles/any/any/x64" />
     <Content Include="..\AspNetCore\bin\$(Configuration)\x64\aspnetcorev2.pdb" PackagePath="contentFiles/any/any/x64" />
 
-    <Content Include="..\OutOfProcessRequestHandler\bin\$(Configuration)\x86\aspnetcorev2_outofprocess.dll" PackagePath="contentFiles/any/any/x86/2.0.0" />
-    <Content Include="..\OutOfProcessRequestHandler\bin\$(Configuration)\x86\aspnetcorev2_outofprocess.pdb" PackagePath="contentFiles/any/any/x86/2.0.0" />
+    <Content Include="..\OutOfProcessRequestHandler\bin\$(Configuration)\Win32\aspnetcorev2_outofprocess.dll" PackagePath="contentFiles/any/any/x86/2.0.0" />
+    <Content Include="..\OutOfProcessRequestHandler\bin\$(Configuration)\Win32\aspnetcorev2_outofprocess.pdb" PackagePath="contentFiles/any/any/x86/2.0.0" />
     <Content Include="..\OutOfProcessRequestHandler\bin\$(Configuration)\x64\aspnetcorev2_outofprocess.dll" PackagePath="contentFiles/any/any/x64/2.0.0" />
     <Content Include="..\OutOfProcessRequestHandler\bin\$(Configuration)\x64\aspnetcorev2_outofprocess.pdb" PackagePath="contentFiles/any/any/x64/2.0.0" />
 

--- a/src/Servers/IIS/build/assets.props
+++ b/src/Servers/IIS/build/assets.props
@@ -178,9 +178,9 @@
           NativeAsset="aspnetcorev2_outofprocess"
           BaseOutputPath="AspNetCoreModuleV2"
           PackageSubPath="$(AspNetCoreModuleOutOfProcessVersion)\"
-          DllLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\OutOfProcessRequestHandler\bin\$(Configuration)\x86\aspnetcorev2_outofprocess.dll"
+          DllLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\OutOfProcessRequestHandler\bin\$(Configuration)\Win32\aspnetcorev2_outofprocess.dll"
           Include="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj"
-          PdbLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\OutOfProcessRequestHandler\bin\$(Configuration)\x86\aspnetcorev2_outofprocess.pdb"
+          PdbLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\OutOfProcessRequestHandler\bin\$(Configuration)\Win32\aspnetcorev2_outofprocess.pdb"
           HandlerPath="2.0.0"
         />
 
@@ -204,9 +204,9 @@
           PropetyName="AspNetCoreModuleV2InProcessHandler"
           BaseOutputPath="AspNetCoreModuleV2"
           ProjectDirectory="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\InProcessRequestHandler"
-          DllLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\InProcessRequestHandler\bin\$(Configuration)\x86\aspnetcorev2_inprocess.dll"
+          DllLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\InProcessRequestHandler\bin\$(Configuration)\Win32\aspnetcorev2_inprocess.dll"
           Include="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj"
-          PdbLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\InProcessRequestHandler\bin\$(Configuration)\x86\aspnetcorev2_inprocess.pdb"
+          PdbLocation="$(MSBuildThisFileDirectory)..\AspNetCoreModuleV2\InProcessRequestHandler\bin\$(Configuration)\Win32\aspnetcorev2_inprocess.pdb"
         />
 
        <RunShimComponents


### PR DESCRIPTION
Try to address https://github.com/aspnet/AspNetCore-Internal/issues/1768

We fixed similar issues in master by preventing double building caused by using x86 as a native project platform.