### PR TITLE
Show error message when activate is invoked directly instead of sourced

### DIFF
--- a/activate.ps1
+++ b/activate.ps1
@@ -1,8 +1,15 @@
 #
 # This file must be used by invoking ". .\activate.ps1" from the command line.
-# You cannot run it directly.
+# You cannot run it directly. See https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scripts#script-scope-and-dot-sourcing
+#
 # To exit from the environment this creates, execute the 'deactivate' function.
 #
+
+if ($MyInvocation.CommandOrigin -eq 'runspace') {
+    Write-Host -f Red "This script cannot be invoked directly."
+    Write-Host -f Red "To function correctly, this script file must be 'dot sourced' by calling `". $PSCommandPath`" (notice the dot at the beginning)."
+    exit 1
+}
 
 function deactivate ([switch]$init) {
 

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -101,8 +101,10 @@ Using Visual Studio Code with this repo requires setting environment variables o
 Use these command to launch VS Code with the right settings.
 
 On Windows (requires PowerShell):
-```
-. activate.ps1
+```ps1
+# The extra dot at the beginning is required to 'dot source' this file into the right scope.
+
+. .\activate.ps1
 code .
 ```
 
@@ -134,6 +136,8 @@ to make the .NET Core command line tool work well. You can set these environment
 On Windows (requires PowerShell):
 
 ```ps1
+# The extra dot at the beginning is required to 'dot source' this file into the right scope.
+
 . .\activate.ps1
 ```
 


### PR DESCRIPTION
Helps users avoid a common mistake which is otherwise not obvious.

Same change as https://github.com/aspnet/Extensions/pull/1137