### PR TITLE
Fix flaky CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader test

### DIFF
--- a/src/Servers/Kestrel/shared/test/MockSystemClock.cs
+++ b/src/Servers/Kestrel/shared/test/MockSystemClock.cs
@@ -9,7 +9,16 @@ namespace Microsoft.AspNetCore.Testing
 {
     public class MockSystemClock : ISystemClock
     {
-        private long _utcNowTicks = DateTimeOffset.UtcNow.Ticks;
+        private static Random _random = new Random();
+
+        private long _utcNowTicks;
+
+        public MockSystemClock()
+        {
+            // Use a random DateTimeOffset to ensure tests that incorrectly use the current DateTimeOffset fail always instead of only rarely.
+            // Pick a date between the min DateTimeOffset and a day before the max DateTimeOffset so there's room to advance the clock.
+            _utcNowTicks = NextLong(DateTimeOffset.MinValue.Ticks, DateTimeOffset.MaxValue.Ticks - TimeSpan.FromDays(1).Ticks);
+        }
 
         public DateTimeOffset UtcNow
         {
@@ -25,5 +34,10 @@ namespace Microsoft.AspNetCore.Testing
         }
 
         public int UtcNowCalled { get; private set; }
+
+        private long NextLong(long minValue, long maxValue)
+        {
+            return (long)(_random.NextDouble() * (maxValue - minValue) + minValue);
+        }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -130,7 +130,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader()
         {
-            var testContext = new TestServiceContext();
             var dataRead = false;
 
             using (var server = new TestServer(async context =>
@@ -154,7 +153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     await connection.ReceiveEnd(
                         "HTTP/1.1 101 Switching Protocols",
                         "Connection: Upgrade",
-                        $"Date: {testContext.DateHeaderValue}",
+                        $"Date: {server.Context.DateHeaderValue}",
                         "",
                         "");
                 }


### PR DESCRIPTION
This fixes the following failure:

```
    CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader [FAIL]
      Assert.Equal() Failure
                                       ↓ (pos 85)
      Expected: ··· 06 Feb 2019 20:27:51 GMT\r\n\r\n
      Actual:   ··· 06 Feb 2019 20:27:52 GMT\r\n\r\n
                                       ↑ (pos 85)
      Stack Trace:
        /home/shalter/aspnet/AspNetCore/src/Servers/Kestrel/shared/test/StreamBackedTestConnection.cs(125,0): at Microsoft.AspNetCore.Testing.StreamBackedTestConnection.Receive(String[] lines)
        /home/shalter/aspnet/AspNetCore/src/Servers/Kestrel/shared/test/StreamBackedTestConnection.cs(130,0): at Microsoft.AspNetCore.Testing.StreamBackedTestConnection.ReceiveEnd(String[] lines)
        /home/shalter/aspnet/AspNetCore/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs(154,0): at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.RequestTests.CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader()
        --- End of stack trace from previous location where exception was thrown ---
      Output:
        | [0.000s] TestLifetime Information: Starting test CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader at 2019-02-06T20:27:51
        | [0.004s] Microsoft.AspNetCore.Hosting.Internal.WebHost Debug: Hosting starting
        | [0.004s] Microsoft.AspNetCore.Hosting.Internal.WebHost Debug: Hosting started
        | [0.004s] Microsoft.AspNetCore.Hosting.Internal.WebHost Debug: Loaded hosting startup assembly xunit.console
        | [0.005s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "0HLKCE689PT4J" started.
        | [0.006s] Microsoft.AspNetCore.Hosting.Internal.WebHost Information: Request starting HTTP/1.1 GET http:///  
        | [0.009s] Microsoft.AspNetCore.Hosting.Internal.WebHost Information: Request finished in 2.9228ms 101 
        | [0.009s] Microsoft.AspNetCore.Hosting.Internal.WebHost Debug: Hosting shutdown
        | [0.009s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "0HLKCE689PT4J" closing because: "The client closed the connection."
        | [0.009s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "0HLKCE689PT4J" disconnecting.
        | [0.085s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "0HLKCE689PT4J" stopped.
        | [0.087s] TestLifetime Information: Finished test CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader in 0.0861237s
```
