### PR TITLE
Remove VisualStudioExtension as a required workload

### DIFF
--- a/korebuild.json
+++ b/korebuild.json
@@ -18,8 +18,7 @@
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
         "Microsoft.VisualStudio.Component.VC.v141.ATL",
         "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
-        "Microsoft.VisualStudio.Component.Windows10SDK.17134",
-        "Microsoft.VisualStudio.Workload.VisualStudioExtension"
+        "Microsoft.VisualStudio.Component.Windows10SDK.17134"
       ]
     }
   }


### PR DESCRIPTION
As a result of changes @pranavkm made recently to the blazor VSIX build, this VS workload is not required anymore. This unblockes us to build with the BuildTools SKU.