### PR TITLE
Fix discrepancy between Version.Details.xml and Versions.props

### DIFF
--- a/docs/ReferenceResolution.md
+++ b/docs/ReferenceResolution.md
@@ -33,3 +33,37 @@ The requirements that led to this system are:
 * [eng/PatchConfig.props](/eng/PatchConfig.props) - lists which assemblies or packages are patching in the current build.
 * [eng/ProjectReferences.props](/eng/ProjectReferences.props) - lists which assemblies or packages might be available to be referenced as a local project
 * [eng/Versions.props](/eng/Versions.props) - contains a list of versions which may be updated by automation.
+
+## Example: adding a new project
+
+Steps for adding a new project to this repo.
+
+1. Create the .csproj
+2. Run `eng/scripts/GenerateProjectList.ps1`
+3. Add it to Extensions.sln
+
+## Example: adding a new dependency
+
+Steps for adding a new package dependency to an existing project. Let's say I'm adding a dependency on System.Banana.
+
+1. Add the package to the .csproj file using `<Reference Include="System.Banana" />`
+2. Add an entry to [eng/Dependencies.props](/eng/Dependencies.props), `<LatestPackageReference Include="System.Banana" Version="0.0.1-beta-1" />`
+3. If this package comes from another dotnet team and should be updated automatically by our bot...
+    1. Change the LatestPackageReference entry to `Version="$(SystemBananaPackageVersion)"`.
+    2. Add an entry to [eng/Versions.props](/eng/Versions.props) like this `<SystemBananaPackageVersion>0.0.1-beta-1</SystemBananaPackageVersion>`.
+    3. Add an entry to [eng/Version.Details.xml](/eng/Version.Details.xml) like this:
+
+        ```xml
+        <ProductDependencies>
+          <!-- ... -->
+          </Dependency>
+            <Dependency Name="System.Banana" Version="0.0.1-beta-1">
+            <Uri>https://github.com/dotnet/corefx</Uri>
+            <Sha>000000</Sha>
+          </Dependency>
+          <!-- ... -->
+        </ProductDependencies>
+        ```
+
+       If you don't know the commit hash of the source code used to produce "0.0.1-beta-1", you can use `000000` as a placeholder for `Sha`
+       as its value is unimportant and will be updated the next time the bot runs.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+  This file is used by automation to update Versions.props and may be used for other purposes, such as
+  static analysis to determine the repo dependency graph.  It should only be modified manually when adding
+  or removing dependencies. Updating versions should be done using the `darc` command line tool.
+
+  See https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md for instructions on using darc.
+-->
 <Dependencies>
   <ProductDependencies>
     <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="3.0.0-preview-19104-04">
@@ -8,10 +16,6 @@
     <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.0.0-preview-19104-04">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>ef2f8975dbe30752fe3a7c4e04efcd798eac3b64</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview.19080.5">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="3.0.0-preview-19104-04">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
@@ -49,331 +53,335 @@
       <Uri>https://github.com/aspnet/EntityFrameworkCore</Uri>
       <Sha>df4350283ae7ff0c67e08af16c0f00fdbd5e22ac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Analyzer.Testing" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.AspNetCore.Analyzer.Testing" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ActivatorUtilities.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.ActivatorUtilities.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.SqlServer" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Caching.SqlServer" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DiagnosticAdapter" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.DiagnosticAdapter" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Hosting" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Http" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Localization.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Localization.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Localization" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Localization" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.AzureAppServices" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.AzureAppServices" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Testing" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging.Testing" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Options" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TypeNameHelper.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.TypeNameHelper.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ValueStopwatch.Sources" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.ValueStopwatch.Sources" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.WebEncoders" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.Extensions.WebEncoders" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.JSInterop" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CSharp" Version="4.6.0-preview.19080.5">
