### PR TITLE
Add a RouterBase type

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -4,10 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components.Layouts;
-using Microsoft.AspNetCore.Components.RenderTree;
-using Microsoft.AspNetCore.Components.Services;
 
 namespace Microsoft.AspNetCore.Components.Routing
 {
@@ -15,106 +11,16 @@ namespace Microsoft.AspNetCore.Components.Routing
     /// A component that displays whichever other component corresponds to the
     /// current navigation location.
     /// </summary>
-    public class Router : IComponent, IDisposable
+    public class Router : RouterBase
     {
-        static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
-
-        RenderHandle _renderHandle;
-        string _baseUri;
-        string _locationAbsolute;
-
-        [Inject] private IUriHelper UriHelper { get; set; }
-
         /// <summary>
         /// Gets or sets the assembly that should be searched, along with its referenced
         /// assemblies, for components matching the URI.
         /// </summary>
         [Parameter] private Assembly AppAssembly { get; set; }
-        
-        /// <summary>
-        /// Gets or sets the type of the component that should be used as a fallback when no match is found for the requested route.
-        /// </summary>
-        [Parameter] private Type FallbackComponent { get; set; }
-
-        private RouteTable Routes { get; set; }
 
         /// <inheritdoc />
-        public void Configure(RenderHandle renderHandle)
-        {
-            _renderHandle = renderHandle;
-            _baseUri = UriHelper.GetBaseUri();
-            _locationAbsolute = UriHelper.GetAbsoluteUri();
-            UriHelper.OnLocationChanged += OnLocationChanged;
-        }
-
-        /// <inheritdoc />
-        public Task SetParametersAsync(ParameterCollection parameters)
-        {
-            parameters.SetParameterProperties(this);
-            var types = ComponentResolver.ResolveComponents(AppAssembly);
-            Routes = RouteTable.Create(types);
-            Refresh();
-            return Task.CompletedTask;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            UriHelper.OnLocationChanged -= OnLocationChanged;
-        }
-
-        private string StringUntilAny(string str, char[] chars)
-        {
-            var firstIndex = str.IndexOfAny(chars);
-            return firstIndex < 0
-                ? str
-                : str.Substring(0, firstIndex);
-        }
-
-        /// <inheritdoc />
-        protected virtual void Render(RenderTreeBuilder builder, Type handler, IDictionary<string, object> parameters)
-        {
-            builder.OpenComponent(0, typeof(LayoutDisplay));
-            builder.AddAttribute(1, LayoutDisplay.NameOfPage, handler);
-            builder.AddAttribute(2, LayoutDisplay.NameOfPageParameters, parameters);
-            builder.CloseComponent();
-        }
-
-        private void Refresh()
-        {
-            var locationPath = UriHelper.ToBaseRelativePath(_baseUri, _locationAbsolute);
-            locationPath = StringUntilAny(locationPath, _queryOrHashStartChar);
-            var context = new RouteContext(locationPath);
-            Routes.Route(context);
-
-            if (context.Handler == null)
-            {
-                if (FallbackComponent != null)
-                {
-                    context.Handler = FallbackComponent;
-                }
-                else
-                {
-                    throw new InvalidOperationException($"'{nameof(Router)}' cannot find any component with a route for '/{locationPath}', and no fallback is defined.");
-                }
-            }
-
-            if (!typeof(IComponent).IsAssignableFrom(context.Handler))
-            {
-                throw new InvalidOperationException($"The type {context.Handler.FullName} " +
-                    $"does not implement {typeof(IComponent).FullName}.");
-            }
-
-            _renderHandle.Render(builder => Render(builder, context.Handler, context.Parameters));
-        }
-
-        private void OnLocationChanged(object sender, string newAbsoluteUri)
-        {
-            _locationAbsolute = newAbsoluteUri;
-            if (_renderHandle.IsInitialized)
-            {
-                Refresh();
-            }
-        }
+        protected override IEnumerable<Type> ResolveRoutableComponents()
+            => ComponentResolver.ResolveComponents(AppAssembly);
     }
 }

