### PR TITLE
Add more logging to a failing tests and move dumps to logs directory

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -207,7 +207,6 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
                 try
                 {
-
                     Assert.IsType<OperationCanceledException>(exception);
                 }
                 catch (Exception e)

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
@@ -203,7 +204,17 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                     cancellationTokenSource.Cancel();
                     await requestCompletedCompletionSource.Task.DefaultTimeout();
                 }
-                Assert.IsType<OperationCanceledException>(exception);
+
+                try
+                {
+
+                    Assert.IsType<OperationCanceledException>(exception);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Unexpected exception");
+                    throw;
+                }
             }
         }
 

--- a/src/Servers/IIS/tools/SetupTestEnvironment.ps1
+++ b/src/Servers/IIS/tools/SetupTestEnvironment.ps1
@@ -8,7 +8,7 @@ Remove-Item "HKLM:\SOFTWARE\Microsoft\IIS Extensions\IIS AspNetCore Module V2\Pa
 
 if (!($DumpFolder))
 {
-    $DumpFolder = "$PSScriptRoot\..\..\..\..\artifacts\dumps"
+    $DumpFolder = "$PSScriptRoot\..\..\..\..\artifacts\logs\dumps"
 }
 if (!(Test-Path $DumpFolder))
 {


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1798

Assert doesn't contain the stack trace.