### PR TITLE
(nit) Move enumerating extra headers to separate method

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -35,10 +35,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (extraHeaders != null && extraHeaders.Count > 0)
             {
                 // Only reserve stack space for the enumartors if there are extra headers
-                CopyExtraHeaders(extraHeaders, ref buffer);
+                CopyExtraHeaders(ref buffer, extraHeaders);
             }
 
-            void CopyExtraHeaders(Dictionary<string, StringValues> headers, ref BufferWriter<PipeWriter> buf)
+            static void CopyExtraHeaders(ref BufferWriter<PipeWriter> buffer, Dictionary<string, StringValues> headers)
             {
                 foreach (var kv in headers)
                 {
@@ -46,10 +46,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         if (value != null)
                         {
-                            buf.Write(_CrLf);
-                            buf.WriteAsciiNoValidation(kv.Key);
-                            buf.Write(_colonSpace);
-                            buf.WriteAsciiNoValidation(value);
+                            buffer.Write(_CrLf);
+                            buffer.WriteAsciiNoValidation(kv.Key);
+                            buffer.Write(_colonSpace);
+                            buffer.WriteAsciiNoValidation(value);
                         }
                     }
                 }


### PR DESCRIPTION
(nit) Only pay the stack zeroing costs (40 bytes) for the 2 x enumerators if used and trims 658 bytes from the method taking it to 71 bytes keeping the data cache hotter.

Before
```asm
; Assembly listing for method HttpResponseHeaders:CopyTo(byref):this
; Lcl frame size = 200

G_M60361_IG01:
       push     rdi
       push     rsi
       push     rbp               ; 2 extra reg pushes to stack
       push     rbx               ;
       sub      rsp, 200
       vzeroupper 
       mov      rsi, rcx
       lea      rdi, [rsp+28H]
       mov      ecx, 40           ; zero 40 bytes of stack
       xor      rax, rax          ;
       rep stosd                  ;
       mov      rcx, rsi
       mov      rdi, rcx
       mov      rsi, rdx

G_M60361_IG02:
       mov      rcx, rdi
       mov      rdx, rsi
       call     HttpResponseHeaders:CopyToFast(byref):this
       cmp      gword ptr [rdi+8], 0
       je       G_M60361_IG23
       ;...
       
; Total bytes of code 729, prolog size 34 for method HttpResponseHeaders:CopyTo(byref):this
```

After
```asm
; Assembly listing for method HttpResponseHeaders:CopyTo(byref):this
; Lcl frame size = 40

G_M60302_IG01:
       push     rdi
       push     rsi
       sub      rsp, 40
       mov      rsi, rcx
       mov      rdi, rdx

G_M60302_IG02:
       mov      rcx, rsi
       mov      rdx, rdi
       call     HttpResponseHeaders:CopyToFast(byref):this
       mov      rcx, gword ptr [rsi+8]
       test     rcx, rcx
       je       SHORT G_M60302_IG04
       ;...
       
; Total bytes of code 71, prolog size 6 for method HttpResponseHeaders:CopyTo(byref):this
```