### PR TITLE
Skip HttpSys.Https tests on Helix

### DIFF
--- a/docs/Helix.md
+++ b/docs/Helix.md
@@ -48,6 +48,6 @@ This will restore, and then publish all of the test projects including some boot
 ## How to skip tests on helix
 There are two main ways to opt out of helix
 - Skipping the entire test project via `<BuildHelixPayload>false</BuildHelixPayload>` in csproj (the default value for this is IsTestProject).
-- Skipping an individual test via `[SkipOnHelix]` which might require including a compile reference to: `<Compile Include="$(SharedSourceRoot)test\xunit\SkipOnHelixAttribute.cs" />`
+- Skipping an individual test via `[SkipOnHelix]` which might require including a compile reference to: `<Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />`
 
 Make sure to file an issue for any skipped tests and include that in a comment next to either of these

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
+    [SkipOnHelix] // https://github.com/aspnet/AspNetCore-Internal/issues/1816
     public class HttpsTests
     {
         [ConditionalFact]

--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
     <Reference Include="System.Net.Http.WinHttpHandler" />
+    <Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Shared/test/SkipOnHelixAttribute.cs
+++ b/src/Shared/test/SkipOnHelixAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
     /// Skip test if a given environment variable is not enabled. To enable the test, set environment variable
     /// to "true" for the test process.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
     public class SkipOnHelixAttribute : Attribute, ITestCondition
     {
         public bool IsMet


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1816

These tests were added recently but they rely on the IIS Express cert. I'm skipping the tests on Helix while we debug that.