+    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview.19080.5">
+    <Dependency Name="Microsoft.CSharp" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="4.6.0-preview.19080.5">
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview.19080.5">
+    <Dependency Name="System.ComponentModel.Annotations" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Net.Http.WinHttpHandler" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Net.WebSockets.WebSocketProtocol" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Net.Http.WinHttpHandler" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Numerics.Vectors" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Net.WebSockets.WebSocketProtocol" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview.19080.5">
+    <Dependency Name="System.Numerics.Vectors" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Security.Permissions" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Security.Principal.Windows" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Channels" Version="4.6.0-preview.19080.5">
+    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview.19105.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>9e074e4a3f3626fa953f36ab79e3cd3e6db1c9de</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview-27404-9">
+    <Dependency Name="System.Threading.Channels" Version="4.6.0-preview.19105.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>000</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview-27405-2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>5ff1240bef06a9a0a6544fcef93808ac26028e43</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview-27404-9">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview-27405-2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>5ff1240bef06a9a0a6544fcef93808ac26028e43</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview-27404-9">
+    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview-27405-2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>5ff1240bef06a9a0a6544fcef93808ac26028e43</Sha>
+      <Sha>000</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Internal.AspNetCore.Analyzers" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Internal.AspNetCore.Analyzers" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.0-preview.19105.3">
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.0.0-preview.19105.4">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>9750bf67ab22d8d28255c6222be282f4c8e49383</Sha>
+      <Sha>000</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,16 @@
 
 -->
 <Project>
-  <!-- These versions should be updated by automation. -->
+  <!--
+
+    These versions should ONLY be updated by automation.
+
+    DO NOT UPDATE THESE MANUALLY. Use the `darc` command line tool to update this file so it stays in sync with
+    Version.Details.xml.
+
+    See https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md for instructions on using darc.
+
+  -->
   <PropertyGroup Label="Automated">
     <!-- Packages from dotnet/core-setup -->
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview-27405-2</MicrosoftExtensionsDependencyModelPackageVersion>
@@ -107,14 +116,21 @@
     <MicrosoftCodeAnalysisRazorPackageVersion>3.0.0-preview-19104-04</MicrosoftCodeAnalysisRazorPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>3.0.0-preview-19104-04</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Label="Build tool dependencies">
+  <!--
+
+    ^^^^^^^^^^
+    SEE NOTE ABOVE.
+
+    Versions above this comment are updated automatically. Don't change them manually.
+
+    Versions below this comment are not managed by automation and can be changed as needed.
+  -->
+  <PropertyGroup Label="Manual">
+    <!-- Build tool dependencies -->
     <InternalAspNetCoreSdkPackageVersion>$(KoreBuildVersion)</InternalAspNetCoreSdkPackageVersion>
     <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">3.0.0-build-20190130.1</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageVersion>1.0.0-alpha-004</MicrosoftNETFrameworkReferenceAssembliesPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
-  </PropertyGroup>
-  <!-- These versions are not managed by automation. -->
-  <PropertyGroup Label="Pinned">
     <!-- Stable dotnet/corefx packages no longer updated for .NET Core 3 -->
     <SystemBuffersPackageVersion>4.5.0</SystemBuffersPackageVersion>
     <SystemCodeDomPackageVersion>4.4.0</SystemCodeDomPackageVersion>

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 1
 Import-Module -Scope Local -Force "$PSScriptRoot/common.psm1"
 
-$repoRoot = Resolve-Path "$PSScriptRoot/../../"
+$repoRoot = Resolve-Path "$PSScriptRoot/../.."
 
 [string[]] $errors = @()
 
@@ -27,6 +27,28 @@ try {
 
     if ($ci) {
         & $repoRoot/build.ps1 -ci /t:InstallDotNet
+    }
+
+    Write-Host "Checking that Versions.props and Version.Details.xml match"
+    [xml] $versionProps = Get-Content "$repoRoot/eng/Versions.props"
+    [xml] $versionDetails = Get-Content "$repoRoot/eng/Version.Details.xml"
+    foreach ($dep in $versionDetails.SelectNodes('//ProductDependencies/Dependency')) {
+        Write-Verbose "Found $dep"
+        $varName = $dep.Name -replace '\.',''
+        $varName = $varName -replace '\-',''
+        $varName = "${varName}PackageVersion"
+        $versionVar = $versionProps.SelectSingleNode("//PropertyGroup[`@Label=`"Automated`"]/$varName")
+        if (-not $versionVar) {
+            LogError "Missing version variable '$varName' in the 'Automated' property group in $repoRoot/eng/Versions.props"
+            continue
+        }
+
+        $expectedVersion = $dep.Version
+        $actualVersion = $versionVar.InnerText
+
+        if ($expectedVersion -ne $actualVersion) {
+            LogError "Version variable '$varName' does not match the value in Version.Details.xml. Expected '$expectedVersion', actual '$actualVersion'"
+        }
     }
 
     Write-Host "Checking that solutions are up to date"


### PR DESCRIPTION
Somehow the versions in these two files is no longer aligned. The bot reads Version.Details.xml and the build uses Versions.props. If they're not aligned, this can cause the bot to not run as expected.

cc @pakrym 