### PR TITLE
Log before releasing streams and firing tokens

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 // don't leak the exception
                 catch (ConnectionResetException)
                 {
-                    AbortIO(isConnectionReset: true);
+                    AbortIO(clientDisconnect: true);
                 }
             }
 

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 // don't leak the exception
                 catch (ConnectionResetException)
                 {
-                    ConnectionReset();
+                    AbortIO(isConnectionReset: true);
                 }
             }
 

--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             try
             {
                 context = (IISHttpContext)GCHandle.FromIntPtr(pvManagedHttpContext).Target;
-                context.ConnectionReset();
+                context.AbortIO(isConnectionReset: true);
             }
             catch (Exception ex)
             {

--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             try
             {
                 context = (IISHttpContext)GCHandle.FromIntPtr(pvManagedHttpContext).Target;
-                context.AbortIO(isConnectionReset: true);
+                context.AbortIO(clientDisconnect: true);
             }
             catch (Exception ex)
             {

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -209,9 +209,9 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                 {
                     Assert.IsType<OperationCanceledException>(exception);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    Logger.LogError(e, "Unexpected exception");
+                    Logger.LogError(exception, "Unexpected exception type");
                     throw;
                 }
             }


### PR DESCRIPTION
Might fix: https://github.com/aspnet/AspNetCore-Internal/issues/1659

I think writes complete too fast so we don't observe when the message gets logged
