### PR TITLE
Improve NullHtmlEncoder perf

### DIFF
--- a/src/Razor/Razor/ref/Microsoft.AspNetCore.Razor.netcoreapp3.0.cs
+++ b/src/Razor/Razor/ref/Microsoft.AspNetCore.Razor.netcoreapp3.0.cs
@@ -61,17 +61,17 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         void Init(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context);
         System.Threading.Tasks.Task ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output);
     }
-    public partial class NullHtmlEncoder : System.Text.Encodings.Web.HtmlEncoder
+    public sealed partial class NullHtmlEncoder : System.Text.Encodings.Web.HtmlEncoder
     {
-        protected NullHtmlEncoder() { }
+        internal NullHtmlEncoder() { }
         public static new Microsoft.AspNetCore.Razor.TagHelpers.NullHtmlEncoder Default { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public override int MaxOutputCharactersPerInputCharacter { get { throw null; } }
         public override void Encode(System.IO.TextWriter output, char[] value, int startIndex, int characterCount) { }
         public override void Encode(System.IO.TextWriter output, string value, int startIndex, int characterCount) { }
         public override string Encode(string value) { throw null; }
-        public unsafe override int FindFirstCharacterToEncode(char* text, int textLength) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public unsafe override int FindFirstCharacterToEncode(char* text, int textLength) { throw null; }
         public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten) { throw null; }
-        public override bool WillEncode(int unicodeScalar) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public override bool WillEncode(int unicodeScalar) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputElementHintAttribute : System.Attribute

--- a/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
+++ b/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
@@ -79,8 +79,9 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                 return;
             }
 
-            var span = value.AsSpan();
-            output.Write(span.Slice(startIndex, characterCount));
+            var span = value.AsSpan(startIndex, characterCount);
+            
+            output.Write(span);
         }
 
         /// <inheritdoc />

--- a/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
+++ b/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
@@ -64,6 +64,21 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
 
         public override void Encode(TextWriter output, string value, int startIndex, int characterCount)
         {
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (characterCount == 0)
+            {
+                return;
+            }
+
             var span = value.AsSpan();
             output.Write(span.Slice(startIndex, characterCount));
         }

--- a/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
+++ b/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 
 namespace Microsoft.AspNetCore.Razor.TagHelpers
@@ -11,12 +12,12 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
     /// A <see cref="HtmlEncoder"/> that does not encode. Should not be used when writing directly to a response
     /// expected to contain valid HTML.
     /// </summary>
-    public class NullHtmlEncoder : HtmlEncoder
+    public sealed class NullHtmlEncoder : HtmlEncoder
     {
         /// <summary>
         /// Initializes a <see cref="NullHtmlEncoder"/> instance.
         /// </summary>
-        protected NullHtmlEncoder()
+        private NullHtmlEncoder()
         {
         }
 
@@ -27,13 +28,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         public static new NullHtmlEncoder Default { get; } = new NullHtmlEncoder();
 
         /// <inheritdoc />
-        public override int MaxOutputCharactersPerInputCharacter
-        {
-            get
-            {
-                return 1;
-            }
-        }
+        public override int MaxOutputCharactersPerInputCharacter => 1;
 
         /// <inheritdoc />
         public override string Encode(string value)
@@ -68,27 +63,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         }
 
         /// <inheritdoc />
-        public override void Encode(TextWriter output, string value, int startIndex, int characterCount)
-        {
-            if (output == null)
-            {
-                throw new ArgumentNullException(nameof(output));
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            if (characterCount == 0)
-            {
-                return;
-            }
-
-            output.Write(value.Substring(startIndex, characterCount));
-        }
-
-        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
         {
             return -1;
@@ -112,6 +87,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool WillEncode(int unicodeScalar)
         {
             return false;

--- a/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
+++ b/src/Razor/Razor/src/TagHelpers/NullHtmlEncoder.cs
@@ -62,6 +62,12 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             output.Write(value, startIndex, characterCount);
         }
 
+        public override void Encode(TextWriter output, string value, int startIndex, int characterCount)
+        {
+            var span = value.AsSpan();
+            output.Write(span.Slice(startIndex, characterCount));
+        }
+
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)


### PR DESCRIPTION
It's used anywhere `IHtmlContent` is rendered.

```
|                      Method |      Mean |     Error |    StdDev | Ratio | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------- |----------:|----------:|----------:|------:|------------:|------------:|------------:|--------------------:|
|           MvcNullHtmlEncode | 0.9833 ns | 0.0121 ns | 0.0101 ns |  1.00 |           - |           - |           - |                   - |
| InlinedBetterNullHtmlEncode | 0.2979 ns | 0.0147 ns | 0.0138 ns |  0.30 |           - |           - |           - |                   - |
```
