### PR TITLE
Suppress Razor warnings about missing doc comments

### DIFF
--- a/src/Razor/Razor/src/Microsoft.AspNetCore.Razor.csproj
+++ b/src/Razor/Razor/src/Microsoft.AspNetCore.Razor.csproj
@@ -11,6 +11,7 @@ Microsoft.AspNetCore.Razor.TagHelpers.ITagHelper</Description>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);taghelper;taghelpers</PackageTags>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <!-- Required to implement an HtmlEncoder -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
This quiets down the MVC build. (Not sure how to get rid of the warnings about the second FSharp import without changing the .NET SDK.)