### PR TITLE
Use MemoryWriter for Platform

### DIFF
--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.cs
@@ -51,11 +51,11 @@ namespace PlatformBenchmarks
             _requestType = requestType;
         }
 
-        public ValueTask ProcessRequestAsync()
+        public Task ProcessRequestAsync()
         {
             if (_requestType == RequestType.PlainText)
             {
-                PlainText(Writer);
+                PlainText(_output);
             }
             else if (_requestType == RequestType.Json)
             {
@@ -63,15 +63,15 @@ namespace PlatformBenchmarks
             }
             else
             {
-                Default(Writer);
+                Default(_output);
             }
 
-            return default;
+            return Task.CompletedTask;
         }
 
-        private static void PlainText(PipeWriter pipeWriter)
+        private static void PlainText(MemoryWriter output)
         {
-            var writer = GetWriter(pipeWriter);
+            var writer = output.GetBufferWriter();
 
             // HTTP 1.1 OK
             writer.Write(_http11OK);
@@ -97,9 +97,9 @@ namespace PlatformBenchmarks
             writer.Commit();
         }
 
-        private static void Json(PipeWriter pipeWriter)
+        private static void Json(MemoryWriter output)
         {
-            var writer = GetWriter(pipeWriter);
+            var writer = output.GetBufferWriter();
 
             // HTTP 1.1 OK
             writer.Write(_http11OK);
@@ -126,9 +126,9 @@ namespace PlatformBenchmarks
             writer.Commit();
         }
 
-        private static void Default(PipeWriter pipeWriter)
+        private static void Default(MemoryWriter output)
         {
-            var writer = GetWriter(pipeWriter);
+            var writer = output.GetBufferWriter();
 
             // HTTP 1.1 OK
             writer.Write(_http11OK);

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferExtensions.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferExtensions.cs
@@ -20,8 +20,7 @@ namespace PlatformBenchmarks
         private static byte[] _numericBytesScratch;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe void WriteNumeric<T>(ref this BufferWriter<T> buffer, uint number)
-             where T : struct, IBufferWriter<byte>
+        internal static unsafe void WriteNumeric(ref this BufferWriter buffer, uint number)
         {
             const byte AsciiDigitStart = (byte)'0';
 
@@ -69,8 +68,7 @@ namespace PlatformBenchmarks
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void WriteNumericMultiWrite<T>(ref this BufferWriter<T> buffer, uint number)
-             where T : struct, IBufferWriter<byte>
+        private static void WriteNumericMultiWrite(ref this BufferWriter buffer, uint number)
         {
             const byte AsciiDigitStart = (byte)'0';
 

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferWriter.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferWriter.cs
@@ -7,13 +7,13 @@ using System.Runtime.CompilerServices;
 
 namespace PlatformBenchmarks
 {
-    public ref struct BufferWriter<T> where T : IBufferWriter<byte>
+    public ref struct BufferWriter
     {
-        private T _output;
+        private MemoryWriter _output;
         private Span<byte> _span;
         private int _buffered;
 
-        public BufferWriter(T output)
+        public BufferWriter(MemoryWriter output)
         {
             _buffered = 0;
             _output = output;

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/HttpApplication.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/HttpApplication.cs
@@ -21,7 +21,7 @@ namespace PlatformBenchmarks
             var httpConnection = new TConnection
             {
                 Reader = connection.Transport.Input,
-                Writer = connection.Transport.Output
+                Output = connection.Transport.Output
             };
             return httpConnection.ExecuteAsync();
         }

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/IHttpConnection.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/IHttpConnection.cs
@@ -10,7 +10,7 @@ namespace PlatformBenchmarks
     public interface IHttpConnection : IHttpHeadersHandler, IHttpRequestLineHandler
     {
         PipeReader Reader { get; set; }
-        PipeWriter Writer { get; set; }
+        PipeWriter Output { get; set; }
         Task ExecuteAsync();
         ValueTask OnReadCompletedAsync();
     }

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/MemoryWriter.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/MemoryWriter.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace PlatformBenchmarks
+{
+    public class MemoryWriter : IBufferWriter<byte>
+    {
+        private PipeWriter _writer;
+        private Memory<byte> _memory;
+        private int _buffered;
+
+        public MemoryWriter(PipeWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void Advance(int count)
+        {
+            _buffered += count;
+            _memory = _memory.Slice(count);
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (_memory.Length < sizeHint)
+            {
+                if (_buffered > 0)
+                {
+                    _writer.Advance(_buffered);
+                    _buffered = 0;
+                }
+
+                _memory = _writer.GetMemory(sizeHint);
+            }
+
+            return _memory;
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (_memory.Length >= sizeHint)
+            {
+                return _memory.Span;
+            }
+
+            return GetMemory(sizeHint).Span;
+        }
+
+        public void Commit()
+        {
+            var buffered = _buffered;
+            if (buffered > 0)
+            {
+                _buffered = 0;
+                _writer.Advance(buffered);
+            }
+
+            _memory = default;
+        }
+
+        public BufferWriter GetBufferWriter() => new BufferWriter(this);
+    }
+}


### PR DESCRIPTION
Cache Memory across the awaits rather than going back to the PipeWriter until the Memory runs out