### PR TITLE
Fixes JsonInputFormatter synchronous read workaround

### DIFF
--- a/src/Mvc/Mvc.Formatters.Json/src/JsonInputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Json/src/JsonInputFormatter.cs
@@ -244,7 +244,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 // read everything into a buffer, and then seek back to the beginning.
                 request.EnableBuffering();
                 Debug.Assert(request.Body.CanSeek);
+            }
 
+            if (!suppressInputFormatterBuffering)
+            { 
                 await request.Body.DrainAsync(CancellationToken.None);
                 request.Body.Seek(0L, SeekOrigin.Begin);
             }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/7606 

PS 2.1/2.2 only. master/3.0 will have this part reworked.