### PR TITLE
Update branding to 2.2.3

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,8 +2,8 @@
   <!-- These package versions may be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Auto" Condition=" '$(DotNetPackageVersionPropsPath)' == '' ">
     <!-- MicrosoftNETCoreApp22PackageVersion is assigned at the bottom so it can automatically pick up MicrosoftNETCoreAppPackageVersion in an orchestrated build. -->
-    <MicrosoftNETCoreAppPackageVersion>2.2.1</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftNETCoreDotNetAppHostPackageVersion>2.2.1</MicrosoftNETCoreDotNetAppHostPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.2.2</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreDotNetAppHostPackageVersion>2.2.2</MicrosoftNETCoreDotNetAppHostPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/repo.props
+++ b/build/repo.props
@@ -18,7 +18,7 @@
     <SignCheckExclusionsFile>$(RepositoryRoot)eng\signcheck.exclusions.txt</SignCheckExclusionsFile>
     <SharedSourcesFolder>$(RepositoryRoot)src\Shared\</SharedSourcesFolder>
     <SharedFxArchitecture Condition="'$(SharedFxArchitecture)' == ''">$(SharedFxRid.Substring($([MSBuild]::Add($(SharedFxRid.LastIndexOf('-')), 1))))</SharedFxArchitecture>
-    <BuildSiteExtensions>true</BuildSiteExtensions>
+    <BuildSiteExtensions>false</BuildSiteExtensions>
     <BuildSiteExtensions Condition="'$(BuildSiteExtensions)' == 'true' AND '$(OS)' != 'Windows_NT'">false</BuildSiteExtensions>
   </PropertyGroup>
 

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>2.2.1</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>2.2.2</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: dotnet-dev-certs-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-dev-certs' ">
@@ -81,8 +81,9 @@
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.AspNetCoreModuleV2-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AspNetCoreModuleV2' ">
-    <BaselinePackageVersion>2.2.1</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AspNetCoreModuleV2' AND '$(TargetFramework)' == 'netcoreapp2.2' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Abstractions' ">
     <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
@@ -137,7 +138,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Google-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' ">
-    <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.2.0, )" />
@@ -220,7 +221,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServices.HostingStartup-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' ">
-    <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND '$(TargetFramework)' == 'net461' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[2.2.0, )" />
@@ -236,7 +237,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServicesIntegration-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' ">
-    <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.2.0, )" />
@@ -528,14 +529,14 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http' ">
-    <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.2.0, )" />
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.ObjectPool" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[2.2.0, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.2.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HttpOverrides-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpOverrides' ">
@@ -656,15 +657,15 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Core' ">
-    <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.2.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.2.0, )" />
@@ -934,18 +935,18 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Routing-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing' ">
-    <BaselinePackageVersion>2.2.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing' AND '$(TargetFramework)' == 'netcoreapp2.2' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.2.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.ObjectPool" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[2.2.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.2.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.ObjectPool" Version="[2.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[2.2.0, )" />
@@ -963,7 +964,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.IIS-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.IIS' ">
-    <BaselinePackageVersion>2.2.1</BaselinePackageVersion>
+    <BaselinePackageVersion>2.2.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.IIS' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.2.0, )" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -4,7 +4,7 @@ This file contains a list of all the packages and their versions which were rele
 build of ASP.NET Core 2.2.x. Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="2.2.1">
+<Baseline Version="2.2.2">
   <Package Id="dotnet-dev-certs" Version="2.2.0" />
   <Package Id="dotnet-sql-cache" Version="2.2.0" />
   <Package Id="dotnet-user-secrets" Version="2.2.0" />
@@ -13,14 +13,14 @@ build of ASP.NET Core 2.2.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="2.2.0-preview-35687" />
   <Package Id="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.AspNetCoreModule" Version="2.2.1" />
