### PR TITLE
Skip first run experience on azure pipelines.

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -103,6 +103,7 @@ jobs:
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
     BuildDirectory: ${{ parameters.buildDirectory }}
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     TeamName: AspNetCore
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk


### PR DESCRIPTION
- Suppresses the 'Welcome to .NET Core!' output that times out tests and causes locked file issues. When using dotnet we're not guarunteed to run in an environment where the dotnet.exe has had its first run experience already invoked. This would cause our functional tests to time out and occasionally crash due to dotnet first run experience sentinels being locked.

aspnet/AspNetCore-Internal#1859
