### PR TITLE
Targeting pack and shared framework fixups

### DIFF
--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -18,11 +18,10 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <PackageTags>aspnetcore;targeting-pack</PackageTags>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 
-    <!-- Subject to change: see https://github.com/dotnet/designs/pull/50 -->
-    <PackageType>TargetingPack</PackageType>
+    <PackageType>DotnetPlatform</PackageType>
     <RefAssemblyPackagePath>ref/$(TargetFramework)/</RefAssemblyPackagePath>
 
-    <LayoutTargetDir>$(TargetingPackLayoutRoot)packs/Microsoft.AspNetCore.App.Ref/$(PackageVersion)/$(RefAssemblyPackagePath)</LayoutTargetDir>
+    <LayoutTargetDir>$(TargetingPackLayoutRoot)packs/Microsoft.AspNetCore.App.Ref/$(PackageVersion)/</LayoutTargetDir>
     <ArchiveOutputFileName>aspnetcore-targeting-pack-$(PackageVersion).zip</ArchiveOutputFileName>
     <ArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName)</ArchiveOutputPath>
 
@@ -56,7 +55,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       $(BuildDependsOn);
       GeneratePackageConflictManifest;
       _ResolveTargetingPackContent;
-      _BatchCopyToOutputDirectory;
       _BatchCopyToLayoutTargetDir;
       _CreateTargetingPackArchive;
     </BuildDependsOn>
@@ -87,15 +85,11 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
       <AspNetCoreReferenceDocXml Include="@(AspNetCoreReferenceAssemblyPath->'%(RootDir)%(Directory)%(FileName).xml')" />
 
-      <!-- Exclude known missing XML docs files. Time-boxing this workaround because we want XML docs for everything. This can be removed when we get a new build with https://github.com/dotnet/core-setup/pull/5109. -->
-      <AspNetCoreReferenceDocXml Remove="@(AspNetCoreReferenceDocXml)"
-        Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '3.0.0-preview-27405-2' AND ('%(FileName)' == 'Microsoft.Extensions.DependencyModel' OR '%(FileName)' == 'Microsoft.DotNet.PlatformAbstractions' )" />
+      <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
+      <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
+      <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(PackageConflictManifestPackagePath)" />
 
-      <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" />
-      <RefPackContent Include="@(AspNetCoreReferenceDocXml)" />
-
-      <_PackageFiles Include="@(RefPackContent)" PackagePath="$(RefAssemblyPackagePath)" />
-      <_PackageFiles Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(PackageConflictManifestPackagePath)" />
+      <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
   </Target>
 
@@ -115,24 +109,13 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <!-- Written to take advantage of target batching in MSBuild. -->
-  <Target Name="_BatchCopyToOutputDirectory"
-          DependsOnTargets="_ResolveTargetingPackContent"
-          Inputs="@(RefPackContent)"
-          Outputs="@(RefPackContent->'$(TargetDir)%(FileName)%(Extension)')">
-
-    <Copy SourceFiles="@(RefPackContent)"
-          DestinationFiles="@(RefPackContent->'$(TargetDir)%(FileName)%(Extension)')"
-          UseHardlinksIfPossible="true" />
-  </Target>
-
-  <!-- Written to take advantage of target batching in MSBuild. -->
   <Target Name="_BatchCopyToLayoutTargetDir"
           DependsOnTargets="_ResolveTargetingPackContent"
           Inputs="@(RefPackContent)"
-          Outputs="@(RefPackContent->'$(LayoutTargetDir)%(FileName)%(Extension)')">
+          Outputs="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(FileName)%(Extension)')">
 
     <Copy SourceFiles="@(RefPackContent)"
-          DestinationFiles="@(RefPackContent->'$(LayoutTargetDir)%(FileName)%(Extension)')"
+          DestinationFiles="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
   </Target>
 

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -15,6 +15,8 @@
     <SharedFxName>Microsoft.AspNetCore.App</SharedFxName>
     <PackageId>$(MSBuildProjectName).$(RuntimeIdentifier)</PackageId>
     <IsShippingPackage>true</IsShippingPackage>
