### PR TITLE
Avoid port conflicts for HttpSys

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestPortHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestPortHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -55,6 +55,35 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
                     }
                 }
             }
+        }
+
+        private const int BasePort = 5001;
+        private const int MaxPort = 8000;
+        private static int NextPort = BasePort;
+
+        // GetNextPort doesn't check for HttpSys urlacls.
+        public static int GetNextHttpSysPort(string scheme)
+        {
+            while (NextPort < MaxPort)
+            {
+                var port = NextPort++;
+
+                using (var server = new HttpListener())
+                {
+                    server.Prefixes.Add($"{scheme}://localhost:{port}/");
+                    try
+                    {
+                        server.Start();
+                        server.Stop();
+                        return port;
+                    }
+                    catch (HttpListenerException)
+                    {
+                    }
+                }
+            }
+            NextPort = BasePort;
+            throw new Exception("Failed to locate a free port.");
         }
     }
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
@@ -32,6 +32,10 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
                     // it should provide a hint URL with "localhost" (IPv4 and IPv6) or "[::1]" (IPv6-only).
                     return new UriBuilder(scheme, "127.0.0.1", 0).Uri;
                 }
+                else if (serverType == ServerType.HttpSys)
+                {
+                    return new UriBuilder(scheme, "localhost", TestPortHelper.GetNextHttpSysPort(scheme)).Uri;
+                }
                 else
                 {
                     // If the server type is not Kestrel, or status messages are disabled, there is no status message


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1795

GetNextPort doesn't cover the case where netsh has a reservation for a specific port but it's not open right now. Kestrel can re-use those ports bug HttpSys can't since it's not the reservation owner.

The easiest way to check for a conflict is to try it. This is about how it's done in HttpSys's own functional tests. https://github.com/aspnet/AspNetCore/blob/4451a804477f7f3d4d0ed89d56c51332d8c3ee25/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs#L125