### PR TITLE
Restore testassets during build to prevent timeouts

### DIFF
--- a/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
+++ b/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
@@ -32,6 +32,7 @@
     <Reference Include="Microsoft.AspNetCore.Razor.Design" />
     <Reference Include="rzc" />
     <Reference Include="Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib" />
+    <ProjectReference Include="..\testassets\RestoreTestProjects\RestoreTestProjects.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <Target Name="GenerateBuildVariablesFile" BeforeTargets="BeforeBuild">

--- a/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
+++ b/src/Razor/Razor.Design/test/IntegrationTests/Microsoft.AspNetCore.Razor.Design.Test.csproj
@@ -32,7 +32,6 @@
     <Reference Include="Microsoft.AspNetCore.Razor.Design" />
     <Reference Include="rzc" />
     <Reference Include="Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib" />
-    <ProjectReference Include="..\testassets\RestoreTestProjects\RestoreTestProjects.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <Target Name="GenerateBuildVariablesFile" BeforeTargets="BeforeBuild">
@@ -60,6 +59,10 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
     <ItemGroup>
       <Compile Include="$(BuildVariablesGeneratedFile)"  Condition="Exists('$(BuildVariablesGeneratedFile)')" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="RestoreTestProjects" BeforeTargets="Restore">
+    <MSBuild Projects="..\testassets\RestoreTestProjects\RestoreTestProjects.csproj" Targets="Restore" />
   </Target>
 
 </Project>

--- a/src/Razor/Razor.Design/test/testassets/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/Razor.Design/test/testassets/RestoreTestProjects/RestoreTestProjects.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AppWithP2PReference\AppWithP2PReference.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\ClassLibrary2\ClassLibrary2.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\SimpleMvc\SimpleMvc.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\SimpleMvcFSharp\SimpleMvcFSharp.fsproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\SimplePages\SimplePages.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\AppWithP2PReference\AppWithP2PReference.csproj" />
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+    <ProjectReference Include="..\ClassLibrary2\ClassLibrary2.csproj" />
+    <ProjectReference Include="..\SimpleMvc\SimpleMvc.csproj" />
+    <ProjectReference Include="..\SimpleMvcFSharp\SimpleMvcFSharp.fsproj" />
+    <ProjectReference Include="..\SimplePages\SimplePages.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Razor/Razor.Design/test/testassets/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/Razor.Design/test/testassets/RestoreTestProjects/RestoreTestProjects.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AppWithP2PReference\AppWithP2PReference.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ClassLibrary2\ClassLibrary2.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvc\SimpleMvc.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimpleMvcFSharp\SimpleMvcFSharp.fsproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\SimplePages\SimplePages.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1695

We did something similar in master (See https://github.com/aspnet/AspNetCore-Tooling/commit/7f49b97eb5b2b3eeeea71c8ceedad01715e1522a). This back-ports the change to improve test reliability. There are some packages like FSharp.Core that currently exclusively get restored during test run.
