### PR TITLE
Increase shutdown timeout in Kestrel's other TestServer

### DIFF
--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
@@ -91,6 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     configureServices(services);
                 })
                 .UseSetting(WebHostDefaults.ApplicationKey, typeof(TestServer).GetTypeInfo().Assembly.FullName)
+                .UseSetting(WebHostDefaults.ShutdownTimeoutKey, TestConstants.DefaultTimeout.TotalSeconds.ToString())
                 .Build();
 
             _host.Start();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
@@ -151,12 +151,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             var stopTask = Task.CompletedTask;
             using (var server = new TestServer(requestDelegate, serviceContext, listenOptions))
-            using (var shutdownCts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            using (var shutdownCts = new CancellationTokenSource(TestConstants.DefaultTimeout))
             {
                 using (var connection = server.CreateConnection())
                 {
-                    // Use the default 5 second shutdown timeout. If it hangs that long, we'll look
-                    // at the collected memory dump.
+                    // We assume all CI servers are really slow, so we use a 30 second default test timeout
+                    // instead of the 5 second default production timeout. If this test is still flaky,
+                    // *then* we can consider collecting and investigating memory dumps.
                     stopTask = server.StopAsync(shutdownCts.Token);
                 }
 


### PR DESCRIPTION
This is a follow up to #7082, where I missed the non-in-memory TestServer. This should reduce test flakiness caused by ungraceful shutdowns being reported.

Addresses #7496 and https://github.com/aspnet/AspNetCore-Internal/issues/1832