### PR TITLE
Don't auto include MVC in all samples

### DIFF
--- a/eng/Workarounds.props
+++ b/eng/Workarounds.props
@@ -12,6 +12,11 @@
     <_ProjectExtensionsWereImported>true</_ProjectExtensionsWereImported>
     <WixTargetsPath>$(WixInstallPath)\wix2010.targets</WixTargetsPath>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Required because the Razor SDK will generate attributes -->
+    <GenerateRazorAssemblyInfo Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true' AND '$(GenerateRazorAssemblyInfo)' == ''">false</GenerateRazorAssemblyInfo>
+  </PropertyGroup>
 
   <!-- Workaround https://developercommunity.visualstudio.com/content/problem/434385/vs2019-preview-2-targetframeworkversion-or-platfor.html -->
   <PropertyGroup>

--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -6,8 +6,6 @@
   -->
   <ItemGroup>
     <FrameworkReference Remove="Microsoft.AspNetCore.App" />
-    <!-- Required because the Razor SDK will generate attributes -->
-    <Reference Include="Microsoft.AspNetCore.Mvc" Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <!-- Workaround https://github.com/dotnet/cli/issues/10528 -->


### PR DESCRIPTION
- Turn of assembly info generation by default in samples
- This stops solutions from building that don't have MVC
- It slows the build of projects that don't need MVC down

PS: It's likely we'll need to turn this on for same of the MVC samples? We'll find out 😄 