### PR TITLE
Always kill processes and remove direct reference to component governance task

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -79,10 +79,6 @@ jobs:
       displayName: Run sign check
       condition: eq(variables['_SignType'], 'real')
 
-    # Detect OSS Components in use in the product. Only needs to run on one OS in the matrix.
-    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-      displayName: Detect components
-      condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
     artifacts:
     - name: Windows_Packages
       path: artifacts/packages/

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -140,20 +140,25 @@ jobs:
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - script: .\$(BuildDirectory)\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
           displayName: Run build.cmd
-        - powershell: eng\scripts\KillProcesses.ps1
-          displayName: Kill processes
-          condition: always()
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
         - script: ./$(BuildDirectory)/build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
           displayName: Run build.sh
-        - script: eng/scripts/KillProcesses.sh
-          displayName: Kill processes
-          condition: always()
     - ${{ if ne(parameters.buildScript, '') }}:
       - script: $(BuildScript) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
         displayName: run $(BuildScript)
 
   - ${{ parameters.afterBuild }}
+
+  - ${{ if eq(parameters.agentOs, 'Windows') }}:
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      continueOnError: true
+      condition: always()
+  - ${{ if ne(parameters.agentOs, 'Windows') }}:
+    - script: eng/scripts/KillProcesses.sh
+      displayName: Kill processes
+      continueOnError: true
+      condition: always()
 
   - task: PublishTestResults@2
     displayName: Publish test results

--- a/eng/scripts/KillProcesses.ps1
+++ b/eng/scripts/KillProcesses.ps1
@@ -1,16 +1,24 @@
 $ErrorActionPreference = 'Continue'
 
-taskkill /T /F /IM dotnet.exe
-taskkill /T /F /IM testhost.exe
-taskkill /T /F /IM iisexpress.exe
-taskkill /T /F /IM iisexpresstray.exe
-taskkill /T /F /IM w3wp.exe
-taskkill /T /F /IM msbuild.exe
-taskkill /T /F /IM vbcscompiler.exe
-taskkill /T /F /IM git.exe
-taskkill /T /F /IM vctip.exe
-taskkill /T /F /IM chrome.exe
-taskkill /T /F /IM h2spec.exe
+function _kill($processName) {
+    try {
+        & cmd /c "taskkill /T /F /IM $processName 2>&1"
+    } catch {
+        Write-Host "Failed to kill $processName: $_"
+    }
+}
+
+_kill dotnet.exe
+_kill testhost.exe
+_kill iisexpress.exe
+_kill iisexpresstray.exe
+_kill w3wp.exe
+_kill msbuild.exe
+_kill vbcscompiler.exe
+_kill git.exe
+_kill vctip.exe
+_kill chrome.exe
+_kill h2spec.exe
 iisreset /restart
 
 exit 0

--- a/eng/scripts/KillProcesses.ps1
+++ b/eng/scripts/KillProcesses.ps1
@@ -2,9 +2,11 @@ $ErrorActionPreference = 'Continue'
 
 function _kill($processName) {
     try {
-        & cmd /c "taskkill /T /F /IM $processName 2>&1"
+        # Redirect stderr to stdout to avoid big red blocks of output in Azure Pipeline logging
+        # when there are no instances of the process
+        & cmd /c "taskkill /T /F /IM ${processName} 2>&1"
     } catch {
-        Write-Host "Failed to kill $processName: $_"
+        Write-Host "Failed to kill ${processName}: $_"
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/aspnet/AspNetCore/issues/7777

Component governance is automatically configured for all builds now.

cc @Eilon  - targeting release/3.0-preview3 because this is affecting builds on all branches