### PR TITLE
Avoid race in FileWatcher test

### DIFF
--- a/src/Tools/Tools.sln
+++ b/src/Tools/Tools.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.0.0
+MinimumVisualStudioVersion = 16.0.0.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-watch", "dotnet-watch\src\dotnet-watch.csproj", "{E16F10C8-5FC3-420B-AB33-D6E5CBE89B75}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-watch.Tests", "dotnet-watch\test\dotnet-watch.Tests.csproj", "{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E16F10C8-5FC3-420B-AB33-D6E5CBE89B75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E16F10C8-5FC3-420B-AB33-D6E5CBE89B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E16F10C8-5FC3-420B-AB33-D6E5CBE89B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E16F10C8-5FC3-420B-AB33-D6E5CBE89B75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EC668D8E-97B9-4758-9E5C-2E5DD6B9137B}
+	EndGlobalSection
+EndGlobal

--- a/src/Tools/dotnet-watch/test/FileWatcherTests.cs
+++ b/src/Tools/dotnet-watch/test/FileWatcherTests.cs
@@ -246,7 +246,13 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                 File.WriteAllText(Path.Combine(dir, "foo2"), string.Empty);
                 File.WriteAllText(Path.Combine(dir, "foo3"), string.Empty);
                 File.WriteAllText(Path.Combine(dir, "foo4"), string.Empty);
-                File.WriteAllText(Path.Combine(dir, "foo4"), string.Empty);
+
+                // On Unix the native file watcher may surface events from
+                // the recent past. Delay to avoid those.
+                // On Unix the file write time is in 1s increments;
+                // if we don't wait, there's a chance that the polling
+                // watcher will not detect the change
+                await Task.Delay(1250);
 
                 var testFileFullPath = Path.Combine(dir, "foo3");
 
@@ -266,11 +272,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
                     watcher.OnFileChange += handler;
                     watcher.EnableRaisingEvents = true;
-
-                    // On Unix the file write time is in 1s increments;
-                    // if we don't wait, there's a chance that the polling
-                    // watcher will not detect the change
-                    await Task.Delay(1000);
 
                     File.WriteAllText(testFileFullPath, string.Empty);
 


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1710#issuecomment-468578004

Summary: We don't know why this started but we do see a possible race in the test we can address.

What we know:
- This started failing Feb 11th.
- There's at least one failure in the 2.2 branch, but most are master.
- It's only failing on aspnet-mac-a03
- It's not affecting PRs as it's an internal agent.
- It's not OS or version specific, it has passed on other similar agents
- There was a [change](https://github.com/aspnet/AspNetCore/commit/7d4b6fccffc5ab4bb75a3dfaa20088a022709a0c#diff-06e0fd743053558ea338c479baee65c9R273) merged on Jan 28th  to make these tests async. It seems unrelated as it didn't fail for more than a week, even on the same agent.
- This agent was recreated on Jan 17th which also seems unrelated.
- The only change to this component in the affected time window was https://github.com/aspnet/AspNetCore/pull/7403/files which primarily changes logging.
- The only other possibly related change the day this started failing was an Extensions dependency update: https://github.com/aspnet/AspNetCore/pull/7397/files