### PR TITLE
Use one SequenceReader+Rewind rather than 2 SequenceReaders

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -228,9 +228,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         public HttpParser() { }
         public HttpParser(bool showErrorDetails) { }
-        bool Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpParser<TRequestHandler>.ParseHeaders(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined, out int consumedBytes) { throw null; }
         bool Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpParser<TRequestHandler>.ParseRequestLine(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined) { throw null; }
-        public bool ParseHeaders(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined, out int consumedBytes) { throw null; }
+        public bool ParseHeaders(TRequestHandler handler, ref System.Buffers.SequenceReader<byte> reader) { throw null; }
         public bool ParseRequestLine(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined) { throw null; }
     }
     public enum HttpScheme
@@ -253,7 +252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     }
     public partial interface IHttpParser<TRequestHandler> where TRequestHandler : Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler, Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpRequestLineHandler
     {
-        bool ParseHeaders(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined, out int consumedBytes);
+        bool ParseHeaders(TRequestHandler handler, ref System.Buffers.SequenceReader<byte> reader);
         bool ParseRequestLine(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined);
     }
     public partial interface IHttpRequestLineHandler

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -189,32 +189,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return result;
         }
 
-        public bool TakeMessageHeaders(ReadOnlySequence<byte> buffer, bool trailers, out SequencePosition consumed, out SequencePosition examined)
+        public bool TakeMessageHeaders(in ReadOnlySequence<byte> buffer, bool trailers, out SequencePosition consumed, out SequencePosition examined)
         {
             // Make sure the buffer is limited
-            bool overLength = false;
-            if (buffer.Length >= _remainingRequestHeadersBytesAllowed)
+            if (buffer.Length > _remainingRequestHeadersBytesAllowed)
             {
-                buffer = buffer.Slice(buffer.Start, _remainingRequestHeadersBytesAllowed);
-
-                // If we sliced it means the current buffer bigger than what we're
-                // allowed to look at
-                overLength = true;
+                return TrimAndTakeMessageHeaders(buffer, trailers, out consumed, out examined);
             }
 
-            var result = _parser.ParseHeaders(new Http1ParsingHandler(this, trailers), buffer, out consumed, out examined, out var consumedBytes);
-            _remainingRequestHeadersBytesAllowed -= consumedBytes;
-
-            if (!result && overLength)
+            var reader = new SequenceReader<byte>(buffer);
+            var result = false;
+            try
             {
-                BadHttpRequestException.Throw(RequestRejectionReason.HeadersExceedMaxTotalSize);
+                result = _parser.ParseHeaders(new Http1ParsingHandler(this, trailers), ref reader);
+
+                if (result)
+                {
+                    TimeoutControl.CancelTimeout();
+                }
+
+                return result;
             }
-            if (result)
+            finally
             {
-                TimeoutControl.CancelTimeout();
+                consumed = reader.Position;
+                _remainingRequestHeadersBytesAllowed -= (int)reader.Consumed;
+
+                if (result)
+                {
+                    examined = consumed;
+                }
+                else
+                {
+                    examined = buffer.End;
+                }
             }
 
-            return result;
+            bool TrimAndTakeMessageHeaders(in ReadOnlySequence<byte> buffer, bool trailers, out SequencePosition consumed, out SequencePosition examined)
+            {
+                var trimmedBuffer = buffer.Slice(buffer.Start, _remainingRequestHeadersBytesAllowed);
+
+                var reader = new SequenceReader<byte>(trimmedBuffer);
+                var result = false;
+                try
+                {
+                    result = _parser.ParseHeaders(new Http1ParsingHandler(this, trailers), ref reader);
+
+                    if (!result)
+                    {
+                        // We read the maximum allowed but didn't complete the headers.
+                        BadHttpRequestException.Throw(RequestRejectionReason.HeadersExceedMaxTotalSize);
+                    }
+
+                    TimeoutControl.CancelTimeout();
+
+                    return result;
+                }
+                finally
+                {
+                    consumed = reader.Position;
+                    _remainingRequestHeadersBytesAllowed -= (int)reader.Consumed;
+
+                    if (result)
+                    {
+                        examined = consumed;
+                    }
+                    else
+                    {
+                        examined = trimmedBuffer.End;
+                    }
+                }
+            }
         }
 
         public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
@@ -10,6 +10,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         bool ParseRequestLine(TRequestHandler handler, in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined);
 
