### PR TITLE
Change SameSite default to None

### DIFF
--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -49,12 +49,12 @@ namespace Microsoft.AspNetCore.Http
         public virtual bool HttpOnly { get; set; }
 
         /// <summary>
-        /// The SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.Lax"/>
+        /// The SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.None"/>
         /// </summary>
         /// <remarks>
         /// Determines the value that will set on <seealso cref="CookieOptions.SameSite"/>.
         /// </remarks>
-        public virtual SameSiteMode SameSite { get; set; } = SameSiteMode.Lax;
+        public virtual SameSiteMode SameSite { get; set; } = SameSiteMode.None;
 
         /// <summary>
         /// The policy that will be used to determine <seealso cref="CookieOptions.Secure"/>.

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -43,10 +43,10 @@ namespace Microsoft.AspNetCore.Http
         public bool Secure { get; set; }
 
         /// <summary>
-        /// Gets or sets the value for the SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.Lax"/>
+        /// Gets or sets the value for the SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.None"/>
         /// </summary>
         /// <returns>The <see cref="SameSiteMode"/> representing the enforcement mode of the cookie.</returns>
-        public SameSiteMode SameSite { get; set; } = SameSiteMode.Lax;
+        public SameSiteMode SameSite { get; set; } = SameSiteMode.None;
 
         /// <summary>
         /// Gets or sets a value that indicates whether a cookie is accessible by client-side script.

--- a/src/Middleware/Rewrite/test/UrlActions/ChangeCookieActionTests.cs
+++ b/src/Middleware/Rewrite/test/UrlActions/ChangeCookieActionTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlActions
 
             var cookieHeaders = context.HttpContext.Response.Headers[HeaderNames.SetCookie];
             var header = Assert.Single(cookieHeaders);
-            Assert.Equal($"Cookie=Chocolate%20Chip; expires={HeaderUtilities.FormatDate(now.AddMinutes(1440))}; domain=contoso.com; path=/recipes; secure; samesite=lax; httponly", header);
+            Assert.Equal($"Cookie=Chocolate%20Chip; expires={HeaderUtilities.FormatDate(now.AddMinutes(1440))}; domain=contoso.com; path=/recipes; secure; httponly", header);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlActions
 
             var cookieHeaders = context.HttpContext.Response.Headers[HeaderNames.SetCookie];
             var header = Assert.Single(cookieHeaders);
-            Assert.Equal($"Cookie=Chocolate%20Chip; samesite=lax", header);
+            Assert.Equal($"Cookie=Chocolate%20Chip", header);
         }
 
 
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlActions
 
             var cookieHeaders = context.HttpContext.Response.Headers[HeaderNames.SetCookie];
             var header = Assert.Single(cookieHeaders);
-            Assert.Equal($"Cookie=; samesite=lax", header);
+            Assert.Equal($"Cookie=", header);
         }
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
@@ -58,7 +58,6 @@ namespace Company.WebApplication1
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
 #if (IndividualLocalAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
@@ -58,7 +58,6 @@ namespace Company.WebApplication1
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
 #if (IndividualLocalAuth)

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Affects the cookie's same site attribute.
         /// </summary>
-        public SameSiteMode MinimumSameSitePolicy { get; set; } = SameSiteMode.Lax;
+        public SameSiteMode MinimumSameSitePolicy { get; set; } = SameSiteMode.None;
 
         /// <summary>
         /// Affects whether cookies must be HttpOnly.

--- a/src/Security/CookiePolicy/test/CookieChunkingTests.cs
+++ b/src/Security/CookiePolicy/test/CookieChunkingTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Internal
             new ChunkingCookieManager() { ChunkSize = null }.AppendResponseCookie(context, "TestCookie", testString, new CookieOptions());
             var values = context.Response.Headers["Set-Cookie"];
             Assert.Single(values);
-            Assert.Equal("TestCookie=" + testString + "; path=/; samesite=lax", values[0]);
+            Assert.Equal("TestCookie=" + testString + "; path=/", values[0]);
         }
 
         [Fact]
@@ -29,18 +29,13 @@ namespace Microsoft.AspNetCore.Internal
             string testString = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
             new ChunkingCookieManager() { ChunkSize = 44 }.AppendResponseCookie(context, "TestCookie", testString, new CookieOptions());
             var values = context.Response.Headers["Set-Cookie"];
