### PR TITLE
Fix build break in Identity tests

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Startup.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ApiAuthSample.Data;
@@ -23,7 +24,9 @@ namespace ApiAuthSample
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDbContext<ApplicationDbContext>(options =>
-                options.UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
+                options
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
 
             services.AddDefaultIdentity<ApplicationUser>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryStoreWithGenericsTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryStoreWithGenericsTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -24,7 +25,10 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         {
             var services = new ServiceCollection();
             services.AddHttpContextAccessor();
-            services.AddDbContext<InMemoryContextWithGenerics>(options => options.UseInMemoryDatabase("Scratch"));
+            services.AddDbContext<InMemoryContextWithGenerics>(
+                options => options
+                    .UseInMemoryDatabase("Scratch")
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)));
             _context = services.BuildServiceProvider().GetRequiredService<InMemoryContextWithGenerics>();
         }
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/DbUtil.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/DbUtil.cs
@@ -5,7 +5,9 @@ using System;
 using System.Data.SqlClient;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
@@ -21,7 +23,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
             services.AddHttpContextAccessor();
             services.AddDbContext<TContext>(options =>
             {
-                options.UseSqlServer(connectionString);
+                options
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .UseSqlServer(connectionString);
             });
             return services;
         }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/DefaultPocoTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/DefaultPocoTest.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -23,7 +24,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
 
             services
                 .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
-                .AddDbContext<IdentityDbContext>(o => o.UseSqlServer(fixture.ConnectionString))
+                .AddDbContext<IdentityDbContext>(o =>
+                    o.UseSqlServer(fixture.ConnectionString)
+                        .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
                 .AddIdentity<IdentityUser, IdentityRole>()
                 .AddEntityFrameworkStores<IdentityDbContext>();
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/MaxKeyLengthSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/MaxKeyLengthSchemaTest.cs
@@ -5,6 +5,7 @@ using System.Data.SqlClient;
 using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -22,7 +23,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
 
             services
                 .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
-                .AddDbContext<IdentityDbContext>(o => o.UseSqlServer(fixture.ConnectionString))
+                .AddDbContext<IdentityDbContext>(o =>
+                    o.UseSqlServer(fixture.ConnectionString)
+                        .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
                 .AddIdentity<IdentityUser, IdentityRole>(o => o.Stores.MaxLengthForKeys = 128)
                 .AddEntityFrameworkStores<IdentityDbContext>();
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserOnlyCustomContextTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserOnlyCustomContextTest.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -67,7 +68,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
 
             services
                 .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
-                .AddDbContext<CustomContext>(o => o.UseSqlServer(fixture.ConnectionString))
+                .AddDbContext<CustomContext>(o =>
+                    o.UseSqlServer(fixture.ConnectionString)
+                        .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
                 .AddIdentityCore<IdentityUser>(o => { })
                 .AddEntityFrameworkStores<CustomContext>();
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserOnlyTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserOnlyTest.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -28,7 +29,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
 
             services
                 .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
-                .AddDbContext<TestUserDbContext>(o => o.UseSqlServer(fixture.ConnectionString))
+                .AddDbContext<TestUserDbContext>(
+                    o => o.UseSqlServer(fixture.ConnectionString)
+                        .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
                 .AddIdentityCore<IdentityUser>(o => { })
                 .AddEntityFrameworkStores<TestUserDbContext>();
 

--- a/src/Identity/samples/IdentitySample.DefaultUI/Startup.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -29,7 +30,8 @@ namespace IdentitySample.DefaultUI
         {
             // Add framework services.
             services.AddDbContext<ApplicationDbContext>(
-                options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"),
+                options => options.ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .UseSqlServer(Configuration.GetConnectionString("DefaultConnection"),
                 x => x.MigrationsAssembly("IdentitySample.DefaultUI")));
 
             services.AddMvc();
@@ -39,7 +41,7 @@ namespace IdentitySample.DefaultUI
                  .AddEntityFrameworkStores<ApplicationDbContext>();
         }
 
- 
+
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {

--- a/src/Identity/samples/IdentitySample.Mvc/Startup.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -30,7 +31,8 @@ namespace IdentitySample
         {
             // Add framework services.
             services.AddDbContext<ApplicationDbContext>(options =>
-                options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+                options.ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
 
             services.AddMvc();
 

--- a/src/Identity/test/Identity.FunctionalTests/Infrastructure/FunctionalTestsServiceCollectionExtensions.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Infrastructure/FunctionalTestsServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Identity.FunctionalTests
@@ -19,7 +20,8 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
     {
         public static IServiceCollection SetupTestDatabase<TContext>(this IServiceCollection services, string databaseName) where TContext : DbContext =>
             services.AddDbContext<TContext>(options =>
-                options.UseInMemoryDatabase(databaseName, memoryOptions => { }));
+                options.ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .UseInMemoryDatabase(databaseName, memoryOptions => { }));
 
         public static IServiceCollection SetupTestThirdPartyLogin(this IServiceCollection services) =>
             services.AddAuthentication()

--- a/src/Identity/testassets/Identity.DefaultUI.WebSite/StartupBase.cs
+++ b/src/Identity/testassets/Identity.DefaultUI.WebSite/StartupBase.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -35,10 +36,12 @@ namespace Identity.DefaultUI.WebSite
             });
 
             services.AddDbContext<TContext>(options =>
-                options.UseSqlServer(
-                    Configuration.GetConnectionString("DefaultConnection"),
-                    sqlOptions => sqlOptions.MigrationsAssembly("Identity.DefaultUI.WebSite")
-                ));
+                options
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .UseSqlServer(
+                        Configuration.GetConnectionString("DefaultConnection"),
+                        sqlOptions => sqlOptions.MigrationsAssembly("Identity.DefaultUI.WebSite")
+                    ));
 
             services.AddDefaultIdentity<TUser>()
                 .AddDefaultUI(Framework)


### PR DESCRIPTION
By configuring the service provider warning to log instead of throw
