### PR TITLE
Support .webmanifest static files.

### DIFF
--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -339,6 +339,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".wcm", "application/vnd.ms-works" },
                 { ".wdb", "application/vnd.ms-works" },
                 { ".webm", "video/webm" },
+                { ".webmanifest", "application/manifest+json" },
                 { ".webp", "image/webp" },
                 { ".wks", "application/vnd.ms-works" },
                 { ".wm", "video/x-ms-wm" },


### PR DESCRIPTION
Add support for static files with .webmanifest extensions which are commonly used for Progressive Web Apps - https://developer.mozilla.org/en-US/docs/Web/Manifest

Addresses #2442
