### PR TITLE
Use ReadOnlySpan<byte> optimization for static data in Kestrel HTTP2 Connection

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -666,7 +666,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await writableBuffer.FlushAsync().AsTask().DefaultTimeout();
         }
 
-        protected Task SendPreambleAsync() => SendAsync(new ArraySegment<byte>(Http2Connection.ClientPreface));
+        protected Task SendPreambleAsync() => SendAsync(Http2Connection.ClientPreface);
 
         protected async Task SendSettingsAsync()
         {


### PR DESCRIPTION
Related to #7422

