### PR TITLE
Disable helix tests on Fedora.28 and 27

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -44,8 +44,8 @@
       Debian.8.Amd64.Open;
       Debian.9.Amd64.Open;
       Fedora.27.Amd64.Open;
-      Fedora.28.Amd64.Open;
       Redhat.7.Amd64.Open;
     </HelixTargetQueues>
+    <!--  TODO: re-enable Fedora.28.Amd64.Open. See https://github.com/aspnet/AspNetCore/issues/7398   -->
   </PropertyGroup>
 </Project> 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -43,9 +43,8 @@
       Centos.7.Amd64.Open;
       Debian.8.Amd64.Open;
       Debian.9.Amd64.Open;
-      Fedora.27.Amd64.Open;
       Redhat.7.Amd64.Open;
     </HelixTargetQueues>
-    <!--  TODO: re-enable Fedora.28.Amd64.Open. See https://github.com/aspnet/AspNetCore/issues/7398   -->
+    <!--  TODO: re-enable Fedora.27.Amd64.Open and Fedora.28.Amd64.Open. See https://github.com/aspnet/AspNetCore/issues/7398   -->
   </PropertyGroup>
 </Project> 


### PR DESCRIPTION
cref https://github.com/aspnet/AspNetCore/issues/7398

Something is wrong with the machines. All tests fail. Disabling to allow time for investigation without blocking PR checks.