### PR TITLE
Make first write use the same BufferWriter

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -356,6 +356,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     return default;
                 }
 
+                // Uses same BufferWriter to write response headers and response
                 var writer = new BufferWriter<PipeWriter>(_pipeWriter);
 
                 WriteResponseHeadersInternal(ref writer, statusCode, reasonPhrase, responseHeaders, autoChunk);
@@ -373,6 +374,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     return default;
                 }
 
+                // Uses same BufferWriter to write response headers and chunk
                 var writer = new BufferWriter<PipeWriter>(_pipeWriter);
 
                 WriteResponseHeadersInternal(ref writer, statusCode, reasonPhrase, responseHeaders, autoChunk);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -236,25 +236,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_advancedBytesForChunk > 0 || buffer.Length > 0)
                 {
                     var writer = new BufferWriter<PipeWriter>(_pipeWriter);
-                    if (_advancedBytesForChunk > 0)
-                    {
-                        WriteCurrentMemoryToPipeWriter(ref writer);
-                    }
-
-                    if (buffer.Length > 0)
-                    {
-
-                        writer.WriteBeginChunkBytes(buffer.Length);
-                        writer.Write(buffer);
-                        writer.WriteEndChunkBytes();
-                    }
-
-                    writer.Commit();
-                    _unflushedBytes += writer.BytesCommitted;
+                    CommitChunkInternal(ref writer, buffer);
                 }
             }
 
             return FlushAsync(cancellationToken);
+        }
+
+        private void CommitChunkInternal(ref BufferWriter<PipeWriter> writer, ReadOnlySpan<byte> buffer)
+        {
+            if (_advancedBytesForChunk > 0)
+            {
+                WriteCurrentMemoryToPipeWriter(ref writer);
+            }
+
+            if (buffer.Length > 0)
+            {
+
+                writer.WriteBeginChunkBytes(buffer.Length);
+                writer.Write(buffer);
+                writer.WriteEndChunkBytes();
+            }
+
+            writer.Commit();
+            _unflushedBytes += writer.BytesCommitted;
         }
 
         public void WriteResponseHeaders(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk)
@@ -268,18 +273,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 var buffer = _pipeWriter;
                 var writer = new BufferWriter<PipeWriter>(buffer);
-
-                writer.Write(HttpVersion11Bytes);
-                var statusBytes = ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
-                writer.Write(statusBytes);
-                responseHeaders.CopyTo(ref writer);
-                writer.Write(EndHeadersBytes);
-
-                writer.Commit();
-
-                _unflushedBytes += writer.BytesCommitted;
-                _autoChunk = autoChunk;
+                WriteResponseHeadersInternal(ref writer, statusCode, reasonPhrase, responseHeaders, autoChunk);
             }
+        }
+
+        private void WriteResponseHeadersInternal(ref BufferWriter<PipeWriter> writer, int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk)
+        {
+            writer.Write(HttpVersion11Bytes);
+            var statusBytes = ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
+            writer.Write(statusBytes);
+            responseHeaders.CopyTo(ref writer);
+            writer.Write(EndHeadersBytes);
+
+            writer.Commit();
+
+            _unflushedBytes += writer.BytesCommitted;
+            _autoChunk = autoChunk;
         }
 
         public void Dispose()
@@ -338,6 +347,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return WriteAsync(ContinueBytes);
         }
 
+        public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken)
+        {
+            lock (_contextLock)
+            {
+                if (_pipeWriterCompleted)
+                {
+                    return default;
+                }
+
+                var writer = new BufferWriter<PipeWriter>(_pipeWriter);
+
+                WriteResponseHeadersInternal(ref writer, statusCode, reasonPhrase, responseHeaders, autoChunk);
+
+                return WriteAsyncInternal(ref writer, buffer, cancellationToken);
+            }
+        }
+
+        public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken)
+        {
+            lock (_contextLock)
+            {
+                if (_pipeWriterCompleted)
+                {
+                    return default;
+                }
+
+                var writer = new BufferWriter<PipeWriter>(_pipeWriter);
+
+                WriteResponseHeadersInternal(ref writer, statusCode, reasonPhrase, responseHeaders, autoChunk);
+
+                CommitChunkInternal(ref writer, buffer);
+
+                return FlushAsync(cancellationToken);
+            }
+        }
+
         private ValueTask<FlushResult> WriteAsync(
             ReadOnlySpan<byte> buffer,
             CancellationToken cancellationToken = default)
@@ -350,36 +395,45 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
 
                 var writer = new BufferWriter<PipeWriter>(_pipeWriter);
-                if (_autoChunk)
-                {
-                    if (_advancedBytesForChunk > 0)
-                    {
-                        // If there is data that was chunked before writing (ex someone did GetMemory->Advance->WriteAsync)
-                        // make sure to write whatever was advanced first
-                        WriteCurrentMemoryToPipeWriter(ref writer);
-                    }
-                    else
-                    {
-                        // If there is an empty write, we still need to update the current chunk
-                        _currentChunkMemoryUpdated = false;
-                    }
-                }
-
-                if (buffer.Length > 0)
-                {
-                    writer.Write(buffer);
-                }
-                writer.Commit();
-
-                var bytesWritten = _unflushedBytes + writer.BytesCommitted;
-                _unflushedBytes = 0;
-
-                return _flusher.FlushAsync(
-                    _minResponseDataRateFeature.MinDataRate,
-                    bytesWritten,
-                    this,
-                    cancellationToken);
+                return WriteAsyncInternal(ref writer, buffer, cancellationToken);
             }
