### PR TITLE
 Don't write empty data for Flush

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -19,14 +19,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     public partial class HttpProtocol : IHttpRequestFeature,
                                         IHttpResponseFeature,
+                                        IResponseBodyPipeFeature,
                                         IHttpUpgradeFeature,
                                         IHttpConnectionFeature,
                                         IHttpRequestLifetimeFeature,
                                         IHttpRequestIdentifierFeature,
                                         IHttpBodyControlFeature,
                                         IHttpMaxRequestBodySizeFeature,
-                                        IHttpResponseStartFeature,
-                                        IResponseBodyPipeFeature
+                                        IHttpResponseStartFeature
     {
         // NOTE: When feature interfaces are added to or removed from this HttpProtocol class implementation,
         // then the list of `implementedFeatures` in the generated code project MUST also be updated.

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Constants.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Constants.cs
@@ -37,7 +37,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public const string ServerName = "Kestrel";
 
         public static readonly TimeSpan RequestBodyDrainTimeout = TimeSpan.FromSeconds(5);
-
-        public static readonly ArraySegment<byte> EmptyData = new ArraySegment<byte>(new byte[0]);
     }
 }


### PR DESCRIPTION
Can skip getting Span etc

Reuse BufferWriter for `WriteCurrentMemoryToPipeWriter`

Ignore whitespace change https://github.com/aspnet/AspNetCore/pull/7415/files?w=1

Plaintext pipelined; left current; right PR:

![image](https://user-images.githubusercontent.com/1142958/52524780-e0d1ae80-2c98-11e9-8da8-a7d9e6ee7a20.png)


/cc @jkotalik @davidfowl 