### PR TITLE
Extend WebApplicationFactory<T>

### DIFF
--- a/src/Mvc/Mvc.Testing/ref/Microsoft.AspNetCore.Mvc.Testing.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Testing/ref/Microsoft.AspNetCore.Mvc.Testing.netcoreapp3.0.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         public Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions ClientOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>> Factories { get { throw null; } }
         public Microsoft.AspNetCore.TestHost.TestServer Server { get { throw null; } }
+        public virtual System.IServiceProvider Services { get { throw null; } }
         protected virtual void ConfigureClient(System.Net.Http.HttpClient client) { }
         protected virtual void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) { }
         public System.Net.Http.HttpClient CreateClient() { throw null; }

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -80,6 +80,18 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         }
 
         /// <summary>
+        /// Gets the <see cref="IServiceProvider"/> created by the server associated with this <see cref="WebApplicationFactory{TEntryPoint}"/>.
+        /// </summary>
+        public virtual IServiceProvider Services
+        {
+            get
+            {
+                EnsureServer();
+                return _host?.Services ?? _server.Host.Services;
+            }
+        }
+
+        /// <summary>
         /// Gets the <see cref="IReadOnlyList{WebApplicationFactory}"/> of factories created from this factory
         /// by further customizing the <see cref="IWebHostBuilder"/> when calling 
         /// <see cref="WebApplicationFactory{TEntryPoint}.WithWebHostBuilder(Action{IWebHostBuilder})"/>.

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
@@ -52,6 +52,17 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.False(factory.CreateWebHostBuilderCalled);
         }
 
+        [Fact]
+        public void TestingInfrastructure_GenericHost_WithWithHostBuilderHasServices()
+        {
+            // Act
+            var factory = new CustomizedFactory<GenericHostWebSite.Startup>();
+
+            // Assert
+            Assert.NotNull(factory.Services);
+            Assert.NotNull(factory.Services.GetService(typeof(IConfiguration)));
+        }
+
         private class CustomizedFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint> where TEntryPoint : class
         {
             public bool GetTestAssembliesCalled { get; private set; }

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Mvc.Testing.Handlers;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using RazorPagesClassLibrary;
 using Xunit;
@@ -129,6 +130,42 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await factory.CreateClient().GetStringAsync("Testing/Builder");
 
             Assert.Equal("GenericTest", response);
+        }
+
+        [Fact]
+        public void TestingInfrastructure_HasServicesUsingWebHostProgram()
+        {
+            var factory = new WebApplicationFactory<BasicWebSite.Program>();
+
+            Assert.NotNull(factory.Services);
+            Assert.NotNull(factory.Services.GetService(typeof(IConfiguration)));
+        }
+
+        [Fact]
+        public void TestingInfrastructure_HasServicesUsingWebHostStartup()
+        {
+            var factory = new WebApplicationFactory<BasicWebSite.Startup>();
+
+            Assert.NotNull(factory.Services);
+            Assert.NotNull(factory.Services.GetService(typeof(IConfiguration)));
+        }
+
+        [Fact]
+        public void TestingInfrastructure_HasServicesUsingGenericHostProgram()
+        {
+            var factory = new WebApplicationFactory<GenericHostWebSite.Program>();
+
+            Assert.NotNull(factory.Services);
+            Assert.NotNull(factory.Services.GetService(typeof(IConfiguration)));
+        }
+
+        [Fact]
+        public void TestingInfrastructure_HasServicesUsingGenericHostStartup()
+        {
+            var factory = new WebApplicationFactory<GenericHostWebSite.Startup>();
+
+            Assert.NotNull(factory.Services);
+            Assert.NotNull(factory.Services.GetService(typeof(IConfiguration)));
         }
 
         private class OverridenService : TestService


### PR DESCRIPTION
This pull request extends `WebApplicationFactory<T>` based on some experiences I've had with it while updating some applications to use ASP.NET Core 3.0 using preview 2 from ASP.NET Core 2.2.

First, it adds a new property, `public virtual IServiceProvider Services`. This is to support the scenario where the test application wants access to the `IServiceProvider` of the hosted service.

In 2.x, this was possible through the access chain `factory.Server.Host.Services`, however in 3.0 if the application is using `IHostBuilder` this access throws the following exception:

```
System.InvalidOperationException:
  The TestServer constructor was not called with a IWebHostBuilder so IWebHost is not available.
```

As the `IHost` vs. `IWebHost` implementation detail is hidden, rather than expose two different properties for the possible hosts and make the caller choose, instead the new property returns the appropriate `IServiceProvider` based on the host that is in use.

The property is `virtual` so that derived instances leveraging the base functionality to use a different host can override the property to change the `IServiceProvider`. An example of this can be seen in this PR for an application of my own where I build on top of `WebApplicationFactory<T>` to host the server on an actual HTTP port for use for browser-based UI tests: https://github.com/martincostello/alexa-london-travel-site/pull/252

Secondly, this PR adds a new method `protected string GetContentRootPath()` that exposes the existing logic to get the content root path for the application being tested. Previously this was private, so if a derived type also needed access to the value for some reason, it had to duplicate the code for itself.

I also considered exposing `EnsureServer()` in some manner so that derived types don't need to "hack" the services being started up by calling either `CreateDefaultClient()` or `Server` so they can ensure the server is running before doing other custom setup actions. I wasn't sure exactly what to call that, so I've left it for now, but if you have any suggestions on the best way to do that, I'd also like to do that either in this PR or a different one.