### PR TITLE
Correct summary comment on ApiConventionTypeMatchBehavior

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApiExplorer/ApiConventionTypeMatchBehavior.cs
+++ b/src/Mvc/Mvc.Core/src/ApiExplorer/ApiConventionTypeMatchBehavior.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
     /// <summary>
-    /// The behavior for matching the name of a convention parameter.
+    /// The behavior for matching the type of a convention parameter.
     /// </summary>
     public enum ApiConventionTypeMatchBehavior
     {


### PR DESCRIPTION
Summary of the changes:
 - Correct summary comment on ApiConventionTypeMatchBehavior

Addresses #bugnumber (in this specific format)
