### PR TITLE
Remove extraneous call to GetMemory in BufferWriter

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/BufferWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/BufferWriter.cs
@@ -73,8 +73,7 @@ namespace System.Buffers
                 Commit();
             }
 
-            _output.GetMemory(count);
-            _span = _output.GetSpan();
+            _span = _output.GetSpan(count);
         }
 
         private void WriteMultiBuffer(ReadOnlySpan<byte> source)


### PR DESCRIPTION
The BufferWriter called GetMemory(count) and dropped the result, only to then call GetSpan(). This moves the count argument to GetSpan, and drops the call to GetMemory.