### PR TITLE
IBufferWriter<T>.Advance(int) invalidates span

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/BufferWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/BufferWriter.cs
@@ -69,6 +69,9 @@ namespace System.Buffers
                 _bytesCommitted += buffered;
                 _buffered = 0;
                 _output.Advance(buffered);
+                
+                // Calling IBufferWriter<T>.Advance(int) may have invalidated our cached Span<T>, so reacquire next time.
+                _span = default;
             }
         }
 

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferWriter.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BufferWriter.cs
@@ -30,6 +30,9 @@ namespace PlatformBenchmarks
             {
                 _buffered = 0;
                 _output.Advance(buffered);
+                
+                // Calling IBufferWriter<T>.Advance(int) may have invalidated our cached Span<T>, so reacquire next time.
+                _span = default;
             }
         }
 


### PR DESCRIPTION
Per https://github.com/dotnet/dotnet-api-docs/pull/1949/files#diff-7c9a27ba441e8b9f136c5e7499b6cae3R47, any call to `IBufferWriter<T>.Advance(int)` should be assumed to have invalidated any prior result of `GetSpan(int)`, so we need to reset our Span so it's reacquired on the next write.