### PR TITLE
Avoid WriteBarrier assign for nulling struct

### DIFF
--- a/src/Http/Http.Features/src/FeatureReferences.cs
+++ b/src/Http/Http.Features/src/FeatureReferences.cs
@@ -15,6 +15,20 @@ namespace Microsoft.AspNetCore.Http.Features
             Revision = collection.Revision;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Initalize(IFeatureCollection collection)
+        {
+            Revision = collection.Revision;
+            Collection = collection;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Initalize(IFeatureCollection collection, int revision)
+        {
+            Revision = revision;
+            Collection = collection;
+        }
+
         public IFeatureCollection Collection { get; private set; }
         public int Revision { get; private set; }
 

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -40,18 +40,19 @@ namespace Microsoft.AspNetCore.Http
 
         public DefaultHttpContext(IFeatureCollection features)
         {
-            _features = new FeatureReferences<FeatureInterfaces>(features);
+            _features.Initalize(features);
             _request = new DefaultHttpRequest(this);
             _response = new DefaultHttpResponse(this);
         }
 
         public void Initialize(IFeatureCollection features)
         {
-            _features = new FeatureReferences<FeatureInterfaces>(features);
-            _request.Initialize();
-            _response.Initialize();
-            _connection?.Initialize(features);
-            _websockets?.Initialize(features);
+            var revision = features.Revision;
+            _features.Initalize(features, revision);
+            _request.Initialize(revision);
+            _response.Initialize(revision);
+            _connection?.Initialize(features, revision);
+            _websockets?.Initialize(features, revision);
         }
 
         public void Uninitialize()

--- a/src/Http/Http/src/Features/QueryFeature.cs
+++ b/src/Http/Http/src/Features/QueryFeature.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Http.Features
                 throw new ArgumentNullException(nameof(features));
             }
 
-            _features = new FeatureReferences<IHttpRequestFeature>(features);
+            _features.Initalize(features);
         }
 
         private IHttpRequestFeature HttpRequestFeature =>

--- a/src/Http/Http/src/Features/RequestCookiesFeature.cs
+++ b/src/Http/Http/src/Features/RequestCookiesFeature.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Http.Features
                 throw new ArgumentNullException(nameof(features));
             }
 
-            _features = new FeatureReferences<IHttpRequestFeature>(features);
+            _features.Initalize(features);
         }
 
         private IHttpRequestFeature HttpRequestFeature =>

--- a/src/Http/Http/src/Features/ResponseCookiesFeature.cs
+++ b/src/Http/Http/src/Features/ResponseCookiesFeature.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Http.Features
                 throw new ArgumentNullException(nameof(features));
             }
 
-            _features = new FeatureReferences<IHttpResponseFeature>(features);
+            _features.Initalize(features);
         }
 
         private IHttpResponseFeature HttpResponseFeature => _features.Fetch(ref _features.Cache, _nullResponseFeature);

--- a/src/Http/Http/src/Internal/DefaultConnectionInfo.cs
+++ b/src/Http/Http/src/Internal/DefaultConnectionInfo.cs
@@ -25,7 +25,12 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public void Initialize( IFeatureCollection features)
         {
-            _features = new FeatureReferences<FeatureInterfaces>(features);
+            _features.Initalize(features);
+        }
+
+        public void Initialize(IFeatureCollection features, int revision)
+        {
+            _features.Initalize(features, revision);
         }
 
         public void Uninitialize()

--- a/src/Http/Http/src/Internal/DefaultHttpRequest.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpRequest.cs
@@ -28,12 +28,17 @@ namespace Microsoft.AspNetCore.Http.Internal
         public DefaultHttpRequest(DefaultHttpContext context)
         {
             _context = context;
-            _features = new FeatureReferences<FeatureInterfaces>(_context.Features);
+            _features.Initalize(context.Features);
         }
 
         public void Initialize()
         {
-            _features = new FeatureReferences<FeatureInterfaces>(_context.Features);
+            _features.Initalize(_context.Features);
+        }
+
+        public void Initialize(int revision)
+        {
+            _features.Initalize(_context.Features, revision);
         }
 
         public void Uninitialize()

--- a/src/Http/Http/src/Internal/DefaultHttpResponse.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpResponse.cs
@@ -25,12 +25,17 @@ namespace Microsoft.AspNetCore.Http.Internal
         public DefaultHttpResponse(DefaultHttpContext context)
         {
             _context = context;
-            _features = new FeatureReferences<FeatureInterfaces>(_context.Features);
+            _features.Initalize(context.Features);
         }
 
         public void Initialize()
         {
-            _features = new FeatureReferences<FeatureInterfaces>(_context.Features);
+            _features.Initalize(_context.Features);
+        }
+
+        public void Initialize(int revision)
+        {
+            _features.Initalize(_context.Features, revision);
         }
 
         public void Uninitialize()

--- a/src/Http/Http/src/Internal/DefaultWebSocketManager.cs
+++ b/src/Http/Http/src/Internal/DefaultWebSocketManager.cs
@@ -25,7 +25,12 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public void Initialize(IFeatureCollection features)
         {
-            _features = new FeatureReferences<FeatureInterfaces>(features);
+            _features.Initalize(features);
+        }
+
+        public void Initialize(IFeatureCollection features, int revision)
+        {
+            _features.Initalize(features, revision);
         }
 
         public void Uninitialize()


### PR DESCRIPTION
Its `default` in the .ctors so only needs the two fields set; `Uninitalize` sets it to `default` so `Initalize` again only needs to set the two fields and doesn't need to blank the `Cache` field.

Workaround for https://github.com/dotnet/coreclr/issues/22661 to skip 5 `Jit_ByRefWriteBarrier`s (and 10 more in called methods + conditionally 4 more; so eliminates up to 19 `CORINFO_HELP_ASSIGN_BYREF` per request)

`Jit_ByRefWriteBarrier` shows up at around 2% of total run time in the TE benchmarks from this entry point:

![image](https://user-images.githubusercontent.com/1142958/52905044-12fc8680-322c-11e9-9d70-a1a3d047ff50.png)

+5% in TE Plaintext benchmarks without the stack clear and the additional skips of the interface lookup for revision in this PR.
```
| Description |       RPS | CPU (%) | Memory (MB) | Avg. Latency (ms) | Ratio |
| ----------- | --------- | ------- | ----------- | ----------------- | ----- |
|     Current | 2,183,750 |      93 |         171 |               3.9 |  1.00 |
|          PR | 2,289,737 |      90 |         169 |               2.8 |  1.05 |
```

/cc @davidfowl 

/cc @kkokosa as I read about these [in a book](https://prodotnetmemory.com/) recently :)