+    <!-- Undo for Preview4. Preview 3 is shipping using the runtime.$(rid) packages instead. -->
+    <IsPackable Condition="'$(PreReleaseLabel)'=='preview3'">false</IsPackable>
 
     <PackageDescription>Provides a default set of APIs for building an ASP.NET Core application. Contains assets used for self-contained deployments.
 
@@ -23,8 +25,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <PackageTags>aspnetcore;shared-framework</PackageTags>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 
-    <!-- Subject to change: see https://github.com/dotnet/designs/pull/50 -->
-    <PackageType>RuntimePack</PackageType>
+    <PackageType>DotnetPlatform</PackageType>
     <!-- NuGet appends target framework to this value. Example: runtimes/win-x64/lib/netcoreapp3.0/ -->
     <BuildOutputTargetFolder>runtimes/$(RuntimeIdentifier)/lib/</BuildOutputTargetFolder>
     <!-- Target framework is not append to this because native assets to not have a target framework. -->

--- a/src/Framework/src/SharedFx.targets
+++ b/src/Framework/src/SharedFx.targets
@@ -15,10 +15,10 @@ This targets file should only be imported by .shfxproj files.
       GenerateSharedFxVersionsFile;
       GenerateBuildDependencyFile;
       PrepareForPublish;
-      GeneratePublishDependencyFile;
-      GenerateSharedFxMetadataFiles;
       GenerateBuildRuntimeConfigurationFiles;
       ComputeAndCopyFilesToPublishDirectory;
+      GeneratePublishDependencyFile;
+      GenerateSharedFxMetadataFiles;
       CopySharedFxToOutput;
       CollectSharedFxOutput;
       PostBuildEvent;

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -49,6 +49,10 @@
         <_Parameter1>ManifestOutputDir</_Parameter1>
         <_Parameter2>%(_ResolvedFrameworkReference.ManifestOutputDir)</_Parameter2>
       </AssemblyAttribute>
+      <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
+        <_Parameter1>RuntimeAssetsOutputPath</_Parameter1>
+        <_Parameter2>%(_ResolvedFrameworkReference.RuntimeAssetsOutputPath)</_Parameter2>
+      </AssemblyAttribute>
     </ItemGroup>
   </Target>
 

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -25,6 +25,33 @@ namespace Microsoft.AspNetCore
         }
 
         [Fact]
+        public void SharedFrameworkContainsExpectedFiles()
+        {
+            var actualAssemblies = Directory.GetFiles(TestData.GetTestDataValue("RuntimeAssetsOutputPath"), "*.dll")
+                .Select(Path.GetFileNameWithoutExtension)
+                .ToHashSet();
+            var expectedAssemblies = TestData.GetSharedFxDependencies()
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+                .ToHashSet();
+
+            _output.WriteLine("==== actual assemblies ====");
+            _output.WriteLine(string.Join('\n', actualAssemblies));
+            _output.WriteLine("==== expected assemblies ====");
+            _output.WriteLine(string.Join('\n', expectedAssemblies));
+
+            var missing = expectedAssemblies.Except(actualAssemblies);
+            var unexpected = actualAssemblies.Except(expectedAssemblies);
+
+            _output.WriteLine("==== missing assemblies from the framework ====");
+            _output.WriteLine(string.Join('\n', missing));
+            _output.WriteLine("==== unexpected assemblies in the framework ====");
+            _output.WriteLine(string.Join('\n', unexpected));
+
+            Assert.Empty(missing);
+            Assert.Empty(unexpected);
+        }
+
+        [Fact]
         public void PlatformManifestListsAllFiles()
         {
             var platformManifestPath = Path.Combine(TestData.GetManifestOutputDir(), "Microsoft.AspNetCore.App.PlatformManifest.txt");


### PR DESCRIPTION
* Fix package type to match spec ('DotnetPlatform')
* Fix missing metadata in MSI installer
* Fix incorrect target order which caused duplicate assemblies in netcore.app and aspnetcore.app (resolves https://github.com/aspnet/AspNetCore-Internal/issues/1784)
