### PR TITLE
Put MVC's functional tests in a separate test group

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
@@ -8,6 +8,7 @@
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);FUNCTIONAL_TESTS</DefineConstants>
+    <TestGroupName>Mvc.FunctionalTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Possible fix to https://github.com/aspnet/AspNetCore/issues/7313
One of the characteristics of these failures were that the
test took long to run. The build log has warnings for
several long running tests. This might be a result of CPU
contention since mondo-ification that make MVC's functional tests
run with nearly every other test project in the solution

