### PR TITLE
Return Completed ReadResult after stream returns 0 bytes

### DIFF
--- a/src/Http/Http/src/StreamPipeReader.cs
+++ b/src/Http/Http/src/StreamPipeReader.cs
@@ -208,6 +208,11 @@ namespace System.IO.Pipelines
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
             // TODO ReadyAsync needs to throw if there are overlapping reads.
+            if (_isWriterCompleted)
+            {
+                return new ReadResult(buffer: default, isCanceled: false, isCompleted: true);
+            }
+
             ThrowIfCompleted();
 
             // PERF: store InternalTokenSource locally to avoid querying it twice (which acquires a lock)

--- a/src/Http/Http/test/StreamPipeReaderTests.cs
+++ b/src/Http/Http/test/StreamPipeReaderTests.cs
@@ -675,7 +675,7 @@ namespace System.IO.Pipelines.Tests
 
         private class ThrowAfterZeroByteReadStream : MemoryStream
         {
-            private bool throwOnNextCallToRead;
+            private bool _throwOnNextCallToRead;
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 return ReadAsync(new Memory<byte>(buffer, offset, count)).AsTask();
@@ -683,14 +683,14 @@ namespace System.IO.Pipelines.Tests
 
             public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
             {
-                if (throwOnNextCallToRead)
+                if (_throwOnNextCallToRead)
                 {
                     throw new Exception();
                 }
                 var bytes = await base.ReadAsync(destination, cancellationToken);
                 if (bytes == 0)
                 {
-                    throwOnNextCallToRead = true;
+                    _throwOnNextCallToRead = true;
                 }
                 return bytes;
             }

--- a/src/Http/Http/test/StreamPipeReaderTests.cs
+++ b/src/Http/Http/test/StreamPipeReaderTests.cs
@@ -607,6 +607,7 @@ namespace System.IO.Pipelines.Tests
             var readResult = await Reader.ReadAsync();
 
             readResult = await Reader.ReadAsync();
+            Assert.True(readResult.Buffer.IsEmpty);
             Assert.True(readResult.IsCompleted);
         }
 

--- a/src/Http/Http/test/StreamPipeTest.cs
+++ b/src/Http/Http/test/StreamPipeTest.cs
@@ -11,7 +11,7 @@ namespace System.IO.Pipelines.Tests
 
         protected const int MinimumSegmentSize = 4096;
 
-        public MemoryStream MemoryStream { get; set; }
+        public Stream Stream { get; set; }
 
         public PipeWriter Writer { get; set; }
 
@@ -19,9 +19,9 @@ namespace System.IO.Pipelines.Tests
 
         protected StreamPipeTest()
         {
-            MemoryStream = new MemoryStream();
-            Writer = new StreamPipeWriter(MemoryStream, MinimumSegmentSize, new TestMemoryPool());
-            Reader = new StreamPipeReader(MemoryStream, new StreamPipeReaderOptions(MinimumSegmentSize, minimumReadThreshold: 256, new TestMemoryPool()));
+            Stream = new MemoryStream();
+            Writer = new StreamPipeWriter(Stream, MinimumSegmentSize, new TestMemoryPool());
+            Reader = new StreamPipeReader(Stream, new StreamPipeReaderOptions(MinimumSegmentSize, minimumReadThreshold: 256, new TestMemoryPool()));
         }
 
         public void Dispose()
