### PR TITLE
Avoid UI flickering after prerendering

### DIFF
--- a/src/Components/Browser.JS/src/Rendering/LogicalElements.ts
+++ b/src/Components/Browser.JS/src/Rendering/LogicalElements.ts
@@ -28,9 +28,12 @@
 const logicalChildrenPropname = createSymbolOrFallback('_blazorLogicalChildren');
 const logicalParentPropname = createSymbolOrFallback('_blazorLogicalParent');
 
-export function toLogicalElement(element: Element) {
-  if (element.childNodes.length > 0) {
-    throw new Error('New logical elements must start empty');
+export function toLogicalElement(element: Element, allowExistingContents?: boolean) {
+  // Normally it's good to assert that the element has started empty, because that's the usual
+  // situation and we probably have a bug if it's not. But for the element that contain prerendered
+  // root components, we want to let them keep their content until we replace it.
+  if (element.childNodes.length > 0 && !allowExistingContents) {
+    throw new Error('New logical elements must start empty, or allowExistingContents must be true');
   }
 
   element[logicalChildrenPropname] = [];

--- a/src/Components/Browser.JS/src/Rendering/Renderer.ts
+++ b/src/Components/Browser.JS/src/Rendering/Renderer.ts
@@ -16,7 +16,6 @@ export function attachRootComponentToElement(browserRendererId: number, elementS
   if (!browserRenderer) {
     browserRenderer = browserRenderers[browserRendererId] = new BrowserRenderer(browserRendererId);
   }
-  clearElement(element);
   browserRenderer.attachRootComponentToElement(componentId, element);
 }
 
@@ -55,12 +54,5 @@ export function renderBatch(browserRendererId: number, batch: RenderBatch) {
   for (let i = 0; i < disposedEventHandlerIdsLength; i++) {
     const eventHandlerId = batch.disposedEventHandlerIdsEntry(disposedEventHandlerIdsValues, i);
     browserRenderer.disposeEventHandler(eventHandlerId);
-  }
-}
-
-function clearElement(element: Element) {
-  let childNode: Node | null;
-  while (childNode = element.firstChild) {
-    element.removeChild(childNode);
   }
 }


### PR DESCRIPTION
Prerendering is a great feature.

But one minor quirk I noticed was that the UI went through a brief -- probably < 50ms -- flash of whiteness when replacing the prerendered elements with client-rendered (interactive) elements.

This PR tweaks the client-side rendering mechanism so there is no longer any async gap between clearing and replacing the content, so the browser never repaints the screen in an intermediate state. It feels slicker.