### PR TITLE
Update baseline test

### DIFF
--- a/test/SharedFx.UnitTests/SharedFxTests.cs
+++ b/test/SharedFx.UnitTests/SharedFxTests.cs
@@ -65,8 +65,8 @@ namespace Microsoft.AspNetCore
                     {
                         var localAssemblyVersion = AssemblyName.GetAssemblyName(file).Version;
                         var dllName = Path.GetFileName(file);
-                        Assert.True(nugetAssemblyVersions.ContainsKey(dllName), $"Expected {dllName} to be in the downloaded dlls");
-                        Assert.True(localAssemblyVersion.CompareTo(nugetAssemblyVersions[dllName]) >= 0, $"Expected the local version of {dllName} to be greater than or equal to the already released version.");
+                        Assert.Contains(dllName, nugetAssemblyVersions.Keys);
+                        Assert.InRange(localAssemblyVersion.CompareTo(nugetAssemblyVersions[dllName]), 0, int.MaxValue);
                     }
                     catch (BadImageFormatException) { }
 

--- a/test/SharedFx.UnitTests/SharedFxTests.cs
+++ b/test/SharedFx.UnitTests/SharedFxTests.cs
@@ -37,12 +37,13 @@ namespace Microsoft.AspNetCore
 
             var zipPath = Path.Combine(AppContext.BaseDirectory, zipName);
 
-            if (!Directory.Exists(AppContext.BaseDirectory + "unzipped"))
+            var tempPath = Path.GetTempPath();
+            if (!Directory.Exists(Path.Combine(tempPath, "unzipped")))
             {
-                ZipFile.ExtractToDirectory(AppContext.BaseDirectory, "unzipped");
+                ZipFile.ExtractToDirectory(zipPath, Path.Combine(tempPath, "unzipped"));
             }
 
-            var nugetAssembliesPath = Path.Combine(AppContext.BaseDirectory, "unzipped", "shared", config.Name, previousVersion);
+            var nugetAssembliesPath = Path.Combine(tempPath, "unzipped", "shared", config.Name, previousVersion);
 
             var files = Directory.GetFiles(nugetAssembliesPath, "*.dll");
             foreach (var file in files)
@@ -70,6 +71,8 @@ namespace Microsoft.AspNetCore
                 catch (BadImageFormatException) { }
 
             });
+
+            Directory.Delete(Path.Combine(tempPath, "unzipped"), true);
         }
 
         [Theory]

--- a/test/SharedFx.UnitTests/SharedFxTests.cs
+++ b/test/SharedFx.UnitTests/SharedFxTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore
         [MemberData(nameof(GetSharedFxConfig))]
         public async Task BaselineTest(SharedFxConfig config)
         {
-
             var previousVersion = TestData.GetPreviousAspNetCoreReleaseVersion();
             var url = new Uri($"https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/" + previousVersion + "/aspnetcore-runtime-internal-" + previousVersion + "-win-x64.zip");
             var zipName = "assemblies.zip";


### PR DESCRIPTION
TeamCity is complaining about permissions for paths. Updating the baseline test to use temp directory. 