### PR TITLE
Account for transitive shared framework dependencies separately

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -37,8 +37,6 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.AspNetCore.Blazor.Mono" Version="$(MicrosoftAspNetCoreBlazorMonoPackageVersion)" />
     <LatestPackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
-    <LatestPackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
-    <LatestPackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
     <LatestPackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Bcl.Json.Sources" Version="$(MicrosoftBclJsonSourcesPackageVersion)" />
@@ -49,6 +47,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <LatestPackageReference Include="Microsoft.CodeAnalysis.Razor" Version="$(MicrosoftCodeAnalysisRazorPackageVersion)" />
     <LatestPackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(MicrosoftEntityFrameworkCoreInMemoryPackageVersion)" />
     <LatestPackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftEntityFrameworkCoreRelationalPackageVersion)" />
     <LatestPackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqlitePackageVersion)" />
@@ -66,8 +65,11 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(MicrosoftExtensionsConfigurationCommandLinePackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(MicrosoftExtensionsConfigurationFileExtensionsPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="$(MicrosoftExtensionsConfigurationIniPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFilePackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="$(MicrosoftExtensionsConfigurationUserSecretsPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
@@ -84,6 +86,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.Extensions.HostFactoryResolver.Sources" Version="$(MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpPackageVersion)"  />
     <LatestPackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsLocalizationPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
@@ -93,9 +96,11 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingDebugPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSourcePackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="$(MicrosoftExtensionsLoggingTraceSourcePackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="$(MicrosoftExtensionsOptionsDataAnnotationsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="$(MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
@@ -144,7 +149,9 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataPackageVersion)" />
     <LatestPackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
     <LatestPackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngPackageVersion)" />
+    <LatestPackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsPackageVersion)" />
     <LatestPackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
+    <LatestPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <LatestPackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsPackageVersion)" />
     <LatestPackageReference Include="System.ServiceProcess.ServiceController" Version="$(SystemServiceProcessServiceControllerPackageVersion)" />
     <LatestPackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPackageVersion)" />

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -3,7 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <RestoreSources>
+    <!-- Temporary - some projects in this folder require a restore target against just-built packages. -->
+    <RestoreSources Condition="'$(_DisableRestoreFromLocalPackages)' != 'true'">
       $(RestoreSources);
       $(ArtifactsShippingPackagesDir);
       $(ArtifactsNonShippingPackagesDir)

--- a/src/Framework/Microsoft.AspNetCore.App.props
+++ b/src/Framework/Microsoft.AspNetCore.App.props
@@ -85,8 +85,7 @@
     <!-- We still be the shared framework but running restore against packages we just built. This sets the version to match the current build number. -->
     <Dependency Update="@(Dependency)" Version="$(PackageVersion)" />
 
-    <!-- Dependencies build as packages in other repos. -->
-    <ExternalDependency Include="Microsoft.DotNet.PlatformAbstractions"                        Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
+    <!-- Dependencies built as packages in other repos that we definitely want in the shared framework. -->
     <ExternalDependency Include="Microsoft.Extensions.Caching.Abstractions"                    Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.Caching.Memory"                          Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.Configuration.Abstractions"              Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
