### PR TITLE
Ignore error output from git diff in code check

### DIFF
--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -133,14 +133,10 @@ try {
     Write-Host "Run git diff to check for pending changes"
 
     # Redirect stderr to stdout because PowerShell does not consistently handle output to stderr
-    $changedFiles = & cmd /c 'git --no-pager diff --ignore-space-at-eol --name-only 2>&1'
+    $changedFiles = & cmd /c 'git --no-pager diff --ignore-space-at-eol --name-only 2>nul'
 
     if ($changedFiles) {
         foreach ($file in $changedFiles) {
-            if (($file -like 'warning:*') -or ($file -like 'The file will have its original line endings*')) {
-                # git might emit warnings to stderr about CRLF vs LR, which can vary from machine to machine based on git's configuration
-                continue
-            }
             $filePath = Resolve-Path "${repoRoot}/${file}"
             LogError "Generated code is not up to date in $file." -filepath $filePath
             & git --no-pager diff --ignore-space-at-eol $filePath

--- a/src/Hosting/Hosting/src/WebHostExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostExtensions.cs
@@ -35,15 +35,6 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Block the calling thread until shutdown is triggered via Ctrl+C or SIGTERM.
-        /// </summary>
-        /// <param name="host">The running <see cref="IWebHost"/>.</param>
-        public static void WaitForShutdown2(this IWebHost host)
-        {
-            host.WaitForShutdownAsync().GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Returns a Task that completes when shutdown is triggered via the given token, Ctrl+C or SIGTERM.
         /// </summary>
         /// <param name="host">The running <see cref="IWebHost"/>.</param>

--- a/src/Hosting/Hosting/src/WebHostExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostExtensions.cs
@@ -35,6 +35,15 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
+        /// Block the calling thread until shutdown is triggered via Ctrl+C or SIGTERM.
+        /// </summary>
+        /// <param name="host">The running <see cref="IWebHost"/>.</param>
+        public static void WaitForShutdown2(this IWebHost host)
+        {
+            host.WaitForShutdownAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Returns a Task that completes when shutdown is triggered via the given token, Ctrl+C or SIGTERM.
         /// </summary>
         /// <param name="host">The running <see cref="IWebHost"/>.</param>


### PR DESCRIPTION
I don't think we care about stderr in git diff and it seems to break to the file name detection.