### PR TITLE
Fix F# template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Startup.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Startup.fs
@@ -44,8 +44,7 @@ type Startup private () =
             routes.MapControllerRoute(
                 name = "default",
                 template = "{controller=Home}/{action=Index}/{id?}") |> ignore
-            ) |> ignore
-            routes.MapRazorPages() |> ignore
+            routes.MapRazorPages() |> ignore) |> ignore
 
         app.UseAuthorization() |> ignore
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Current template fails to build

````
c:\temp\asp>dotnet new mvc -lang F#
The template "ASP.NET Core Web App (Model-View-Controller)" was created successfully.
This template contains technologies from parties other than Microsoft, see https://aka.ms/aspnetcore-template-3pn-210 for details.

Processing post-creation actions...
Running 'dotnet restore' on c:\temp\asp\asp.fsproj...
  Restoring packages for c:\temp\asp\asp.fsproj...
  Generating MSBuild file c:\temp\asp\obj\asp.fsproj.nuget.g.props.
  Generating MSBuild file c:\temp\asp\obj\asp.fsproj.nuget.g.targets.
  Restore completed in 162.09 ms for c:\temp\asp\asp.fsproj.

Restore succeeded.


c:\temp\asp>dotnet build
Microsoft (R) Build Engine version 16.0.386-preview+ga1e757f759 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 12.59 ms for c:\temp\asp\asp.fsproj.
C:\Program Files\dotnet\sdk\3.0.100-preview3-010283\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(151,5): message NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview [c:\temp\asp\asp.fsproj]
c:\temp\asp\Startup.fs(42,13): error FS0597: Successive arguments should be separated by spaces or tupled, and arguments involving function or method applications should be parenthesized [c:\temp\asp\asp.fsproj]

Build FAILED.

c:\temp\asp\Startup.fs(42,13): error FS0597: Successive arguments should be separated by spaces or tupled, and arguments involving function or method applications should be parenthesized [c:\temp\asp\asp.fsproj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:01.84

c:\temp\asp>
````