### PR TITLE
Fix “must comprised of”

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/IKeyEscrowSink.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/IKeyEscrowSink.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         /// Stores the given key material to the escrow service.
         /// </summary>
         /// <param name="keyId">The id of the key being persisted to escrow.</param>
-        /// <param name="element">The unencrypted XML element that comprises the key material.</param>
+        /// <param name="element">The unencrypted key material in XML form.</param>
         void Store(Guid keyId, XElement element);
     }
 }

--- a/src/DataProtection/DataProtection/src/Secret.cs
+++ b/src/DataProtection/DataProtection/src/Secret.cs
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.DataProtection
         }
 
         /// <summary>
-        /// Returns a Secret comprised entirely of random bytes retrieved from
+        /// Returns a Secret made entirely of random bytes retrieved from
         /// a cryptographically secure RNG.
         /// </summary>
         public static Secret Random(int numBytes)

--- a/src/Identity/Extensions.Core/src/PasswordOptions.cs
+++ b/src/Identity/Extensions.Core/src/PasswordOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Identity
         public int RequiredLength { get; set; } = 6;
 
         /// <summary>
-        /// Gets or sets the minimum number of unique chars a password must comprised of. Defaults to 1.
+        /// Gets or sets the minimum number of unique characters which a password must contain. Defaults to 1.
         /// </summary>
         public int RequiredUniqueChars { get; set; } = 1;
 

--- a/src/SignalR/clients/csharp/Client/src/HubConnectionBuilderHttpExtensions.cs
+++ b/src/SignalR/clients/csharp/Client/src/HubConnectionBuilderHttpExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// </summary>
         /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
         /// <param name="url">The URL the <see cref="HttpConnection"/> will use.</param>
-        /// <param name="transports">A bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use.</param>
+        /// <param name="transports">A bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use.</param>
         /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, string url, HttpTransportType transports)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// </summary>
         /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
         /// <param name="url">The URL the <see cref="HttpConnection"/> will use.</param>
-        /// <param name="transports">A bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use.</param>
+        /// <param name="transports">A bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use.</param>
         /// <param name="configureHttpConnection">The delegate that configures the <see cref="HttpConnection"/>.</param>
         /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, string url, HttpTransportType transports, Action<HttpConnectionOptions> configureHttpConnection)
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// </summary>
         /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
         /// <param name="url">The URL the <see cref="HttpConnection"/> will use.</param>
-        /// <param name="transports">A bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use.</param>
+        /// <param name="transports">A bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use.</param>
         /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, Uri url, HttpTransportType transports)
         {
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// </summary>
         /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
         /// <param name="url">The URL the <see cref="HttpConnection"/> will use.</param>
-        /// <param name="transports">A bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use.</param>
+        /// <param name="transports">A bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use.</param>
         /// <param name="configureHttpConnection">The delegate that configures the <see cref="HttpConnection"/>.</param>
         /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, Uri url, HttpTransportType transports, Action<HttpConnectionOptions> configureHttpConnection)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         /// Initializes a new instance of the <see cref="HttpConnection"/> class.
         /// </summary>
         /// <param name="url">The URL to connect to.</param>
-        /// <param name="transports">A bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use.</param>
+        /// <param name="transports">A bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use.</param>
         public HttpConnection(Uri url, HttpTransportType transports)
             : this(url, transports, loggerFactory: null)
         {
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         /// Initializes a new instance of the <see cref="HttpConnection"/> class.
         /// </summary>
         /// <param name="url">The URL to connect to.</param>
-        /// <param name="transports">A bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use.</param>
+        /// <param name="transports">A bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         public HttpConnection(Uri url, HttpTransportType transports, ILoggerFactory loggerFactory)
             : this(CreateHttpOptions(url, transports), loggerFactory)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionOptions.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionOptions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         public Uri Url { get; set; }
 
         /// <summary>
-        /// Gets or sets a bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the client should use to send HTTP requests.
+        /// Gets or sets a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the client should use to send HTTP requests.
         /// </summary>
         public HttpTransportType Transports { get; set; }
 

--- a/src/SignalR/common/Http.Connections.Common/src/HttpTransports.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/HttpTransports.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Http.Connections
     public static class HttpTransports
     {
         /// <summary>
-        /// A bitmask comprised of all available <see cref="HttpTransportType"/> values.
+        /// A bitmask combining all available <see cref="HttpTransportType"/> values.
         /// </summary>
         public static readonly HttpTransportType All = HttpTransportType.WebSockets | HttpTransportType.ServerSentEvents | HttpTransportType.LongPolling;
     }

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public IList<IAuthorizeData> AuthorizationData { get; }
 
         /// <summary>
-        /// Gets or sets a bitmask comprised of one or more <see cref="HttpTransportType"/> that specify what transports the server should use to receive HTTP requests.
+        /// Gets or sets a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the server should use to receive HTTP requests.
         /// </summary>
         public HttpTransportType Transports { get; set; }
 


### PR DESCRIPTION
The first commit fixes a grammatical error.
The second commit avoids the newer sense of the word ‘comprise’:

> Although it has been in use since the late 18th century, sense 2 is still attacked as wrong. Why it has been singled out is not clear, but until comparatively recent times it was found chiefly in scientific or technical writing rather than belles lettres. Our current evidence shows a slight shift in usage: sense 2 is somewhat more frequent in recent literary use than the earlier senses. You should be aware, however, that if you use sense 2 you may be subject to criticism for doing so, and you may want to choose a safer synonym such as _compose_ or _make up_.

https://www.merriam-webster.com/dictionary/comprise#usage-1-anchor