### PR TITLE
Fixed two misspelling of 'tenant' in properties' inline XML documentation

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         public string Instance { get; set; }
 
         /// <summary>
-        /// Gets or sets the domain of the Azure Active Directory tennant.
+        /// Gets or sets the domain of the Azure Active Directory tenant.
         /// </summary>
         public string Domain { get; set; }
 

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Authentication.AzureADB2C.UI
         public string Instance { get; set; }
 
         /// <summary>
-        /// Gets or sets the domain of the Azure Active Directory B2C tennant.
+        /// Gets or sets the domain of the Azure Active Directory B2C tenant.
         /// </summary>
         public string Domain { get; set; }
 


### PR DESCRIPTION
In two files, just a misspell in the documentation
- Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptions.cs
- AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptions.cs