### PR TITLE
Make StartAsync not throw if we haven't started the response

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -484,6 +484,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Memory<byte> GetMemory(int sizeHint = 0) { throw null; }
         public System.Span<byte> GetSpan(int sizeHint = 0) { throw null; }
+        public void Reset() { }
         public System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> Write100ContinueAsync() { throw null; }
         public System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> WriteChunkAsync(System.ReadOnlySpan<byte> buffer, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task WriteDataAsync(System.ReadOnlySpan<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -954,6 +955,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> FlushAsync(System.Threading.CancellationToken cancellationToken);
         System.Memory<byte> GetMemory(int sizeHint = 0);
         System.Span<byte> GetSpan(int sizeHint = 0);
+        void Reset();
         System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> Write100ContinueAsync();
         System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> WriteChunkAsync(System.ReadOnlySpan<byte> data, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task WriteDataAsync(System.ReadOnlySpan<byte> data, System.Threading.CancellationToken cancellationToken);
@@ -1297,6 +1299,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         public System.Span<byte> GetSpan(int sizeHint = 0) { throw null; }
         void Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpOutputAborter.Abort(Microsoft.AspNetCore.Connections.ConnectionAbortedException abortReason) { }
         System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpOutputProducer.WriteChunkAsync(System.ReadOnlySpan<byte> data, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public void Reset() { }
         public System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> Write100ContinueAsync() { throw null; }
         public System.Threading.Tasks.Task WriteChunkAsync(System.ReadOnlySpan<byte> span, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task WriteDataAsync(System.ReadOnlySpan<byte> data, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (bytes >= 0)
                     {
-                        if (_currentSegment.Length < _position + bytes)
+                        if (_currentSegment.Length - bytes < _position)
                         {
                             throw new ArgumentOutOfRangeException("Can't advance past buffer size.");
                         }
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 else if (_autoChunk)
                 {
-                    if (bytes + _advancedBytesForChunk > _currentChunkMemory.Length - BeginChunkLengthMax - EndChunkLength)
+                    if (_advancedBytesForChunk > _currentChunkMemory.Length - BeginChunkLengthMax - EndChunkLength - bytes)
                     {
                         throw new ArgumentOutOfRangeException("Can't advance past buffer size.");
                     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private long _unflushedBytes;
         private bool _autoChunk;
         private readonly PipeWriter _pipeWriter;
-        private const int MemorySizeThreshold = 1024;
         private const int BeginChunkLengthMax = 5;
         private const int EndChunkLength = 2;
 
@@ -606,7 +605,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             // If the sizeHint is 0, any capacity will do
             // Otherwise, the buffer must have enough space for the entire size hint, or we need to add a segment.
-            if ((sizeHint == 0 && remainingSize > 0) || (sizeHint > 0 && remainingSize >= Math.Min(MemorySizeThreshold, sizeHint)))
+            if ((sizeHint == 0 && remainingSize > 0) || (sizeHint > 0 && remainingSize >= sizeHint))
             {
                 // We have capacity in the current segment
                 return;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -355,11 +355,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 _position = 0;
 
-                if (_currentSegmentOwner != null)
-                {
-                    _currentSegmentOwner.Dispose();
-                    _currentSegmentOwner = null;
-                }
+                DisposeCurrentSegment();
             }
         }
 
@@ -382,13 +378,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                 }
 
-                if (_currentSegmentOwner != null)
-                {
-                    _currentSegmentOwner.Dispose();
-                }
+                DisposeCurrentSegment();
 
                 CompletePipe();
             }
+        }
+
+        private void DisposeCurrentSegment()
+        {
+            _currentSegmentOwner?.Dispose();
+            _currentSegmentOwner = null;
+            _currentSegment = default;
         }
 
         private void CompletePipe()
@@ -658,7 +658,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             public Memory<byte> Buffer { get; }
             public int Length { get; }
 
-            public ReadOnlySpan<byte> Span => Buffer.Span;
+            public ReadOnlySpan<byte> Span => Buffer.Span.Slice(0, Length);
 
             public CompletedBuffer(IMemoryOwner<byte> owner, Memory<byte> buffer, int length)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private IMemoryOwner<byte> _fakeMemoryOwner;
 
         // Fields needed to store writes before calling either startAsync or Write/FlushAsync
-        private LinkedList<CompletedBuffer> _completedSegments;
+        private List<CompletedBuffer> _completedSegments;
         private Memory<byte> _currentSegment;
         private IMemoryOwner<byte> _currentSegmentOwner;
         private int _position;
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         if (_currentSegment.Length < _position + bytes)
                         {
-                            throw new InvalidOperationException("Can't advance past buffer size.");
+                            throw new ArgumentOutOfRangeException("Can't advance past buffer size.");
                         }
 
                         _position += bytes;
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (bytes + _advancedBytesForChunk > _currentChunkMemory.Length - BeginChunkLengthMax - EndChunkLength)
                     {
-                        throw new InvalidOperationException("Can't advance past buffer size.");
+                        throw new ArgumentOutOfRangeException("Can't advance past buffer size.");
                     }
                     _advancedBytesForChunk += bytes;
                 }
@@ -622,13 +622,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 // We're adding a segment to the list
                 if (_completedSegments == null)
                 {
-                    _completedSegments = new LinkedList<CompletedBuffer>();
+                    _completedSegments = new List<CompletedBuffer>();
                 }
 
                 // Position might be less than the segment length if there wasn't enough space to satisfy the sizeHint when
                 // GetMemory was called. In that case we'll take the current segment and call it "completed", but need to
                 // ignore any empty space in it.
-                _completedSegments.AddLast(new CompletedBuffer(_currentSegmentOwner, _currentSegment, _position));
+                _completedSegments.Add(new CompletedBuffer(_currentSegmentOwner, _currentSegment, _position));
             }
 
             if (sizeHint <= _memoryPool.MaxBufferSize)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -56,12 +56,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private Memory<byte> _currentChunkMemory;
         private bool _currentChunkMemoryUpdated;
         private IMemoryOwner<byte> _fakeMemoryOwner;
-        private bool _startCalled;
 
+        // Fields needed to store writes before calling either startAsync or Write/FlushAsync
         private LinkedList<CompletedBuffer> _completedSegments;
         private Memory<byte> _currentSegment;
         private IMemoryOwner<byte> _currentSegmentOwner;
         private int _position;
+        private bool _startCalled;
 
         public Http1OutputProducer(
             PipeWriter pipeWriter,

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -538,7 +538,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             var memoryMaxLength = _currentChunkMemory.Length - BeginChunkLengthMax - EndChunkLength;
-            if (_advancedBytesForChunk >= memoryMaxLength - sizeHint)
+            if (_advancedBytesForChunk >= memoryMaxLength - sizeHint && _advancedBytesForChunk > 0)
             {
                 // Chunk is completely written, commit it to the pipe so GetMemory will return a new chunk of memory.
                 var writer = new BufferWriter<PipeWriter>(_pipeWriter);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -538,7 +538,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             var memoryMaxLength = _currentChunkMemory.Length - BeginChunkLengthMax - EndChunkLength;
-            if (_advancedBytesForChunk >= memoryMaxLength - Math.Min(MemorySizeThreshold, sizeHint))
+            if (_advancedBytesForChunk >= memoryMaxLength - sizeHint)
             {
                 // Chunk is completely written, commit it to the pipe so GetMemory will return a new chunk of memory.
                 var writer = new BufferWriter<PipeWriter>(_pipeWriter);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         // Once write or flush is called, we modify the _currentChunkMemory to prepend the size of data written
         // and append the end terminator.
 
-        private bool _autoChunk; // FOR SURE
+        private bool _autoChunk;
         private int _advancedBytesForChunk;
         private Memory<byte> _currentChunkMemory;
         private bool _currentChunkMemoryUpdated;
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private Memory<byte> _currentSegment;
         private IMemoryOwner<byte> _currentSegmentOwner;
         private int _position;
-        private bool _startCalled; // FOR SURE
+        private bool _startCalled;
 
         public Http1OutputProducer(
             PipeWriter pipeWriter,
@@ -476,6 +476,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
+        public void Reset()
+        {
+            Debug.Assert(_currentSegmentOwner == null);
+            Debug.Assert(_completedSegments == null || _completedSegments.Count == 0);
+            _autoChunk = false;
+            _startCalled = false;
+            _currentChunkMemoryUpdated = false;
+        }
+
         private ValueTask<FlushResult> WriteAsync(
             ReadOnlySpan<byte> buffer,
             CancellationToken cancellationToken = default)
@@ -653,11 +662,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _position = 0;
         }
 
-        public void Reset()
-        {
-            _autoChunk = false;
-            _startCalled = false;
-        }
 
         /// <summary>
         /// Holds a byte[] from the pool and a size value. Basically a Memory but guaranteed to be backed by an ArrayPool byte[], so that we know we can return it.

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1285,25 +1285,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Memory<byte> GetMemory(int sizeHint = 0)
         {
-            ThrowIfResponseNotStarted();
-
             return Output.GetMemory(sizeHint);
         }
 
         public Span<byte> GetSpan(int sizeHint = 0)
         {
-            ThrowIfResponseNotStarted();
-
             return Output.GetSpan(sizeHint);
-        }
-
-        [StackTraceHidden]
-        private void ThrowIfResponseNotStarted()
-        {
-            if (!HasResponseStarted)
-            {
-                throw new InvalidOperationException(CoreStrings.StartAsyncBeforeGetMemory);
-            }
         }
 
         public ValueTask<FlushResult> FlushPipeAsync(CancellationToken cancellationToken)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -45,6 +45,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         // Keep-alive is default for HTTP/1.1 and HTTP/2; parsing and errors will change its value
         // volatile, see: https://msdn.microsoft.com/en-us/library/x13ttww7.aspx
         protected volatile bool _keepAlive = true;
+        // _canWriteResponseBody is set in CreateResponseHeaders.
+        // If we are writing with GetMemory/Advance before calling StartAsync, assume we can write and throw away contents if we can't.
         private bool _canWriteResponseBody = true;
         private bool _hasAdvanced;
         private bool _requireGetMemoryNextCall;
@@ -1283,7 +1285,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             if (_requireGetMemoryNextCall)
             {
-                throw new InvalidOperationException("Invalid ordering of calling StartAsync and Advance. Call StartAsync before calling GetMemory/GetSpan and Advance.");
+                throw new InvalidOperationException("Invalid ordering of calling StartAsync and Advance. " +
+                    "Call StartAsync before calling GetMemory/GetSpan and Advance.");
             }
 
             if (_canWriteResponseBody)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -355,6 +355,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             RequestHeaders = HttpRequestHeaders;
             ResponseHeaders = HttpResponseHeaders;
 
+            _isLeasedMemoryInvalid = true;
+            _hasAdvanced = false;
+            _canWriteResponseBody = true;
+
             if (_scheme == null)
             {
                 var tlsFeature = ConnectionFeatures?[typeof(ITlsConnectionFeature)];

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -388,6 +388,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
 
+            Output?.Reset();
+
             _requestHeadersParsed = 0;
 
             _responseBytesWritten = 0;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -25,5 +25,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         void Complete();
         ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
         ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
+        void Reset();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -279,6 +279,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // This will noop for now. See: https://github.com/aspnet/AspNetCore/issues/7370
         }
 
+        public void Reset()
+        {
+        }
+
         private async ValueTask<FlushResult> ProcessDataWrites()
         {
             FlushResult flushResult = default;

--- a/src/Servers/Kestrel/shared/test/TestApp.cs
+++ b/src/Servers/Kestrel/shared/test/TestApp.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Testing
             var bytes = data.ToArray();
 
             response.Headers["Content-Length"] = bytes.Length.ToString();
+            await response.StartAsync();
 
             var memory = response.BodyWriter.GetMemory(bytes.Length);
             bytes.CopyTo(memory);

--- a/src/Servers/Kestrel/shared/test/TestApp.cs
+++ b/src/Servers/Kestrel/shared/test/TestApp.cs
@@ -49,7 +49,6 @@ namespace Microsoft.AspNetCore.Testing
             if (buffer.Length > 0)
             {
                 await request.Body.ReadUntilEndAsync(buffer).DefaultTimeout();
-                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory(buffer.Length);
                 buffer.CopyTo(memory);
                 response.BodyWriter.Advance(buffer.Length);
@@ -66,7 +65,6 @@ namespace Microsoft.AspNetCore.Testing
             var bytes = data.ToArray();
 
             response.Headers["Content-Length"] = bytes.Length.ToString();
-            await response.StartAsync();
 
             var memory = response.BodyWriter.GetMemory(bytes.Length);
             bytes.CopyTo(memory);

--- a/src/Servers/Kestrel/shared/test/TestApp.cs
+++ b/src/Servers/Kestrel/shared/test/TestApp.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Testing
             if (buffer.Length > 0)
             {
                 await request.Body.ReadUntilEndAsync(buffer).DefaultTimeout();
+                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory(buffer.Length);
                 buffer.CopyTo(memory);
                 response.BodyWriter.Advance(buffer.Length);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -429,8 +429,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory();
+
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
                 fisrtPartOfResponse.CopyTo(memory);
                 response.BodyWriter.Advance(6);
@@ -476,7 +476,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.StartAsync();
 
                 var memory = response.BodyWriter.GetMemory();
                 length.Value = memory.Length;
@@ -590,7 +589,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
 
-                await response.StartAsync();
+                await Task.CompletedTask;
 
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
@@ -633,6 +632,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
+                await Task.CompletedTask;
 
                 // To avoid using span in an async method
                 void NonAsyncMethod()
@@ -646,8 +646,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     secondPartOfResponse.CopyTo(span.Slice(6));
                     response.BodyWriter.Advance(6);
                 }
-
-                await response.StartAsync();
 
                 NonAsyncMethod();
             }, testContext))
@@ -684,9 +682,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
 
-                await response.StartAsync();
-
                 var memory = response.BodyWriter.GetMemory(4096);
+
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
                 fisrtPartOfResponse.CopyTo(memory);
                 response.BodyWriter.Advance(6);
@@ -725,8 +722,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-
-                await response.StartAsync();
+                await Task.CompletedTask;
 
                 var memory = response.BodyWriter.GetMemory(0);
 
@@ -768,8 +764,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-
-                await response.StartAsync();
+                await Task.CompletedTask;
 
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes(new string('a', writeSize));
@@ -806,7 +801,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -920,7 +920,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Equal(4096, memory.Length);
 
                 memory = response.BodyWriter.GetMemory(1000000);
-                Assert.Equal(4096, memory.Length);
+                Assert.Equal(1000000, memory.Length);
                 await Task.CompletedTask;
             }, testContext))
             {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -2634,8 +2634,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
             await InitializeConnectionAsync(async httpContext =>
             {
+                await Task.CompletedTask;
                 var response = httpContext.Response;
-                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory();
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);
@@ -2681,7 +2681,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.StartAsync();
 
                 var memory = response.BodyWriter.GetMemory();
                 Assert.Equal(4096, memory.Length);
@@ -2884,7 +2883,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 var response = httpContext.Response;
 
-                await response.StartAsync();
 
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
@@ -2931,7 +2929,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 var response = httpContext.Response;
 
-                await response.StartAsync();
+                await Task.CompletedTask;
 
                 var memory = response.BodyWriter.GetMemory(0);
                 Assert.Equal(4096, memory.Length);
@@ -2972,7 +2970,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);
@@ -3037,7 +3034,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 var response = httpContext.Response;
                 response.ContentLength = 12;
-                await response.StartAsync();
+                await Task.CompletedTask;
 
                 void NonAsyncMethod()
                 {
@@ -3088,7 +3085,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 var response = httpContext.Response;
                 response.ContentLength = 12;
-                await response.StartAsync();
+                await Task.CompletedTask;
 
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
@@ -3174,8 +3171,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 var response = httpContext.Response;
                 response.ContentLength = 54;
-                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory(4096);
+
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);
                 response.BodyWriter.Advance(6);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -2680,8 +2680,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
             await InitializeConnectionAsync(async httpContext =>
             {
-                await httpContext.Response.StartAsync();
                 var response = httpContext.Response;
+                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory();
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);
@@ -2727,7 +2727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(async httpContext =>
             {
                 var response = httpContext.Response;
-
+                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory();
                 Assert.Equal(4096, memory.Length);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes(new string('a', memory.Length));
@@ -3059,6 +3059,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(async httpContext =>
             {
                 var response = httpContext.Response;
+                await response.StartAsync();
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);
@@ -3170,11 +3171,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>(HeaderNames.Path, "/"),
                 new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
             };
-            await InitializeConnectionAsync(async httpContext =>
+            await InitializeConnectionAsync(httpContext =>
             {
                 var response = httpContext.Response;
                 response.ContentLength = 12;
-                await Task.CompletedTask;
 
                 var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
@@ -3184,6 +3184,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var secondPartOfResponse = Encoding.ASCII.GetBytes("World!");
                 secondPartOfResponse.CopyTo(memory.Slice(6));
                 response.BodyWriter.Advance(6);
+                return Task.CompletedTask;
             });
 
             await StartStreamAsync(1, headers, endStream: true);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -3631,13 +3631,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             using (var server = new TestServer(async httpContext =>
             {
-                var memory = httpContext.Response.BodyPipe.GetMemory();
+                var memory = httpContext.Response.BodyWriter.GetMemory();
                 Assert.Equal(4096, memory.Length);
 
                 await httpContext.Response.StartAsync();
                 // Original memory is disposed, don't compare against it.
 
-                memory = httpContext.Response.BodyPipe.GetMemory();
+                memory = httpContext.Response.BodyWriter.GetMemory();
                 Assert.NotEqual(4096, memory.Length);
 
             }, new TestServiceContext(LoggerFactory)))
@@ -3668,11 +3668,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             using (var server = new TestServer(async httpContext =>
             {
-                var memory = httpContext.Response.BodyPipe.GetMemory();
+                var memory = httpContext.Response.BodyWriter.GetMemory();
 
                 await httpContext.Response.StartAsync();
 
-                Assert.Throws<InvalidOperationException>(() => httpContext.Response.BodyPipe.Advance(1));
+                Assert.Throws<InvalidOperationException>(() => httpContext.Response.BodyWriter.Advance(1));
 
             }, new TestServiceContext(LoggerFactory)))
             {


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore/issues/7779.

One scenario this doesn't support is calling StartAsync after calling GetMemory and using the memory immediately after. @halter73 and I deemed it too difficult to fix well and is an incredibly niche scenario.
```c#
public async Task AppFunc(HttpContext context)
{
    var memory = context.Response.BodyPipe.GetMemory();
    await context.Response.StartAsync();
    // Try using the memory here, you'll get an ODE.
    // Advance will also 
}
```

I added a check that would see if Advance was called immediately after calling StartAsync and throw if so. 