### PR TITLE
C++ client: Skip flaky tests

### DIFF
--- a/src/SignalR/clients/cpp/test/signalrclienttests/connection_impl_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/connection_impl_tests.cpp
@@ -769,47 +769,47 @@ TEST(connection_impl_stop, can_start_and_stop_connection)
 }
 
 // Flaky test: "transport timed out when trying to connect"
-// TEST(connection_impl_stop, can_start_and_stop_connection_multiple_times)
-// {
-//     auto writer = std::shared_ptr<log_writer>{std::make_shared<memory_log_writer>()};
+TEST(connection_impl_stop, DISABLED_can_start_and_stop_connection_multiple_times)
+{
+    auto writer = std::shared_ptr<log_writer>{std::make_shared<memory_log_writer>()};
 
-//     {
-//         auto websocket_client = create_test_websocket_client(
-//             /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); });
-//         auto connection = create_connection(websocket_client, writer, trace_level::state_changes);
+    {
+        auto websocket_client = create_test_websocket_client(
+            /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); });
+        auto connection = create_connection(websocket_client, writer, trace_level::state_changes);
 
-//         connection->start()
-//             .then([connection]()
-//         {
-//             return connection->stop();
-//         })
-//         .then([connection]()
-//         {
-//             return connection->start();
-//         }).get();
-//     }
+        connection->start()
+            .then([connection]()
+        {
+            return connection->stop();
+        })
+        .then([connection]()
+        {
+            return connection->start();
+        }).get();
+    }
 
-//     auto memory_writer = std::dynamic_pointer_cast<memory_log_writer>(writer);
+    auto memory_writer = std::dynamic_pointer_cast<memory_log_writer>(writer);
 
-//     // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
-//     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
-//     // to happen and if it does not the test will fail
-//     for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 8; wait_time_ms <<= 1)
-//     {
-//         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
-//     }
+    // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
+    // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
+    // to happen and if it does not the test will fail
+    for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 8; wait_time_ms <<= 1)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
+    }
 
-//     auto log_entries = memory_writer->get_log_entries();
-//     ASSERT_EQ(8U, log_entries.size());
-//     ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[0]));
-//     ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[1]));
-//     ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[2]));
-//     ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
-//     ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[4]));
-//     ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[5]));
-//     ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[6]));
-//     ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[7]));
-// }
+    auto log_entries = memory_writer->get_log_entries();
+    ASSERT_EQ(8U, log_entries.size());
+    ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[0]));
+    ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[1]));
+    ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[2]));
+    ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
+    ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[4]));
+    ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[5]));
+    ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[6]));
+    ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[7]));
+}
 
 TEST(connection_impl_stop, dtor_stops_the_connection)
 {

--- a/src/SignalR/clients/cpp/test/signalrclienttests/connection_impl_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/connection_impl_tests.cpp
@@ -768,47 +768,48 @@ TEST(connection_impl_stop, can_start_and_stop_connection)
     ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
 }
 
-TEST(connection_impl_stop, can_start_and_stop_connection_multiple_times)
-{
-    auto writer = std::shared_ptr<log_writer>{std::make_shared<memory_log_writer>()};
+// Flaky test: "transport timed out when trying to connect"
+// TEST(connection_impl_stop, can_start_and_stop_connection_multiple_times)
+// {
+//     auto writer = std::shared_ptr<log_writer>{std::make_shared<memory_log_writer>()};
 
-    {
-        auto websocket_client = create_test_websocket_client(
-            /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); });
-        auto connection = create_connection(websocket_client, writer, trace_level::state_changes);
+//     {
+//         auto websocket_client = create_test_websocket_client(
+//             /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); });
+//         auto connection = create_connection(websocket_client, writer, trace_level::state_changes);
 
-        connection->start()
-            .then([connection]()
-        {
-            return connection->stop();
-        })
-        .then([connection]()
-        {
-            return connection->start();
-        }).get();
-    }
+//         connection->start()
+//             .then([connection]()
+//         {
+//             return connection->stop();
+//         })
+//         .then([connection]()
+//         {
+//             return connection->start();
+//         }).get();
+//     }
 
