### PR TITLE
[Templates] Imports and CSS tweaks for forms/validation

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/_ViewImports.cshtml
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.JSInterop

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/wwwroot/css/site.css
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/wwwroot/css/site.css
@@ -84,6 +84,18 @@ app {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 @media (max-width: 767.98px) {
     .main .top-row {
         display: none;

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/_ViewImports.cshtml
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.JSInterop

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/wwwroot/css/site.css
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/wwwroot/css/site.css
@@ -84,6 +84,18 @@ app {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 @media (max-width: 767.98px) {
     .main .top-row {
         display: none;

--- a/src/Components/Blazor/testassets/StandaloneApp/wwwroot/css/site.css
+++ b/src/Components/Blazor/testassets/StandaloneApp/wwwroot/css/site.css
@@ -84,6 +84,18 @@ app {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 @media (max-width: 767.98px) {
     .main .top-row {
         display: none;

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/style.css
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/style.css
@@ -1,9 +1,9 @@
-.modified.valid {
-    box-shadow: 0px 0px 0px 2px rgb(78, 203, 37);
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
 }
 
 .invalid {
-    box-shadow: 0px 0px 0px 2px rgb(255, 0, 0);
+    outline: 1px solid red;
 }
 
 .validation-message {

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/site.css
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/site.css
@@ -84,6 +84,18 @@ app {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 @media (max-width: 767.98px) {
     .main .top-row {
         display: none;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Components/_ViewImports.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Components/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.JSInterop

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/wwwroot/css/site.css
@@ -84,6 +84,18 @@ app {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 @media (max-width: 767.98px) {
     .main .top-row {
         display: none;


### PR DESCRIPTION
Following @rynowak's app-building/verification exercise, this PR:

* Adds `Microsoft.AspNetCore.Components.Forms` to the default `_ViewImports.cshtml` in the Components/Blazor templates
* Adds initial CSS styling for the build-in forms/validation classes so they have a visual effect

These changes are extremely low-risk. They affect the template only, and only in trivial ways. The value of this change is that it cleans up the developer experience around forms and validation, which is one of the key new Components features for Preview 3.