### PR TITLE
Replace EnvironmentName with Environments

### DIFF
--- a/src/Hosting/Abstractions/src/EnvironmentName.cs
+++ b/src/Hosting/Abstractions/src/EnvironmentName.cs
@@ -6,6 +6,7 @@ namespace Microsoft.AspNetCore.Hosting
     /// <summary>
     /// Commonly used environment names.
     /// </summary>
+    [System.Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.Environments.", error: false)]
     public static class EnvironmentName
     {
         public static readonly string Development = "Development";

--- a/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
     public class HostingEnvironment : IHostingEnvironment, Extensions.Hosting.IHostingEnvironment, IWebHostEnvironment
 #pragma warning restore CS0618 // Type or member is obsolete
     {
-        public string EnvironmentName { get; set; } = Hosting.EnvironmentName.Production;
+        public string EnvironmentName { get; set; } = Extensions.Hosting.Environments.Production;
 
         public string ApplicationName { get; set; }
 

--- a/src/Hosting/Hosting/test/StartupManagerTests.cs
+++ b/src/Hosting/Hosting/test/StartupManagerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.Tests.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -510,7 +511,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IServiceProviderFactory<MyContainer>, MyContainerFactory>();
             var services = serviceCollection.BuildServiceProvider();
 
-            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartup), EnvironmentName.Development);
+            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartup), Environments.Development);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
@@ -526,7 +527,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IServiceProviderFactory<MyContainer>, MyContainerFactory>();
             var services = serviceCollection.BuildServiceProvider();
 
-            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartupBaseClass), EnvironmentName.Development);
+            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartupBaseClass), Environments.Development);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
@@ -542,13 +543,13 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IServiceProviderFactory<MyContainer>, MyContainerFactory>();
             var services = serviceCollection.BuildServiceProvider();
 
-            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartupEnvironmentBased), EnvironmentName.Production);
+            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartupEnvironmentBased), Environments.Production);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
 
             Assert.IsType<MyContainer>(app.ApplicationServices);
-            Assert.Equal(((MyContainer)app.ApplicationServices).Environment, EnvironmentName.Production);
+            Assert.Equal(((MyContainer)app.ApplicationServices).Environment, Environments.Production);
         }
 
         [Fact]
@@ -557,7 +558,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var serviceCollection = new ServiceCollection();
             var services = serviceCollection.BuildServiceProvider();
 
-            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartup), EnvironmentName.Development);
+            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartup), Environments.Development);
 
             Assert.Throws<InvalidOperationException>(() => startup.ConfigureServicesDelegate(serviceCollection));
         }
@@ -568,7 +569,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var serviceCollection = new ServiceCollection();
             var services = serviceCollection.BuildServiceProvider();
 
-            Assert.Throws<InvalidOperationException>(() => StartupLoader.LoadMethods(services, typeof(MyContainerStartupBaseClass), EnvironmentName.Development));
+            Assert.Throws<InvalidOperationException>(() => StartupLoader.LoadMethods(services, typeof(MyContainerStartupBaseClass), Environments.Development));
         }
 
         [Fact]
@@ -578,7 +579,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IServiceProviderFactory<MyContainer>, MyContainerFactory>();
             var services = serviceCollection.BuildServiceProvider();
 
-            Assert.Throws<InvalidOperationException>(() => StartupLoader.LoadMethods(services, typeof(MyContainerStartupWithOverloads), EnvironmentName.Development));
+            Assert.Throws<InvalidOperationException>(() => StartupLoader.LoadMethods(services, typeof(MyContainerStartupWithOverloads), Environments.Development));
         }
 
         [Fact]
@@ -588,7 +589,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IServiceProviderFactory<MyContainer>, MyBadContainerFactory>();
             var services = serviceCollection.BuildServiceProvider();
 
-            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartup), EnvironmentName.Development);
+            var startup = StartupLoader.LoadMethods(services, typeof(MyContainerStartup), Environments.Development);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
@@ -629,12 +630,12 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             public void ConfigureDevelopmentContainer(MyContainer container)
             {
-                container.Environment = EnvironmentName.Development;
+                container.Environment = Environments.Development;
             }
 
             public void ConfigureProductionContainer(MyContainer container)
             {
-                container.Environment = EnvironmentName.Production;
+                container.Environment = Environments.Production;
             }
 
             public void Configure(IApplicationBuilder app)

--- a/src/Hosting/Hosting/test/WebHostConfigurationsTests.cs
+++ b/src/Hosting/Hosting/test/WebHostConfigurationsTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Hosting.Tests
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
                 { WebHostDefaults.WebRootKey, "wwwroot"},
                 { WebHostDefaults.ApplicationKey, "MyProjectReference"},
                 { WebHostDefaults.StartupAssemblyKey, "MyProjectReference" },
