### PR TITLE
Align host behavior with respect to exceptions

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostedServiceExecutor.cs
+++ b/src/Hosting/Hosting/src/Internal/HostedServiceExecutor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public Task StopAsync(CancellationToken token)
         {
-            return ExecuteAsync(service => service.StopAsync(token), throwOnfirstFailure: false);
+            return ExecuteAsync(service => service.StopAsync(token), throwOnFirstFailure: false);
         }
 
         private async Task ExecuteAsync(Func<IHostedService, Task> callback, bool throwOnFirstFailure = true)
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
                 catch (Exception ex)
                 {
-                    if (throwOnfirstFailure)
+                    if (throwOnFirstFailure)
                     {
                         throw;
                     }

--- a/src/Hosting/Hosting/src/Internal/HostedServiceExecutor.cs
+++ b/src/Hosting/Hosting/src/Internal/HostedServiceExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,31 +21,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _services = services;
         }
 
-        public async Task StartAsync(CancellationToken token)
+        public Task StartAsync(CancellationToken token)
         {
-            try
-            {
-                await ExecuteAsync(service => service.StartAsync(token));
-            }
-            catch (Exception ex)
-            {
-                _logger.ApplicationError(LoggerEventIds.HostedServiceStartException, "An error occurred starting the application", ex);
-            }
+            return ExecuteAsync(service => service.StartAsync(token));
         }
 
-        public async Task StopAsync(CancellationToken token)
+        public Task StopAsync(CancellationToken token)
         {
-            try
-            {
-                await ExecuteAsync(service => service.StopAsync(token));
-            }
-            catch (Exception ex)
-            {
-                _logger.ApplicationError(LoggerEventIds.HostedServiceStopException, "An error occurred stopping the application", ex);
-            }
+            return ExecuteAsync(service => service.StopAsync(token), throwOnfirstFailure: false);
         }
 
-        private async Task ExecuteAsync(Func<IHostedService, Task> callback)
+        private async Task ExecuteAsync(Func<IHostedService, Task> callback, bool throwOnfirstFailure = true)
         {
             List<Exception> exceptions = null;
 
@@ -57,6 +43,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
                 catch (Exception ex)
                 {
+                    if (throwOnfirstFailure)
+                    {
+                        throw;
+                    }
+
                     if (exceptions == null)
                     {
                         exceptions = new List<Exception>();

--- a/src/Hosting/Hosting/src/Internal/HostedServiceExecutor.cs
+++ b/src/Hosting/Hosting/src/Internal/HostedServiceExecutor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             return ExecuteAsync(service => service.StopAsync(token), throwOnfirstFailure: false);
         }
 
-        private async Task ExecuteAsync(Func<IHostedService, Task> callback, bool throwOnfirstFailure = true)
+        private async Task ExecuteAsync(Func<IHostedService, Task> callback, bool throwOnFirstFailure = true)
         {
             List<Exception> exceptions = null;
 

--- a/src/Hosting/Hosting/test/WebHostTests.cs
+++ b/src/Hosting/Hosting/test/WebHostTests.cs
@@ -458,26 +458,26 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
-        public async Task WebHostNotifiesAllIApplicationLifetimeEventsCallbacksEvenIfTheyThrow()
+        public async Task WebHostDoesNotNotifyAllIApplicationLifetimeEventsCallbacksIfTheyThrow()
         {
-            bool[] events1 = null;
-            bool[] events2 = null;
+            bool[] hostedSeviceCalls1 = null;
+            bool[] hostedServiceCalls2 = null;
 
             using (var host = CreateBuilder()
                 .UseFakeServer()
                 .ConfigureServices(services =>
                 {
-                    events1 = RegisterCallbacksThatThrow(services);
-                    events2 = RegisterCallbacksThatThrow(services);
+                    hostedSeviceCalls1 = RegisterCallbacksThatThrow(services);
+                    hostedServiceCalls2 = RegisterCallbacksThatThrow(services);
                 })
                 .Build())
             {
-                await host.StartAsync();
-                Assert.True(events1[0]);
-                Assert.True(events2[0]);
+                await Assert.ThrowsAsync<InvalidOperationException>(() => host.StartAsync());
+                Assert.True(hostedSeviceCalls1[0]);
+                Assert.False(hostedServiceCalls2[0]);
                 host.Dispose();
-                Assert.True(events1[1]);
-                Assert.True(events2[1]);
+                Assert.True(hostedSeviceCalls1[1]);
+                Assert.True(hostedServiceCalls2[1]);
             }
         }
 
@@ -667,17 +667,17 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
-        public async Task WebHostNotifiesAllIHostedServicesAndIApplicationLifetimeCallbacksEvenIfTheyThrow()
+        public async Task WebHostDoesNotNotifyAllIHostedServicesAndIApplicationLifetimeCallbacksIfTheyThrow()
         {
-            bool[] events1 = null;
-            bool[] events2 = null;
+            bool[] hostedServiceCalls1 = null;
+            bool[] hostedServiceCalls2 = null;
 
             using (var host = CreateBuilder()
                 .UseFakeServer()
                 .ConfigureServices(services =>
                 {
-                    events1 = RegisterCallbacksThatThrow(services);
-                    events2 = RegisterCallbacksThatThrow(services);
+                    hostedServiceCalls1 = RegisterCallbacksThatThrow(services);
+                    hostedServiceCalls2 = RegisterCallbacksThatThrow(services);
                 })
                 .Build())
             {
@@ -690,14 +690,14 @@ namespace Microsoft.AspNetCore.Hosting
                 var started2 = RegisterCallbacksThatThrow(applicationLifetime2.ApplicationStarted);
                 var stopping2 = RegisterCallbacksThatThrow(applicationLifetime2.ApplicationStopping);
 
-                await host.StartAsync();
-                Assert.True(events1[0]);
-                Assert.True(events2[0]);
+                await Assert.ThrowsAsync<InvalidOperationException>(() => host.StartAsync());
+                Assert.True(hostedServiceCalls1[0]);
+                Assert.False(hostedServiceCalls2[0]);
                 Assert.True(started.All(s => s));
                 Assert.True(started2.All(s => s));
                 host.Dispose();
-                Assert.True(events1[1]);
-                Assert.True(events2[1]);
+                Assert.True(hostedServiceCalls1[1]);
+                Assert.True(hostedServiceCalls2[1]);
                 Assert.True(stopping.All(s => s));
                 Assert.True(stopping2.All(s => s));
             }


### PR DESCRIPTION
- Don't catch errors in IHostedService.StartAsync
- Only catch errors when executing StopAsync but rethrow an aggregate
- Updated the tests

Fixes https://github.com/aspnet/AspNetCore/issues/5900