### PR TITLE
Ensure messages are processed in order

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/LongPollingTransport.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/LongPollingTransport.java
@@ -98,7 +98,7 @@ class LongPollingTransport implements Transport {
                     } else {
                         if (response.getContent() != null) {
                             logger.debug("Message received.");
-                            threadPool.execute(() -> this.onReceive(response.getContent()));
+                            this.onReceive(response.getContent());
                         } else {
                             logger.debug("Poll timed out, reissuing.");
                         }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -172,6 +172,9 @@ public class LongPollingTransportTest {
                     } else if (requestCount.get() == 2) {
                         requestCount.incrementAndGet();
                         return Single.just(new HttpResponse(200, "", "SECOND"));
+                    } else if (requestCount.get() == 3) {
+                        requestCount.incrementAndGet();
+                        return Single.just(new HttpResponse(200, "", "THIRD"));
                     }
 
                     return Single.just(new HttpResponse(204, "", ""));
@@ -186,7 +189,7 @@ public class LongPollingTransportTest {
         transport.setOnReceive((msg) -> {
             onReceiveCalled.set(true);
             message.set(message.get() + msg);
-            if (messageCount.incrementAndGet() == 2) {
+            if (messageCount.incrementAndGet() == 3) {
                 blocker.onComplete();
             }
         });
@@ -196,8 +199,9 @@ public class LongPollingTransportTest {
         transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertTrue(blocker.blockingAwait(1, TimeUnit.SECONDS));
         assertTrue(onReceiveCalled.get());
-        assertEquals("FIRSTSECOND", message.get());
+        assertEquals("FIRSTSECONDTHIRD", message.get());
     }
+
 
     @Test
     public void LongPollingTransportSendsHeaders() {

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -202,7 +202,6 @@ public class LongPollingTransportTest {
         assertEquals("FIRSTSECONDTHIRD", message.get());
     }
 
-
     @Test
     public void LongPollingTransportSendsHeaders() {
         AtomicInteger requestCount = new AtomicInteger();


### PR DESCRIPTION
Fixes #7602 
This makes sure that messages on the client are processed in order. 