-            Assert.Equal(9, values.Count);
+            Assert.Equal(4, values.Count);
             Assert.Equal<string[]>(new[]
             {
-                "TestCookie=chunks-8; path=/; samesite=lax",
-                "TestCookieC1=abcdefgh; path=/; samesite=lax",
-                "TestCookieC2=ijklmnop; path=/; samesite=lax",
-                "TestCookieC3=qrstuvwx; path=/; samesite=lax",
-                "TestCookieC4=yz012345; path=/; samesite=lax",
-                "TestCookieC5=6789ABCD; path=/; samesite=lax",
-                "TestCookieC6=EFGHIJKL; path=/; samesite=lax",
-                "TestCookieC7=MNOPQRST; path=/; samesite=lax",
-                "TestCookieC8=UVWXYZ; path=/; samesite=lax",
+                "TestCookie=chunks-3; path=/",
+                "TestCookieC1=abcdefghijklmnopqrstuv; path=/",
+                "TestCookieC2=wxyz0123456789ABCDEFGH; path=/",
+                "TestCookieC3=IJKLMNOPQRSTUVWXYZ; path=/",
             }, values);
         }
 
@@ -117,14 +112,14 @@ namespace Microsoft.AspNetCore.Internal
             Assert.Equal(8, cookies.Count);
             Assert.Equal(new[]
             {
-                "TestCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC1=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC2=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC3=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC4=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC5=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC6=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
-                "TestCookieC7=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; samesite=lax",
+                "TestCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC1=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC2=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC3=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC4=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC5=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC6=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
+                "TestCookieC7=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/",
             }, cookies);
         }
     }

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 context.Response.Cookies.Append("Test", "Value");
                 return Task.CompletedTask;
             });
-            Assert.Equal("Test=Value; path=/; samesite=lax", httpContext.Response.Headers[HeaderNames.SetCookie]);
+            Assert.Equal("Test=Value; path=/", httpContext.Response.Headers[HeaderNames.SetCookie]);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 context.Response.Cookies.Append("Test", "Value", new CookieOptions() { IsEssential = false });
                 return Task.CompletedTask;
             });
-            Assert.Equal("Test=Value; path=/; samesite=lax", httpContext.Response.Headers[HeaderNames.SetCookie]);
+            Assert.Equal("Test=Value; path=/", httpContext.Response.Headers[HeaderNames.SetCookie]);
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 context.Response.Cookies.Append("Test", "Value", new CookieOptions() { IsEssential = true });
                 return Task.CompletedTask;
             });
-            Assert.Equal("Test=Value; path=/; samesite=lax", httpContext.Response.Headers[HeaderNames.SetCookie]);
+            Assert.Equal("Test=Value; path=/", httpContext.Response.Headers[HeaderNames.SetCookie]);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 context.Response.Cookies.Append("Test", "Value");
                 return Task.CompletedTask;
             });
-            Assert.Equal("Test=Value; path=/; samesite=lax", httpContext.Response.Headers[HeaderNames.SetCookie]);
+            Assert.Equal("Test=Value; path=/", httpContext.Response.Headers[HeaderNames.SetCookie]);
         }
 
         [Fact]
@@ -223,12 +223,12 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             Assert.Equal("yes", consentCookie.Value);
             Assert.True(consentCookie.Expires.HasValue);
             Assert.True(consentCookie.Expires.Value > DateTimeOffset.Now + TimeSpan.FromDays(364));
-            Assert.Equal(Net.Http.Headers.SameSiteMode.Lax, consentCookie.SameSite);
+            Assert.Equal(Net.Http.Headers.SameSiteMode.None, consentCookie.SameSite);
             Assert.NotNull(consentCookie.Expires);
             var testCookie = cookies[1];
             Assert.Equal("Test", testCookie.Name);
             Assert.Equal("Value", testCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.Lax, testCookie.SameSite);
+            Assert.Equal(Net.Http.Headers.SameSiteMode.None, testCookie.SameSite);
             Assert.Null(testCookie.Expires);
         }
 
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 return Task.CompletedTask;
             });
 
