### PR TITLE
Add missing conversions on EventCallbackFactory

### DIFF
--- a/src/Components/Components/src/EventCallbackFactory.cs
+++ b/src/Components/Components/src/EventCallbackFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Components
@@ -12,6 +13,23 @@ namespace Microsoft.AspNetCore.Components
     /// </summary>
     public sealed class EventCallbackFactory
     {
+        /// <summary>
+        /// Returns the provided <paramref name="callback"/>. For internal framework use only.
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="callback"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EventCallback Create(object receiver, EventCallback callback)
+        {
+            if (receiver == null)
+            {
+                throw new ArgumentNullException(nameof(receiver));
+            }
+
+            return callback;
+        }
+
         /// <summary>
         /// Creates an <see cref="EventCallback"/> for the provided <paramref name="receiver"/> and
         /// <paramref name="callback"/>.
@@ -101,6 +119,40 @@ namespace Microsoft.AspNetCore.Components
         }
 
         /// <summary>
+        /// Returns the provided <paramref name="callback"/>. For internal framework use only.
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="callback"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Create<T>(object receiver, string callback)
+        {
+            if (receiver == null)
+            {
+                throw new ArgumentNullException(nameof(receiver));
+            }
+
+            return callback;
+        }
+
+        /// <summary>
+        /// Returns the provided <paramref name="callback"/>. For internal framework use only.
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="callback"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EventCallback<T> Create<T>(object receiver, EventCallback<T> callback)
+        {
+            if (receiver == null)
+            {
+                throw new ArgumentNullException(nameof(receiver));
+            }
+
+            return callback;
+        }
+
+        /// <summary>
         /// Creates an <see cref="EventCallback"/> for the provided <paramref name="receiver"/> and
         /// <paramref name="callback"/>.
         /// </summary>
@@ -186,6 +238,34 @@ namespace Microsoft.AspNetCore.Components
             }
 
             return CreateCore<T>(receiver, callback);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="EventCallback"/> for the provided <paramref name="receiver"/> and
+        /// <paramref name="callback"/>. For internal framework use only.
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="callback"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EventCallback<T> CreateInferred<T>(object receiver, Action<T> callback, T value)
+        {
+            return Create(receiver, callback);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="EventCallback"/> for the provided <paramref name="receiver"/> and
+        /// <paramref name="callback"/>. For internal framework use only.
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="callback"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EventCallback<T> CreateInferred<T>(object receiver, Func<T, Task> callback, T value)
+        {
+            return Create(receiver, callback);
         }
 
         private EventCallback CreateCore(object receiver, MulticastDelegate callback)

--- a/src/Components/Components/test/EventCallbackFactoryTest.cs
+++ b/src/Components/Components/test/EventCallbackFactoryTest.cs
@@ -10,6 +10,25 @@ namespace Microsoft.AspNetCore.Components
     public class EventCallbackFactoryTest
     {
         [Fact]
+        public void Create_EventCallback_ReturnsInput()
+        {
+            // Arrange
+            var component = new EventComponent();
+            var @delegate = (Action)component.SomeAction;
+            var input = new EventCallback(component, @delegate);
+
+            var anotherComponent = new EventComponent();
+
+            // Act
+            var callback = EventCallback.Factory.Create(anotherComponent, input);
+
+            // Assert
+            Assert.Same(@delegate, callback.Delegate);
+            Assert.Same(component, callback.Receiver);
+            Assert.False(callback.RequiresExplicitReceiver);
+        }
+
+        [Fact]
         public void Create_Action_AlreadyBoundToReceiver()
         {
             // Arrange
@@ -218,6 +237,39 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
+        public void CreateT_String_ReturnsInput()
+        {
+            // Arrange
+            var component = new EventComponent();
+            var input = "some_js";
+
+            // Act
+            var callback = EventCallback.Factory.Create<UIMouseEventArgs>(component, input);
+
+            // Assert
+            Assert.Same(input, callback);
+        }
+
+        [Fact]
+        public void CreateT_EventCallback_ReturnsInput()
+        {
+            // Arrange
+            var component = new EventComponent();
+            var @delegate = (Action)component.SomeAction;
+            var input = new EventCallback<string>(component, @delegate);
+
+            var anotherComponent = new EventComponent();
+
+            // Act
+            var callback = EventCallback.Factory.Create<string>(anotherComponent, input);
+
+            // Assert
+            Assert.Same(@delegate, callback.Delegate);
+            Assert.Same(component, callback.Receiver);
+            Assert.False(callback.RequiresExplicitReceiver);
+        }
+
+        [Fact]
         public void CreateT_Action_AlreadyBoundToReceiver()
         {
             // Arrange
@@ -422,6 +474,38 @@ namespace Microsoft.AspNetCore.Components
             // Assert
             Assert.Same(@delegate, callback.Delegate);
             Assert.Same(anotherComponent, callback.Receiver);
+            Assert.True(callback.RequiresExplicitReceiver);
+        }
+
+        [Fact]
+        public void CreateInferred_ActionT()
+        {
+            // Arrange
+            var component = new EventComponent();
+            var @delegate = (Action<string>)((s) => { });
+
+            // Act
+            var callback = EventCallback.Factory.CreateInferred<string>(component, @delegate, "hi");
+
+            // Assert
+            Assert.Same(@delegate, callback.Delegate);
+            Assert.Same(component, callback.Receiver);
+            Assert.True(callback.RequiresExplicitReceiver);
+        }
+
+        [Fact]
+        public void CreateInferred_FuncTTask()
+        {
+            // Arrange
+            var component = new EventComponent();
+            var @delegate = (Func<string, Task>)((s) => Task.CompletedTask);
+
+            // Act
+            var callback = EventCallback.Factory.CreateInferred<string>(component, @delegate, "hi");
+
+            // Assert
+            Assert.Same(@delegate, callback.Delegate);
+            Assert.Same(component, callback.Receiver);
             Assert.True(callback.RequiresExplicitReceiver);
         }
 


### PR DESCRIPTION
These are APIs that are called exclusively from generated code. I discovered that these were missing when I implemented the compiler support.