### PR TITLE
Remove unnecessary Flush

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -794,9 +794,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private ValueTask<FlushResult> FlushAsyncInternal(CancellationToken cancellationToken)
+        private Task FlushAsyncInternal()
         {
-            return Output.FlushAsync(cancellationToken);
+            return Output.FlushAsync(default).AsTask();
         }
 
         private void VerifyAndUpdateWrite(int count)
@@ -996,7 +996,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (!HasFlushedHeaders)
             {
                 _requestProcessingStatus = RequestProcessingStatus.HeadersFlushed;
-                return FlushAsyncInternal(default).AsTask();
+                return FlushAsyncInternal();
             }
 
             return Task.CompletedTask;
@@ -1354,7 +1354,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (data.Length == 0)
                     {
-                        return !firstWrite ? default : FlushAsyncInternal(cancellationToken);
+                        return !firstWrite ? default : Output.FlushAsync(cancellationToken);
                     }
 
                     return Output.WriteChunkAsync(data.Span, cancellationToken);
@@ -1368,7 +1368,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else
             {
                 HandleNonBodyResponseWrite();
-                return !firstWrite ? default : FlushAsyncInternal(cancellationToken);
+                return !firstWrite ? default : Output.FlushAsync(cancellationToken);
             }
         }
 
@@ -1401,7 +1401,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (data.Length == 0)
                     {
-                        return await FlushAsyncInternal(cancellationToken);
+                        return await Output.FlushAsync(cancellationToken);
                     }
 
                     return await Output.WriteChunkAsync(data.Span, cancellationToken);
@@ -1415,7 +1415,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else
             {
                 HandleNonBodyResponseWrite();
-                return await FlushAsyncInternal(cancellationToken);
+                return await Output.FlushAsync(cancellationToken);
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -750,7 +750,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private Task FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
         {
-
             while (onCompleted.TryPop(out var entry))
             {
                 try
@@ -792,14 +791,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     Log.ApplicationError(ConnectionId, TraceIdentifier, ex);
                 }
             }
-
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private async Task InitializeAndFlushAsyncAwaited(Task initializeTask, CancellationToken cancellationToken)
-        {
-            await initializeTask;
-            await FlushAsyncInternal(cancellationToken);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -807,12 +798,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             _requestProcessingStatus = RequestProcessingStatus.HeadersFlushed;
             return Output.FlushAsync(cancellationToken);
-        }
-
-        private Task WriteDataAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
-        {
-            _requestProcessingStatus = RequestProcessingStatus.HeadersFlushed;
-            return Output.WriteDataAsync(data.Span, cancellationToken: cancellationToken);
         }
 
         private void VerifyAndUpdateWrite(int count)
@@ -1376,6 +1361,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else
                 {
                     CheckLastWrite();
+                    _requestProcessingStatus = RequestProcessingStatus.HeadersFlushed;
                     return Output.WriteDataToPipeAsync(data.Span, cancellationToken: cancellationToken);
                 }
             }


### PR DESCRIPTION
When the body has been written to the headers are flushed so it doesn't need a second flush at end; so set `_requestProcessingStatus = RequestProcessingStatus.HeadersFlushed`

Currently handled for `_autoChunk` but not for `ContentLength`

![image](https://user-images.githubusercontent.com/1142958/52528204-67ee4900-2cd0-11e9-969d-f8b9322f2ddb.png)


/cc @jkotalik @davidfowl