### PR TITLE
Automatically set 'PrivateAssets=All' for .Sources references

### DIFF
--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -87,12 +87,6 @@
     <Reference Remove="@(Reference)" />
   </ItemGroup>
 
-  <ItemDefinitionGroup>
-    <Reference>
-      <SharedSources>false</SharedSources>
-    </Reference>
-  </ItemDefinitionGroup>
-
   <!--
     This target resolves remaining Referene items to Packages, if possible. If not, they are left as Reference items fo the SDK to resolve.
     This target helps ensure projects within the shared framework do no unintentionally add new references,
@@ -104,7 +98,11 @@
     <Error Condition="@(_InvalidReferenceToSharedFxOnlyAssembly->Count()) != 0"
            Text="Cannot reference &quot;%(_InvalidReferenceToSharedFxOnlyAssembly.Identity)&quot; directly because it is part of the shared framework and this project is not. Use &lt;FrameworkReference Include=&quot;Microsoft.AspNetCore.App&quot; /&gt; instead." />
 
-    <Error Condition="@(_InvalidReferenceToNonSharedFxAssembly->Count()) != 0 AND '%(_InvalidReferenceToNonSharedFxAssembly.SharedSources)' != 'true'"
+    <ItemGroup>
+      <_InvalidReferenceToNonSharedFxAssembly Remove="@(_InvalidReferenceToNonSharedFxAssembly)" Condition="$([System.String]::new('%(Identity)').EndsWith('.Sources'))" />
+    </ItemGroup>
+
+    <Error Condition="@(_InvalidReferenceToNonSharedFxAssembly->Count()) != 0"
            Text="Cannot reference &quot;%(_InvalidReferenceToNonSharedFxAssembly.Identity)&quot;. This dependency is not in the shared framework. See docs/SharedFramework.md for instructions on how to modify what is in the shared framework." />
   </Target>
 
@@ -119,8 +117,8 @@
 
       <!-- Ensure only content asset are consumed from .Sources packages -->
       <Reference>
-        <IncludeAssets Condition="'%(SharedSources)' == 'true'">ContentFiles</IncludeAssets>
-        <PrivateAssets Condition="'%(SharedSources)' == 'true'">All</PrivateAssets>
+        <IncludeAssets Condition="$([System.String]::new('%(Identity)').EndsWith('.Sources'))">ContentFiles</IncludeAssets>
+        <PrivateAssets Condition="$([System.String]::new('%(Identity)').EndsWith('.Sources'))">All</PrivateAssets>
       </Reference>
 
       <!-- Identify if any references were present in the last release of this package, but have been removed. -->

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -48,7 +48,17 @@
     <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">false</UseProjectReferences>
   </PropertyGroup>
 
+  <ItemDefinitionGroup>
+    <Reference>
+      <IsSharedSource></IsSharedSource>
+    </Reference>
+  </ItemDefinitionGroup>
+
   <ItemGroup>
+    <Reference Update="@(Reference)">
+      <IsSharedSource Condition="'%(IsSharedSource)' == '' AND $([System.String]::new('%(Identity)').EndsWith('.Sources'))">true</IsSharedSource>
+    </Reference>
+
     <!-- Packages which are implicitly defined by the .NET Core SDK. -->
     <_ImplicitPackageReference Include="@(PackageReference->WithMetadataValue('IsImplicitlyDefined', 'true'))" />
     <!-- Capture a list of references which were set explicitly in the project. -->
@@ -67,7 +77,8 @@
         @(AspNetCoreAppReference);
         @(AspNetCoreAppReferenceAndPackage);
         @(ExternalAspNetCoreAppReference);
-        @(_CompilationOnlyReference)" />
+        @(_CompilationOnlyReference);
+        @(Reference->WithMetadataValue('IsSharedSource', 'true'))" />
     <!-- TODO: remove Newtonsoft.Json from this list once https://github.com/aspnet/AspNetCore/issues/4260 is resolved -->
 
     <!--
@@ -98,10 +109,6 @@
     <Error Condition="@(_InvalidReferenceToSharedFxOnlyAssembly->Count()) != 0"
            Text="Cannot reference &quot;%(_InvalidReferenceToSharedFxOnlyAssembly.Identity)&quot; directly because it is part of the shared framework and this project is not. Use &lt;FrameworkReference Include=&quot;Microsoft.AspNetCore.App&quot; /&gt; instead." />
 
-    <ItemGroup>
-      <_InvalidReferenceToNonSharedFxAssembly Remove="@(_InvalidReferenceToNonSharedFxAssembly)" Condition="$([System.String]::new('%(Identity)').EndsWith('.Sources'))" />
-    </ItemGroup>
-
     <Error Condition="@(_InvalidReferenceToNonSharedFxAssembly->Count()) != 0"
            Text="Cannot reference &quot;%(_InvalidReferenceToNonSharedFxAssembly.Identity)&quot;. This dependency is not in the shared framework. See docs/SharedFramework.md for instructions on how to modify what is in the shared framework." />
   </Target>
