### PR TITLE
Backport SSR fix

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/DefaultHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/DefaultHttpClient.ts
@@ -4,15 +4,8 @@
 import { AbortError } from "./Errors";
 import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
 import { ILogger } from "./ILogger";
+import { NodeHttpClient } from "./NodeHttpClient";
 import { XhrHttpClient } from "./XhrHttpClient";
-
-let nodeHttpClientModule: any;
-if (typeof XMLHttpRequest === "undefined") {
-    // In order to ignore the dynamic require in webpack builds we need to do this magic
-    // @ts-ignore: TS doesn't know about these names
-    const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
-    nodeHttpClientModule = requireFunc("./NodeHttpClient");
-}
 
 /** Default implementation of {@link @aspnet/signalr.HttpClient}. */
 export class DefaultHttpClient extends HttpClient {
@@ -24,10 +17,8 @@ export class DefaultHttpClient extends HttpClient {
 
         if (typeof XMLHttpRequest !== "undefined") {
             this.httpClient = new XhrHttpClient(logger);
-        } else if (typeof nodeHttpClientModule !== "undefined") {
-            this.httpClient = new nodeHttpClientModule.NodeHttpClient(logger);
         } else {
-            throw new Error("No HttpClient could be created.");
+            this.httpClient = new NodeHttpClient(logger);
         }
     }
 

--- a/src/SignalR/clients/ts/signalr/src/EmptyNodeHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/EmptyNodeHttpClient.ts
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// This is an empty implementation of the NodeHttpClient that will be included in browser builds so the output file will be smaller
+
+import { HttpClient, HttpResponse } from "./HttpClient";
+import { ILogger } from "./ILogger";
+
+export class NodeHttpClient extends HttpClient {
+    // @ts-ignore: Need ILogger to compile, but unused variables generate errors
+    public constructor(logger: ILogger) {
+        super();
+    }
+
+    public send(): Promise<HttpResponse> {
+        return Promise.reject(new Error("If using Node either provide an XmlHttpRequest polyfill or consume the cjs or esm script instead of the browser/signalr.js one."));
+    }
+}

--- a/src/SignalR/clients/ts/webpack.config.base.js
+++ b/src/SignalR/clients/ts/webpack.config.base.js
@@ -39,7 +39,10 @@ module.exports = function (modulePath, browserBaseName, options) {
         },
         resolve: {
             extensions: [".ts", ".js"],
-            alias: options.alias,
+            alias: {
+                "./NodeHttpClient": path.resolve(__dirname, "signalr/src/EmptyNodeHttpClient.ts"),
+                ...options.alias,
+            }
         },
         output: {
             filename: `${browserBaseName}.js`,
@@ -72,7 +75,6 @@ module.exports = function (modulePath, browserBaseName, options) {
             }),
             // ES6 Promise uses this module in certain circumstances but we don't need it.
             new webpack.IgnorePlugin(/vertx/),
-            new webpack.IgnorePlugin(/NodeHttpClient/),
             new webpack.IgnorePlugin(/eventsource/),
         ],
         externals: options.externals,


### PR DESCRIPTION
Backport of https://github.com/aspnet/AspNetCore/pull/8047
Fixes https://github.com/aspnet/AspNetCore/issues/7823

#### Description

The SignalR Typescript/javascript client was not able to run in Server Side Rendering apps. This fixes the client to be able to run in such environments.

#### Customer Impact

Customers will be able to use Server Side Rendering with SignalR when it would fail before.

#### Regression?

None, this scenario most likely never worked.

#### Risk

Low, our automated testing runs the known supported scenarios so they wont be broken. This is fixing a scenario we weren't aware of but should work.

@muratg 