### PR TITLE
Remove web::uri usage from public API

### DIFF
--- a/src/SignalR/clients/cpp/src/signalrclient/connection_impl.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/connection_impl.cpp
@@ -80,13 +80,13 @@ namespace signalr
 
             m_disconnect_cts = pplx::cancellation_token_source();
             m_start_completed_event.reset();
-            m_message_id = m_groups_token = m_connection_id = _XPLATSTR("");
+            m_connection_id = _XPLATSTR("");
         }
 
         return start_negotiate(m_base_url, 0);
     }
 
-    pplx::task<void> connection_impl::start_negotiate(const web::uri& url, int redirect_count)
+    pplx::task<void> connection_impl::start_negotiate(const utility::string_t& url, int redirect_count)
     {
         if (redirect_count >= MAX_NEGOTIATE_REDIRECTS)
         {
@@ -214,7 +214,7 @@ namespace signalr
         return pplx::create_task(start_tce);
     }
 
-    pplx::task<std::shared_ptr<transport>> connection_impl::start_transport(const web::uri& url)
+    pplx::task<std::shared_ptr<transport>> connection_impl::start_transport(const utility::string_t& url)
     {
         auto connection = shared_from_this();
 
@@ -294,7 +294,7 @@ namespace signalr
             .then([transport](){ return pplx::task_from_result(transport); });
     }
 
-    pplx::task<void> connection_impl::send_connect_request(const std::shared_ptr<transport>& transport, const web::uri& url, const pplx::task_completion_event<void>& connect_request_tce)
+    pplx::task<void> connection_impl::send_connect_request(const std::shared_ptr<transport>& transport, const utility::string_t& url, const pplx::task_completion_event<void>& connect_request_tce)
     {
         auto logger = m_logger;
         auto query_string = _XPLATSTR("id=" + m_connection_id);
@@ -479,7 +479,7 @@ namespace signalr
         return m_connection_state.load();
     }
 
-    utility::string_t connection_impl::get_connection_id() const
+    utility::string_t connection_impl::get_connection_id() const noexcept
     {
         if (m_connection_state.load() == connection_state::connecting)
         {
@@ -507,7 +507,7 @@ namespace signalr
         m_disconnected = disconnected;
     }
 
-    void connection_impl::ensure_disconnected(const utility::string_t& error_message)
+    void connection_impl::ensure_disconnected(const utility::string_t& error_message) const
     {
         const auto state = get_connection_state();
         if (state != connection_state::disconnected)

--- a/src/SignalR/clients/cpp/src/signalrclient/connection_impl.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/connection_impl.h
@@ -41,14 +41,14 @@ namespace signalr
         pplx::task<void> stop();
 
         connection_state get_connection_state() const noexcept;
-        utility::string_t get_connection_id() const;
+        utility::string_t get_connection_id() const noexcept;
 
         void set_message_received(const std::function<void(const utility::string_t&)>& message_received);
         void set_disconnected(const std::function<void()>& disconnected);
         void set_client_config(const signalr_client_config& config);
 
     private:
-        web::uri m_base_url;
+        utility::string_t m_base_url;
         std::atomic<connection_state> m_connection_state;
         logger m_logger;
         std::shared_ptr<transport> m_transport;
@@ -63,17 +63,14 @@ namespace signalr
         std::mutex m_stop_lock;
         event m_start_completed_event;
         utility::string_t m_connection_id;
-        utility::string_t m_connection_data;
-        utility::string_t m_message_id;
-        utility::string_t m_groups_token;
 
         connection_impl(const utility::string_t& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
             std::unique_ptr<web_request_factory> web_request_factory, std::unique_ptr<transport_factory> transport_factory);
 
-        pplx::task<std::shared_ptr<transport>> start_transport(const web::uri& url);
+        pplx::task<std::shared_ptr<transport>> start_transport(const utility::string_t& url);
         pplx::task<void> send_connect_request(const std::shared_ptr<transport>& transport,
-            const web::uri& url, const pplx::task_completion_event<void>& connect_request_tce);
-        pplx::task<void> start_negotiate(const web::uri& url, int redirect_count);
+            const utility::string_t& url, const pplx::task_completion_event<void>& connect_request_tce);
+        pplx::task<void> start_negotiate(const utility::string_t& url, int redirect_count);
 
         void process_response(const utility::string_t& response);
 
@@ -85,6 +82,6 @@ namespace signalr
         void invoke_message_received(const utility::string_t& message);
 
         static utility::string_t translate_connection_state(connection_state state);
-        void ensure_disconnected(const utility::string_t& error_message);
+        void ensure_disconnected(const utility::string_t& error_message) const;
     };
 }