+        }
+
+        private ValueTask<FlushResult> WriteAsyncInternal(
+            ref BufferWriter<PipeWriter> writer,
+            ReadOnlySpan<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (_autoChunk)
+            {
+                if (_advancedBytesForChunk > 0)
+                {
+                    // If there is data that was chunked before writing (ex someone did GetMemory->Advance->WriteAsync)
+                    // make sure to write whatever was advanced first
+                    WriteCurrentMemoryToPipeWriter(ref writer);
+                }
+                else
+                {
+                    // If there is an empty write, we still need to update the current chunk
+                    _currentChunkMemoryUpdated = false;
+                }
+            }
+
+            if (buffer.Length > 0)
+            {
+                writer.Write(buffer);
+            }
+
+            writer.Commit();
+
+            var bytesWritten = _unflushedBytes + writer.BytesCommitted;
+            _unflushedBytes = 0;
+
+            return _flusher.FlushAsync(
+                _minResponseDataRateFeature.MinDataRate,
+                bytesWritten,
+                this,
+                cancellationToken);
         }
 
         // These methods are for chunked http responses that use GetMemory/Advance

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -283,7 +283,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             ApplicationAbort();
         }
 
-
         Task IHttpResponseStartFeature.StartAsync(CancellationToken cancellationToken)
         {
             if (HasResponseStarted)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1280,7 +1280,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 HandleNonBodyResponseWrite();
 
                 // For HEAD requests, we still use the number of bytes written for logging
-                // how many bytes were written. 
+                // how many bytes were written.
                 VerifyAndUpdateWrite(bytes);
             }
         }
@@ -1346,9 +1346,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public ValueTask<FlushResult> WritePipeAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
         {
             // For the first write, ensure headers are flushed if WriteDataAsync isn't called.
-            var firstWrite = !HasResponseStarted;
-
-            if (firstWrite)
+            if (!HasResponseStarted)
             {
                 return FirstWriteAsync(data, cancellationToken);
             }
@@ -1392,7 +1390,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return FirstWriteAsyncAwaited(startingTask, data, cancellationToken);
             }
 
-            var responseHeaders = InitializeResponseFirstWrite(data.Length);
 
             return FirstWriteAsyncInternal(data, responseHeaders, cancellationToken);
         }
@@ -1401,13 +1398,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             await initializeTask;
 
-            var responseHeaders = InitializeResponseFirstWrite(data.Length);
-
             return await FirstWriteAsyncInternal(data, responseHeaders, cancellationToken);
         }
 
         private ValueTask<FlushResult> FirstWriteAsyncInternal(ReadOnlyMemory<byte> data, HttpResponseHeaders responseHeaders, CancellationToken cancellationToken)
         {
+            var responseHeaders = InitializeResponseFirstWrite(data.Length);
+
             if (_canWriteResponseBody)
             {
                 if (_autoChunk)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1406,7 +1406,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return await FirstWriteAsyncInternal(data, responseHeaders, cancellationToken);
         }
 
-        private async ValueTask<FlushResult> FirstWriteAsyncInternal(ReadOnlyMemory<byte> data, HttpResponseHeaders responseHeaders, CancellationToken cancellationToken)
+        private ValueTask<FlushResult> FirstWriteAsyncInternal(ReadOnlyMemory<byte> data, HttpResponseHeaders responseHeaders, CancellationToken cancellationToken)
         {
             if (_canWriteResponseBody)
             {
@@ -1415,22 +1415,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     if (data.Length == 0)
                     {
                         Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk);
-                        return await Output.FlushAsync(cancellationToken);
+                        return Output.FlushAsync(cancellationToken);
                     }
 
-                    return await Output.FirstWriteChunkedAsync(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, data.Span, cancellationToken);
+                    return Output.FirstWriteChunkedAsync(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, data.Span, cancellationToken);
                 }
                 else
                 {
                     CheckLastWrite();
-                    return await Output.FirstWriteAsync(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, data.Span, cancellationToken);
+                    return Output.FirstWriteAsync(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, data.Span, cancellationToken);
                 }
             }
             else
             {
                 Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk);
                 HandleNonBodyResponseWrite();
-                return await Output.FlushAsync(cancellationToken);
+                return Output.FlushAsync(cancellationToken);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1391,17 +1391,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
 