@@ -117,8 +124,8 @@
 
       <!-- Ensure only content asset are consumed from .Sources packages -->
       <Reference>
-        <IncludeAssets Condition="$([System.String]::new('%(Identity)').EndsWith('.Sources'))">ContentFiles</IncludeAssets>
-        <PrivateAssets Condition="$([System.String]::new('%(Identity)').EndsWith('.Sources'))">All</PrivateAssets>
+        <IncludeAssets Condition="'%(IsSharedSource)' == 'true'">ContentFiles</IncludeAssets>
+        <PrivateAssets Condition="'%(IsSharedSource)' == 'true'">All</PrivateAssets>
       </Reference>
 
       <!-- Identify if any references were present in the last release of this package, but have been removed. -->

--- a/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <ProjectReference Condition="'$(BuildNodeJS)' != 'false'" Include="$(RepositoryRoot)src\Components\Browser.JS\src\Microsoft.AspNetCore.Components.Browser.JS.npmproj" ReferenceOutputAssembly="false" />
     <Reference Include="Microsoft.AspNetCore.Components" />
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
     <Reference Include="Microsoft.Extensions.FileProviders.Composite" />
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Mono.Cecil" />

--- a/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
+++ b/src/Components/Blazor/Cli/src/Microsoft.AspNetCore.Blazor.Cli.csproj
@@ -17,7 +17,7 @@
     <Reference Include="Microsoft.AspNetCore.Components.Server" />
     <Reference Include="Microsoft.AspNetCore.ResponseCompression" />
     <Reference Include="Microsoft.AspNetCore" />
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
   </ItemGroup>
 
   <!--

--- a/src/Components/Components/perf/Microsoft.AspNetCore.Components.Performance.csproj
+++ b/src/Components/Components/perf/Microsoft.AspNetCore.Components.Performance.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
     <Reference Include="Microsoft.AspNetCore.Components" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
@@ -26,7 +26,7 @@
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/TestHost/src/Microsoft.AspNetCore.TestHost.csproj
+++ b/src/Hosting/TestHost/src/Microsoft.AspNetCore.TestHost.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
-    <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" />
     <Reference Include="System.IO.Pipelines" />
   </ItemGroup>
 

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -21,7 +21,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
-    <Reference Include="Microsoft.Extensions.ActivatorUtilities.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.ActivatorUtilities.Sources" />
     <Reference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 

--- a/src/Http/Http/perf/Microsoft.AspNetCore.Http.Performance.csproj
+++ b/src/Http/Http/perf/Microsoft.AspNetCore.Http.Performance.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
     <Reference Include="Microsoft.AspNetCore.Http" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Http/Routing/perf/Microsoft.AspNetCore.Routing.Performance.csproj
+++ b/src/Http/Routing/perf/Microsoft.AspNetCore.Routing.Performance.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -28,7 +28,7 @@ Microsoft.AspNetCore.Routing.RouteCollection</Description>
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
-    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.ObjectPool" />
     <Reference Include="Microsoft.Extensions.Options" />

--- a/src/Http/Routing/tools/Swaggatherer/Swaggatherer.csproj
+++ b/src/Http/Routing/tools/Swaggatherer/Swaggatherer.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Middleware/Diagnostics/src/Microsoft.AspNetCore.Diagnostics.csproj
+++ b/src/Middleware/Diagnostics/src/Microsoft.AspNetCore.Diagnostics.csproj
@@ -24,7 +24,7 @@
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Middleware/ResponseCompression/perf/Microsoft.AspNetCore.ResponseCompression.Performance.csproj
+++ b/src/Middleware/ResponseCompression/perf/Microsoft.AspNetCore.ResponseCompression.Performance.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
     <Reference Include="Microsoft.AspNetCore.Http" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
     <Reference Include="Microsoft.AspNetCore.ResponseCompression" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Abstractions/Microsoft.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Abstractions/Microsoft.AspNetCore.Mvc.Abstractions.csproj
@@ -21,7 +21,7 @@ Microsoft.AspNetCore.Mvc.IActionResult</Description>
   </ItemGroup>
 
   <ItemGroup Label="Sources packages">
-    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Microsoft.AspNetCore.Mvc.Core.csproj
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Microsoft.AspNetCore.Mvc.Core.csproj
@@ -44,9 +44,9 @@ Microsoft.AspNetCore.Mvc.RouteAttribute</Description>
   </ItemGroup>
 
   <ItemGroup Label="Sources packages">