-            Assert.Equal("Test=Value; path=/; samesite=lax", httpContext.Response.Headers[HeaderNames.SetCookie]);
+            Assert.Equal("Test=Value; path=/", httpContext.Response.Headers[HeaderNames.SetCookie]);
         }
 
         [Fact]
@@ -400,12 +400,12 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var testCookie = cookies[0];
             Assert.Equal("Test", testCookie.Name);
             Assert.Equal("Value1", testCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.Lax, testCookie.SameSite);
+            Assert.Equal(Net.Http.Headers.SameSiteMode.None, testCookie.SameSite);
             Assert.Null(testCookie.Expires);
             var consentCookie = cookies[1];
             Assert.Equal(".AspNet.Consent", consentCookie.Name);
             Assert.Equal("", consentCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.Lax, consentCookie.SameSite);
+            Assert.Equal(Net.Http.Headers.SameSiteMode.None, consentCookie.SameSite);
             Assert.NotNull(consentCookie.Expires);
         }
 
@@ -486,7 +486,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
 
             var reader = new StreamReader(httpContext.Response.Body);
             Assert.Equal("Started.Withdrawn.", await reader.ReadToEndAsync());
-            Assert.Equal("Test=Value1; path=/; samesite=lax", httpContext.Response.Headers[HeaderNames.SetCookie]);
+            Assert.Equal("Test=Value1; path=/", httpContext.Response.Headers[HeaderNames.SetCookie]);
         }
 
         [Fact]
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var testCookie = cookies[0];
             Assert.Equal("Test", testCookie.Name);
             Assert.Equal("", testCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.Lax, testCookie.SameSite);
+            Assert.Equal(Net.Http.Headers.SameSiteMode.None, testCookie.SameSite);
             Assert.NotNull(testCookie.Expires);
         }
 
@@ -576,7 +576,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var consentCookie = cookies[0];
             Assert.Equal(".AspNet.Consent", consentCookie.Name);
             Assert.Equal("yes", consentCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.Lax, consentCookie.SameSite);
+            Assert.Equal(Net.Http.Headers.SameSiteMode.None, consentCookie.SameSite);
             Assert.NotNull(consentCookie.Expires);
 
             cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers["ManualCookie"]);

--- a/src/Security/CookiePolicy/test/CookiePolicyTests.cs
+++ b/src/Security/CookiePolicy/test/CookiePolicyTests.cs
@@ -59,10 +59,10 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                     transaction =>
                     {
                         Assert.NotNull(transaction.SetCookie);
-                        Assert.Equal("A=A; path=/; secure; samesite=lax", transaction.SetCookie[0]);
-                        Assert.Equal("B=B; path=/; secure; samesite=lax", transaction.SetCookie[1]);
-                        Assert.Equal("C=C; path=/; secure; samesite=lax", transaction.SetCookie[2]);
-                        Assert.Equal("D=D; path=/; secure; samesite=lax", transaction.SetCookie[3]);
+                        Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
+                        Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
+                        Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
+                        Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
                     }));
         }
 
@@ -79,10 +79,10 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                     transaction =>
                     {
                         Assert.NotNull(transaction.SetCookie);
-                        Assert.Equal("A=A; path=/; samesite=lax", transaction.SetCookie[0]);
-                        Assert.Equal("B=B; path=/; samesite=lax", transaction.SetCookie[1]);
-                        Assert.Equal("C=C; path=/; samesite=lax", transaction.SetCookie[2]);
-                        Assert.Equal("D=D; path=/; secure; samesite=lax", transaction.SetCookie[3]);
+                        Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+                        Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+                        Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+                        Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
                     }));
         }
 
@@ -99,19 +99,19 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                     transaction =>
                     {
                         Assert.NotNull(transaction.SetCookie);
-                        Assert.Equal("A=A; path=/; samesite=lax", transaction.SetCookie[0]);
-                        Assert.Equal("B=B; path=/; samesite=lax", transaction.SetCookie[1]);
-                        Assert.Equal("C=C; path=/; samesite=lax", transaction.SetCookie[2]);
-                        Assert.Equal("D=D; path=/; secure; samesite=lax", transaction.SetCookie[3]);
+                        Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+                        Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+                        Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+                        Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
                     }),
                 new RequestTest("https://example.com/secureSame",
                     transaction =>
                     {
                         Assert.NotNull(transaction.SetCookie);
-                        Assert.Equal("A=A; path=/; secure; samesite=lax", transaction.SetCookie[0]);
-                        Assert.Equal("B=B; path=/; secure; samesite=lax", transaction.SetCookie[1]);
-                        Assert.Equal("C=C; path=/; secure; samesite=lax", transaction.SetCookie[2]);
-                        Assert.Equal("D=D; path=/; secure; samesite=lax", transaction.SetCookie[3]);
+                        Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
+                        Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
+                        Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
+                        Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
                     }));
         }
 
