### PR TITLE
Remove private assets

### DIFF
--- a/src/SignalR/Directory.Build.props
+++ b/src/SignalR/Directory.Build.props
@@ -16,7 +16,7 @@
     <Content Include="$(MSBuildThisFileDirectory)xunit.runner.json" Link="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Reference Include="Microsoft.Extensions.Logging.Testing" PrivateAssets="All" />
+    <Reference Include="Microsoft.Extensions.Logging.Testing" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Helix wasn't running any SignalR tests, this should fix it.

@natemcmaster Why was `PrivateAssets` set?