### PR TITLE
Remove capture of "this" from local function

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 producer._unflushedBytes = 0;
 
                 // If there is an empty write, we still need to update the current chunk
-                _currentChunkMemoryUpdated = false;
+                producer._currentChunkMemoryUpdated = false;
 
                 return producer._flusher.FlushAsync(producer._minResponseDataRateFeature.MinDataRate, bytesWritten, producer, token);
             }


### PR DESCRIPTION
@benaadams Was it important that "producer" was an argument instead of capturing "this"? The method generated by the compiler for the capture version doesn't look bad other than not being static.