-  <Package Id="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="2.2.1" />
+  <Package Id="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.Core" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="2.2.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.OAuth" Version="2.2.0" />
@@ -30,8 +30,8 @@ build of ASP.NET Core 2.2.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authorization.Policy" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.2.0" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.2.2" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.CookiePolicy" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Cors" Version="2.2.0" />
@@ -61,7 +61,7 @@ build of ASP.NET Core 2.2.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.Http.Connections" Version="1.1.0" />
   <Package Id="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Http.Features" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.Http" Version="2.2.0" />
+  <Package Id="Microsoft.AspNetCore.Http" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.HttpsPolicy" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
@@ -75,7 +75,7 @@ build of ASP.NET Core 2.2.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.Mvc.Cors" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
@@ -101,9 +101,9 @@ build of ASP.NET Core 2.2.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Rewrite" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.Routing" Version="2.2.0" />
+  <Package Id="Microsoft.AspNetCore.Routing" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.Server.HttpSys" Version="2.2.0" />
-  <Package Id="Microsoft.AspNetCore.Server.IIS" Version="2.2.1" />
+  <Package Id="Microsoft.AspNetCore.Server.IIS" Version="2.2.2" />
   <Package Id="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
   <Package Id="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
   <Package Id="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.2.0" />

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -39,5 +39,8 @@ Later on, this will be checked using this condition:
       java:signalr;
     </PackagesInPatch>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.3' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/src/PackageArchive/Archive.CiServer.Patch.Compat/ArchiveBaseline.2.2.2.txt
+++ b/src/PackageArchive/Archive.CiServer.Patch.Compat/ArchiveBaseline.2.2.2.txt
@@ -1,0 +1,1 @@
+system.reflection.emit\4.0.1\.signature.p7s

--- a/src/PackageArchive/Archive.CiServer.Patch/ArchiveBaseline.2.2.2.txt
+++ b/src/PackageArchive/Archive.CiServer.Patch/ArchiveBaseline.2.2.2.txt
@@ -1,0 +1,1 @@
+system.reflection.emit\4.0.1\.signature.p7s

--- a/src/PackageArchive/ZipManifestGenerator/README.md
+++ b/src/PackageArchive/ZipManifestGenerator/README.md
@@ -19,13 +19,13 @@ To generate a new manifest for the incremental CI server package caches, you wou
 
 ```ps1
 $ProdConBuild='20180919-01'
-$Version='2.1.5'
+$Version='2.2.1'
 
-$patchUrl = "https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/${ProdconBuild}/final/assets/aspnetcore/Runtime/${Version}/nuGetPackagesArchive-ci-server-${Version}.patch.zip"
+$patchUrl = "https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-2/${ProdconBuild}/final/assets/aspnetcore/Runtime/${Version}/nuGetPackagesArchive-ci-server-${Version}.patch.zip"
 
 dotnet run $patchUrl "../Archive.CiServer.Patch/ArchiveBaseline.${Version}.txt"
 
-$compatPatchUrl = "https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/${ProdconBuild}/final/assets/aspnetcore/Runtime/${Version}/nuGetPackagesArchive-ci-server-compat-${Version}.patch.zip"
+$compatPatchUrl = "https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-2/${ProdconBuild}/final/assets/aspnetcore/Runtime/${Version}/nuGetPackagesArchive-ci-server-compat-${Version}.patch.zip"
 
 dotnet run $compatPatchUrl "../Archive.CiServer.Patch.Compat/ArchiveBaseline.${Version}.txt"
 ```

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>2</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>2</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>3</AspNetCorePatchVersion>
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PreReleaseBrandingLabel></PreReleaseBrandingLabel>
     <BuildNumber Condition="'$(BuildNumber)' == '' OR '$(UsingLocalBuildNumber)' == 'true'">$([System.DateTime]::Now.ToString('yyMMdd'))-99</BuildNumber>


### PR DESCRIPTION
- new version
- update baselines
- grab latest released Microsoft.NetCore.App and Microsoft.NETCore.DotNetAppHost

nit:
- updated ZipManifestGenerator's README.md to use 2.2 examples