@@ -44,27 +44,27 @@ namespace System.IO.Pipelines.Tests
 
         public void Write(byte[] data)
         {
-            MemoryStream.Write(data, 0, data.Length);
-            MemoryStream.Position = 0;
+            Stream.Write(data, 0, data.Length);
+            Stream.Position = 0;
         }
 
         public void WriteWithoutPosition(byte[] data)
         {
-            MemoryStream.Write(data, 0, data.Length);
+            Stream.Write(data, 0, data.Length);
         }
 
         public void Append(byte[] data)
         {
-            var originalPosition = MemoryStream.Position;
-            MemoryStream.Write(data, 0, data.Length);
-            MemoryStream.Position = originalPosition;
+            var originalPosition = Stream.Position;
+            Stream.Write(data, 0, data.Length);
+            Stream.Position = originalPosition;
         }
 
         public byte[] ReadWithoutFlush()
         {
-            MemoryStream.Position = 0;
-            var buffer = new byte[MemoryStream.Length];
-            var result = MemoryStream.Read(buffer, 0, (int)MemoryStream.Length);
+            Stream.Position = 0;
+            var buffer = new byte[Stream.Length];
+            var result = Stream.Read(buffer, 0, (int)Stream.Length);
             return buffer;
         }
     }

--- a/src/Http/Http/test/StreamPipeWriterTests.cs
+++ b/src/Http/Http/test/StreamPipeWriterTests.cs
@@ -32,7 +32,7 @@ namespace System.IO.Pipelines.Tests
         [InlineData(8000, 8000)]
         public async Task CanAdvanceWithPartialConsumptionOfFirstSegment(int firstWriteLength, int secondWriteLength)
         {
-            Writer = new StreamPipeWriter(MemoryStream, MinimumSegmentSize, new TestMemoryPool(maxBufferSize: 20000));
+            Writer = new StreamPipeWriter(Stream, MinimumSegmentSize, new TestMemoryPool(maxBufferSize: 20000));
             await Writer.WriteAsync(Encoding.ASCII.GetBytes("a"));
 
             var expectedLength = firstWriteLength + secondWriteLength + 1;
@@ -136,8 +136,8 @@ namespace System.IO.Pipelines.Tests
         [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/4621")]
         public async Task CancelPendingFlushBetweenWritesAllDataIsPreserved()
         {
-            MemoryStream = new SingleWriteStream();
-            Writer = new StreamPipeWriter(MemoryStream);
+            Stream = new SingleWriteStream();
+            Writer = new StreamPipeWriter(Stream);
             FlushResult flushResult = new FlushResult();
 
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -174,8 +174,8 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public async Task CancelPendingFlushAfterAllWritesAllDataIsPreserved()
         {
-            MemoryStream = new CannotFlushStream();
-            Writer = new StreamPipeWriter(MemoryStream);
+            Stream = new CannotFlushStream();
+            Writer = new StreamPipeWriter(Stream);
             FlushResult flushResult = new FlushResult();
 
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -211,8 +211,8 @@ namespace System.IO.Pipelines.Tests
         {
             var writeSize = 16;
             var singleWriteStream = new SingleWriteStream();
-            MemoryStream = singleWriteStream;
-            Writer = new StreamPipeWriter(MemoryStream, minimumSegmentSize: writeSize);
+            Stream = singleWriteStream;
+            Writer = new StreamPipeWriter(Stream, minimumSegmentSize: writeSize);
 
             for (var i = 0; i < 10; i++)
             {
@@ -392,7 +392,7 @@ namespace System.IO.Pipelines.Tests
         private void WriteStringToStream(string input)
         {
             var buffer = Encoding.ASCII.GetBytes(input);
-            MemoryStream.Write(buffer, 0, buffer.Length);
+            Stream.Write(buffer, 0, buffer.Length);
         }
 
         private async Task WriteStringToPipeWriter(string input)


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore/issues/7329. This is a combination of 2 bugs:
1. StreamPipeReader.ReadAsync shouldn't call Stream.ReadAsync if the stream previously return 0 bytes. This PR solves this issue. 
Note: most implementation of Stream continue to return 0 bytes from ReadAsync after the stream is completed.
2. ResponseStream.ReadAsync should probably not complete the PipeReader https://github.com/aspnet/AspNetCore/blob/master/src/Hosting/TestHost/src/ResponseStream.cs#L118. We don't do this in ReadOnlyPipeStream today. This is a problem because calling ReadAsync after it return 0 bytes will throw an exception rather than returning 0 bytes.