-    auto memory_writer = std::dynamic_pointer_cast<memory_log_writer>(writer);
+//     auto memory_writer = std::dynamic_pointer_cast<memory_log_writer>(writer);
 
-    // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
-    // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
-    // to happen and if it does not the test will fail
-    for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 8; wait_time_ms <<= 1)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
-    }
+//     // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
+//     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
+//     // to happen and if it does not the test will fail
+//     for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 8; wait_time_ms <<= 1)
+//     {
+//         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
+//     }
 
-    auto log_entries = memory_writer->get_log_entries();
-    ASSERT_EQ(8U, log_entries.size());
-    ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[0]));
-    ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[1]));
-    ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[2]));
-    ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
-    ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[4]));
-    ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[5]));
-    ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[6]));
-    ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[7]));
-}
+//     auto log_entries = memory_writer->get_log_entries();
+//     ASSERT_EQ(8U, log_entries.size());
+//     ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[0]));
+//     ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[1]));
+//     ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[2]));
+//     ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
+//     ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[4]));
+//     ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[5]));
+//     ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[6]));
+//     ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[7]));
+// }
 
 TEST(connection_impl_stop, dtor_stops_the_connection)
 {

--- a/src/SignalR/clients/cpp/test/signalrclienttests/hub_connection_impl_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/hub_connection_impl_tests.cpp
@@ -86,35 +86,35 @@ TEST(stop, disconnected_callback_called_when_hub_connection_stops)
 }
 
 // Flaky test: ASSERT_EQ(4U, log_entries.size()) was 3
-// TEST(stop, connection_stopped_when_going_out_of_scope)
-// {
-//     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
+TEST(stop, DISABLED_connection_stopped_when_going_out_of_scope)
+{
+    std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-//     {
-//         auto websocket_client = create_test_websocket_client(
-//             /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); });
-//         auto hub_connection = create_hub_connection(websocket_client, writer, trace_level::state_changes);
+    {
+        auto websocket_client = create_test_websocket_client(
+            /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); });
+        auto hub_connection = create_hub_connection(websocket_client, writer, trace_level::state_changes);
 
-//         hub_connection->start().get();
-//     }
+        hub_connection->start().get();
+    }
 
-//     auto memory_writer = std::dynamic_pointer_cast<memory_log_writer>(writer);
+    auto memory_writer = std::dynamic_pointer_cast<memory_log_writer>(writer);
 
-//     // The underlying connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
-//     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
-//     // to happen and if it does not the test will fail. There is nothing we can block on.
-//     for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 4; wait_time_ms <<= 1)
-//     {
-//         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
-//     }
+    // The underlying connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
+    // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
+    // to happen and if it does not the test will fail. There is nothing we can block on.
+    for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 4; wait_time_ms <<= 1)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
+    }
 
-//     auto log_entries = memory_writer->get_log_entries();
-//     ASSERT_EQ(4U, log_entries.size());
-//     ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[0]));
-//     ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[1]));
-//     ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[2]));
-//     ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
-// }
+    auto log_entries = memory_writer->get_log_entries();
+    ASSERT_EQ(4U, log_entries.size());
+    ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), remove_date_from_log_entry(log_entries[0]));
+    ASSERT_EQ(_XPLATSTR("[state change] connecting -> connected\n"), remove_date_from_log_entry(log_entries[1]));
+    ASSERT_EQ(_XPLATSTR("[state change] connected -> disconnecting\n"), remove_date_from_log_entry(log_entries[2]));
+    ASSERT_EQ(_XPLATSTR("[state change] disconnecting -> disconnected\n"), remove_date_from_log_entry(log_entries[3]));
+}
 
 TEST(stop, stop_cancels_pending_callbacks)
 {
@@ -224,7 +224,8 @@ TEST(hub_invocation, hub_connection_invokes_users_code_on_hub_invocations)
     ASSERT_EQ(_XPLATSTR("[\"message\",1]"), *payload);
 }
 
