### PR TITLE
Improve service reference filenames and class names

### DIFF
--- a/src/Mvc/Extensions.ApiDescription.Design/src/CSharpIdentifier.cs
+++ b/src/Mvc/Extensions.ApiDescription.Design/src/CSharpIdentifier.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.Text;
+
+// Copied from
+// https://github.com/aspnet/AspNetCore-Tooling/blob/master/src/Razor/src/Microsoft.AspNetCore.Razor.Language/CSharpIdentifier.cs
+namespace Microsoft.Extensions.ApiDescription.Tasks
+{
+    internal static class CSharpIdentifier
+    {
+        // CSharp Spec §2.4.2
+        private static bool IsIdentifierStart(char character)
+        {
+            return char.IsLetter(character) ||
+                character == '_' ||
+                CharUnicodeInfo.GetUnicodeCategory(character) == UnicodeCategory.LetterNumber;
+        }
+
+        public static bool IsIdentifierPart(char character)
+        {
+            return char.IsDigit(character) ||
+                   IsIdentifierStart(character) ||
+                   IsIdentifierPartByUnicodeCategory(character);
+        }
+
+        private static bool IsIdentifierPartByUnicodeCategory(char character)
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(character);
+
+            return category == UnicodeCategory.NonSpacingMark || // Mn
+                category == UnicodeCategory.SpacingCombiningMark || // Mc
+                category == UnicodeCategory.ConnectorPunctuation || // Pc
+                category == UnicodeCategory.Format; // Cf
+        }
+
+        public static string SanitizeIdentifier(string inputName)
+        {
+            if (!IsIdentifierStart(inputName[0]) && IsIdentifierPart(inputName[0]))
+            {
+                inputName = "_" + inputName;
+            }
+
+            var builder = new StringBuilder(inputName.Length);
+            for (var i = 0; i < inputName.Length; i++)
+            {
+                var ch = inputName[i];
+                builder.Append(IsIdentifierPart(ch) ? ch : '_');
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Mvc/Extensions.ApiDescription.Design/src/GetUriReferenceMetadata.cs
+++ b/src/Mvc/Extensions.ApiDescription.Design/src/GetUriReferenceMetadata.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -14,6 +15,9 @@ namespace Microsoft.Extensions.ApiDescription.Tasks
     /// </summary>
     public class GetUriReferenceMetadata : Task
     {
+        private static readonly char[] InvalidFilenameCharacters = Path.GetInvalidFileNameChars();
+        private static readonly string[] InvalidFilenameStrings = new[] { ".." };
+
         /// <summary>
         /// Default directory for DocumentPath metadata values.
         /// </summary>
@@ -41,68 +45,74 @@ namespace Microsoft.Extensions.ApiDescription.Tasks
                 var newItem = new TaskItem(item);
                 outputs.Add(newItem);
 
+                var uri = item.ItemSpec;
+                var builder = new UriBuilder(uri);
+                if (!builder.Uri.IsAbsoluteUri)
+                {
+                    Log.LogError($"{nameof(Inputs)} item '{uri}' is not an absolute URI.");
+                    return false;
+                }
+
+                if (!string.Equals(Uri.UriSchemeHttp, builder.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(Uri.UriSchemeHttps, builder.Scheme, StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogError($"{nameof(Inputs)} item '{uri}' does not have scheme {Uri.UriSchemeHttp} or " +
+                        $"{Uri.UriSchemeHttps}.");
+                    return false;
+                }
+
+                // If not specified, base filename on the URI.
                 var documentPath = item.GetMetadata("DocumentPath");
                 if (string.IsNullOrEmpty(documentPath))
                 {
-                    var uri = item.ItemSpec;
-                    var builder = new UriBuilder(uri);
-                    if (!builder.Uri.IsAbsoluteUri)
+                    // Default to a fairly long but identifiable and fairly unique filename.
+                    var documentPathBuilder = new StringBuilder(builder.Host);
+                    if (!string.IsNullOrEmpty(builder.Path) &&
+                        !string.Equals("/", builder.Path, StringComparison.Ordinal))
                     {
-                        Log.LogError($"{nameof(Inputs)} item '{uri}' is not an absolute URI.");
-                        return false;
+                        documentPathBuilder.Append(builder.Path);
                     }
 
-                    if (!string.Equals(Uri.UriSchemeHttp, builder.Scheme, StringComparison.OrdinalIgnoreCase) &&
-                        !string.Equals(Uri.UriSchemeHttps, builder.Scheme, StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrEmpty(builder.Query) &&
+                        !string.Equals("?", builder.Query, StringComparison.Ordinal))
                     {
-                        Log.LogError($"{nameof(Inputs)} item '{uri}' does not have scheme {Uri.UriSchemeHttp} or " +
-                            $"{Uri.UriSchemeHttps}.");
-                        return false;
+                        documentPathBuilder.Append(builder.Query);
                     }
 
-                    var host = builder.Host
-                      .Replace("/", string.Empty)
-                      .Replace("[", string.Empty)
-                      .Replace("]", string.Empty)
-                      .Replace(':', '_');
-                    var path = builder.Path
-                      .Replace("!", string.Empty)
-                      .Replace("'", string.Empty)
-                      .Replace("$", string.Empty)
-                      .Replace("%", string.Empty)
-                      .Replace("&", string.Empty)
-                      .Replace("(", string.Empty)
-                      .Replace(")", string.Empty)
-                      .Replace("*", string.Empty)
-                      .Replace("@", string.Empty)
-                      .Replace("~", string.Empty)
-                      .Replace('/', '_')
-                      .Replace(':', '_')
-                      .Replace(';', '_')
-                      .Replace('+', '_')
-                      .Replace('=', '_');
-
-                    documentPath = host + path;
-                    if (char.IsLower(documentPath[0]))
+                    // Sanitize the string because it likely contains illegal filename characters such as '/' and '?'.
+                    // (Do not treat slashes as folder separators.)
+                    documentPath = documentPathBuilder.ToString();
+                    documentPath = string.Join("_", documentPath.Split(InvalidFilenameCharacters));
+                    while (documentPath.Contains(InvalidFilenameStrings[0]))
                     {
-                        documentPath = char.ToUpper(documentPath[0]) + documentPath.Substring(startIndex: 1);
+                        documentPath = string.Join(
+                            ".",
+                            documentPath.Split(InvalidFilenameStrings, StringSplitOptions.None));
                     }
 
+                    // URI might end with ".json". Don't duplicate that or a final period.
                     if (!documentPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
                     {
-                        documentPath = $"{documentPath}.json";
+                        if (documentPath.EndsWith(".", StringComparison.Ordinal))
+                        {
+                            documentPath += "json";
+                        }
+                        else
+                        {
+                            documentPath += ".json";
+                        }
                     }
                 }
 
                 documentPath = GetFullPath(documentPath);
-                MetadataSerializer.SetMetadata(newItem, "DocumentPath", documentPath);
-
                 if (!destinations.Add(documentPath))
                 {
                     // This case may occur when user is experimenting e.g. with multiple code generators or options.
                     // May also occur when user accidentally duplicates DocumentPath metadata.
                     Log.LogError(Resources.FormatDuplicateUriDocumentPaths(documentPath));
                 }
+
+                MetadataSerializer.SetMetadata(newItem, "DocumentPath", documentPath);
             }
 
             Outputs = outputs.ToArray();

--- a/src/Mvc/Extensions.ApiDescription.Design/src/build/Microsoft.Extensions.ApiDescription.Design.props
+++ b/src/Mvc/Extensions.ApiDescription.Design/src/build/Microsoft.Extensions.ApiDescription.Design.props
@@ -91,7 +91,7 @@
       -->
       <DocumentName />
       <!--
-        Full path where the API description document is placed. Default filename is %(Filename).%(DocumentName).json.
+        Full path where the API description document is placed. Default filename is %(Filename)_%(DocumentName).json.
         Filenames and relative paths (if explicitly set) are combined with $(ServiceProjectReferenceDirectory).
       -->
       <DocumentPath />
@@ -116,7 +116,7 @@
     </ServiceUriReference>
 
     <ServiceFileReference>
-      <!-- Name of the class to generate. Defaults to %(Filename)Client but with an uppercase first letter. -->
+      <!-- Name of the class to generate. Defaults to match final segment of %(OutputPath). -->
       <ClassName />
       <!--
         Code generator to use. Required and must end with "CSharp" or "TypeScript" (the currently-supported target
@@ -130,7 +130,7 @@
       <Namespace />
       <!--
         Path to place generated code. Code generator may interpret path as a filename or directory. Default filename or
-        folder name is %(ClassName).[cs|ts]. Filenames and relative paths (if explicitly set) are combined with
+        folder name is %(Filename)Client.[cs|ts]. Filenames and relative paths (if explicitly set) are combined with
         $(ServiceFileReferenceDirectory). Final value (depending on $(ServiceFileReferenceDirectory)) is likely to be
         a path relative to the client project.
       -->

--- a/src/Mvc/Extensions.ApiDescription.Design/src/build/Microsoft.Extensions.ApiDescription.Design.targets
+++ b/src/Mvc/Extensions.ApiDescription.Design/src/build/Microsoft.Extensions.ApiDescription.Design.targets
@@ -311,7 +311,7 @@
         <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
       </Compile>
 
-      <!-- Otherwise, add all descendent files with the expected extension. -->
+      <!-- Otherwise, add all descendant files with the expected extension. -->
       <TypeScriptCompile Remove="@(_Directories -> '%(Identity)/**/*.ts')" />
       <TypeScriptCompile Include="@(_Directories -> '%(Identity)/**/*.ts')">
         <SourceDocument>%(_Directories.FullPath)</SourceDocument>

--- a/src/Mvc/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
+++ b/src/Mvc/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
@@ -117,12 +117,14 @@ namespace Microsoft.Extensions.ApiDescription.Tool.Commands
                     }
 
                     writer.Flush();
-                    stream.Position = 0L;
-                    using (var outStream = File.Create(context.OutputPath))
+                    if (stream.Length > 0L)
                     {
-                        stream.CopyTo(outStream);
-
-                        outStream.Flush();
+                        stream.Position = 0L;
+                        using (var outStream = File.Create(context.OutputPath))
+                        {
+                            stream.CopyTo(outStream);
+                            outStream.Flush();
+                        }
                     }
                 }
 


### PR DESCRIPTION
- #4927
- fully-sanitize class names and filenames
- default metadata in sequence [URI or project&document name ->] `%(DocumentPath)` -> `%(OutputPath)` -> `%(ClassName)`
  - if user sets metadata explicitly, the override affects defaults later in the sequence
- separate some nested validations and defaulting steps
  - provide default `%(DocumentName}` even if `%(DocumentPath}` is set explicitly
  - validate URI is absolute even if `%(DocumentPath}` is set explicitly

other:
- don't write out an empty Open API / Swagger file

nits:
- do not use default `%(DocumentName}` in default `%(DocumentPath)` for `<ServiceProjectReference>` items
- do not use empty URI path or query string in default `%(DocumentPath)` for `<ServiceUriReference>` items