### PR TITLE
Isolate message compiler output files

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/AspNetCore.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/AspNetCore.vcxproj
@@ -298,6 +298,9 @@
   <ItemGroup>
     <Xml Include="aspnetcore_schema_v2.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <MessageFile Include="..\CommonLib\aspnetcore_msg.mc" />
+  </ItemGroup>
   <Import Project="..\..\build\native.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/aspnetcoremodule.rc
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/aspnetcoremodule.rc
@@ -2,7 +2,7 @@
 //
 #include <windows.h>
 #include "version.h"
-#include "..\CommonLib\Aspnetcore_msg.rc"
+#include "Aspnetcore_msg.rc"
 #include "..\CommonLib\resources.h"
 /////////////////////////////////////////////////////////////////////////////
 // English (United States) resources

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/CommonLib.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/CommonLib.vcxproj
@@ -273,23 +273,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <CustomBuild Include="aspnetcore_msg.mc">
-      <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mc %(FullPath)</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Compiling Event Messages ...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(Filename).rc;%(Filename).h;MSG0409.bin</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mc %(FullPath)</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling Event Messages ...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Filename).rc;%(Filename).h;MSG0409.bin</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mc %(FullPath)</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Compiling Event Messages ...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Filename).rc;%(Filename).h;MSG0409.bin</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mc %(FullPath)</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling Event Messages ...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Filename).rc;%(Filename).h;MSG0409.bin</Outputs>
-    </CustomBuild>
+    <MessageFile Include="aspnetcore_msg.mc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="..\..\build\native.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/stdafx.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/stdafx.h
@@ -48,8 +48,6 @@
 #include "iapplication.h"
 #include "debugutil.h"
 #include "requesthandler.h"
-#include "resources.h"
-#include "aspnetcore_msg.h"
 #include "Helpers.h"
 #include "GlobalVersionUtility.h"
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessRequestHandler.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessRequestHandler.vcxproj
@@ -269,6 +269,9 @@
     </None>
     <None Include="Source.def" />
   </ItemGroup>
+  <ItemGroup>
+    <MessageFile Include="..\CommonLib\aspnetcore_msg.mc" />
+  </ItemGroup>
   <Import Project="..\..\build\native.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/OutOfProcessRequestHandler.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/OutOfProcessRequestHandler.vcxproj
@@ -278,6 +278,9 @@
     </None>
     <None Include="Source.def" />
   </ItemGroup>
+  <ItemGroup>
+    <MessageFile Include="..\CommonLib\aspnetcore_msg.mc" />
+  </ItemGroup>
   <Import Project="..\..\build\native.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/RequestHandlerLib.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/RequestHandlerLib.vcxproj
@@ -214,6 +214,10 @@
       <Project>{4787a64f-9a3e-4867-a55a-70cb4b2b2ffe}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <MessageFile Include="..\CommonLib\aspnetcore_msg.mc" />
+  </ItemGroup>
+  <Import Project="..\..\build\native.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/Servers/IIS/build/native.targets
+++ b/src/Servers/IIS/build/native.targets
@@ -10,7 +10,6 @@
       <Command>mc %(FullPath) -h $(IntDir) -r $(IntDir)</Command>
       <Message>Compiling Event Messages ...</Message>
       <Outputs>$(IntDir)\%(Filename).rc;$(IntDir)\%(Filename).h;$(IntDir)\MSG0409.bin</Outputs>
-      <CustomBuildAfterTargets>BuildGenerateSources</CustomBuildAfterTargets>
     </CustomBuild>
 
     <MessageFile Remove="@(MessageFile)" />

--- a/src/Servers/IIS/build/native.targets
+++ b/src/Servers/IIS/build/native.targets
@@ -1,4 +1,21 @@
 <Project>
+
+  <PropertyGroup>
+    <IncludePath>$(IncludePath);$(IntDir)</IncludePath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="@(MessageFile->Count()) != 0">
+    <CustomBuild Include="@(MessageFile)">
+      <FileType>Document</FileType>
+      <Command>mc %(FullPath) -h $(IntDir) -r $(IntDir)</Command>
+      <Message>Compiling Event Messages ...</Message>
+      <Outputs>$(IntDir)\%(Filename).rc;$(IntDir)\%(Filename).h;$(IntDir)\MSG0409.bin</Outputs>
+      <CustomBuildAfterTargets>BuildGenerateSources</CustomBuildAfterTargets>
+    </CustomBuild>
+
+    <MessageFile Remove="@(MessageFile)" />
+  </ItemGroup>
+
   <Target Name="CreateVersionHeader" BeforeTargets="PrepareForBuild">
     <ItemGroup>
       <VersionHeaderContents Include="// Copyright (c) .NET Foundation. All rights reserved." />


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/8126

Let every project that needs compiled message file compile it on their own. Place compiled output if platform-specific subdirectory so they don't clash.