### PR TITLE
Ensure build manifest has a consistent URI, despite what AzDO says

### DIFF
--- a/build/Maestro/Maestro.csproj
+++ b/build/Maestro/Maestro.csproj
@@ -30,7 +30,7 @@
       OutputPath="$(ManifestsPath)aspnetcore-$(TargetRuntimeIdentifier)-$(PackageVersion).xml"
       BuildId="$(PackageVersion)"
       BuildData="Location=https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json"
-      RepoUri="$(BUILD_REPOSITORY_URI)"
+      RepoUri="$(RepositoryUrl)"
       RepoBranch="$(BUILD_SOURCEBRANCH)"
       RepoCommit="$(BUILD_SOURCEVERSION)" />
   </Target>


### PR DESCRIPTION
Resolves https://github.com/aspnet/AspNetCore-Internal/issues/1855

FYI @dougbu @Eilon  - this is required to unblock publishing to Maestro

BUILD_REPOSITORY_URI is not always consistent with a build. It varies by job

Job | BUILD_REPOSITORY_URI
----|---- 
Linux x64 | https://dnceng@dev.azure.com/dnceng/internal/_git/aspnet-AspNetCore
Windows ARM  | https://dnceng.visualstudio.com/internal/_git/aspnet-AspNetCore

cc @mmitche 