### PR TITLE
Enable docker for the worker template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/vs-2017.3.host.json
@@ -14,8 +14,7 @@
   "icon": "vs-2017.3/Empty.png",
   "learnMoreLink": "https://go.microsoft.com/fwlink/?linkid=2072778",
   "uiFilters": [ "oneaspnet" ],
-  "supportsDocker": false,
-  "legacyTemplateIdentity": "Microsoft.NetCore.CSharp.EmptyWorker",
+  "supportsDocker": true,
   "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }


### PR DESCRIPTION
#6817 The basic scenario works fine with the defaults.

Also, Phil said we didn't need `legacyTemplateIdentity` for new templates.