### PR TITLE
[2.1. test only] Remove checks for Microsoft.VisualStudio.Web.CodeGeneration.Design in templates

### DIFF
--- a/src/Templating/test/Templates.Test/MvcTemplateTest.cs
+++ b/src/Templating/test/Templates.Test/MvcTemplateTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
@@ -112,7 +112,7 @@ namespace Templates.Test
             {
                 Assert.Contains(".db", projectFileContents);
             }
-            Assert.Contains("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
+            Assert.DoesNotContain("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
 
             if (targetFrameworkOverride != null)
             {

--- a/src/Templating/test/Templates.Test/RazorPagesTemplateTest.cs
+++ b/src/Templating/test/Templates.Test/RazorPagesTemplateTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
@@ -92,7 +92,7 @@ namespace Templates.Test
             {
                 Assert.Contains(".db", projectFileContents);
             }
-            Assert.Contains("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
+            Assert.DoesNotContain("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
 
             if (targetFrameworkOverride != null)
             {


### PR DESCRIPTION
- see aspnet/AspNetCore-Internal#1759