### PR TITLE
Detect Classic SignalR Server

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
@@ -28,6 +28,10 @@ class NegotiateResponse {
                     case "error":
                         this.error = reader.nextString();
                         break;
+                    case "ProtocolVersion":
+                        this.error = "Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.";
+                        reader.skipValue();
+                        break;
                     case "url":
                         this.redirectUrl = reader.nextString();
                         break;
@@ -69,7 +73,6 @@ class NegotiateResponse {
                         break;
                 }
             } while (reader.hasNext());
-
             reader.endObject();
             reader.close();
         } catch (IOException ex) {

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
@@ -29,9 +29,8 @@ class NegotiateResponse {
                         this.error = reader.nextString();
                         break;
                     case "ProtocolVersion":
-                        this.error = "Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.";
-                        reader.skipValue();
-                        break;
+                        this.error = "Detected an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.";
+                        return;
                     case "url":
                         this.redirectUrl = reader.nextString();
                         break;

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1278,7 +1278,7 @@ class HubConnectionTest {
 
         RuntimeException exception = assertThrows(RuntimeException.class,
                 () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
-        assertEquals("Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.",
+        assertEquals("Detected an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.",
                 exception.getMessage());
     }
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/7781
Detect a user trying to connect to a classic SignalR Server with a Core client and guide them in the right direction.
Related: https://github.com/aspnet/AspNetCore/issues/7705
