### PR TITLE
Retry on SauceLabs failure

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -25,11 +25,8 @@
   </Target>
 
   <Target Name="RunBrowserTests">
-    <Message Text="Running JavaScript client Browser tests" Importance="high" />
-    <Yarn Command="run test:inner -- --no-color --configuration $(Configuration)" WorkingDirectory="$(RepositoryRoot)src/SignalR/clients/ts/FunctionalTests" />
-    <Message Text="Running JavaScript tests" Importance="high" />
-
     <!-- Skip the "inner" test run when we're running DailyTests -->
+    <Message Condition="'$(DailyTests)' != 'true'" Text="Running JavaScript client Browser tests locally" Importance="high" />
     <Yarn Command="run test:inner -- --no-color --configuration $(Configuration)"
           Condition="'$(DailyTests)' != 'true'"
           WorkingDirectory="$(RepositoryRoot)src/SignalR/clients/ts/FunctionalTests" />
@@ -39,11 +36,20 @@
       <_TestSauceArgs>--verbose --no-color --configuration $(Configuration) --sauce-user "$(SauceUser)" --sauce-key "$(SauceKey)"</_TestSauceArgs>
       <_TestSauceArgs Condition="'$(BrowserTestHostName)' != ''">$(_TestSauceArgs) --use-hostname "$(BrowserTestHostName)"</_TestSauceArgs>
     </PropertyGroup>
+    
+    <Message Condition="'$(DailyTests)' == 'true'" Text="Running JavaScript client Browser tests on SauceLabs" Importance="high" />
     <Message Text="test:sauce Args = $(_TestSauceArgs)" Importance="high" />
     <Exec Command="npm run test:sauce -- $(_TestSauceArgs)"
           Condition="'$(DailyTests)' == 'true'"
           WorkingDirectory="$(RepositoryRoot)src/SignalR/clients/ts/FunctionalTests"
-          IgnoreStandardErrorWarningFormat="true" />
+          IgnoreStandardErrorWarningFormat="true">
+      <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
+    </Exec>
+    <Message Condition="'$(ErrorCode)' == '1'" Text="First run failed with $(ErrorCode) -- Rerunning sauce labs tests" Importance="high" />
+    <Exec Command="npm run test:sauce -- $(_TestSauceArgs)"
+      Condition="'$(ErrorCode)' == '1'"
+      WorkingDirectory="$(RepositoryRoot)src/SignalR/clients/ts/FunctionalTests"
+      IgnoreStandardErrorWarningFormat="true"/>
   </Target>
 
 </Project>

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -41,10 +41,13 @@
     <Message Text="test:sauce Args = $(_TestSauceArgs)" Importance="high" />
     <Exec Command="npm run test:sauce -- $(_TestSauceArgs)"
           Condition="'$(DailyTests)' == 'true'"
+          ContinueOnError="true"
           WorkingDirectory="$(RepositoryRoot)src/SignalR/clients/ts/FunctionalTests"
           IgnoreStandardErrorWarningFormat="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
     </Exec>
+    <Message Importance="high" Text="$(ErrorCode)"/>
+
     <Message Condition="'$(ErrorCode)' == '1'" Text="First run failed with $(ErrorCode) -- Rerunning sauce labs tests" Importance="high" />
     <Exec Command="npm run test:sauce -- $(_TestSauceArgs)"
       Condition="'$(ErrorCode)' == '1'"

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -53,9 +53,7 @@ describe("hubConnection", () => {
         describe("using " + protocol.name + " over " + HttpTransportType[transportType] + " transport", async () => {
             it("can invoke server method and receive result", (done) => {
                 const message = "你好，世界！";
-                
                 expect(true).toBe(false);
-
                 const hubConnection = getConnectionBuilder(transportType)
                     .withHubProtocol(protocol)
                     .build();

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -53,7 +53,7 @@ describe("hubConnection", () => {
         describe("using " + protocol.name + " over " + HttpTransportType[transportType] + " transport", async () => {
             it("can invoke server method and receive result", (done) => {
                 const message = "你好，世界！";
-                expect(true).toBe(false);
+
                 const hubConnection = getConnectionBuilder(transportType)
                     .withHubProtocol(protocol)
                     .build();

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -53,6 +53,8 @@ describe("hubConnection", () => {
         describe("using " + protocol.name + " over " + HttpTransportType[transportType] + " transport", async () => {
             it("can invoke server method and receive result", (done) => {
                 const message = "你好，世界！";
+                
+                expect(true).toBe(false);
 
                 const hubConnection = getConnectionBuilder(transportType)
                     .withHubProtocol(protocol)


### PR DESCRIPTION
Adding a simple retry for when our SauceLabs tests fail.
Turns out we also had a small mistake in this logic where we were are running the browser tests locally even when we specifically don't want to. 
