### PR TITLE
Handle models containing special characters

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -399,12 +399,17 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             {
                 htmlAttributes["multiple"] = "multiple";
             }
-
+			
+            // Handle special characters into a passed model. Otherwise the generated html-output is broken.
+            var encodedModel = modelExplorer.Model is string modelAsString
+                ? System.Web.HttpUtility.HtmlEncode(modelAsString)
+                : modelExplorer.Model;
+			
             return Generator.GenerateTextBox(
                 ViewContext,
                 modelExplorer,
-                For.Name,
-                modelExplorer.Model,
+                SourceExpression.Name,
+                encodedModel,
                 format,
                 htmlAttributes);
         }

--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -408,7 +408,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             return Generator.GenerateTextBox(
                 ViewContext,
                 modelExplorer,
-                SourceExpression.Name,
+                For.Name,
                 encodedModel,
                 format,
                 htmlAttributes);


### PR DESCRIPTION
Input-Data which contains special characters could break the output html. To avoid this behaviour the input-model is encoded.