-        bool ParseHeaders(TRequestHandler handler, in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined, out int consumedBytes);
+        bool ParseHeaders(TRequestHandler handler, ref SequenceReader<byte> reader);
     }
 }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
@@ -83,8 +83,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
 
             _buffer = _buffer.Slice(consumed, _buffer.End);
+            var reader = new SequenceReader<byte>(_buffer);
 
-            if (!_parser.ParseHeaders(new Adapter(this), _buffer, out consumed, out examined, out var consumedBytes))
+            if (!_parser.ParseHeaders(new Adapter(this), ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
@@ -58,7 +58,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             _buffer = _buffer.Slice(consumed, _buffer.End);
 
-            if (!_parser.ParseHeaders(new Adapter(this), _buffer, out consumed, out examined, out var consumedBytes))
+            var reader = new SequenceReader<byte>(_buffer);
+            if (!_parser.ParseHeaders(new Adapter(this), ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
@@ -21,16 +21,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         public static readonly NullParser<Http1ParsingHandler> Instance = new NullParser<Http1ParsingHandler>();
 
-        public bool ParseHeaders(TRequestHandler handler, in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined, out int consumedBytes)
+        public bool ParseHeaders(TRequestHandler handler, ref SequenceReader<byte> reader)
         {
             handler.OnHeader(new Span<byte>(_hostHeaderName), new Span<byte>(_hostHeaderValue));
             handler.OnHeader(new Span<byte>(_acceptHeaderName), new Span<byte>(_acceptHeaderValue));
             handler.OnHeader(new Span<byte>(_connectionHeaderName), new Span<byte>(_connectionHeaderValue));
             handler.OnHeadersComplete();
-
-            consumedBytes = 0;
-            consumed = buffer.Start;
-            examined = buffer.End;
 
             return true;
         }


### PR DESCRIPTION
SequenceReader is a *very* chunky struct; so taking a copy of it to rewind 2 chars in an uncommon case is expensive as it forces stack reservation and zeroing for the copy:

Also move the exception handling to the outer method, and clean up the loop

```diff
                Method |     Mean |    Error |   StdDev |        Op/s | Scaled |
 --------------------- |---------:|---------:|---------:|------------:|-------:|
- PlaintextTechEmpower | 310.4 ns | 1.301 ns | 1.153 ns | 3,221,411.1 |   1.00 |
+ PlaintextTechEmpower | 271.8 ns | 2.267 ns | 2.121 ns | 3,679,437.9 |   1.00 |
-           LiveAspNet | 526.9 ns | 2.322 ns | 1.939 ns | 1,897,874.1 |   1.70 |
+           LiveAspNet | 454.3 ns | 2.496 ns | 2.212 ns | 2,201,384.0 |   1.55 |
-              Unicode | 687.7 ns | 3.629 ns | 3.217 ns | 1,454,153.2 |   2.22 |
+              Unicode | 614.2 ns | 3.414 ns | 3.193 ns | 1,628,024.1 |   2.09 |
```

(Some PR changes highlighted by diff)
```diff
; Assembly listing for method HttpParser`1:ParseHeaders(struct,byref):bool:this
-; Lcl frame size = 1032
+; Lcl frame size = 120

-mov      ecx, 226
+mov      ecx, 14
 xor      rax, rax
 rep stosd 
```
Zeroing in the common path to set it to `default(SequenceReader<byte>)`
```diff
-    call     SequenceReader`1:GetNextSpan():this
-
-G_M20071_IG23:
-    xor      rcx, rcx
-    lea      rax, bword ptr [rbp-108H]
-    vxorps   xmm0, xmm0
-    vmovdqu  qword ptr [rax], xmm0
-    vmovdqu  qword ptr [rax+16], xmm0
-    vmovdqu  qword ptr [rax+32], xmm0
-    vmovdqu  qword ptr [rax+48], xmm0
-    vmovdqu  qword ptr [rax+64], xmm0
-    vmovdqu  qword ptr [rax+80], xmm0
-    mov      qword ptr [rax+96], rcx
-    mov      dword ptr [rbp-10CH], ecx
-
-G_M20071_IG24:
-    cmp      byte  ptr [rbp-8CH], 0
-    je       G_M20071_IG190

+    call     SequenceReader`1:GetNextSpan():this
+
+G_M20042_IG23:
+    xor      ecx, ecx
+    mov      dword ptr [rbp-A4H], ecx
+
+G_M20042_IG24:
+    cmp      byte  ptr [rbp-8CH], 0
+    je       G_M20042_IG204
```


/cc @JeremyKuhne @davidfowl 