--- a/src/SignalR/clients/cpp/src/signalrclient/constants.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/constants.h
@@ -3,9 +3,6 @@
 
 #pragma once
 
-#include "cpprest/details/basic_types.h"
-
 #define SIGNALR_VERSION _XPLATSTR("0.1.0-alpha0")
-#define PROTOCOL _XPLATSTR("1.4")
 #define USER_AGENT _XPLATSTR("SignalR.Client.Cpp/") SIGNALR_VERSION
 #define MAX_NEGOTIATE_REDIRECTS 100

--- a/src/SignalR/clients/cpp/src/signalrclient/http_sender.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/http_sender.cpp
@@ -10,7 +10,7 @@ namespace signalr
 {
     namespace http_sender
     {
-        pplx::task<utility::string_t> get(web_request_factory& request_factory, const web::uri& url,
+        pplx::task<utility::string_t> get(web_request_factory& request_factory, const utility::string_t& url,
             const signalr_client_config& signalr_client_config)
         {
             auto request = request_factory.create_web_request(url);
@@ -32,7 +32,7 @@ namespace signalr
             });
         }
 
-        pplx::task<utility::string_t> post(web_request_factory& request_factory, const web::uri& url,
+        pplx::task<utility::string_t> post(web_request_factory& request_factory, const utility::string_t& url,
             const signalr_client_config& signalr_client_config)
         {
             auto request = request_factory.create_web_request(url);

--- a/src/SignalR/clients/cpp/src/signalrclient/http_sender.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/http_sender.h
@@ -12,10 +12,10 @@ namespace signalr
 {
     namespace http_sender
     {
-        pplx::task<utility::string_t> get(web_request_factory& request_factory, const web::uri& url,
+        pplx::task<utility::string_t> get(web_request_factory& request_factory, const utility::string_t& url,
             const signalr_client_config& client_config = signalr_client_config{});
 
-        pplx::task<utility::string_t> post(web_request_factory& request_factory, const web::uri& url,
+        pplx::task<utility::string_t> post(web_request_factory& request_factory, const utility::string_t& url,
             const signalr_client_config& client_config = signalr_client_config{});
     }
 }

--- a/src/SignalR/clients/cpp/src/signalrclient/hub_connection_impl.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/hub_connection_impl.cpp
@@ -43,7 +43,7 @@ namespace signalr
         const std::shared_ptr<log_writer>& log_writer, std::unique_ptr<web_request_factory> web_request_factory,
         std::unique_ptr<transport_factory> transport_factory)
         : m_connection(connection_impl::create(url, trace_level, log_writer,
-        std::move(web_request_factory), std::move(transport_factory))),m_logger(log_writer, trace_level),
+        std::move(web_request_factory), std::move(transport_factory))), m_logger(log_writer, trace_level),
         m_callback_manager(json::value::parse(_XPLATSTR("{ \"error\" : \"connection went out of scope before invocation result was received\"}"))),
         m_disconnected([]() noexcept {}), m_handshakeReceived(false)
     { }

--- a/src/SignalR/clients/cpp/src/signalrclient/request_sender.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/request_sender.cpp
@@ -11,7 +11,7 @@ namespace signalr
 {
     namespace request_sender
     {
-        pplx::task<negotiation_response> negotiate(web_request_factory& request_factory, const web::uri& base_url,
+        pplx::task<negotiation_response> negotiate(web_request_factory& request_factory, const utility::string_t& base_url,
             const signalr_client_config& signalr_client_config)
         {
             auto negotiate_url = url_builder::build_negotiate(base_url);

--- a/src/SignalR/clients/cpp/src/signalrclient/request_sender.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/request_sender.h
@@ -14,7 +14,7 @@ namespace signalr
 {
     namespace request_sender
     {
-        pplx::task<negotiation_response> negotiate(web_request_factory& request_factory, const web::uri &base_url,
+        pplx::task<negotiation_response> negotiate(web_request_factory& request_factory, const utility::string_t& base_url,
             const signalr_client_config& signalr_client_config = signalr::signalr_client_config{});
     }
 }

--- a/src/SignalR/clients/cpp/src/signalrclient/transport.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/transport.h
@@ -13,7 +13,7 @@ namespace signalr
     class transport
     {
     public:
-        virtual pplx::task<void> connect(const web::uri &url) = 0;
+        virtual pplx::task<void> connect(const utility::string_t &url) = 0;
 
         virtual pplx::task<void> send(const utility::string_t &data) = 0;
 

--- a/src/SignalR/clients/cpp/src/signalrclient/url_builder.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/url_builder.cpp
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include "constants.h"
 #include "cpprest/http_client.h"
 #include "signalrclient/transport_type.h"
 
@@ -10,55 +9,6 @@ namespace signalr
 {
     namespace url_builder
     {
-        utility::string_t get_transport_name(transport_type transport)
-        {
-            _ASSERTE(transport == transport_type::websockets || transport == transport_type::long_polling);
-
-            return transport == transport_type::websockets
-                ? utility::string_t(_XPLATSTR("webSockets"))
-                : utility::string_t(_XPLATSTR("longPolling"));
-        }
-
-        void append_transport(web::uri_builder &builder, transport_type transport)
-        {
-            if (transport > static_cast<transport_type>(-1))
-            {
-                builder.append_query(_XPLATSTR("transport"), get_transport_name(transport));
-            }
-        }
-
-        void append_connection_token(web::uri_builder &builder, const utility::string_t &connection_token)
-        {
-            if (connection_token.length() > 0)
-            {
-                builder.append_query(_XPLATSTR("connectionToken"), connection_token, /* do_encoding */ true);
-            }
-        }
-
-        void append_connection_data(web::uri_builder& builder, const utility::string_t& connection_data)
-        {
-            if (connection_data.length() > 0)
-            {
-                builder.append_query(_XPLATSTR("connectionData"), connection_data, /* do_encoding */ true);
-            }
-        }
-
-        void append_message_id(web::uri_builder& builder, const utility::string_t& message_id)
-        {
-            if (message_id.length() > 0)
-            {
-                builder.append_query(_XPLATSTR("messageId"), message_id, /* do_encoding */ true);
-            }
-        }
-
-        void append_groups_token(web::uri_builder& builder, const utility::string_t& groups_token)
-        {
-            if (groups_token.length() > 0)
-            {
-                builder.append_query(_XPLATSTR("groupsToken"), groups_token, /* do_encoding */ true);
-            }
-        }
-
         web::uri_builder &convert_to_websocket_url(web::uri_builder &builder, transport_type transport)
         {
             if (transport == transport_type::websockets)
@@ -89,22 +39,20 @@ namespace signalr
             return builder.append_path(command);
         }
 
-        web::uri build_negotiate(const web::uri& base_url)
+        utility::string_t build_negotiate(const utility::string_t& base_url)
         {
-            return build_uri(base_url, _XPLATSTR("negotiate")).to_uri();
+            return build_uri(base_url, _XPLATSTR("negotiate")).to_string();
         }
 
-        web::uri build_connect(const web::uri& base_url, transport_type transport, const utility::string_t& query_string)
+        utility::string_t build_connect(const utility::string_t& base_url, transport_type transport, const utility::string_t& query_string)
         {
             auto builder = build_uri(base_url, _XPLATSTR(""), query_string);
-            return convert_to_websocket_url(builder, transport).to_uri();
-            //auto builder = build_uri(base_url, _XPLATSTR("connect"), transport, connection_data, query_string);
-            //return convert_to_websocket_url(builder, transport).to_uri();
+            return convert_to_websocket_url(builder, transport).to_string();
         }
 
-        web::uri build_start(const web::uri &base_url, const utility::string_t &query_string)
+        utility::string_t build_start(const utility::string_t& base_url, const utility::string_t &query_string)
         {
-            return build_uri(base_url, _XPLATSTR(""), query_string).to_uri();
+            return build_uri(base_url, _XPLATSTR(""), query_string).to_string();
         }
     }
 }

--- a/src/SignalR/clients/cpp/src/signalrclient/url_builder.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/url_builder.h
@@ -10,8 +10,8 @@ namespace signalr
 {
     namespace url_builder
     {
-        web::uri build_negotiate(const web::uri& base_url);
-        web::uri build_connect(const web::uri& base_url, transport_type transport, const utility::string_t& query_string);
-        web::uri build_start(const web::uri& base_url, const utility::string_t& query_string);
+        utility::string_t build_negotiate(const utility::string_t& base_url);
+        utility::string_t build_connect(const utility::string_t& base_url, transport_type transport, const utility::string_t& query_string);
+        utility::string_t build_start(const utility::string_t& base_url, const utility::string_t& query_string);
     }
 }

--- a/src/SignalR/clients/cpp/src/signalrclient/web_request.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/web_request.cpp
@@ -7,7 +7,7 @@
 
 namespace signalr
 {
-    web_request::web_request(const web::uri &url)
+    web_request::web_request(const utility::string_t& url)
         : m_url(url)
     { }
 

--- a/src/SignalR/clients/cpp/src/signalrclient/web_request.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/web_request.h
@@ -11,7 +11,7 @@ namespace signalr
     class web_request
     {
     public:
-        explicit web_request(const web::uri &url);
+        explicit web_request(const utility::string_t& url);
 
         virtual void set_method(const utility::string_t &method);
         virtual void set_user_agent(const utility::string_t &user_agent_string);
@@ -24,7 +24,7 @@ namespace signalr
         virtual ~web_request();
 
     private:
-        const web::uri m_url;
+        const utility::string_t m_url;
         web::http::http_request m_request;
         utility::string_t m_user_agent_string;
         signalr_client_config m_signalr_client_config;

--- a/src/SignalR/clients/cpp/src/signalrclient/web_request_factory.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/web_request_factory.cpp
@@ -7,7 +7,7 @@
 
 namespace signalr
 {
-    std::unique_ptr<web_request> web_request_factory::create_web_request(const web::uri &url)
+    std::unique_ptr<web_request> web_request_factory::create_web_request(const utility::string_t& url)
     {
         return std::make_unique<web_request>(url);
     }

--- a/src/SignalR/clients/cpp/src/signalrclient/web_request_factory.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/web_request_factory.h
@@ -11,7 +11,7 @@ namespace signalr
     class web_request_factory
     {
     public:
-        virtual std::unique_ptr<web_request> create_web_request(const web::uri &url);
+        virtual std::unique_ptr<web_request> create_web_request(const utility::string_t& url);
 
         virtual ~web_request_factory();
     };

--- a/src/SignalR/clients/cpp/src/signalrclient/websocket_transport.cpp
+++ b/src/SignalR/clients/cpp/src/signalrclient/websocket_transport.cpp
@@ -41,9 +41,10 @@ namespace signalr
         return transport_type::websockets;
     }
 
-    pplx::task<void> websocket_transport::connect(const web::uri &url)
+    pplx::task<void> websocket_transport::connect(const utility::string_t& url)
     {
-        _ASSERTE(url.scheme() == _XPLATSTR("ws") || url.scheme() == _XPLATSTR("wss"));
+        web::uri uri(url);
+        _ASSERTE(uri.scheme() == _XPLATSTR("ws") || uri.scheme() == _XPLATSTR("wss"));
 
         {
             std::lock_guard<std::mutex> stop_lock(m_start_stop_lock);
@@ -55,7 +56,7 @@ namespace signalr
 
             m_logger.log(trace_level::info,
                 utility::string_t(_XPLATSTR("[websocket transport] connecting to: "))
-                .append(url.to_string()));
+                .append(url));
 
             auto websocket_client = m_websocket_client_factory();
 

--- a/src/SignalR/clients/cpp/src/signalrclient/websocket_transport.h
+++ b/src/SignalR/clients/cpp/src/signalrclient/websocket_transport.h
@@ -25,7 +25,7 @@ namespace signalr
 
         websocket_transport& operator=(const websocket_transport&) = delete;
 
-        pplx::task<void> connect(const web::uri &url) override;
+        pplx::task<void> connect(const utility::string_t& url) override;
 
         pplx::task<void> send(const utility::string_t &data) override;
 

--- a/src/SignalR/clients/cpp/test/signalrclienttests/Build/VS/signalrclienttests.vcxproj
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/Build/VS/signalrclienttests.vcxproj
@@ -93,9 +93,6 @@
     <PackageReference Include="cpprestsdk.v140.windesktop.msvcstl.dyn.rt-dyn" Version="2.9.1" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="AfterBuild">
-    <Exec Command="copy /y &quot;$(SolutionDir)bin\Desktop\$(Platform)\$(Configuration)\dll\$(SignalrClientTargetName).dll&quot; &quot;$(SolutionDir)bin\Desktop\$(Platform)\$(Configuration)\$(SignalrClientTargetName).dll&quot;" />
-  </Target>
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/SignalR/clients/cpp/test/signalrclienttests/request_sender_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/request_sender_tests.cpp
@@ -13,8 +13,8 @@ using namespace signalr;
 
 TEST(request_sender_negotiate, request_created_with_correct_url)
 {
-    web::uri requested_url;
-    auto request_factory = test_web_request_factory([&requested_url](const web::uri &url) -> std::unique_ptr<web_request>
+    utility::string_t requested_url;
+    auto request_factory = test_web_request_factory([&requested_url](const utility::string_t& url) -> std::unique_ptr<web_request>
     {
         utility::string_t response_body(
             _XPLATSTR("{ \"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", ")
@@ -24,24 +24,30 @@ TEST(request_sender_negotiate, request_created_with_correct_url)
         return std::unique_ptr<web_request>(new web_request_stub((unsigned short)200, _XPLATSTR("OK"), response_body));
     });
 
-    request_sender::negotiate(request_factory, web::uri{ _XPLATSTR("http://fake/signalr") }).get();
+    request_sender::negotiate(request_factory, _XPLATSTR("http://fake/signalr")).get();
 
-    ASSERT_EQ(web::uri(_XPLATSTR("http://fake/signalr/negotiate")), requested_url);
+    ASSERT_EQ(_XPLATSTR("http://fake/signalr/negotiate"), requested_url);
 }
 
 TEST(request_sender_negotiate, negotiation_request_sent_and_response_serialized)
 {
-    auto request_factory = test_web_request_factory([](const web::uri&) -> std::unique_ptr<web_request>
+    auto request_factory = test_web_request_factory([](const utility::string_t&) -> std::unique_ptr<web_request>
     {
         utility::string_t response_body(
             _XPLATSTR("{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", ")
-            _XPLATSTR("\"availableTransports\" : [] }"));
+            _XPLATSTR("\"availableTransports\" : [ { \"transport\": \"WebSockets\", \"transferFormats\": [ \"Text\", \"Binary\" ] },")
+            _XPLATSTR("{ \"transport\": \"ServerSentEvents\", \"transferFormats\": [ \"Text\" ] } ] }"));
 
         return std::unique_ptr<web_request>(new web_request_stub((unsigned short)200, _XPLATSTR("OK"), response_body));
     });
 
-    auto response = request_sender::negotiate(request_factory, web::uri{ _XPLATSTR("http://fake/signalr") }).get();
+    auto response = request_sender::negotiate(request_factory, _XPLATSTR("http://fake/signalr")).get();
 
     ASSERT_EQ(_XPLATSTR("f7707523-307d-4cba-9abf-3eef701241e8"), response.connectionId);
-    // TODO: response.availableTransports
+    ASSERT_EQ(2u, response.availableTransports.size());
+    ASSERT_EQ(2u, response.availableTransports[0].transfer_formats.size());
+    ASSERT_EQ(_XPLATSTR("Text"), response.availableTransports[0].transfer_formats[0]);
+    ASSERT_EQ(_XPLATSTR("Binary"), response.availableTransports[0].transfer_formats[1]);
+    ASSERT_EQ(1u, response.availableTransports[1].transfer_formats.size());
+    ASSERT_EQ(_XPLATSTR("Text"), response.availableTransports[1].transfer_formats[0]);
 }

--- a/src/SignalR/clients/cpp/test/signalrclienttests/test_web_request_factory.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/test_web_request_factory.cpp
@@ -6,11 +6,11 @@
 
 using namespace signalr;
 
-test_web_request_factory::test_web_request_factory(std::function<std::unique_ptr<web_request>(const web::uri &url)> create_web_request_fn)
+test_web_request_factory::test_web_request_factory(std::function<std::unique_ptr<web_request>(const utility::string_t& url)> create_web_request_fn)
     : m_create_web_request_fn(create_web_request_fn)
 { }
 
-std::unique_ptr<web_request> test_web_request_factory::create_web_request(const web::uri &url)
+std::unique_ptr<web_request> test_web_request_factory::create_web_request(const utility::string_t& url)
 {
     return m_create_web_request_fn(url);
 }

--- a/src/SignalR/clients/cpp/test/signalrclienttests/test_web_request_factory.h
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/test_web_request_factory.h
@@ -11,10 +11,10 @@ using namespace signalr;
 class test_web_request_factory : public web_request_factory
 {
 public:
-    explicit test_web_request_factory(std::function<std::unique_ptr<web_request>(const web::uri &url)> create_web_request_fn);
+    explicit test_web_request_factory(std::function<std::unique_ptr<web_request>(const utility::string_t& url)> create_web_request_fn);
 
-    virtual std::unique_ptr<web_request> create_web_request(const web::uri &url) override;
+    virtual std::unique_ptr<web_request> create_web_request(const utility::string_t& url) override;
 
 private:
-    std::function<std::unique_ptr<web_request>(const web::uri &url)> m_create_web_request_fn;
+    std::function<std::unique_ptr<web_request>(const utility::string_t& url)> m_create_web_request_fn;
 };

--- a/src/SignalR/clients/cpp/test/signalrclienttests/url_builder_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/url_builder_tests.cpp
@@ -9,20 +9,20 @@ using namespace signalr;
 TEST(url_builder_negotiate, url_correct_if_query_string_empty)
 {
     ASSERT_EQ(
-        web::uri(_XPLATSTR("http://fake/negotiate")),
-        url_builder::build_negotiate(web::uri{ _XPLATSTR("http://fake/") }));
+        _XPLATSTR("http://fake/negotiate"),
+        url_builder::build_negotiate(_XPLATSTR("http://fake/")));
 }
 
 TEST(url_builder_negotiate, url_correct_if_query_string_not_empty)
 {
     ASSERT_EQ(
-        web::uri(_XPLATSTR("http://fake/negotiate?q1=1&q2=2")),
-        url_builder::build_negotiate(web::uri{ _XPLATSTR("http://fake/?q1=1&q2=2") }));
+        _XPLATSTR("http://fake/negotiate?q1=1&q2=2"),
+        url_builder::build_negotiate(_XPLATSTR("http://fake/?q1=1&q2=2")));
 }
 
 TEST(url_builder_connect_webSockets, url_correct_if_query_string_not_empty)
 {
     ASSERT_EQ(
-        web::uri(_XPLATSTR("ws://fake/?q1=1&q2=2")),
-        url_builder::build_connect(web::uri{ _XPLATSTR("http://fake/") }, transport_type::websockets, _XPLATSTR("q1=1&q2=2")));
+        _XPLATSTR("ws://fake/?q1=1&q2=2"),
+        url_builder::build_connect(_XPLATSTR("http://fake/"), transport_type::websockets, _XPLATSTR("q1=1&q2=2")));
 }

--- a/src/SignalR/clients/cpp/test/signalrclienttests/web_request_stub.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/web_request_stub.cpp
@@ -5,7 +5,7 @@
 #include "web_request_stub.h"
 
 web_request_stub::web_request_stub(unsigned short status_code, const utility::string_t& reason_phrase, const utility::string_t& response_body)
-    : web_request(web::uri(_XPLATSTR(""))), m_status_code(status_code), m_reason_phrase(reason_phrase), m_response_body(response_body)
+    : web_request(_XPLATSTR("")), m_status_code(status_code), m_reason_phrase(reason_phrase), m_response_body(response_body)
 { }
 
 void web_request_stub::set_method(const utility::string_t &method)

--- a/src/SignalR/clients/cpp/test/signalrclienttests/web_request_tests.cpp
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/web_request_tests.cpp
@@ -10,7 +10,7 @@ using namespace signalr;
 
 TEST(web_request_get_response, DISABLED_sends_request_receives_response)
 {
-    web::uri url(_XPLATSTR("http://localhost:56000/web_request_test"));
+    utility::string_t url(_XPLATSTR("http://localhost:56000/web_request_test"));
     auto request_received = false;
     utility::string_t user_agent_string;
 


### PR DESCRIPTION
Also removed a couple redundant tests and enabled some of the disabled ones since they should be fixed.

Deleted some old unused code I found too.

And fixed a flaky build issue with copying a dll