-TEST(invoke, invoke_creates_correct_payload)
+// Flaky test: "error" thrown in test body
+TEST(invoke, DISABLED_invoke_creates_correct_payload)
 {
     utility::string_t payload;
 
@@ -251,7 +252,8 @@ TEST(invoke, invoke_creates_correct_payload)
     ASSERT_EQ(_XPLATSTR("{\"arguments\":[],\"target\":\"method\",\"type\":1}\x1e"), payload);
 }
 
-TEST(invoke, callback_not_called_if_send_throws)
+// "error" thrown in test body
+TEST(invoke, DISABLED_callback_not_called_if_send_throws)
 {
     auto websocket_client = create_test_websocket_client(
         /* receive function */ []() { return pplx::task_from_result(std::string("{ }\x1e")); },
@@ -270,7 +272,7 @@ TEST(invoke, callback_not_called_if_send_throws)
         ASSERT_STREQ("error", e.what());
     }
 
-    // stop completes all outstanting callbacks so if we did not remove a callback when `invoke_void` failed an
+    // stop completes all outstanding callbacks so if we did not remove a callback when `invoke_void` failed an
     // unobserved exception exception would be thrown. Note that this would happen on a different thread and would
     // crash the process
     hub_connection->stop().get();
@@ -436,269 +438,269 @@ TEST(invoke_void, invoke_unblocks_task_when_server_completes_call)
 }
 
 // Flaky test: crashes test process
-// TEST(invoke_void, invoke_logs_if_callback_for_given_id_not_found)
-// {
-//     auto message_received_event = std::make_shared<event>();
+TEST(invoke_void, DISABLED_invoke_logs_if_callback_for_given_id_not_found)
+{
+    auto message_received_event = std::make_shared<event>();
 
-//     int call_number = -1;
-//     auto websocket_client = create_test_websocket_client(
-//         /* receive function */ [call_number, message_received_event]()
-//         mutable {
-//         std::string responses[]
-//         {
-//             "{ }\x1e",
-//             "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
-//             "{}"
-//         };
+    int call_number = -1;
+    auto websocket_client = create_test_websocket_client(
+        /* receive function */ [call_number, message_received_event]()
+        mutable {
+        std::string responses[]
+        {
+            "{ }\x1e",
+            "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
+            "{}"
+        };
 
-//         call_number = std::min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
-//         if (call_number > 1)
-//         {
-//             message_received_event->set();
-//         }
+        if (call_number > 1)
+        {
+            message_received_event->set();
+        }
 
-//         return pplx::task_from_result(responses[call_number]);
-//     });
+        return pplx::task_from_result(responses[call_number]);
+    });
 
-//     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
-//     auto hub_connection = create_hub_connection(websocket_client, writer, trace_level::info);
-//     hub_connection->start().get();
+    std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
+    auto hub_connection = create_hub_connection(websocket_client, writer, trace_level::info);
+    hub_connection->start().get();
 
-//     ASSERT_FALSE(message_received_event->wait(5000));
+    ASSERT_FALSE(message_received_event->wait(5000));
 
-//     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
-//     ASSERT_TRUE(log_entries.size() > 1);
+    auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
+    ASSERT_TRUE(log_entries.size() > 1);
 
-//     auto entry = remove_date_from_log_entry(log_entries[1]);
-//     ASSERT_EQ(_XPLATSTR("[info        ] no callback found for id: 0\n"), entry);
-// }
-
-// TODO Flaky until hub_connection.start waits for handshake response
-//TEST(invoke_void, invoke_propagates_errors_from_server_as_exceptions)
-//{
-//    auto callback_registered_event = std::make_shared<event>();
-//
-//    int call_number = -1;
-//    auto websocket_client = create_test_websocket_client(
-//        /* receive function */ [call_number, callback_registered_event]()
-//        mutable {
-//        std::string responses[]
-//        {
-//            "{ }\x1e",
-//            "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
-//            "{}"
-//        };
-//
-//        call_number = std::min(call_number + 1, 2);
-//
-//        if (call_number > 0)
-//        {
-//            callback_registered_event->wait();
-//        }
-//
-//        return pplx::task_from_result(responses[call_number]);
-//    });
-//
-//    auto hub_connection = create_hub_connection(websocket_client);
-//    try
-//    {
-//        hub_connection->start()
-//            .then([hub_connection, callback_registered_event]()
-//        {
-//            auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
-//            callback_registered_event->set();
-//            return t;
-//        }).get();
-//
-//        ASSERT_TRUE(false); // exception expected but not thrown
-//    }
-//    catch (const std::runtime_error& e)
-//    {
-//        ASSERT_STREQ("\"Ooops\"", e.what());
-//    }
-//}
+    auto entry = remove_date_from_log_entry(log_entries[1]);
+    ASSERT_EQ(_XPLATSTR("[info        ] no callback found for id: 0\n"), entry);
+}
 
 // TODO Flaky until hub_connection.start waits for handshake response
