### PR TITLE
Remove docker support from gRPC templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/vs-2017.3.host.json
@@ -14,6 +14,6 @@
   "icon": "vs-2017.3/Empty.png",
   "learnMoreLink": "https://go.microsoft.com/fwlink/?LinkID=784883",
   "uiFilters": [ "oneaspnet" ],
-  "supportsDocker": true,
+  "supportsDocker": false,
   "excludeLaunchSettings": false
 }


### PR DESCRIPTION
Docker support doesn't work properly in a multi-project scenario, so I'll remove the UI element. 
![image](https://user-images.githubusercontent.com/2030323/53271602-d0abcd00-36a3-11e9-9808-6af0c66ab0ec.png)
The expected mechanism is to to click Add 
![image](https://user-images.githubusercontent.com/2030323/53271792-54fe5000-36a4-11e9-82a2-c93dca8cb79a.png)

I'm removing docker support for the gRPC templates since we are looking into moving away from multi-project templates anyway.

cc @Eilon @muratg for preview3 ask mode.