### PR TITLE
PointerID type string replaced to long

### DIFF
--- a/src/Components/Components/src/UIEventArgs.cs
+++ b/src/Components/Components/src/UIEventArgs.cs
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Components
         /// <summary>
         /// A unique identifier for the pointer causing the event.
         /// </summary>
-        public string PointerId { get; set; }
+        public long PointerId { get; set; }
 
         /// <summary>
         /// The width (magnitude on the X axis), in CSS pixels, of the contact geometry of the pointer.


### PR DESCRIPTION
Summary of the changes
 - PointerID should be long but was string
 - It was giving error - System.ArgumentException: Object of type 'System.Int64' cannot be converted to type 'System.String'.

Addresses #7418
