### PR TITLE
add content type into extension provider for passbook Apple wallet files

### DIFF
--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -226,6 +226,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".pfx", "application/x-pkcs12" },
                 { ".pgm", "image/x-portable-graymap" },
                 { ".pko", "application/vnd.ms-pki.pko" },
+                { ".pkpass", "application/vnd.apple.pkpass" },
                 { ".pma", "application/x-perfmon" },
                 { ".pmc", "application/x-perfmon" },
                 { ".pml", "application/x-perfmon" },


### PR DESCRIPTION
Adding support of `.pkpass` file extension used for Apple wallet passboook files.