@@ -128,10 +128,10 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 transaction =>
                 {
                     Assert.NotNull(transaction.SetCookie);
-                    Assert.Equal("A=A; path=/; samesite=lax; httponly", transaction.SetCookie[0]);
-                    Assert.Equal("B=B; path=/; samesite=lax; httponly", transaction.SetCookie[1]);
-                    Assert.Equal("C=C; path=/; samesite=lax; httponly", transaction.SetCookie[2]);
-                    Assert.Equal("D=D; path=/; samesite=lax; httponly", transaction.SetCookie[3]);
+                    Assert.Equal("A=A; path=/; httponly", transaction.SetCookie[0]);
+                    Assert.Equal("B=B; path=/; httponly", transaction.SetCookie[1]);
+                    Assert.Equal("C=C; path=/; httponly", transaction.SetCookie[2]);
+                    Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
                 }));
         }
 
@@ -148,10 +148,10 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 transaction =>
                 {
                     Assert.NotNull(transaction.SetCookie);
-                    Assert.Equal("A=A; path=/; samesite=lax", transaction.SetCookie[0]);
-                    Assert.Equal("B=B; path=/; samesite=lax", transaction.SetCookie[1]);
-                    Assert.Equal("C=C; path=/; samesite=lax", transaction.SetCookie[2]);
-                    Assert.Equal("D=D; path=/; samesite=lax; httponly", transaction.SetCookie[3]);
+                    Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+                    Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+                    Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+                    Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
                 }));
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                     Assert.NotNull(transaction.SetCookie);
                     Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
                     Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
-                    Assert.Equal("C=C; path=/; samesite=lax", transaction.SetCookie[2]);
+                    Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
                     Assert.Equal("D=D; path=/; samesite=lax", transaction.SetCookie[3]);
                     Assert.Equal("E=E; path=/; samesite=strict", transaction.SetCookie[4]);
                 }));
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                     {
                         context.Response.Cookies.Append("A", "A");
                         context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
-                        context.Response.Cookies.Append("C", "C", new CookieOptions());
+                        context.Response.Cookies.Append("C", "C", new CookieOptions() { SameSite = Http.SameSiteMode.Strict });
                         context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
                         return Task.FromResult(0);
                     });
@@ -242,10 +242,10 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var transaction = await server.SendAsync("http://example.com/login");
 
             Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("Hao=Hao; path=/; samesite=lax", transaction.SetCookie[0]);
-            Assert.Equal("Hao=Hao; path=/; samesite=lax", transaction.SetCookie[1]);
-            Assert.Equal("Hao=Hao; path=/; samesite=lax", transaction.SetCookie[2]);
-            Assert.Equal("Hao=Hao; path=/; secure; samesite=lax", transaction.SetCookie[3]);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[0]);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[1]);
+            Assert.Equal("Hao=Hao; path=/; samesite=strict", transaction.SetCookie[2]);
+            Assert.Equal("Hao=Hao; path=/; secure", transaction.SetCookie[3]);
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
 
             Assert.NotNull(transaction.SetCookie);
             Assert.Equal(1, transaction.SetCookie.Count);
-            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=lax", transaction.SetCookie[0]);
+            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure", transaction.SetCookie[0]);
         }
 
         [Fact]


### PR DESCRIPTION
 #2675 #4661 Note this changes the basic infrastructure defaults but does not change any given component's behavior as each component already specified their SameSite config.

SameSite defaults:
- Session: Lax
- CookieTempDataProvider: Lax
- Antiforgery: Strict
- CookieAuth: Lax
- Twitter state cookie: Lax
- Remote auth corrilation cookie (OAuth): None
- OIDC nonce cookie: None

[WIP] Running tests to make sure I didn't miss any.