### PR TITLE
Use new version of h2spec

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -151,7 +151,7 @@
     <MicrosoftIdentityModelLoggingPackageVersion>5.3.0</MicrosoftIdentityModelLoggingPackageVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion>5.3.0</MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion>
     <MicrosoftIdentityModelProtocolsWsFederationPackageVersion>5.3.0</MicrosoftIdentityModelProtocolsWsFederationPackageVersion>
-    <MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>2.1.2</MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>
+    <MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>2.2.1</MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>
     <MicrosoftNETCoreWindowsApiSetsPackageVersion>1.0.1</MicrosoftNETCoreWindowsApiSetsPackageVersion>
     <MicrosoftOwinSecurityCookiesPackageVersion>3.0.1</MicrosoftOwinSecurityCookiesPackageVersion>
     <MicrosoftOwinTestingPackageVersion>3.0.1</MicrosoftOwinTestingPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -151,7 +151,7 @@
     <MicrosoftIdentityModelLoggingPackageVersion>5.3.0</MicrosoftIdentityModelLoggingPackageVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion>5.3.0</MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion>
     <MicrosoftIdentityModelProtocolsWsFederationPackageVersion>5.3.0</MicrosoftIdentityModelProtocolsWsFederationPackageVersion>
-    <MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>2.1.1</MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>
+    <MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>2.1.2</MicrosoftInternalAspNetCoreH2SpecAllPackageVersion>
     <MicrosoftNETCoreWindowsApiSetsPackageVersion>1.0.1</MicrosoftNETCoreWindowsApiSetsPackageVersion>
     <MicrosoftOwinSecurityCookiesPackageVersion>3.0.1</MicrosoftOwinSecurityCookiesPackageVersion>
     <MicrosoftOwinTestingPackageVersion>3.0.1</MicrosoftOwinTestingPackageVersion>

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -23,7 +23,7 @@ namespace Interop.FunctionalTests
         SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support")]
     public class H2SpecTests : LoggedTest
     {
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/6691")]
+        [ConditionalTheory]
         [MemberData(nameof(H2SpecTestCases))]
         [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7299
         public async Task RunIndividualTestCase(H2SpecTestCase testCase)


### PR DESCRIPTION
 #6691 We'll see if this fixes our timeouts.
Note the dependency was misversioned as 2.1.2 instead of 2.2.1. Will followup with murat.