### PR TITLE
Add temporary signcheck exclusion for comhost inside shared runtime

### DIFF
--- a/eng/signcheck.exclusions.txt
+++ b/eng/signcheck.exclusions.txt
@@ -1,5 +1,6 @@
 */AppHostTemplate/apphost.exe;AspNetCoreRuntime.*.nupkg; Exclude the apphost because this is expected to be code-signed by customers after the SDK modifies it.
 */runtime.*.microsoft.netcore.dotnetapphost/*/apphost.exe;Microsoft.AspNetCore.AzureAppServices.SiteExtension.*.nupkg; Exclude the apphost because this is expected to be code-signed by customers after the SDK modifies it.
+*/Microsoft.NETCore.App/*/comhost.dll;AspNetCoreRuntime.3.0.*.nupkg; Workaround https://github.com/dotnet/core-setup/issues/5253
 *.js;; Exclude all JavaScript files from codesigning because we don't expect these to run on Windows Script Host
 *.binlog;; Exclude msbuild log files
 *.symbols.nupkg;; Exclude NuGet symbols packages. These are not shipped to customers and should not be code signed.


### PR DESCRIPTION
Workaround https://github.com/dotnet/core-setup/issues/5253

Fix signcheck failures:
```

[File] AspNetCoreRuntime.3.0.x64.3.0.0-preview4-19125-09.nupkg, Signed: True

[File] 0833626f316b72011de3acb878c4b3bb.dll, Signed: False, Full Name: content/shared/Microsoft.NETCore.App/3.0.0-preview4-27424-1/comhost.dll [Error] HRESULT: 800b0100 (No signature was present in the subject)

[File] AspNetCoreRuntime.3.0.x86.3.0.0-preview4-19125-09.nupkg, Signed: True

[File] 0833626f316b72011de3acb878c4b3bb.dll, Signed: False, Full Name: content/shared/Microsoft.NETCore.App/3.0.0-preview4-27424-1/comhost.dll [Error] HRESULT: 800b0100 (No signature was present in the subject)

```