### PR TITLE
Cleanup of unused code in Identity

### DIFF
--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -40,7 +40,6 @@ namespace Microsoft.AspNetCore.Identity
         private readonly Dictionary<string, IUserTwoFactorTokenProvider<TUser>> _tokenProviders =
             new Dictionary<string, IUserTwoFactorTokenProvider<TUser>>();
 
-        private TimeSpan _defaultLockout = TimeSpan.Zero;
         private bool _disposed;
         private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
         private IServiceProvider _services;

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -1044,7 +1044,6 @@ namespace Microsoft.AspNetCore.Identity
         public virtual Task<IdentityResult> AddClaimAsync(TUser user, Claim claim)
         {
             ThrowIfDisposed();
-            var claimStore = GetClaimStore();
             if (claim == null)
             {
                 throw new ArgumentNullException(nameof(claim));

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -1122,7 +1122,6 @@ namespace Microsoft.AspNetCore.Identity
         public virtual Task<IdentityResult> RemoveClaimAsync(TUser user, Claim claim)
         {
             ThrowIfDisposed();
-            var claimStore = GetClaimStore();
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2070,12 +2070,12 @@ namespace Microsoft.AspNetCore.Identity
         public virtual Task<IList<TUser>> GetUsersForClaimAsync(Claim claim)
         {
             ThrowIfDisposed();
-            var store = GetClaimStore();
+            var claimStore = GetClaimStore();
             if (claim == null)
             {
                 throw new ArgumentNullException(nameof(claim));
             }
-            return store.GetUsersForClaimAsync(claim, CancellationToken);
+            return claimStore.GetUsersForClaimAsync(claim, CancellationToken);
         }
 
         /// <summary>

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Identity
 
         private bool _disposed;
         private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
-        private IServiceProvider _services;
+        private readonly IServiceProvider _services;
 
         /// <summary>
         /// The cancellation token used to cancel operations.

--- a/src/Identity/test/Identity.Test/UserManagerTest.cs
+++ b/src/Identity/test/Identity.Test/UserManagerTest.cs
@@ -657,9 +657,9 @@ namespace Microsoft.AspNetCore.Identity.Test
         {
             var manager = MockHelpers.TestUserManager(new NoopUserStore());
             Assert.False(manager.SupportsUserClaim);
-            await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.AddClaimAsync(null, null));
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.AddClaimsAsync(null, null));
             await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.ReplaceClaimAsync(null, null, null));
-            await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.RemoveClaimAsync(null, null));
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.RemoveClaimsAsync(null, null));
             await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.GetClaimsAsync(null));
         }
 


### PR DESCRIPTION
Summary of the changes within `UserManager.cs`:
- Removed unused code
- Added `readonly` to a private field
- Renamed local variable from `store` to `claimStore`