### PR TITLE
Add package conflict manifest data to the targeting pack

### DIFF
--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -84,16 +84,14 @@
     <!--
       Turn Reference items into a ProjectReference when UseProjectReferences is true.
       Order matters. This comes before package resolution because projects should be used when possible instead of packages.
-
-      ProjectReferenceByAssemblyName can be used by project targets to determine which references were resolved to projects.
     -->
-    <ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
+    <_ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
       Include="@(ProjectReferenceProvider)"
       Exclude="@(_UnusedProjectReferenceProvider)" />
 
-    <ProjectReference Include="@(ProjectReferenceByAssemblyName->'%(ProjectPath)')" />
+    <ProjectReference Include="@(_ProjectReferenceByAssemblyName->'%(ProjectPath)')" />
 
-    <Reference Remove="@(ProjectReferenceByAssemblyName)" />
+    <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
 
     <!-- Use _ReferenceTemp to workaround issues in Visual Studio which causes a conflict between Reference, packages, and projects. -->
     <_ReferenceTemp Include="@(Reference)" />
@@ -131,7 +129,7 @@
       </Reference>
 
       <!-- Identify if any references were present in the last release of this package, but have been removed. -->
-      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(ProjectReferenceByAssemblyName);@(PackageReference)" />
+      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(_ProjectReferenceByAssemblyName);@(PackageReference)" />
 
       <!--
         MSBuild does not provide a way to join on matching identities in a Condition,

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -84,14 +84,16 @@
     <!--
       Turn Reference items into a ProjectReference when UseProjectReferences is true.
       Order matters. This comes before package resolution because projects should be used when possible instead of packages.
+
+      ProjectReferenceByAssemblyName can be used by project targets to determine which references were resolved to projects.
     -->
-    <_ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
+    <ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
       Include="@(ProjectReferenceProvider)"
       Exclude="@(_UnusedProjectReferenceProvider)" />
 
-    <ProjectReference Include="@(_ProjectReferenceByAssemblyName->'%(ProjectPath)')" />
+    <ProjectReference Include="@(ProjectReferenceByAssemblyName->'%(ProjectPath)')" />
 
-    <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
+    <Reference Remove="@(ProjectReferenceByAssemblyName)" />
 
     <!-- Use _ReferenceTemp to workaround issues in Visual Studio which causes a conflict between Reference, packages, and projects. -->
     <_ReferenceTemp Include="@(Reference)" />
@@ -129,7 +131,7 @@
       </Reference>
 
       <!-- Identify if any references were present in the last release of this package, but have been removed. -->
-      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(_ProjectReferenceByAssemblyName);@(PackageReference)" />
+      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(ProjectReferenceByAssemblyName);@(PackageReference)" />
 
       <!--
         MSBuild does not provide a way to join on matching identities in a Condition,

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -96,8 +96,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(TargetDir)$(PackageConflictManifestFileName)">
     <ItemGroup>
-      <_AspNetCoreAppPackageOverrides Include="@(PackageReference->'%(Identity)|%(Version)')" Condition=" '%(PackageReference.PrivateAssets)' != 'All' " />
       <_AspNetCoreAppPackageOverrides Include="@(ProjectReferenceByAssemblyName->'%(Identity)|$(SharedFxVersion)')" />
+      <_AspNetCoreAppPackageOverrides Include="@(PackageReference->'%(Identity)|%(Version)')" Condition=" '%(PackageReference.PrivateAssets)' != 'All' " />
+      <_AspNetCoreAppPackageOverrides Include="@(_TransitiveExternalAspNetCoreAppReference->'%(Identity)|%(Version)')" />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -96,9 +96,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(TargetDir)$(PackageConflictManifestFileName)">
     <ItemGroup>
-      <_AspNetCoreAppPackageOverrides Include="@(ProjectReferenceByAssemblyName->'%(Identity)|$(SharedFxVersion)')" />
-      <_AspNetCoreAppPackageOverrides Include="@(PackageReference->'%(Identity)|%(Version)')" Condition=" '%(PackageReference.PrivateAssets)' != 'All' " />
-      <_AspNetCoreAppPackageOverrides Include="@(_TransitiveExternalAspNetCoreAppReference->'%(Identity)|%(Version)')" />
+      <_AspNetCoreAppPackageOverrides Include="@(ReferencePath->'%(NuGetPackageId)|%(NuGetPackageVersion)')" Condition=" '%(ReferencePath.NuGetPackageId)' != 'Microsoft.NETCore.App' AND '%(ReferencePath.NuGetSourceType)' == 'Package' " />
+      <_AspNetCoreAppPackageOverrides Include="@(ReferencePath->'%(FileName)|$(SharedFxVersion)')" Condition=" '%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' " />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -35,6 +35,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <!-- This project should not be referenced via the `<Reference>` impementation. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+
+    <PackageConflictManifestFileName>Microsoft.AspNetCore.App.PackageOverrides.txt</PackageConflictManifestFileName>
+    <PackageConflictManifestPackagePath>build/$(TargetFramework)/</PackageConflictManifestPackagePath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,6 +50,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <PropertyGroup>
     <BuildDependsOn>
       $(BuildDependsOn);
+      GeneratePackageConflictManifest;
       _ResolveTargetingPackContent;
       _BatchCopyToOutputDirectory;
     </BuildDependsOn>
@@ -83,7 +87,23 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" />
 
       <_PackageFiles Include="@(RefPackContent)" PackagePath="$(RefAssemblyPackagePath)" />
+      <_PackageFiles Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(PackageConflictManifestPackagePath)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="GeneratePackageConflictManifest"
+          DependsOnTargets="ResolveReferences"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(TargetDir)$(PackageConflictManifestFileName)">
+    <ItemGroup>
+      <_AspNetCoreAppPackageOverrides Include="@(PackageReference->'%(Identity)|%(Version)')" Condition=" '%(PackageReference.PrivateAssets)' != 'All' " />
+      <_AspNetCoreAppPackageOverrides Include="@(ProjectReferenceByAssemblyName->'%(Identity)|$(SharedFxVersion)')" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+        Lines="@(_AspNetCoreAppPackageOverrides)"
+        File="$(TargetDir)$(PackageConflictManifestFileName)"
+        Overwrite="true" />
   </Target>
 
   <!-- Written to take advantage of target batching in MSBuild. -->

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -36,8 +36,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- This project should not be referenced via the `<Reference>` impementation. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
 
-    <PackageConflictManifestFileName>Microsoft.AspNetCore.App.PackageOverrides.txt</PackageConflictManifestFileName>
-    <PackageConflictManifestPackagePath>build/$(TargetFramework)/</PackageConflictManifestPackagePath>
+    <PackageConflictManifestFileName>PackageOverrides.txt</PackageConflictManifestFileName>
+    <PackageConflictManifestPackagePath>data/</PackageConflictManifestPackagePath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Example file this generates:

[Microsoft.AspNetCore.App.PackageOverrides.txt](https://github.com/aspnet/AspNetCore/files/2862555/Microsoft.AspNetCore.App.PackageOverrides.txt)

Part of https://github.com/aspnet/AspNetCore/issues/6501

cc @nguerrera @dsplaisted @dagood 