### PR TITLE
Made changes to stream <-> pipe adapters

### DIFF
--- a/src/Http/Http/test/StreamPipeReaderTests.cs
+++ b/src/Http/Http/test/StreamPipeReaderTests.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -373,6 +374,30 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public async Task ArrayPoolUsedByDefault()
+        {
+            WriteByteArray(20);
+            var reader = new StreamPipeReader(Stream);
+            var result = await reader.ReadAsync();
+
+            SequenceMarshal.TryGetReadOnlySequenceSegment(
+                result.Buffer,
+                out var startSegment,
+                out var startIndex,
+                out var endSegment,
+                out var endIndex);
+
+            var start = (BufferSegment)startSegment;
+            var end = (BufferSegment)endSegment;
+
+            Assert.Same(start, end);
+            Assert.IsType<byte[]>(start.MemoryOwner);
+
+            reader.AdvanceTo(result.Buffer.End);
+            reader.Complete();
+        }
+
+        [Fact]
         public void CancelledReadAsyncReturnsTaskWithValue()
         {
             Reader.CancelPendingRead();
@@ -593,7 +618,7 @@ namespace System.IO.Pipelines.Tests
         public async Task ReadAsyncWithEmptyDataCompletesStream()
         {
             WriteByteArray(0);
-            
+
             var readResult = await Reader.ReadAsync();
 
             Assert.True(readResult.IsCompleted);

--- a/src/Http/Http/test/StreamPipeTest.cs
+++ b/src/Http/Http/test/StreamPipeTest.cs
@@ -17,17 +17,21 @@ namespace System.IO.Pipelines.Tests
 
         public PipeReader Reader { get; set; }
 
+        public TestMemoryPool Pool { get; set; }
+
         protected StreamPipeTest()
         {
+            Pool = new TestMemoryPool();
             Stream = new MemoryStream();
-            Writer = new StreamPipeWriter(Stream, MinimumSegmentSize, new TestMemoryPool());
-            Reader = new StreamPipeReader(Stream, new StreamPipeReaderOptions(MinimumSegmentSize, minimumReadThreshold: 256, new TestMemoryPool()));
+            Writer = new StreamPipeWriter(Stream, MinimumSegmentSize, Pool);
+            Reader = new StreamPipeReader(Stream, new StreamPipeReaderOptions(MinimumSegmentSize, minimumReadThreshold: 256, Pool));
         }
 
         public void Dispose()
         {
             Writer.Complete();
             Reader.Complete();
+            Pool.Dispose();
         }
 
         public byte[] Read()

--- a/src/Http/Http/test/StreamPipeWriterTests.cs
+++ b/src/Http/Http/test/StreamPipeWriterTests.cs
@@ -321,6 +321,24 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public void GetMemorySameAsTheMaxPoolSizeUsesThePool()
+        {
+            var memory = Writer.GetMemory(Pool.MaxBufferSize);
+
+            Assert.Equal(Pool.MaxBufferSize, memory.Length);
+            Assert.Equal(1, Pool.GetRentCount());
+        }
+
+        [Fact]
+        public void GetMemoryBiggerThanPoolSizeAllocatesUnpooledArray()
+        {
+            var memory = Writer.GetMemory(Pool.MaxBufferSize + 1);
+
+            Assert.Equal(Pool.MaxBufferSize + 1, memory.Length);
+            Assert.Equal(0, Pool.GetRentCount());
+        }
+
+        [Fact]
         public void CallComplete_GetMemoryThrows()
         {
             Writer.Complete();


### PR DESCRIPTION
- Use the array pool by default when the shared memory pool is specified for both the StreamPipeReader and StreamPipeWriter
- Support allocating unpooled memory if the StreamPipeWriter is asked for memory outside of the max pool size