-//TEST(invoke_void, invoke_propagates_hub_errors_from_server_as_hub_exceptions)
-//{
-//    auto callback_registered_event = std::make_shared<event>();
-//
-//    int call_number = -1;
-//    auto websocket_client = create_test_websocket_client(
-//        /* receive function */ [call_number, callback_registered_event]()
-//        mutable {
-//        std::string responses[]
-//        {
-//            "{ }\x1e",
-//            "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
-//            "{}"
-//        };
-//
-//        call_number = std::min(call_number + 1, 2);
-//
-//        if (call_number > 0)
-//        {
-//            callback_registered_event->wait();
-//        }
-//
-//        return pplx::task_from_result(responses[call_number]);
-//    });
-//
-//    auto hub_connection = create_hub_connection(websocket_client);
-//    try
-//    {
-//        hub_connection->start()
-//            .then([hub_connection, callback_registered_event]()
-//        {
-//            auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
-//            callback_registered_event->set();
-//            return t;
-//        }).get();
-//
-//        ASSERT_TRUE(false); // exception expected but not thrown
-//    }
-//    catch (const hub_exception& e)
-//    {
-//        ASSERT_STREQ("\"Ooops\"", e.what());
-//    }
-//}
+TEST(invoke_void, DISABLED_invoke_propagates_errors_from_server_as_exceptions)
+{
+   auto callback_registered_event = std::make_shared<event>();
+
+   int call_number = -1;
+   auto websocket_client = create_test_websocket_client(
+       /* receive function */ [call_number, callback_registered_event]()
+       mutable {
+       std::string responses[]
+       {
+           "{ }\x1e",
+           "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
+           "{}"
+       };
+
+       call_number = std::min(call_number + 1, 2);
+
+       if (call_number > 0)
+       {
+           callback_registered_event->wait();
+       }
+
+       return pplx::task_from_result(responses[call_number]);
+   });
+
+   auto hub_connection = create_hub_connection(websocket_client);
+   try
+   {
+       hub_connection->start()
+           .then([hub_connection, callback_registered_event]()
+       {
+           auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
+           callback_registered_event->set();
+           return t;
+       }).get();
+
+       ASSERT_TRUE(false); // exception expected but not thrown
+   }
+   catch (const std::runtime_error& e)
+   {
+       ASSERT_STREQ("\"Ooops\"", e.what());
+   }
+}
 
 // TODO Flaky until hub_connection.start waits for handshake response
