### PR TITLE
Wait for stop to complete in SignalR test.

### DIFF
--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1352,7 +1352,7 @@ class HubConnectionTest {
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
 
         TimeUnit.MILLISECONDS.sleep(100);
-        hubConnection.stop();
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
 
         String[] sentMessages = mockTransport.getSentMessages();
         assertTrue(sentMessages.length > 1);


### PR DESCRIPTION
Not waiting for stop to complete was causing a race.
Fixes the Java failure filed here https://github.com/aspnet/AspNetCore-Internal/issues/1810