-                { WebHostDefaults.EnvironmentKey, EnvironmentName.Development},
+                { WebHostDefaults.EnvironmentKey, Environments.Development},
                 { WebHostDefaults.DetailedErrorsKey, "true"},
                 { WebHostDefaults.CaptureStartupErrorsKey, "true" },
                 { WebHostDefaults.SuppressStatusMessagesKey, "true" }
@@ -29,7 +30,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             Assert.Equal("wwwroot", config.WebRoot);
             Assert.Equal("MyProjectReference", config.ApplicationName);
             Assert.Equal("MyProjectReference", config.StartupAssembly);
-            Assert.Equal(EnvironmentName.Development, config.Environment);
+            Assert.Equal(Environments.Development, config.Environment);
             Assert.True(config.CaptureStartupErrors);
             Assert.True(config.DetailedErrors);
             Assert.True(config.SuppressStatusMessages);
@@ -38,10 +39,10 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         [Fact]
         public void ReadsOldEnvKey()
         {
-            var parameters = new Dictionary<string, string>() { { "ENVIRONMENT", EnvironmentName.Development } };
+            var parameters = new Dictionary<string, string>() { { "ENVIRONMENT", Environments.Development } };
             var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build());
 
-            Assert.Equal(EnvironmentName.Development, config.Environment);
+            Assert.Equal(Environments.Development, config.Environment);
         }
 
         [Theory]

--- a/src/Hosting/Hosting/test/WebHostTests.cs
+++ b/src/Hosting/Hosting/test/WebHostTests.cs
@@ -812,8 +812,8 @@ namespace Microsoft.AspNetCore.Hosting
 #pragma warning disable CS0618 // Type or member is obsolete
                 var env2 = host.Services.GetService<AspNetCore.Hosting.IHostingEnvironment>();
 #pragma warning restore CS0618 // Type or member is obsolete
-                Assert.Equal(EnvironmentName.Production, env.EnvironmentName);
-                Assert.Equal(EnvironmentName.Production, env2.EnvironmentName);
+                Assert.Equal(Environments.Production, env.EnvironmentName);
+                Assert.Equal(Environments.Production, env2.EnvironmentName);
             }
         }
 
@@ -822,7 +822,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var vals = new Dictionary<string, string>
             {
-                { "Environment", EnvironmentName.Staging }
+                { "Environment", Environments.Staging }
             };
 
             var builder = new ConfigurationBuilder()
@@ -835,8 +835,8 @@ namespace Microsoft.AspNetCore.Hosting
 #pragma warning disable CS0618 // Type or member is obsolete
                 var env2 = host.Services.GetService<AspNetCore.Hosting.IHostingEnvironment>();
 #pragma warning restore CS0618 // Type or member is obsolete
-                Assert.Equal(EnvironmentName.Staging, env.EnvironmentName);
-                Assert.Equal(EnvironmentName.Staging, env.EnvironmentName);
+                Assert.Equal(Environments.Staging, env.EnvironmentName);
+                Assert.Equal(Environments.Staging, env.EnvironmentName);
             }
         }
 
@@ -873,7 +873,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 await host.StartAsync();
                 var env = host.Services.GetRequiredService<IHostEnvironment>();
-                Assert.True(env.IsEnvironment(EnvironmentName.Production));
+                Assert.True(env.IsEnvironment(Environments.Production));
                 Assert.True(env.IsEnvironment("producTion"));
             }
         }

--- a/src/Hosting/samples/SampleStartups/StartupFullControl.cs
+++ b/src/Hosting/samples/SampleStartups/StartupFullControl.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 // Note that this sample will not run. It is only here to illustrate usage patterns.
@@ -25,7 +26,7 @@ namespace SampleStartups
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory()) // Override the content root with the current directory
                 .UseUrls("http://*:1000", "https://*:902")
-                .UseEnvironment(EnvironmentName.Development)
+                .UseEnvironment(Environments.Development)
                 .UseWebRoot("public")
                 .ConfigureServices(services =>
                 {

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Hosting;
-using EnvironmentName = Microsoft.Extensions.Hosting.EnvironmentName;
 
 namespace Microsoft.AspNetCore.Mvc.Testing
 {
@@ -307,7 +306,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             var hostBuilder = HostFactoryResolver.ResolveHostBuilderFactory<IHostBuilder>(typeof(TEntryPoint).Assembly)?.Invoke(Array.Empty<string>());
             if (hostBuilder != null)
             {
-                hostBuilder.UseEnvironment(EnvironmentName.Development);
+                hostBuilder.UseEnvironment(Environments.Development);
             }
             return hostBuilder;
         }
@@ -336,7 +335,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             }
             else
             {
-                return builder.UseEnvironment(EnvironmentName.Development);
+                return builder.UseEnvironment(Environments.Development);
             }
         }
 


### PR DESCRIPTION
The second half of #7733. 

Interestingly `using EnvironmentName = Microsoft.Extensions.Hosting.EnvironmentName;` was not generating an obsolete warning. Seems like a roslyn bug.