### PR TITLE
 Disable ubuntu and debian ARM queues

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -37,16 +37,15 @@
       Windows.10.Amd64.ClientRS4.VS2017.Open;
       OSX.1012.Amd64.Open;
       Ubuntu.1810.Amd64.Open;
-      Ubuntu.1804.Arm64.Open;
       Ubuntu.1604.Amd64.Open;
       Centos.7.Amd64.Open;
       Debian.8.Amd64.Open;
       Debian.9.Amd64.Open;
-      Debian.9.Arm64.Open;
       Redhat.7.Amd64.Open;
       Fedora.27.Amd64.Open;
       Fedora.28.Amd64.Open;      
     </HelixTargetQueues>
+    <!--  TODO: re-enable Debian.9.Arm64.Open and Ubuntu.1804.Arm64.Open    -->
     <!--  TODO: re-enable Ubuntu.1604.Arm64.Open; curl not found -->
   </PropertyGroup>
 </Project> 


### PR DESCRIPTION
Helix tests is failing for everyone because these queues are not functioning. Tests timeout after several hours of waiting for agents.

For example: https://mc.dot.net/#/user/aspnetcore/pr~2Faspnet~2Faspnetcore/ci/20190219.42

cc @MattGal 