-    <Reference Include="Microsoft.Extensions.ParameterDefaultValue.Sources" SharedSources="true" />
-    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" SharedSources="true" />
-    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.ParameterDefaultValue.Sources" />
+    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" />
+    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/src/Microsoft.AspNetCore.Mvc.Testing/Microsoft.AspNetCore.Mvc.Testing.csproj
+++ b/src/Mvc/src/Microsoft.AspNetCore.Mvc.Testing/Microsoft.AspNetCore.Mvc.Testing.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
-    <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" />
     <Reference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <Reference Include="AngleSharp" />
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
     <Reference Include="Selenium.Support" />
     <Reference Include="Selenium.WebDriver.MicrosoftDriver" />
     <Reference Include="Selenium.WebDriver" />

--- a/src/Razor/Razor/src/Microsoft.AspNetCore.Razor.csproj
+++ b/src/Razor/Razor/src/Microsoft.AspNetCore.Razor.csproj
@@ -20,7 +20,7 @@ Microsoft.AspNetCore.Razor.TagHelpers.ITagHelper</Description>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Html.Abstractions" />
-    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/benchmarks/Microsoft.AspNetCore.Security.Performance/Microsoft.AspNetCore.Security.Performance.csproj
+++ b/src/Security/benchmarks/Microsoft.AspNetCore.Security.Performance/Microsoft.AspNetCore.Security.Performance.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authorization.Policy" />
     <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />

--- a/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
+++ b/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
-    <Reference Include="Microsoft.Extensions.ActivatorUtilities.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.ActivatorUtilities.Sources" />
     <Reference Include="System.IO.Pipelines" />
   </ItemGroup>
 

--- a/src/Servers/IIS/IIS/benchmarks/IIS.Performance/IIS.Performance.csproj
+++ b/src/Servers/IIS/IIS/benchmarks/IIS.Performance/IIS.Performance.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
   </ItemGroup>
 

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
@@ -14,10 +14,10 @@
     <Compile Include="$(KestrelSharedSourceRoot)test\TestHttp1Connection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestKestrelTrace.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -20,7 +20,7 @@
     <Reference Include="FSharp.Core" />
     <Reference Include="System.Reflection.Metadata" />
     <Reference Include="System.Threading.Tasks.Extensions" />
-    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.TypeNameHelper.Sources" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalR/common/Http.Connections.Common/src/Microsoft.AspNetCore.Http.Connections.Common.csproj
+++ b/src/SignalR/common/Http.Connections.Common/src/Microsoft.AspNetCore.Http.Connections.Common.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" >
-    <Reference Include="Microsoft.Bcl.Json.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Bcl.Json.Sources" />
     <Reference Include="System.Buffers" />
   </ItemGroup>
 

--- a/src/SignalR/common/Http.Connections/src/Microsoft.AspNetCore.Http.Connections.csproj
+++ b/src/SignalR/common/Http.Connections/src/Microsoft.AspNetCore.Http.Connections.csproj
@@ -28,7 +28,7 @@
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.WebSockets" />
-    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" />
     <Reference Include="Newtonsoft.Json" />
     <Reference Include="System.Security.Principal.Windows" />
   </ItemGroup>

--- a/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Reference Include="Microsoft.Bcl.Json.Sources" SharedSources="true" />
+    <Reference Include="Microsoft.Bcl.Json.Sources" />
     <Reference Include="System.Buffers" />
   </ItemGroup>
 

--- a/src/SignalR/common/testassets/Tests.Utils/Microsoft.AspNetCore.SignalR.Tests.Utils.csproj
+++ b/src/SignalR/common/testassets/Tests.Utils/Microsoft.AspNetCore.SignalR.Tests.Utils.csproj
@@ -19,7 +19,7 @@
     <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
     <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
-    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/SignalR/perf/Microbenchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks.csproj
+++ b/src/SignalR/perf/Microbenchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks.csproj
@@ -28,7 +28,7 @@
     <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
     <Reference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.ValueStopwatch.Sources" />
     <Reference Include="Moq" />
     <Reference Include="System.Reactive.Linq" />
     <Reference Include="System.Threading.Channels" />

--- a/src/SignalR/perf/benchmarkapps/Crankier/Crankier.csproj
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Crankier.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.SignalR.Client" />
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/SignalR/samples/ClientSample/ClientSample.csproj
+++ b/src/SignalR/samples/ClientSample/ClientSample.csproj
@@ -13,7 +13,7 @@
     <Reference Include="Microsoft.AspNetCore.SignalR.Client" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
+++ b/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
     <Reference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
+++ b/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
     <Reference Include="System.Data.SqlClient" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
     <Reference Include="Microsoft.Extensions.Configuration.UserSecrets" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-watch/src/dotnet-watch.csproj
+++ b/src/Tools/dotnet-watch/src/dotnet-watch.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Follow-up to #7510 

When a `<reference>` ends in the name `.Sources`, set PrivateAssets=All (exclude from generated nuspec) and IncludeAssets=ContentFiles (only consume content files, not .dll's)
