### PR TITLE
Use environment tag helper for bootstrap in Razor Components template. Fixes #6886

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Pages/Index.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Pages/Index.cshtml
@@ -3,10 +3,19 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RazorComponentsWeb-CSharp</title>
-    <base href="/" />
-    <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
+    <base href="~/" />
+    <environment include="Development">
+        <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    </environment>
+    <environment exclude="Development">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+              asp-fallback-href="css/bootstrap/bootstrap.min.css"
+              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute"
+              crossorigin="anonymous"
+              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"/>
+    </environment>
     <link href="css/site.css" rel="stylesheet" />
 </head>
 <body>


### PR DESCRIPTION
I'm not a fan of having this in the template, because it clutters up `Index.cshtml` and takes opinions about things that (in my opinion) we have no business having opinions about, such as whether to use a CDN or which specific CDN to use. It feels like we have it just because we implemented the feature, not because it's the right starting point for most people. Despite that, I recognize we should either include it here or remove it everywhere, and that's a longer discussion, so here it is.

Note that it's still using `bootstrap.css.min` in the development case, because with modern browser dev tools being what they are, there's very little reason to be having different versions of CSS files (that you can't edit anyway, given CDN usage) in development versus production, and I don't want to be misleading about app payload size.

This PR also sets the base href to `~/`, which simplifies things for people using non-root pathbase deployments.