### PR TITLE
Fix #4212 area ambient value page->controller

### DIFF
--- a/src/Http/Routing/test/UnitTests/Template/TemplateBinderTests.cs
+++ b/src/Http/Routing/test/UnitTests/Template/TemplateBinderTests.cs
@@ -1381,6 +1381,40 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             Assert.Equal(expected, boundTemplate);
         }
 
+        // Regression test for aspnet/AspNetCore#4212
+        //
+        // An ambient value should be used to satisfy a required value even if if we're discarding
+        // ambient values.
+        [Fact]
+        public void BindValues_LinkingFromPageToAControllerInAreaWithAmbientArea_Success()
+        {
+            // Arrange
+            var expected = "/Admin/LG2/SomeAction";
+
+            var template = "{area}/{controller=Home}/{action=Index}/{id?}";
+            var defaults = new RouteValueDictionary();
+            var ambientValues = new RouteValueDictionary(new { area = "Admin", page = "/LGAnotherPage", id = "17" });
+            var explicitValues = new RouteValueDictionary(new { controller = "LG2", action = "SomeAction" });
+            var binder = new TemplateBinder(
+                UrlEncoder.Default,
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+                RoutePatternFactory.Parse(
+                    template,
+                    defaults,
+                    parameterPolicies: null,
+                    requiredValues: new { area = "Admin", action = "SomeAction", controller = "LG2", page = (string)null }),
+                defaults,
+                requiredKeys: new string[] { "area", "action", "controller", "page" },
+                parameterPolicies: null);
+
+            // Act
+            var result = binder.GetValues(ambientValues, explicitValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+            // Assert
+            Assert.Equal(expected, boundTemplate);
+        }
+
         [Fact]
         public void BindValues_HasUnmatchingAmbientValues_Discard()
         {

--- a/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
+++ b/src/Mvc/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
@@ -323,7 +323,7 @@ Hello from page";
             var expected =
 @"<a href=""/Accounts/Manage/RenderPartials"">Link inside area</a>
 <a href=""/Products/List/old/20"">Link to external area</a>
-<a href="""">Link to area action</a>
+<a href=""/Accounts"">Link to area action</a>
 <a href=""/Admin"">Link to non-area page</a>";
 
             // Act


### PR DESCRIPTION
This change enhances our ambient value logic to also deal with required
values. In 2.2 we introduced a 'required values' semantic to allow route
values to appear "to the left" of a route pattern for the purpose of
ambient values copying. This is a complicated way of saying "when you
like to a different endpoint then discard the ambient values".

What we didn't consider is that some ambient values are special (like
area). So basically, we'll allow an ambient value to be used if it's
part of the required values - even if we've already decided to discard
the ambient values.

This is a pretty surgical fix and only affected the desired scenario
based on tests.

-----

I also removed an optimization that I think is broken. I put an earlier
optimization in place that attempted to count ambient values as they
were "seen" to try and avoid some extra copying. This copying loop has a
cost even if it no-ops which is what I was trying to prevent.

Unfortunately since we added 'required values' - it's now possible for
an ambient value to be double-counted, which makes this optimization
incorrect.

