### PR TITLE
Skip NodeServices tests on helix

### DIFF
--- a/src/Middleware/NodeServices/test/Microsoft.AspNetCore.NodeServices.Tests.csproj
+++ b/src/Middleware/NodeServices/test/Microsoft.AspNetCore.NodeServices.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <!-- https://github.com/aspnet/AspNetCore/issues/8044 -->
-    <BuildHelixPayload>false<BuildHelixPayload>
+    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Middleware/NodeServices/test/Microsoft.AspNetCore.NodeServices.Tests.csproj
+++ b/src/Middleware/NodeServices/test/Microsoft.AspNetCore.NodeServices.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <!-- https://github.com/aspnet/AspNetCore/issues/8044 -->
+    <BuildHelixPayload>false<BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/test/Libuv.BindTests/Libuv.BindTests.csproj
+++ b/src/Servers/Kestrel/test/Libuv.BindTests/Libuv.BindTests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <TestGroupName>Libuv.BindTests</TestGroupName>
+    <!-- https://github.com/aspnet/AspNetCore/issues/8046 -->
+    <HelixProjectPlatform Remove="OSX" />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/test/Libuv.BindTests/Libuv.BindTests.csproj
+++ b/src/Servers/Kestrel/test/Libuv.BindTests/Libuv.BindTests.csproj
@@ -4,10 +4,13 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <TestGroupName>Libuv.BindTests</TestGroupName>
-    <!-- https://github.com/aspnet/AspNetCore/issues/8046 -->
-    <HelixProjectPlatform Remove="OSX" />
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- https://github.com/aspnet/AspNetCore/issues/8046 -->
+    <HelixProjectPlatform Remove="OSX" />
+  </ItemGroup>
+    
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />
     <Compile Include="..\BindTests\**\*.cs" />


### PR DESCRIPTION
NodeJs not installed on helix boxes by default currently

https://github.com/aspnet/AspNetCore/issues/8044 tracking this skip