-//TEST(invoke_void, invoke_creates_hub_exception_even_if_no_error_data)
-//{
-//    auto callback_registered_event = std::make_shared<event>();
-//
-//    int call_number = -1;
-//    auto websocket_client = create_test_websocket_client(
-//        /* receive function */ [call_number, callback_registered_event]()
-//        mutable {
-//        std::string responses[]
-//        {
-//            "{ }\x1e",
-//            "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
-//            "{}"
-//        };
-//
-//        call_number = std::min(call_number + 1, 2);
-//
-//        if (call_number > 0)
-//        {
-//            callback_registered_event->wait();
-//        }
-//
-//        return pplx::task_from_result(responses[call_number]);
-//    });
-//
-//    auto hub_connection = create_hub_connection(websocket_client);
-//    try
-//    {
-//        hub_connection->start()
-//            .then([hub_connection, callback_registered_event]()
-//        {
-//            auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
-//            callback_registered_event->set();
-//            return t;
-//        }).get();
-//
-//        ASSERT_TRUE(false); // exception expected but not thrown
-//    }
-//    catch (const hub_exception& e)
-//    {
-//        ASSERT_STREQ("\"Ooops\"", e.what());
-//    }
-//}
+TEST(invoke_void, DISABLED_invoke_propagates_hub_errors_from_server_as_hub_exceptions)
+{
+   auto callback_registered_event = std::make_shared<event>();
+
+   int call_number = -1;
+   auto websocket_client = create_test_websocket_client(
+       /* receive function */ [call_number, callback_registered_event]()
+       mutable {
+       std::string responses[]
+       {
+           "{ }\x1e",
+           "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
+           "{}"
+       };
+
+       call_number = std::min(call_number + 1, 2);
+
+       if (call_number > 0)
+       {
+           callback_registered_event->wait();
+       }
+
+       return pplx::task_from_result(responses[call_number]);
+   });
+
+   auto hub_connection = create_hub_connection(websocket_client);
+   try
+   {
+       hub_connection->start()
+           .then([hub_connection, callback_registered_event]()
+       {
+           auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
+           callback_registered_event->set();
+           return t;
+       }).get();
+
+       ASSERT_TRUE(false); // exception expected but not thrown
+   }
+   catch (const hub_exception& e)
+   {
+       ASSERT_STREQ("\"Ooops\"", e.what());
+   }
+}
 
 // TODO Flaky until hub_connection.start waits for handshake response
-//TEST(invoke_void, invoke_creates_runtime_error_when_hub_exception_indicator_false)
-//{
-//    auto callback_registered_event = std::make_shared<event>();
-//
-//    int call_number = -1;
-//    auto websocket_client = create_test_websocket_client(
-//        /* receive function */ [call_number, callback_registered_event]()
-//        mutable {
-//        std::string responses[]
-//        {
-//            "{ }\x1e",
-//            "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
-//            "{}"
-//        };
-//
-//        call_number = std::min(call_number + 1, 2);
-//
-//        if (call_number > 0)
-//        {
-//            callback_registered_event->wait();
-//        }
-//
-//        return pplx::task_from_result(responses[call_number]);
-//    });
-//
-//    auto hub_connection = create_hub_connection(websocket_client);
-//    try
-//    {
-//        hub_connection->start()
-//            .then([hub_connection, callback_registered_event]()
-//        {
-//            auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
-//            callback_registered_event->set();
-//            return t;
-//        }).get();
-//
-//        ASSERT_TRUE(false); // exception expected but not thrown
-//    }
-//    catch (const signalr_exception& e)
-//    {
-//        ASSERT_STREQ("\"Ooops\"", e.what());
-//        ASSERT_TRUE(dynamic_cast<const hub_exception *>(&e) == nullptr);
-//    }
-//}
+TEST(invoke_void, DISABLED_invoke_creates_hub_exception_even_if_no_error_data)
+{
+   auto callback_registered_event = std::make_shared<event>();
+
+   int call_number = -1;
+   auto websocket_client = create_test_websocket_client(
+       /* receive function */ [call_number, callback_registered_event]()
+       mutable {
+       std::string responses[]
+       {
+           "{ }\x1e",
+           "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
+           "{}"
+       };
+
+       call_number = std::min(call_number + 1, 2);
+
+       if (call_number > 0)
+       {
+           callback_registered_event->wait();
+       }
+
+       return pplx::task_from_result(responses[call_number]);
+   });
+
+   auto hub_connection = create_hub_connection(websocket_client);
+   try
+   {
+       hub_connection->start()
+           .then([hub_connection, callback_registered_event]()
+       {
+           auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
+           callback_registered_event->set();
+           return t;
+       }).get();
+
+       ASSERT_TRUE(false); // exception expected but not thrown
+   }
+   catch (const hub_exception& e)
+   {
+       ASSERT_STREQ("\"Ooops\"", e.what());
+   }
+}
 
 // TODO Flaky until hub_connection.start waits for handshake response
