### PR TITLE
Add docs for Microsoft.AspNetCore.Mvc.TagHelpers.

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/ref/Microsoft.AspNetCore.Mvc.TagHelpers.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.TagHelpers/ref/Microsoft.AspNetCore.Mvc.TagHelpers.netcoreapp3.0.cs
@@ -221,10 +221,15 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute("img", Attributes="asp-append-version,src", TagStructure=Microsoft.AspNetCore.Razor.TagHelpers.TagStructure.WithoutEndTag)]
     public partial class ImageTagHelper : Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper
     {
+        [System.ObsoleteAttribute("This constructor is obsolete and will be removed in a future version.")]
         public ImageTagHelper(Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnvironment, Microsoft.AspNetCore.Mvc.Razor.Infrastructure.TagHelperMemoryCacheProvider cacheProvider, Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider fileVersionProvider, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory urlHelperFactory) : base (default(Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory), default(System.Text.Encodings.Web.HtmlEncoder)) { }
+        [Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute]
+        public ImageTagHelper(Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider fileVersionProvider, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory urlHelperFactory) : base (default(Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory), default(System.Text.Encodings.Web.HtmlEncoder)) { }
         [Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute("asp-append-version")]
         public bool AppendVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ObsoleteAttribute("This property is obsolete and will be removed in a future version.")]
         protected internal Microsoft.Extensions.Caching.Memory.IMemoryCache Cache { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        [System.ObsoleteAttribute("This property is obsolete and will be removed in a future version.")]
         protected internal Microsoft.AspNetCore.Hosting.IWebHostEnvironment HostingEnvironment { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public override int Order { get { throw null; } }
         [Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute("src")]

--- a/src/Mvc/Mvc.TagHelpers/src/AnchorTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/AnchorTagHelper.cs
@@ -52,6 +52,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="AnchorTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
         /// <summary>

--- a/src/Mvc/Mvc.TagHelpers/src/Cache/DistributedCacheTagHelperService.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/Cache/DistributedCacheTagHelperService.cs
@@ -39,6 +39,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
         private readonly ILogger _logger;
         private readonly ConcurrentDictionary<CacheTagKey, Task<IHtmlContent>> _workers;
 
+        /// <summary>
+        /// Creates a new <see cref="DistributedCacheTagHelperService"/>.
+        /// </summary>
+        /// <param name="storage">The <see cref="DistributedCacheTagHelper"/>'s <see cref="IDistributedCacheTagHelperStorage"/>.</param>
+        /// <param name="formatter">The <see cref="IDistributedCacheTagHelperFormatter"/> for cache value serialization.</param>
+        /// <param name="HtmlEncoder">The <see cref="HtmlEncoder"/> used to encode cache content.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
         public DistributedCacheTagHelperService(
             IDistributedCacheTagHelperStorage storage,
             IDistributedCacheTagHelperFormatter formatter,

--- a/src/Mvc/Mvc.TagHelpers/src/CacheTagHelperMemoryCacheFactory.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/CacheTagHelperMemoryCacheFactory.cs
@@ -6,8 +6,16 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.TagHelpers
 {
+    /// <summary>
+    /// A factory for <see cref="IMemoryCache"/>s configured using <see cref="CacheTagHelperOptions"/>.
+    /// <see cref="CacheTagHelper"/> uses this factory to set its <see cref="CacheTagHelper.MemoryCache"/>.
+    /// </summary>
     public class CacheTagHelperMemoryCacheFactory
     {
+        /// <summary>
+        /// Creates a new <see cref="CacheTagHelperMemoryCacheFactory"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="CacheTagHelperOptions"/> to apply to the <see cref="Cache"/>.</param>
         public CacheTagHelperMemoryCacheFactory(IOptions<CacheTagHelperOptions> options)
         {
             Cache = new MemoryCache(new MemoryCacheOptions
@@ -22,6 +30,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Cache = cache;
         }
 
+        /// <summary>
+        /// Gets the <see cref="IMemoryCache"/>.
+        /// </summary>
         public IMemoryCache Cache { get; }
     }
 }

--- a/src/Mvc/Mvc.TagHelpers/src/EnvironmentTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/EnvironmentTagHelper.cs
@@ -59,6 +59,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// </remarks>
         public string Exclude { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IWebHostEnvironment"/> for the application.
+        /// </summary>
         protected IWebHostEnvironment HostingEnvironment { get; }
 
         /// <inheritdoc />

--- a/src/Mvc/Mvc.TagHelpers/src/FormActionTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/FormActionTagHelper.cs
@@ -98,6 +98,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IUrlHelperFactory"/> used to create an <see cref="IUrlHelper"/> to generate links.
+        /// </summary>
         protected IUrlHelperFactory UrlHelperFactory { get; }
 
         /// <summary>

--- a/src/Mvc/Mvc.TagHelpers/src/FormTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/FormTagHelper.cs
@@ -45,10 +45,16 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="FormTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
         /// <summary>

--- a/src/Mvc/Mvc.TagHelpers/src/ImageTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ImageTagHelper.cs
@@ -32,13 +32,31 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <summary>
         /// Creates a new <see cref="ImageTagHelper"/>.
         /// </summary>
-        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
-        /// <param name="cacheProvider">The <see cref="TagHelperMemoryCacheProvider"/>.</param>
         /// <param name="fileVersionProvider">The <see cref="IFileVersionProvider"/>.</param>
         /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
         /// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
         // Decorated with ActivatorUtilitiesConstructor since we want to influence tag helper activation
         // to use this constructor in the default case.
+        [ActivatorUtilitiesConstructor]
+        public ImageTagHelper(
+            IFileVersionProvider fileVersionProvider,
+            HtmlEncoder htmlEncoder,
+            IUrlHelperFactory urlHelperFactory)
+            : base(urlHelperFactory, htmlEncoder)
+        {
+            FileVersionProvider = fileVersionProvider;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ImageTagHelper"/>.
+        /// This constructor is obsolete and will be removed in a future version.
+        /// </summary>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        /// <param name="cacheProvider">The <see cref="TagHelperMemoryCacheProvider"/>.</param>
+        /// <param name="fileVersionProvider">The <see cref="IFileVersionProvider"/>.</param>
+        /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
+        /// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public ImageTagHelper(
             IWebHostEnvironment hostingEnvironment,
             TagHelperMemoryCacheProvider cacheProvider,
@@ -73,8 +91,18 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [HtmlAttributeName(AppendVersionAttributeName)]
         public bool AppendVersion { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IWebHostEnvironment"/> for the application.
+        /// This property is obsolete and will be removed in a future version.
+        /// </summary>
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
         protected internal IWebHostEnvironment HostingEnvironment { get; }
 
+        /// <summary>
+        /// Gets the <see cref="IMemoryCache"/> used to store globbed urls.
+        /// This property is obsolete and will be removed in a future version.
+        /// </summary>
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
         protected internal IMemoryCache Cache { get; }
 
         internal IFileVersionProvider FileVersionProvider { get; private set; }

--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -76,8 +76,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="InputTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Mvc/Mvc.TagHelpers/src/LabelTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/LabelTagHelper.cs
@@ -29,10 +29,16 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="LabelTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
         /// <summary>

--- a/src/Mvc/Mvc.TagHelpers/src/LinkTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/LinkTagHelper.cs
@@ -210,12 +210,24 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [HtmlAttributeName(FallbackTestValueAttributeName)]
         public string FallbackTestValue { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IWebHostEnvironment"/> for the application.
+        /// </summary>
         protected internal IWebHostEnvironment HostingEnvironment { get; }
 
+        /// <summary>
+        /// Gets the <see cref="IMemoryCache"/> used to store globbed urls.
+        /// </summary>
         protected internal IMemoryCache Cache { get; }
 
+        /// <summary>
+        /// Gets the <see cref="System.Text.Encodings.Web.JavaScriptEncoder"/> used to encode fallback information.
+        /// </summary>
         protected JavaScriptEncoder JavaScriptEncoder { get; }
 
+        /// <summary>
+        /// Gets the <see cref="GlobbingUrlBuilder"/> used to populate included and excluded urls.
+        /// </summary>
         // Internal for ease of use when testing.
         protected internal GlobbingUrlBuilder GlobbingUrlBuilder { get; set; }
 

--- a/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
+++ b/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>ASP.NET Core MVC default tag helpers. Contains tag helpers for anchor tags, HTML input elements, caching, scripts, links (for CSS), and more.</Description>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;aspnetcoremvc;taghelper;taghelpers</PackageTags>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>

--- a/src/Mvc/Mvc.TagHelpers/src/OptionTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/OptionTagHelper.cs
@@ -32,8 +32,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="OptionTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Mvc/Mvc.TagHelpers/src/PartialTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/PartialTagHelper.cs
@@ -32,6 +32,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private readonly ICompositeViewEngine _viewEngine;
         private readonly IViewBufferScope _viewBufferScope;
 
+        /// <summary>
+        /// Creates a new <see cref="PartialTagHelper"/>.
+        /// </summary>
+        /// <param name="viewEngine">The <see cref="ICompositeViewEngine"/> used to locate the partial view.</param>
+        /// <param name="viewBufferScope">The <see cref="IViewBufferScope"/>.</param>
         public PartialTagHelper(
             ICompositeViewEngine viewEngine,
             IViewBufferScope viewBufferScope)
@@ -91,6 +96,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// </summary>
         public ViewDataDictionary ViewData { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Mvc/Mvc.TagHelpers/src/RenderAtEndOfFormTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/RenderAtEndOfFormTagHelper.cs
@@ -23,6 +23,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -900;
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Mvc/Mvc.TagHelpers/src/ScriptTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ScriptTagHelper.cs
@@ -176,14 +176,26 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [HtmlAttributeName(FallbackTestExpressionAttributeName)]
         public string FallbackTestExpression { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IWebHostEnvironment"/> for the application.
+        /// </summary>
         protected internal IWebHostEnvironment HostingEnvironment { get; }
 
+        /// <summary>
+        /// Gets the <see cref="IMemoryCache"/> used to store globbed urls.
+        /// </summary>
         protected internal IMemoryCache Cache { get; private set; }
 
         internal IFileVersionProvider FileVersionProvider { get; private set; }
 
+        /// <summary>
+        /// Gets the <see cref="System.Text.Encodings.Web.JavaScriptEncoder"/> used to encode fallback information.
+        /// </summary>
         protected JavaScriptEncoder JavaScriptEncoder { get; }
 
+        /// <summary>
+        /// Gets the <see cref="GlobbingUrlBuilder"/> used to populate included and excluded urls.
+        /// </summary>
         // Internal for ease of use when testing.
         protected internal GlobbingUrlBuilder GlobbingUrlBuilder { get; set; }
 

--- a/src/Mvc/Mvc.TagHelpers/src/SelectTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/SelectTagHelper.cs
@@ -37,8 +37,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="SelectTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Mvc/Mvc.TagHelpers/src/TextAreaTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/TextAreaTagHelper.cs
@@ -29,8 +29,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="TextAreaTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Mvc/Mvc.TagHelpers/src/ValidationMessageTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ValidationMessageTagHelper.cs
@@ -32,12 +32,21 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="ValidationMessageTagHelper"/>'s output.
+        /// </summary>
         protected IHtmlGenerator Generator { get; }
 
+        /// <summary>
+        /// Gets an expression to be evaluated against the current model.
+        /// </summary>
         [HtmlAttributeName(ValidationForAttributeName)]
         public ModelExpression For { get; set; }
 

--- a/src/Mvc/Mvc.TagHelpers/src/ValidationSummaryTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ValidationSummaryTagHelper.cs
@@ -30,10 +30,16 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// <inheritdoc />
         public override int Order => -1000;
 
+        /// <summary>
+        /// Gets the <see cref="Rendering.ViewContext"/> of the executing view.
+        /// </summary>
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="IHtmlGenerator"/> used to generate the <see cref="ValidationSummaryTagHelper"/>'s output.
+        /// </summary>
         [HtmlAttributeNotBound]
         protected IHtmlGenerator Generator { get; }
 

--- a/src/Mvc/Mvc.TagHelpers/test/DefaultTagHelperActivatorTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/DefaultTagHelperActivatorTest.cs
@@ -53,20 +53,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             Assert.Same(FileVersionProvider, linkTagHelper.FileVersionProvider);
         }
 
-        [Fact]
-        public void ImageTagHelper_DoesNotUseMemoryCacheInstanceFromDI()
-        {
-            // Arrange
-            var activator = new DefaultTagHelperActivator(new TypeActivatorCache());
-            var viewContext = CreateViewContext();
-
-            var imageTagHelper = activator.Create<ImageTagHelper>(viewContext);
-
-            Assert.Same(CacheProvider.Cache, imageTagHelper.Cache);
-            Assert.Same(HostingEnvironment, imageTagHelper.HostingEnvironment);
-            Assert.Same(FileVersionProvider, imageTagHelper.FileVersionProvider);
-        }
-
         private ViewContext CreateViewContext()
         {
             var services = new ServiceCollection()

--- a/src/Mvc/Mvc.TagHelpers/test/ImageTagHelperTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/ImageTagHelperTest.cs
@@ -264,8 +264,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var fileVersionProvider = new DefaultFileVersionProvider(hostingEnvironment, cacheProvider);
 
             return new ImageTagHelper(
-                hostingEnvironment,
-                new TagHelperMemoryCacheProvider(),
                 fileVersionProvider,
                 new HtmlTestEncoder(),
                 urlHelperFactory)


### PR DESCRIPTION
- Also obsoleted two unused members on `ImageTagHelper`.
- Removed `NoWarn` for docs on `Microsoft.AspNetCore.Mvc.TagHelpers`.

Addresses https://github.com/aspnet/Docs/issues/10593
