### PR TITLE
Update helix sdk and try workaround for warning

### DIFF
--- a/eng/helix/Directory.Build.props
+++ b/eng/helix/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/eng/helix/Directory.Build.props
+++ b/eng/helix/Directory.Build.props
@@ -1,0 +1,2 @@
+﻿<Project>
+</Project>

--- a/eng/helix/Directory.Build.props
+++ b/eng/helix/Directory.Build.props
@@ -1,2 +1,0 @@
-﻿<Project>
-</Project>

--- a/eng/helix/Directory.Build.targets
+++ b/eng/helix/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/eng/helix/Directory.Build.targets
+++ b/eng/helix/Directory.Build.targets
@@ -1,2 +1,0 @@
-<Project>
-</Project>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Test">
 
   <!-- Version included until we get global.json generation to support this SDK. -->
-  <Sdk Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19107.1" />
+  <Sdk Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19173.6" />
 
   <Target Name="Gather" BeforeTargets="Test">
     <ItemGroup>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Test">
 
   <!-- Version included until we get global.json generation to support this SDK. -->
-  <Sdk Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19073.6" />
+  <Sdk Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19107.1" />
 
   <Target Name="Gather" BeforeTargets="Test">
     <ItemGroup>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -22,8 +22,6 @@
   </Target>
 
   <PropertyGroup>
-    <!-- helix SDK issue https://github.com/dotnet/arcade/issues/1605 -->
-    <SkipInvalidConfigurations>true</SkipInvalidConfigurations>
     <HelixSource>pr/aspnet/aspnetcore</HelixSource>
     <HelixType>ci</HelixType>
     <HelixBuild>private-$(USERNAME)</HelixBuild>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Test">
 
   <!-- Version included until we get global.json generation to support this SDK. -->
-  <Sdk Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19173.6" />
+  <Sdk Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19073.6" />
 
   <Target Name="Gather" BeforeTargets="Test">
     <ItemGroup>


### PR DESCRIPTION
Try workaround suggested for https://github.com/dotnet/arcade/issues/1605

Also pickup fix for parallel uploads https://github.com/dotnet/arcade/issues/1483 to see if it improves helix run time
