### PR TITLE
Helix fail if exceptions thrown during test discovery

### DIFF
--- a/eng/helix/vstest/runtests.cmd
+++ b/eng/helix/vstest/runtests.cmd
@@ -15,6 +15,10 @@ powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePo
 
 set HELIX=true
 
+%HELIX_CORRELATION_PAYLOAD%\sdk\dotnet vstest %target% -lt >discovered.txt
+find /c "Exception thrown" discovered.txt
+if %errorlevel% equ 0 exit 1
+
 %DOTNET_ROOT%\dotnet vstest %target% --logger:trx --logger:console;verbosity=normal
 
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
