### PR TITLE
Remove extraneous call to GetMemory

### DIFF
--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferWriter.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferWriter.cs
@@ -71,8 +71,7 @@ namespace PlatformBenchmarks
                 Commit();
             }
 
-            _output.GetMemory(count);
-            _span = _output.GetSpan();
+            _span = _output.GetSpan(count);
         }
 
         private void WriteMultiBuffer(ReadOnlySpan<byte> source)


### PR DESCRIPTION
For Platform

From https://github.com/aspnet/AspNetCore/pull/7354
And https://github.com/TechEmpower/FrameworkBenchmarks/pull/4419

/cc @sebastienros @AArnott @davidfowl @pakrym @halter73