### PR TITLE
Added endpoint routing support

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -900,8 +900,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(TransportTypes))]
-        public async Task ClientWillFailAuthEndPointIfNotAuthorized(HttpTransportType transportType)
+        [MemberData(nameof(TransportTypesWithAuth))]
+        public async Task ClientWillFailAuthEndPointIfNotAuthorized(HttpTransportType transportType, string hubPath)
         {
             bool ExpectedErrors(WriteContext writeContext)
             {
@@ -912,7 +912,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             {
                 var hubConnection = new HubConnectionBuilder()
                     .WithLoggerFactory(LoggerFactory)
-                    .WithUrl(server.Url + "/authorizedhub", transportType)
+                    .WithUrl(server.Url + hubPath, transportType)
                     .Build();
                 try
                 {
@@ -1195,6 +1195,17 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                             }
                         }
                     }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> TransportTypesWithAuth()
+        {
+            foreach (var transport in TransportTypes().SelectMany(t => t).Cast<HttpTransportType>())
+            {
+                foreach (var path in new[] { "/authorizedhub", "/authorizedhub2" })
+                {
+                    yield return new object[] { transport, path };
                 }
             }
         }

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -901,6 +901,28 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
+        public async Task ClientWillFailAuthEndPointIfNotAuthorized(HttpTransportType transportType)
+        {
+            using (StartServer<Startup>(out var server))
+            {
+                var hubConnection = new HubConnectionBuilder()
+                    .WithLoggerFactory(LoggerFactory)
+                    .WithUrl(server.Url + "/authorizedhub", transportType)
+                    .Build();
+                try
+                {
+                    var ex = await Assert.ThrowsAnyAsync<HttpRequestException>(() => hubConnection.StartAsync().OrTimeout());
+                    Assert.Equal("Response status code does not indicate success: 401 (Unauthorized).", ex.Message);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TransportTypes))]
         public async Task ClientCanUseJwtBearerTokenForAuthenticationWhenRedirected(HttpTransportType transportType)
         {
             using (StartServer<Startup>(out var server))

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -903,7 +903,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [MemberData(nameof(TransportTypes))]
         public async Task ClientWillFailAuthEndPointIfNotAuthorized(HttpTransportType transportType)
         {
-            using (StartServer<Startup>(out var server))
+            bool ExpectedErrors(WriteContext writeContext)
+            {
+                return writeContext.Exception is HttpRequestException;
+            }
+
+            using (StartServer<Startup>(out var server, ExpectedErrors))
             {
                 var hubConnection = new HubConnectionBuilder()
                     .WithLoggerFactory(LoggerFactory)

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -221,4 +221,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
     {
         public string Echo(string message) => TestHubMethodsImpl.Echo(message);
     }
+
+    // Authorization is added via endpoint routing in Startup
+    public class HubWithAuthorization2 : Hub
+    {
+        public string Echo(string message) => TestHubMethodsImpl.Echo(message);
+    }
 }

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     return context.Response.WriteAsync(GenerateJwtToken());
                 });
 
-                routes.MapGet("/redirect", context =>
+                routes.Map("/redirect/{*anything}", context =>
                 {
                     return context.Response.WriteAsync(JsonConvert.SerializeObject(new
                     {

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Http.Connections.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    public static class ConnectionEndpointRouteBuilderExtensions
+    {
+        /// <summary>
+        /// Maps incoming requests with the specified path to the provided connection pipeline.
+        /// </summary>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
+        /// <param name="pattern">The request path.</param>
+        /// <param name="configure">A callback to configure the connection.</param>
+        public static IEndpointConventionBuilder MapConnections(this IEndpointRouteBuilder builder, string pattern, Action<IConnectionBuilder> configure) =>
+            builder.MapConnections(pattern, new HttpConnectionDispatcherOptions(), configure);
+
+        /// <summary>
+        /// Maps incoming requests with the specified path to the provided connection pipeline.
+        /// </summary>
+        /// <typeparam name="TConnectionHandler">The <see cref="ConnectionHandler"/> type.</typeparam>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
+        /// <param name="pattern">The request path.</param>
+        public static IEndpointConventionBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder builder, string pattern) where TConnectionHandler : ConnectionHandler
+        {
+            return builder.MapConnectionHandler<TConnectionHandler>(pattern, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Maps incoming requests with the specified path to the provided connection pipeline.
+        /// </summary>
+        /// <typeparam name="TConnectionHandler">The <see cref="ConnectionHandler"/> type.</typeparam>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
+        /// <param name="pattern">The request path.</param>
+        /// <param name="configureOptions">A callback to configure dispatcher options.</param>
+        public static IEndpointConventionBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder builder, string pattern, Action<HttpConnectionDispatcherOptions> configureOptions) where TConnectionHandler : ConnectionHandler
+        {
+            var authorizeAttributes = typeof(TConnectionHandler).GetCustomAttributes<AuthorizeAttribute>(inherit: true);
+            var options = new HttpConnectionDispatcherOptions();
+            foreach (var attribute in authorizeAttributes)
+            {
+                options.AuthorizationData.Add(attribute);
+            }
+            configureOptions?.Invoke(options);
+
+            return builder.MapConnections(pattern, options, b =>
+            {
+                b.UseConnectionHandler<TConnectionHandler>();
+            });
+        }
+
+
+        /// <summary>
+        /// Maps incoming requests with the specified path to the provided connection pipeline.
+        /// </summary>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
+        /// <param name="pattern">The request path.</param>
+        /// <param name="options">Options used to configure the connection.</param>
+        /// <param name="configure">A callback to configure the connection.</param>
+        public static IEndpointConventionBuilder MapConnections(this IEndpointRouteBuilder builder, string pattern, HttpConnectionDispatcherOptions options, Action<IConnectionBuilder> configure)
+        {
+            var dispatcher = builder.ServiceProvider.GetRequiredService<HttpConnectionDispatcher>();
+
+            var connectionBuilder = new ConnectionBuilder(builder.ServiceProvider);
+            configure(connectionBuilder);
+            var connectionDelegate = connectionBuilder.Build();
+
+            // REVIEW: Consider expanding the internals of the dispatcher as endpoint routes instead of
+            // using if statemants we can let the matcher handle
+
+            var conventionBuilders = new List<IEndpointConventionBuilder>();
+
+            // Build the negotiate application
+            var app = builder.CreateApplicationBuilder();
+            app.UseWebSockets();
+            app.Run(c => dispatcher.ExecuteNegotiateAsync(c, options));
+            var negotiateHandler = app.Build();
+
+            var negotiateBuilder = builder.Map(pattern + "/negotiate", negotiateHandler);
+            conventionBuilders.Add(negotiateBuilder);
+
+            // build the execute handler part of the protocol
+            app = builder.CreateApplicationBuilder();
+            app.UseWebSockets();
+            app.Run(c => dispatcher.ExecuteAsync(c, options, connectionDelegate));
+            var executehandler = app.Build();
+
+            var executeBuilder = builder.Map(pattern, executehandler);
+            conventionBuilders.Add(executeBuilder);
+
+            var compositeConventionBuilder = new CompositeEndpointConventionBuilder(conventionBuilders);
+
+            // Add metadata to all of Endpoints
+            compositeConventionBuilder.Add(e =>
+            {
+                // Add the authorization data as metadata
+                foreach (var data in options.AuthorizationData)
+                {
+                    e.Metadata.Add(data);
+                }
+            });
+
+            return compositeConventionBuilder;
+        }
+
+        private class CompositeEndpointConventionBuilder : IEndpointConventionBuilder
+        {
+            private readonly List<IEndpointConventionBuilder> _endpointConventionBuilders;
+
+            public CompositeEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
+            {
+                _endpointConventionBuilders = endpointConventionBuilders;
+            }
+
+            public void Add(Action<EndpointBuilder> convention)
+            {
+                foreach (var endpointConventionBuilder in _endpointConventionBuilders)
+                {
+                    endpointConventionBuilder.Add(convention);
+                }
+            }
+        }
+    }
+}

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -15,9 +15,10 @@ namespace Microsoft.AspNetCore.Routing
         /// <summary>
         /// Maps incoming requests with the specified path to the provided connection pipeline.
         /// </summary>
-        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
-        /// <param name="pattern">The request path.</param>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
         /// <param name="configure">A callback to configure the connection.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
         public static IEndpointConventionBuilder MapConnections(this IEndpointRouteBuilder builder, string pattern, Action<IConnectionBuilder> configure) =>
             builder.MapConnections(pattern, new HttpConnectionDispatcherOptions(), configure);
 
@@ -25,8 +26,9 @@ namespace Microsoft.AspNetCore.Routing
         /// Maps incoming requests with the specified path to the provided connection pipeline.
         /// </summary>
         /// <typeparam name="TConnectionHandler">The <see cref="ConnectionHandler"/> type.</typeparam>
-        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
-        /// <param name="pattern">The request path.</param>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
         public static IEndpointConventionBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder builder, string pattern) where TConnectionHandler : ConnectionHandler
         {
             return builder.MapConnectionHandler<TConnectionHandler>(pattern, configureOptions: null);
@@ -36,9 +38,10 @@ namespace Microsoft.AspNetCore.Routing
         /// Maps incoming requests with the specified path to the provided connection pipeline.
         /// </summary>
         /// <typeparam name="TConnectionHandler">The <see cref="ConnectionHandler"/> type.</typeparam>
-        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
-        /// <param name="pattern">The request path.</param>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
         /// <param name="configureOptions">A callback to configure dispatcher options.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
         public static IEndpointConventionBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder builder, string pattern, Action<HttpConnectionDispatcherOptions> configureOptions) where TConnectionHandler : ConnectionHandler
         {
             var options = new HttpConnectionDispatcherOptions();
@@ -73,10 +76,11 @@ namespace Microsoft.AspNetCore.Routing
         /// <summary>
         /// Maps incoming requests with the specified path to the provided connection pipeline.
         /// </summary>
-        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
-        /// <param name="pattern">The request path.</param>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
         /// <param name="options">Options used to configure the connection.</param>
         /// <param name="configure">A callback to configure the connection.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
         public static IEndpointConventionBuilder MapConnections(this IEndpointRouteBuilder builder, string pattern, HttpConnectionDispatcherOptions options, Action<IConnectionBuilder> configure)
         {
             var dispatcher = builder.ServiceProvider.GetRequiredService<HttpConnectionDispatcher>();

--- a/src/SignalR/samples/JwtSample/Startup.cs
+++ b/src/SignalR/samples/JwtSample/Startup.cs
@@ -66,11 +66,15 @@ namespace JwtSample
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseFileServer();
-            app.UseSignalR(options => options.MapHub<Broadcaster>("/broadcast"));
 
-            var routeBuilder = new RouteBuilder(app);
-            routeBuilder.MapGet("generatetoken", c => c.Response.WriteAsync(GenerateToken(c)));
-            app.UseRouter(routeBuilder.Build());
+            app.UseRouting(routes =>
+            {
+                routes.MapHub<Broadcaster>("/broadcast");
+                routes.MapGet("/generatetoken", context =>
+                {
+                    return context.Response.WriteAsync(GenerateToken(context));
+                });
+            });
         }
 
         private string GenerateToken(HttpContext httpContext)

--- a/src/SignalR/samples/SignalRSamples/Startup.cs
+++ b/src/SignalR/samples/SignalRSamples/Startup.cs
@@ -4,9 +4,11 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -55,23 +57,17 @@ namespace SignalRSamples
 
             app.UseCors("Everything");
 
-            app.UseSignalR(routes =>
+            app.UseRouting(routes =>
             {
                 routes.MapHub<DynamicChat>("/dynamic");
                 routes.MapHub<Chat>("/default");
                 routes.MapHub<Streaming>("/streaming");
                 routes.MapHub<UploadHub>("/uploading");
                 routes.MapHub<HubTChat>("/hubT");
-            });
 
-            app.UseConnections(routes =>
-            {
                 routes.MapConnectionHandler<MessagesConnectionHandler>("/chat");
-            });
 
-            app.Use(next => (context) =>
-            {
-                if (context.Request.Path.StartsWithSegments("/deployment"))
+                routes.MapGet("/deployment", context =>
                 {
                     var attributes = Assembly.GetAssembly(typeof(Startup)).GetCustomAttributes<AssemblyMetadataAttribute>();
 
@@ -99,9 +95,12 @@ namespace SignalRSamples
 
                         json.WriteTo(writer);
                     }
-                }
-                return Task.CompletedTask;
+
+                    return Task.CompletedTask;
+                });
             });
+
+            app.UseAuthorization();
         }
     }
 }

--- a/src/SignalR/samples/SocialWeather/Startup.cs
+++ b/src/SignalR/samples/SocialWeather/Startup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SocialWeather.Json;
@@ -30,8 +31,12 @@ namespace SocialWeather
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseConnections(o => o.MapConnectionHandler<SocialWeatherConnectionHandler>("/weather"));
             app.UseFileServer();
+
+            app.UseRouting(routes =>
+            {
+                routes.MapConnectionHandler<SocialWeatherConnectionHandler>("/weather");
+            });
 
             var formatterResolver = app.ApplicationServices.GetRequiredService<FormatterResolver>();
             formatterResolver.AddFormatter<WeatherReport, JsonStreamFormatter<WeatherReport>>("json");

--- a/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    public static class HubEndpointRouteBuilderExtensions
+    {
+        /// <summary>
+        /// Maps incoming requests with the specified path to the specified <see cref="Hub"/> type.
+        /// </summary>
+        /// <typeparam name="THub">The <see cref="Hub"/> type to map requests to.</typeparam>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
+        /// <param name="pattern">The request path.</param>
+        public static IEndpointConventionBuilder MapHub<THub>(this IEndpointRouteBuilder builder, string pattern) where THub : Hub
+        {
+            return builder.MapHub<THub>(pattern, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Maps incoming requests with the specified path to the specified <see cref="Hub"/> type.
+        /// </summary>
+        /// <typeparam name="THub">The <see cref="Hub"/> type to map requests to.</typeparam>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
+        /// <param name="pattern">The request path.</param>
+        /// <param name="configureOptions">A callback to configure dispatcher options.</param>
+        public static IEndpointConventionBuilder MapHub<THub>(this IEndpointRouteBuilder builder, string pattern, Action<HttpConnectionDispatcherOptions> configureOptions) where THub : Hub
+        {
+            var marker = builder.ServiceProvider.GetService<SignalRMarkerService>();
+
+            if (marker == null)
+            {
+                throw new InvalidOperationException("Unable to find the required services. Please add all the required services by calling " +
+                                                    "'IServiceCollection.AddSignalR' inside the call to 'ConfigureServices(...)' in the application startup code.");
+            }
+
+            // find auth attributes
+            var authorizeAttributes = typeof(THub).GetCustomAttributes<AuthorizeAttribute>(inherit: true);
+            var options = new HttpConnectionDispatcherOptions();
+            foreach (var attribute in authorizeAttributes)
+            {
+                options.AuthorizationData.Add(attribute);
+            }
+            configureOptions?.Invoke(options);
+
+            return builder.MapConnections(pattern, options, b =>
+            {
+                b.UseHub<THub>();
+            });
+        }
+    }
+}

--- a/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
@@ -1,10 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Authorization;
-using System.Linq;
 
 namespace Microsoft.AspNetCore.Routing
 {

--- a/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
@@ -14,8 +14,9 @@ namespace Microsoft.AspNetCore.Routing
         /// Maps incoming requests with the specified path to the specified <see cref="Hub"/> type.
         /// </summary>
         /// <typeparam name="THub">The <see cref="Hub"/> type to map requests to.</typeparam>
-        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
-        /// <param name="pattern">The request path.</param>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
         public static IEndpointConventionBuilder MapHub<THub>(this IEndpointRouteBuilder builder, string pattern) where THub : Hub
         {
             return builder.MapHub<THub>(pattern, configureOptions: null);
@@ -25,9 +26,10 @@ namespace Microsoft.AspNetCore.Routing
         /// Maps incoming requests with the specified path to the specified <see cref="Hub"/> type.
         /// </summary>
         /// <typeparam name="THub">The <see cref="Hub"/> type to map requests to.</typeparam>
-        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/></param>
-        /// <param name="pattern">The request path.</param>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
         /// <param name="configureOptions">A callback to configure dispatcher options.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
         public static IEndpointConventionBuilder MapHub<THub>(this IEndpointRouteBuilder builder, string pattern, Action<HttpConnectionDispatcherOptions> configureOptions) where THub : Hub
         {
             var marker = builder.ServiceProvider.GetService<SignalRMarkerService>();

--- a/src/SignalR/server/SignalR/test/MapSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/MapSignalRTests.cs
@@ -68,6 +68,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             builder
                 .UseKestrel()
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                })
                 .Configure(app =>
                 {
                     executedConfigure = true;

--- a/src/SignalR/server/SignalR/test/MapSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/MapSignalRTests.cs
@@ -1,8 +1,11 @@
-﻿using System;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -36,8 +39,42 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 {
                     executedConfigure = true;
 
-                    var ex = Assert.Throws<InvalidOperationException>(() => {
+                    var ex = Assert.Throws<InvalidOperationException>(() =>
+                    {
                         app.UseSignalR(routes =>
+                        {
+                            routes.MapHub<AuthHub>("/overloads");
+                        });
+                    });
+
+                    Assert.Equal("Unable to find the required services. Please add all the required services by calling " +
+                                 "'IServiceCollection.AddSignalR' inside the call to 'ConfigureServices(...)' in the application startup code.", ex.Message);
+                })
+                .UseUrls("http://127.0.0.1:0");
+
+            using (var host = builder.Build())
+            {
+                host.Start();
+            }
+
+            Assert.True(executedConfigure);
+        }
+
+        [Fact]
+        public void NotAddingSignalRServiceThrowsWhenUsingEndpointRouting()
+        {
+            var executedConfigure = false;
+            var builder = new WebHostBuilder();
+
+            builder
+                .UseKestrel()
+                .Configure(app =>
+                {
+                    executedConfigure = true;
+
+                    var ex = Assert.Throws<InvalidOperationException>(() =>
+                    {
+                        app.UseRouting(routes =>
                         {
                             routes.MapHub<AuthHub>("/overloads");
                         });
@@ -101,6 +138,49 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(2, authCount);
         }
 
+        [Fact]
+        public void MapHubEndPointRoutingFindsAttributesOnHub()
+        {
+            var authCount = 0;
+            using (var host = BuildWebHostWithEndPointRouting(routes => routes.MapHub<AuthHub>("/path", options =>
+            {
+                authCount += options.AuthorizationData.Count;
+            })))
+            {
+                host.Start();
+
+                var dataSource = host.Services.GetRequiredService<EndpointDataSource>();
+                // We register 2 endpoints (/negotiate and /)
+                Assert.Equal(2, dataSource.Endpoints.Count);
+                Assert.NotNull(dataSource.Endpoints[0].Metadata.GetMetadata<IAuthorizeData>());
+                Assert.NotNull(dataSource.Endpoints[1].Metadata.GetMetadata<IAuthorizeData>());
+            }
+
+            Assert.Equal(1, authCount);
+        }
+
+        [Fact]
+        public void MapHubEndPointRoutingAppliesAttributesBeforeConventions()
+        {
+            void ConfigureRoutes(IEndpointRouteBuilder routes)
+            {
+                // This "Foo" policy should override the default auth attribute
+                routes.MapHub<AuthHub>("/path")
+                      .RequireAuthorization(new AuthorizeAttribute("Foo"));
+            }
+
+            using (var host = BuildWebHostWithEndPointRouting(ConfigureRoutes))
+            {
+                host.Start();
+
+                var dataSource = host.Services.GetRequiredService<EndpointDataSource>();
+                // We register 2 endpoints (/negotiate and /)
+                Assert.Equal(2, dataSource.Endpoints.Count);
+                Assert.Equal("Foo", dataSource.Endpoints[0].Metadata.GetMetadata<IAuthorizeData>()?.Policy);
+                Assert.Equal("Foo", dataSource.Endpoints[1].Metadata.GetMetadata<IAuthorizeData>()?.Policy);
+            }
+        }
+
         private class InvalidHub : Hub
         {
             public void OverloadedMethod(int num)
@@ -124,6 +204,22 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Authorize]
         private class AuthHub : Hub
         {
+        }
+
+        private IWebHost BuildWebHostWithEndPointRouting(Action<IEndpointRouteBuilder> configure)
+        {
+            return new WebHostBuilder()
+                .UseKestrel()
+                .ConfigureServices(services =>
+                {
+                    services.AddSignalR();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting(routes => configure(routes));
+                })
+                .UseUrls("http://127.0.0.1:0")
+                .Build();
         }
 
         private IWebHost BuildWebHost(Action<HubRouteBuilder> configure)

--- a/src/SignalR/server/SignalR/test/Startup.cs
+++ b/src/SignalR/server/SignalR/test/Startup.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
@@ -28,17 +29,14 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseConnections(routes =>
+            app.UseRouting(routes =>
             {
+                routes.MapHub<UncreatableHub>("/uncreatable");
+
                 routes.MapConnectionHandler<EchoConnectionHandler>("/echo");
                 routes.MapConnectionHandler<WriteThenCloseConnectionHandler>("/echoAndClose");
                 routes.MapConnectionHandler<HttpHeaderConnectionHandler>("/httpheader");
                 routes.MapConnectionHandler<AuthConnectionHandler>("/auth");
-            });
-
-            app.UseSignalR(routes =>
-            {
-                routes.MapHub<UncreatableHub>("/uncreatable");
             });
         }
     }

--- a/src/SignalR/server/StackExchangeRedis/test/Startup.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 
@@ -28,7 +29,10 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseSignalR(options => options.MapHub<EchoHub>("/echo"));
+            app.UseRouting(routes =>
+            {
+                routes.MapHub<EchoHub>("/echo");
+            });
         }
 
         private class UserNameIdProvider : IUserIdProvider


### PR DESCRIPTION
- Basic endpoint routing support to for SignalR hubs, ConnectionHandler and IConnectionBuilder endpoints
- Updated all functional tests and samples to use it

Follow up items:
- Add hub metadata (this will come in handy when consumers of the datasource try are trying to determine which end points are hub endpoints
- Maybe explode the `HttpConnectionDispatcher` a bit more so all dispatching is handled by the route matcher
- Decide if we leave the legacy auth logic inside of the dispatcher

Fixes https://github.com/aspnet/AspNetCore/issues/5295 and #5366