### PR TITLE
Remove Microsoft.AspNetCore.All from site extension description

### DIFF
--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -7,7 +7,7 @@
 
     <TrimmedVersion>$(VersionPrefix.Substring(0, $(VersionPrefix.LastIndexOf('.'))))</TrimmedVersion>
     <Title>ASP.NET Core $(TrimmedVersion) ($(TargetArchitecture)) Runtime </Title>
-    <Description>This site extension installs Microsoft.AspNetCore.All, Microsoft.AspNetCore.App and Microsoft.NetCore.App shared runtimes.</Description>
+    <Description>This site extension installs Microsoft.AspNetCore.App and Microsoft.NetCore.App shared runtimes.</Description>
     <PackageTags>aspnetcore;AzureSiteExtension</PackageTags>
     <PackageId>AspNetCoreRuntime.$(TrimmedVersion).$(TargetArchitecture)</PackageId>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
We don't ship it anymore.