--- a/src/Components/Components/src/Routing/RouterBase.cs
+++ b/src/Components/Components/src/Routing/RouterBase.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Layouts;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Services;
+
+namespace Microsoft.AspNetCore.Components.Routing
+{
+    /// <summary>
+    /// A base type for custom component routers.
+    /// </summary>
+    public abstract class RouterBase : IComponent, IDisposable
+    {
+        static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
+
+        RenderHandle _renderHandle;
+        string _baseUri;
+        string _locationAbsolute;
+
+        [Inject] private IUriHelper UriHelper { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the component that should be used as a fallback when no match is found for the requested route.
+        /// </summary>
+        [Parameter] private Type FallbackComponent { get; set; }
+
+        private RouteTable Routes { get; set; }
+
+        /// <inheritdoc />
+        public void Configure(RenderHandle renderHandle)
+        {
+            _renderHandle = renderHandle;
+            _baseUri = UriHelper.GetBaseUri();
+            _locationAbsolute = UriHelper.GetAbsoluteUri();
+            UriHelper.OnLocationChanged += OnLocationChanged;
+        }
+
+        /// <inheritdoc />
+        public Task SetParametersAsync(ParameterCollection parameters)
+        {
+            parameters.SetParameterProperties(this);
+            var types = ResolveRoutableComponents();
+            Routes = RouteTable.Create(types);
+            Refresh();
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Resolves the types of components that can be routed to.
+        /// </summary>
+        /// <returns>An enumerable of types of components that can be routed to.</returns>
+        protected abstract IEnumerable<Type> ResolveRoutableComponents();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Frees resources used by the component.
+        /// </summary>
+        /// <param name="disposing">A boolean value indicating whether this is a managed dispose.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            UriHelper.OnLocationChanged -= OnLocationChanged;
+        }
+
+        private string StringUntilAny(string str, char[] chars)
+        {
+            var firstIndex = str.IndexOfAny(chars);
+            return firstIndex < 0
+                ? str
+                : str.Substring(0, firstIndex);
+        }
+
+        /// <inheritdoc />
+        protected virtual void Render(RenderTreeBuilder builder, Type handler, IDictionary<string, object> parameters)
+        {
+            builder.OpenComponent(0, typeof(LayoutDisplay));
+            builder.AddAttribute(1, LayoutDisplay.NameOfPage, handler);
+            builder.AddAttribute(2, LayoutDisplay.NameOfPageParameters, parameters);
+            builder.CloseComponent();
+        }
+
+        private void Refresh()
+        {
+            var locationPath = UriHelper.ToBaseRelativePath(_baseUri, _locationAbsolute);
+            locationPath = StringUntilAny(locationPath, _queryOrHashStartChar);
+            var context = new RouteContext(locationPath);
+            Routes.Route(context);
+
+            if (context.Handler == null)
+            {
+                if (FallbackComponent != null)
+                {
+                    context.Handler = FallbackComponent;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"'{nameof(Router)}' cannot find any component with a route for '/{locationPath}', and no fallback is defined.");
+                }
+            }
+
+            if (!typeof(IComponent).IsAssignableFrom(context.Handler))
+            {
+                throw new InvalidOperationException($"The type {context.Handler.FullName} " +
+                    $"does not implement {typeof(IComponent).FullName}.");
+            }
+
+            _renderHandle.Render(builder => Render(builder, context.Handler, context.Parameters));
+        }
+
+        private void OnLocationChanged(object sender, string newAbsoluteUri)
+        {
+            _locationAbsolute = newAbsoluteUri;
+            if (_renderHandle.IsInitialized)
+            {
+                Refresh();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a `RouterBase` type that can be used to implement custom routers without the need to reimplement or copy the complete `Microsoft.AspNetCore.Components.Routing` namespace.   

This adds a method `protected abstract IEnumerable<Type> ResolveRoutableComponents()` that is used to resolve the types of components that can be routed.  

A custom router is free to override this without reimplementing the actual routing mechanism (`RouteTable`, etc)

