### PR TITLE
(nit) Transport.Sockets pass ReadOnlySequence<byte> via in

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     public sealed partial class SocketSender : Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal.SocketSenderReceiverBase
     {
         public SocketSender(System.Net.Sockets.Socket socket, System.IO.Pipelines.PipeScheduler scheduler) : base (default(System.Net.Sockets.Socket), default(System.IO.Pipelines.PipeScheduler)) { }
-        public Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal.SocketAwaitableEventArgs SendAsync(System.Buffers.ReadOnlySequence<byte> buffers) { throw null; }
+        public Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal.SocketAwaitableEventArgs SendAsync(in System.Buffers.ReadOnlySequence<byte> buffers) { throw null; }
     }
     public abstract partial class SocketSenderReceiverBase : System.IDisposable
     {

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 var isCompleted = result.IsCompleted;
                 if (!buffer.IsEmpty)
                 {
-                    await _sender.SendAsync(buffer);
+                    await _sender.SendAsync(in buffer);
                 }
 
                 output.AdvanceTo(end);

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 var isCompleted = result.IsCompleted;
                 if (!buffer.IsEmpty)
                 {
-                    await _sender.SendAsync(in buffer);
+                    await _sender.SendAsync(buffer);
                 }
 
                 output.AdvanceTo(end);

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 _awaitableEventArgs.SetBuffer(null, 0, 0);
             }
 
-            _awaitableEventArgs.BufferList = GetBufferList(in buffers);
+            _awaitableEventArgs.BufferList = GetBufferList(buffers);
 
             if (!_socket.SendAsync(_awaitableEventArgs))
             {

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
         }
 
-        public SocketAwaitableEventArgs SendAsync(ReadOnlySequence<byte> buffers)
+        public SocketAwaitableEventArgs SendAsync(in ReadOnlySequence<byte> buffers)
         {
             if (buffers.IsSingleSegment)
             {
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 _awaitableEventArgs.SetBuffer(null, 0, 0);
             }
 
-            _awaitableEventArgs.BufferList = GetBufferList(buffers);
+            _awaitableEventArgs.BufferList = GetBufferList(in buffers);
 
             if (!_socket.SendAsync(_awaitableEventArgs))
             {
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             return _awaitableEventArgs;
         }
 
-        private List<ArraySegment<byte>> GetBufferList(ReadOnlySequence<byte> buffer)
+        private List<ArraySegment<byte>> GetBufferList(in ReadOnlySequence<byte> buffer)
         {
             Debug.Assert(!buffer.IsEmpty);
             Debug.Assert(!buffer.IsSingleSegment);


### PR DESCRIPTION
(nit) Its a 32-byte `readonly struct` so it avoids a chunky copy

e.g. adding the param to `SendAsync` changes `ProcessSends` from
```asm
; Lcl frame size = 440
       ; ...
       B964000000           mov      ecx, 100  ; 100 bytes zeroed
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
       ; ...

       4885C9               test     rcx, rcx                     ; <--- test
       0F84F1000000         je       G_M43695_IG37
       488B8B00010000       mov      rcx, gword ptr [rbx+256]

G_M43695_IG32:
       C5FA6F4590           vmovdqu  xmm0, qword ptr [rbp-70H]    ; Copy for param
       C5FA7F8558FEFFFF     vmovdqu  qword ptr [rbp-1A8H], xmm0   ;
       C5FA6F45A0           vmovdqu  xmm0, qword ptr [rbp-60H]    ;
       C5FA7F8568FEFFFF     vmovdqu  qword ptr [rbp-198H], xmm0   ;

G_M43695_IG33:
       488D9558FEFFFF       lea      rdx, bword ptr [rbp-1A8H]
       3909                 cmp      dword ptr [rcx], ecx         ; <--- null ref check
       E8125BFEFF           call     SocketSender:SendAsync(struct):ref:this
```
To
```asm
; Lcl frame size = 408
       ; ...
       B95C000000           mov      ecx, 92  ; 92 bytes zeroed
       33C0                 xor      rax, rax
       F3AB                 rep stosd
       ; ... 
       
       4885C9               test     rcx, rcx                     ; <--- test
       0F84D0000000         je       G_M43709_IG35
       488B8B00010000       mov      rcx, gword ptr [rbx+256]
       488D5590             lea      rdx, bword ptr [rbp-70H]
       3909                 cmp      dword ptr [rcx], ecx         ; <--- null ref check
       E8B74CFEFF           call     SocketSender:SendAsync(byref):ref:this
```