### PR TITLE
AzureAD options should always register their configurations

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAuthenticationBuilderExtensions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAuthenticationBuilderExtensions.cs
@@ -58,9 +58,9 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.Configure(TryAddJwtBearerSchemeMapping(scheme, jwtBearerScheme));
 
-            builder.Services.TryAddSingleton<IConfigureOptions<AzureADOptions>, AzureADOptionsConfiguration>();
+            builder.Services.ConfigureOptions<AzureADOptionsConfiguration>();
 
-            builder.Services.AddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerOptionsConfiguration>();
+            builder.Services.ConfigureOptions<JwtBearerOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
             builder.AddJwtBearer(jwtBearerScheme, o => { });
@@ -113,11 +113,9 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.Configure(TryAddOpenIDCookieSchemeMappings(scheme, openIdConnectScheme, cookieScheme));
 
-            builder.Services.TryAddSingleton<IConfigureOptions<AzureADOptions>, AzureADOptionsConfiguration>();
-
-            builder.Services.TryAddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectOptionsConfiguration>();
-
-            builder.Services.TryAddSingleton<IConfigureOptions<CookieAuthenticationOptions>, CookieOptionsConfiguration>();
+            builder.Services.ConfigureOptions<AzureADOptionsConfiguration>();
+            builder.Services.ConfigureOptions<OpenIdConnectOptionsConfiguration>();
+            builder.Services.ConfigureOptions<CookieOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
 

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAuthenticationBuilderExtensions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAuthenticationBuilderExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.TryAddSingleton<IConfigureOptions<AzureADOptions>, AzureADOptionsConfiguration>();
 
-            builder.Services.TryAddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerOptionsConfiguration>();
+            builder.Services.AddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
             builder.AddJwtBearer(jwtBearerScheme, o => { });

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CAuthenticationBuilderExtensions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CAuthenticationBuilderExtensions.cs
@@ -59,9 +59,9 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.Configure(TryAddJwtBearerSchemeMapping(scheme, jwtBearerScheme));
 
-            builder.Services.TryAddSingleton<IConfigureOptions<AzureADB2COptions>, AzureADB2COptionsConfiguration>();
+            builder.Services.AddSingleton<IConfigureOptions<AzureADB2COptions>, AzureADB2COptionsConfiguration>();
 
-            builder.Services.TryAddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerOptionsConfiguration>();
+            builder.Services.AddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
             builder.AddJwtBearer(jwtBearerScheme, o => { });
@@ -114,11 +114,11 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.Configure(TryAddOpenIDCookieSchemeMappings(scheme, openIdConnectScheme, cookieScheme));
 
-            builder.Services.TryAddSingleton<IConfigureOptions<AzureADB2COptions>, AzureADB2COptionsConfiguration>();
+            builder.Services.AddSingleton<IConfigureOptions<AzureADB2COptions>, AzureADB2COptionsConfiguration>();
 
-            builder.Services.TryAddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectOptionsConfiguration>();
+            builder.Services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectOptionsConfiguration>();
 
-            builder.Services.TryAddSingleton<IConfigureOptions<CookieAuthenticationOptions>, CookieOptionsConfiguration>();
+            builder.Services.AddSingleton<IConfigureOptions<CookieAuthenticationOptions>, CookieOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
 

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CAuthenticationBuilderExtensions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CAuthenticationBuilderExtensions.cs
@@ -59,9 +59,8 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.Configure(TryAddJwtBearerSchemeMapping(scheme, jwtBearerScheme));
 
-            builder.Services.AddSingleton<IConfigureOptions<AzureADB2COptions>, AzureADB2COptionsConfiguration>();
-
-            builder.Services.AddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerOptionsConfiguration>();
+            builder.Services.ConfigureOptions<AzureADB2COptionsConfiguration>();
+            builder.Services.ConfigureOptions<JwtBearerOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
             builder.AddJwtBearer(jwtBearerScheme, o => { });
@@ -114,11 +113,9 @@ namespace Microsoft.AspNetCore.Authentication
 
             builder.Services.Configure(TryAddOpenIDCookieSchemeMappings(scheme, openIdConnectScheme, cookieScheme));
 
-            builder.Services.AddSingleton<IConfigureOptions<AzureADB2COptions>, AzureADB2COptionsConfiguration>();
-
-            builder.Services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectOptionsConfiguration>();
-
-            builder.Services.AddSingleton<IConfigureOptions<CookieAuthenticationOptions>, CookieOptionsConfiguration>();
+            builder.Services.ConfigureOptions<AzureADB2COptionsConfiguration>();
+            builder.Services.ConfigureOptions<OpenIdConnectOptionsConfiguration>();
+            builder.Services.ConfigureOptions<CookieOptionsConfiguration>();
 
             builder.Services.Configure(scheme, configureOptions);
 


### PR DESCRIPTION
Unlike other services that should be TryAdded, options configurations must always be registered, since they already have logic that targets only the specific instance.  This fixes the weird behavior you get where configuring (or adding any other bearer auth) will basically prevent the AzureAD options from being properly configured

Fixes https://github.com/aspnet/AspNetCore/issues/6033

@Tratcher @javiercn 