@@ -102,7 +101,6 @@
     <ExternalDependency Include="Microsoft.Extensions.Configuration"                           Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.DependencyInjection.Abstractions"        Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.DependencyInjection"                     Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <ExternalDependency Include="Microsoft.Extensions.DependencyModel"                         Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions"   Version="$(MicrosoftExtensionsDiagnosticsHealthChecksAbstractionsPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.Diagnostics.HealthChecks"                Version="$(MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion)"  />
     <ExternalDependency Include="Microsoft.Extensions.FileProviders.Abstractions"              Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
@@ -129,14 +127,32 @@
     <ExternalDependency Include="Microsoft.Extensions.Primitives"                              Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
     <ExternalDependency Include="Microsoft.Extensions.WebEncoders"                             Version="$(MicrosoftExtensionsWebEncodersPackageVersion)" />
     <ExternalDependency Include="Microsoft.JSInterop"                                          Version="$(MicrosoftJSInteropPackageVersion)" />
-    <ExternalDependency Include="Newtonsoft.Json"                                              Version="$(NewtonsoftJsonPackageVersion)" />
-    <ExternalDependency Include="System.IO.Pipelines"                                          Version="$(SystemIOPipelinesPackageVersion)" />
-    <ExternalDependency Include="System.Runtime.CompilerServices.Unsafe"                       Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
-    <ExternalDependency Include="System.Security.Cryptography.Pkcs"                            Version="$(SystemSecurityCryptographyPkcsPackageVersion)" />
-    <ExternalDependency Include="System.Security.Cryptography.Xml"                             Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
-    <ExternalDependency Include="System.Security.Permissions"                                  Version="$(SystemSecurityPermissionsPackageVersion)" />
-    <ExternalDependency Include="System.Text.Encodings.Web"                                    Version="$(SystemTextEncodingsWebPackageVersion)" />
-    <ExternalDependency Include="System.Threading.Channels"                                    Version="$(SystemThreadingChannelsPackageVersion)" />
+
+    <!--
+      Transitive dependencies of other assemblies in the shared framework. These are listed separately and should not be included directly
+      when setting `<Reference>`. These are listed for the purpose of tests and servicing builds only.
+      If implementation details change and these assemblies are no longer showing up in the shared framework as a result of that,
+      it is okay to remove these transitive dependencies.
+    -->
+    <_TransitiveExternalDependency Include="Microsoft.DotNet.PlatformAbstractions"              Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
+    <_TransitiveExternalDependency Include="Microsoft.Extensions.DependencyModel"               Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
+    <_TransitiveExternalDependency Include="Newtonsoft.Json"                                    Version="$(NewtonsoftJsonPackageVersion)" />
+    <_TransitiveExternalDependency Include="System.IO.Pipelines"                                Version="$(SystemIOPipelinesPackageVersion)" />
+    <_TransitiveExternalDependency Include="System.Runtime.CompilerServices.Unsafe"             Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
+    <_TransitiveExternalDependency Include="System.Security.Cryptography.Pkcs"                  Version="$(SystemSecurityCryptographyPkcsPackageVersion)" />
+    <_TransitiveExternalDependency Include="System.Security.Cryptography.Xml"                   Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
+    <_TransitiveExternalDependency Include="System.Security.Permissions"                        Version="$(SystemSecurityPermissionsPackageVersion)" />
+    <_TransitiveExternalDependency Include="System.Text.Encodings.Web"                          Version="$(SystemTextEncodingsWebPackageVersion)" />
+    <_TransitiveExternalDependency Include="System.Threading.Channels"                          Version="$(SystemThreadingChannelsPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsServicingBuild)' == 'true' ">
+    <!--
+      Once we start to build a servicing release, hoist transitive dependencies to be direct dependencies.
+      This will help us ensure servicing builds carry the latest versions of dependencies, even if we aren't rebuilding
+      the original direct dependency that pulled in the transitive reference.
+    -->
+    <ExternalDependency Include="@(_TransitiveExternalDependency)" />
   </ItemGroup>
 
 </Project>

--- a/src/Framework/pkg/Metapackage.targets
+++ b/src/Framework/pkg/Metapackage.targets
@@ -30,6 +30,7 @@
       <AllowExplicitVersion>true</AllowExplicitVersion>
     </PackageReference>
 
+    <!-- Note: do not add _TransitiveExternalDependency to this list. This is intentionally not listed as a direct package reference. -->
     <PackageReference Include="@(Dependency);@(ExternalDependency)" />
   </ItemGroup>
 
@@ -71,6 +72,7 @@
 
     <ItemGroup>
       <_AspNetAppPackageConflictOverrides Include="@(Dependency->'%(Identity)|%(Version)')" Condition=" '%(Dependency.Version)' != '' " />
+      <_AspNetAppPackageConflictOverrides Include="@(ExternalDependency->'%(Identity)|%(Version)')" Condition=" '%(ExternalDependency.Version)' != '' " />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -37,7 +37,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="@(Dependency)" />
+    <!-- Note: do not add _TransitiveExternalDependency to this list. This is intentionally not listed as a direct package reference. -->
+    <Reference Include="@(Dependency);@(ExternalDependency)" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputInRepoRoot>true</OutputInRepoRoot>
+    <!-- Temporary flag to disable restoring this project against the artifacts/ folder. -->
+    <_DisableRestoreFromLocalPackages>true</_DisableRestoreFromLocalPackages>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Framework/src/SharedFx.targets
+++ b/src/Framework/src/SharedFx.targets
@@ -139,6 +139,7 @@ This targets file should only be imported by .shfxproj files.
       <AllowExplicitVersion>true</AllowExplicitVersion>
     </PackageReference>
 
+    <!-- Note: do not add _TransitiveExternalDependency to this list. This is intentionally not listed as a direct package reference. -->
     <PackageReference Include="@(Dependency);@(ExternalDependency)">
       <IncludeAssets>Runtime;Native</IncludeAssets>
       <Publish>true</Publish>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -41,7 +41,7 @@
     <ItemGroup>
       <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
         <_Parameter1>SharedFxDependencies</_Parameter1>
-        <_Parameter2>@(Dependency);@(ExternalDependency)</_Parameter2>
+        <_Parameter2>@(Dependency);@(ExternalDependency);@(_TransitiveExternalDependency)</_Parameter2>
       </AssemblyAttribute>
       <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
         <_Parameter1>MetadataOutputPath</_Parameter1>


### PR DESCRIPTION
Put transitive external dependencies of the shared framework in a separate category, and don't reference them directly unless we are building a patch. This will help us find changes to dependencies, such as the removal of JSON.NET or possible changes to Crypto.Xml.

FYI @dsplaisted - this also fixes missing Microsoft.Extensions.Hosting.dll from the reference assembly package.