-//TEST(invoke_void, invoke_creates_runtime_error)
-//{
-//    auto callback_registered_event = std::make_shared<event>();
-//
-//    int call_number = -1;
-//    auto websocket_client = create_test_websocket_client(
-//        /* receive function */ [call_number, callback_registered_event]()
-//        mutable {
-//        std::string responses[]
-//        {
-//            "{ }\x1e",
-//            "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
-//        };
-//
-//        call_number = std::min(call_number + 1, 1);
-//
-//        if (call_number > 0)
-//        {
-//            callback_registered_event->wait();
-//        }
-//
-//        return pplx::task_from_result(responses[call_number]);
-//    });
-//
-//    auto hub_connection = create_hub_connection(websocket_client);
-//    try
-//    {
-//        hub_connection->start()
-//            .then([hub_connection, callback_registered_event]()
-//        {
-//            auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
-//            callback_registered_event->set();
-//            return t;
-//        }).get();
-//
-//        ASSERT_TRUE(false); // exception expected but not thrown
-//    }
-//    catch (const signalr_exception& e)
-//    {
-//        ASSERT_STREQ("\"Ooops\"", e.what());
-//        ASSERT_TRUE(dynamic_cast<const hub_exception *>(&e) == nullptr);
-//    }
-//}
+TEST(invoke_void, DISABLED_invoke_creates_runtime_error_when_hub_exception_indicator_false)
+{
+   auto callback_registered_event = std::make_shared<event>();
+
+   int call_number = -1;
+   auto websocket_client = create_test_websocket_client(
+       /* receive function */ [call_number, callback_registered_event]()
+       mutable {
+       std::string responses[]
+       {
+           "{ }\x1e",
+           "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
+           "{}"
+       };
+
+       call_number = std::min(call_number + 1, 2);
+
+       if (call_number > 0)
+       {
+           callback_registered_event->wait();
+       }
+
+       return pplx::task_from_result(responses[call_number]);
+   });
+
+   auto hub_connection = create_hub_connection(websocket_client);
+   try
+   {
+       hub_connection->start()
+           .then([hub_connection, callback_registered_event]()
+       {
+           auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
+           callback_registered_event->set();
+           return t;
+       }).get();
+
+       ASSERT_TRUE(false); // exception expected but not thrown
+   }
+   catch (const signalr_exception& e)
+   {
+       ASSERT_STREQ("\"Ooops\"", e.what());
+       ASSERT_TRUE(dynamic_cast<const hub_exception *>(&e) == nullptr);
+   }
+}
+
+// TODO Flaky until hub_connection.start waits for handshake response
+TEST(invoke_void, DISABLED_invoke_creates_runtime_error)
+{
+   auto callback_registered_event = std::make_shared<event>();
+
+   int call_number = -1;
+   auto websocket_client = create_test_websocket_client(
+       /* receive function */ [call_number, callback_registered_event]()
+       mutable {
+       std::string responses[]
+       {
+           "{ }\x1e",
+           "{ \"type\": 3, \"invocationId\": \"0\", \"error\": \"Ooops\" }\x1e"
+       };
+
+       call_number = std::min(call_number + 1, 1);
+
+       if (call_number > 0)
+       {
+           callback_registered_event->wait();
+       }
+
+       return pplx::task_from_result(responses[call_number]);
+   });
+
+   auto hub_connection = create_hub_connection(websocket_client);
+   try
+   {
+       hub_connection->start()
+           .then([hub_connection, callback_registered_event]()
+       {
+           auto t = hub_connection->invoke_void(_XPLATSTR("method"), json::value::array());
+           callback_registered_event->set();
+           return t;
+       }).get();
+
+       ASSERT_TRUE(false); // exception expected but not thrown
+   }
+   catch (const signalr_exception& e)
+   {
+       ASSERT_STREQ("\"Ooops\"", e.what());
+       ASSERT_TRUE(dynamic_cast<const hub_exception *>(&e) == nullptr);
+   }
+}
 
 TEST(connection_id, can_get_connection_id)
 {

--- a/src/SignalR/clients/cpp/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/websocket_transport_tests.cpp
@@ -98,24 +98,24 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
 }
 
 // Flaky test: crashes test process
-// TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_transport)
-// {
-//     auto client = std::make_shared<test_websocket_client>();
-//     auto ws_transport = websocket_transport::create([&](){ return client; }, logger(std::make_shared<trace_log_writer>(), trace_level::none),
-//         [](const utility::string_t&){}, [](const std::exception&){});
+TEST(websocket_transport_connect, DISABLED_cannot_call_connect_on_already_connected_transport)
+{
+    auto client = std::make_shared<test_websocket_client>();
+    auto ws_transport = websocket_transport::create([&](){ return client; }, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){}, [](const std::exception&){});
 
-//     ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
+    ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
 
-//     try
-//     {
-//         ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
-//         ASSERT_TRUE(false); // exception not thrown
-//     }
-//     catch (const std::exception &e)
-//     {
-//         ASSERT_EQ(_XPLATSTR("transport already connected"), utility::conversions::to_string_t(e.what()));
-//     }
-// }
+    try
+    {
+        ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
+        ASSERT_TRUE(false); // exception not thrown
+    }
+    catch (const std::exception &e)
+    {
+        ASSERT_EQ(_XPLATSTR("transport already connected"), utility::conversions::to_string_t(e.what()));
+    }
+}
 
 TEST(websocket_transport_connect, can_connect_after_disconnecting)
 {

--- a/src/SignalR/clients/cpp/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/websocket_transport_tests.cpp
@@ -97,24 +97,25 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
         entry);
 }
 
-TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_transport)
-{
-    auto client = std::make_shared<test_websocket_client>();
-    auto ws_transport = websocket_transport::create([&](){ return client; }, logger(std::make_shared<trace_log_writer>(), trace_level::none),
-        [](const utility::string_t&){}, [](const std::exception&){});
+// Flaky test: crashes test process
+// TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_transport)
+// {
+//     auto client = std::make_shared<test_websocket_client>();
+//     auto ws_transport = websocket_transport::create([&](){ return client; }, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+//         [](const utility::string_t&){}, [](const std::exception&){});
 
-    ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
+//     ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
 
-    try
-    {
-        ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
-        ASSERT_TRUE(false); // exception not thrown
-    }
-    catch (const std::exception &e)
-    {
-        ASSERT_EQ(_XPLATSTR("transport already connected"), utility::conversions::to_string_t(e.what()));
-    }
-}
+//     try
+//     {
+//         ws_transport->connect(_XPLATSTR("ws://fakeuri.org")).wait();
+//         ASSERT_TRUE(false); // exception not thrown
+//     }
+//     catch (const std::exception &e)
+//     {
+//         ASSERT_EQ(_XPLATSTR("transport already connected"), utility::conversions::to_string_t(e.what()));
+//     }
+// }
 
 TEST(websocket_transport_connect, can_connect_after_disconnecting)
 {


### PR DESCRIPTION
CI's found a few flaky tests. Will look at these as part of reviewing the current tests when adding new ones, and removing unneeded ones.