-            return FirstWriteAsyncInternal(data, responseHeaders, cancellationToken);
+            return FirstWriteAsyncInternal(data, cancellationToken);
         }
 
         private async ValueTask<FlushResult> FirstWriteAsyncAwaited(Task initializeTask, ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
         {
             await initializeTask;
 
-            return await FirstWriteAsyncInternal(data, responseHeaders, cancellationToken);
+            return await FirstWriteAsyncInternal(data, cancellationToken);
         }
 
-        private ValueTask<FlushResult> FirstWriteAsyncInternal(ReadOnlyMemory<byte> data, HttpResponseHeaders responseHeaders, CancellationToken cancellationToken)
+        private ValueTask<FlushResult> FirstWriteAsyncInternal(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
         {
             var responseHeaders = InitializeResponseFirstWrite(data.Length);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1390,7 +1390,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return FirstWriteAsyncAwaited(startingTask, data, cancellationToken);
             }
 
-
             return FirstWriteAsyncInternal(data, cancellationToken);
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         ValueTask<FlushResult> WriteChunkAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
         ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken);
         ValueTask<FlushResult> Write100ContinueAsync();
-        void WriteResponseHeaders(int statusCode, string ReasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk);
+        void WriteResponseHeaders(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk);
         // This takes ReadOnlySpan instead of ReadOnlyMemory because it always synchronously copies data before flushing.
         ValueTask<FlushResult> WriteDataToPipeAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
         Task WriteDataAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
@@ -23,5 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Memory<byte> GetMemory(int sizeHint = 0);
         void CancelPendingFlush();
         void Complete();
+        ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
+        ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -253,7 +253,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
+        public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
+        {
+            lock (_dataWriterLock)
+            {
+                WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk);
+
+                return WriteDataToPipeAsync(data, cancellationToken);
+            }
+        }
+
         ValueTask<FlushResult> IHttpOutputProducer.WriteChunkAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
@@ -316,42 +331,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 useSynchronizationContext: false,
                 minimumSegmentSize: KestrelMemoryPool.MinimumSegmentSize
             ));
-
-        public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
-        {
-            lock (_dataWriterLock)
-            {
-                // The HPACK header compressor is stateful, if we compress headers for an aborted stream we must send them.
-                // Optimize for not compressing or sending them.
-                if (_completed)
-                {
-                    return default;
-                }
-
-                _frameWriter.WriteResponseHeaders(_streamId, statusCode, responseHeaders);
-
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return new ValueTask<FlushResult>(Task.FromCanceled<FlushResult>(cancellationToken));
-                }
-
-                // This length check is important because we don't want to set _startedWritingDataFrames unless a data
-                // frame will actually be written causing the headers to be flushed.
-                if (data.Length == 0)
-                {
-                    return default;
-                }
-
-                _startedWritingDataFrames = true;
-
-                _dataPipe.Writer.Write(data);
-                return _flusher.FlushAsync(this, cancellationToken);
-            }
-        }
-
-        public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore/issues/7429

Creating two BufferWriters per request calls GetSpan twice, which can be avoided if we continue to use the same BufferWriter.

Using the benchmark driver:

| Scenario | RPS | Command Line |
|---|---|---|
| Before PipeWriter changes  | 2,111,659  |   dotnet run -- --server http://10.195.201.248:5001 --client http://10.195.202.5:5002 -n Plaintext -j https://raw.githubusercontent.com/aspnet/Benchmarks/master/src/Benchmarks/benchmarks.plaintext.json --warmup 15 --duration 15 --aspNetCoreVersion 3.0.0-preview-19108-04 --nuget-package "LOCATION_OF_PACKAGE\runtime.win-x64.Microsoft.AspNetCore.App.3.0.0-preview3-19108-47.nupkg" --self-contained |
| After PipeWriter changes  |  1,949,950 |  dotnet run -- --server http://10.195.201.248:5001 --client http://10.195.202.5:5002 -n Plaintext -j https://raw.githubusercontent.com/aspnet/Benchmarks/master/src/Benchmarks/benchmarks.plaintext.json --warmup 15 --duration 15 --aspNetCoreVersion 3.0.0-preview-19108-04 --nuget-package "LOCATION_OF_PACKAGE\runtime.win-x64.Microsoft.AspNetCore.App.3.0.0-preview3-19108-53.nupkg" --self-contained | 
| Current master branch | 2,073,460  |  dotnet run -- --server http://10.195.201.248:5001 --client http://10.195.202.5:5002 -n Plaintext -j https://raw.githubusercontent.com/aspnet/Benchmarks/master/src/Benchmarks/benchmarks.plaintext.json --warmup 15 --duration 15 --aspNetCoreVersion "Latest" --runtimeVersion "Latest"--self-contained   |
| This PR  |  2,120,896 | dotnet run -- --server http://10.195.201.248:5001 --client http://10.195.202.5:5002 -n Plaintext -j https://raw.githubusercontent.com/aspnet/Benchmarks/master/src/Benchmarks/benchmarks.plaintext.json --warmup 15 --duration 15 --aspNetCoreVersion "Latest" --runtimeVersion "Latest" --outputFile LOCATION_OF_DLL\Microsoft.AspNetCore.Server.Kestrel.Core.dll --self-contained  |

I'm going to run this here before merging: https://msit.powerbi.com/groups/b5743765-ec44-4dfc-91df-e32401023530/reports/10265790-7e2e-41d3-9388-86ab72be3fe9/ReportSection6e3fb3ea755b1686e32d. The benchmark driver RPS fluctuations by around ~50k RPS. 

cc @benaadams 