### PR TITLE
Fix StartsWithPortableAndBootstraperExe

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/DotNetCommands.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DotNetCommands.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             var result = Path.Combine(Directory.GetCurrentDirectory(), _dotnetFolderName);
             if (!string.IsNullOrEmpty(dotnetHome))
             {
-                // DOTNET_ROOT has x64 appended to the path, which we append again in GetDotNetInstallDir
                 result = dotnetHome;
             }
             else if (!string.IsNullOrEmpty(dotnetRoot))
             {
+                // DOTNET_ROOT has x64 appended to the path, which we append again in GetDotNetInstallDir
                 result = dotnetRoot.Substring(0, dotnetRoot.Length - 3);
             }
             else if (!string.IsNullOrEmpty(userProfile))

--- a/src/Hosting/Server.IntegrationTesting/src/Common/DotNetCommands.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DotNetCommands.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         // Compare to https://github.com/aspnet/BuildTools/blob/314c98e4533217a841ff9767bb38e144eb6c93e4/tools/KoreBuild.Console/Commands/CommandContext.cs#L76
         public static string GetDotNetHome()
         {
-            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_HOME");
+            var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
             var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
             var home = Environment.GetEnvironmentVariable("HOME");
 
@@ -24,7 +25,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             if (!string.IsNullOrEmpty(dotnetHome))
             {
                 // DOTNET_ROOT has x64 appended to the path, which we append again in GetDotNetInstallDir
-                result = dotnetHome.Substring(0, dotnetHome.Length - 3);
+                result = dotnetHome;
+            }
+            else if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                result = dotnetRoot.Substring(0, dotnetRoot.Length - 3);
             }
             else if (!string.IsNullOrEmpty(userProfile))
             {

--- a/src/Hosting/Server.IntegrationTesting/src/Common/DotNetCommands.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DotNetCommands.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,14 +16,15 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         // Compare to https://github.com/aspnet/BuildTools/blob/314c98e4533217a841ff9767bb38e144eb6c93e4/tools/KoreBuild.Console/Commands/CommandContext.cs#L76
         public static string GetDotNetHome()
         {
-            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_HOME");
+            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_ROOT");
             var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
             var home = Environment.GetEnvironmentVariable("HOME");
 
             var result = Path.Combine(Directory.GetCurrentDirectory(), _dotnetFolderName);
             if (!string.IsNullOrEmpty(dotnetHome))
             {
-                result = dotnetHome;
+                // DOTNET_ROOT has x64 appended to the path, which we append again in GetDotNetInstallDir
+                result = dotnetHome.Substring(0, dotnetHome.Length - 3);
             }
             else if (!string.IsNullOrEmpty(userProfile))
             {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         public async Task StartsWithPortableAndBootstraperExe()
         {
             var deploymentParameters = _fixture.GetBaseDeploymentParameters(_fixture.InProcessTestSite);
-            deploymentParameters.TransformPath((path, root) => Helpers.GetInProcessTestSitesName() + ".exe");
+            deploymentParameters.TransformPath((path, root) => "InProcessWebSite.exe");
             deploymentParameters.TransformArguments((arguments, root) => "");
 
             deploymentParameters.EnvironmentVariables["PATH"] = Path.GetDirectoryName(DotNetCommands.GetDotNetExecutable(deploymentParameters.RuntimeArchitecture));

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -108,7 +108,6 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             Assert.Equal(1, TestSink.Writes.Count(w => w.Message.Contains("Invoking where.exe to find dotnet.exe")));
         }
 
-
         [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7972
         [ConditionalTheory]
         [InlineData(RuntimeArchitecture.x64)]
@@ -186,17 +185,27 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             await StartAsync(deploymentParameters);
         }
 
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7972
         [ConditionalFact]
         [RequiresIIS(IISCapability.PoolEnvironmentVariables)]
         public async Task StartsWithPortableAndBootstraperExe()
         {
             var deploymentParameters = _fixture.GetBaseDeploymentParameters(_fixture.InProcessTestSite);
+            deploymentParameters.PublishApplicationBeforeDeployment = true;
+
             // We need the right dotnet on the path in IIS
-            deploymentParameters.EnvironmentVariables["PATH"] = Path.GetDirectoryName(DotNetCommands.GetDotNetExecutable(deploymentParameters.RuntimeArchitecture));
             // ReferenceTestTasks is workaround for https://github.com/dotnet/sdk/issues/2482
-            deploymentParameters.AdditionalPublishParameters = "AppHost";
             var deploymentResult = await DeployAsync(deploymentParameters);
+            deploymentResult.ModifyWebConfig(element => element
+                .Descendants("system.webServer")
+                .Single()
+                .GetOrAdd("aspNetCore")
+                .SetAttributeValue("processPath", Helpers.GetInProcessTestSitesName() + ".exe"));
+
+            deploymentResult.ModifyWebConfig(element => element
+                .Descendants("system.webServer")
+                .Single()
+                .GetOrAdd("aspNetCore")
+                .SetAttributeValue("arguments", ""));
 
             Assert.True(File.Exists(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.exe")));
             Assert.False(File.Exists(Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll")));

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -193,9 +193,9 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             deploymentParameters.TransformPath((path, root) => "InProcessWebSite.exe");
             deploymentParameters.TransformArguments((arguments, root) => "");
 
+            // We need the right dotnet on the path in IIS
             deploymentParameters.EnvironmentVariables["PATH"] = Path.GetDirectoryName(DotNetCommands.GetDotNetExecutable(deploymentParameters.RuntimeArchitecture));
 
-            // We need the right dotnet on the path in IIS
             // ReferenceTestTasks is workaround for https://github.com/dotnet/sdk/issues/2482
             var deploymentResult = await DeployAsync(deploymentParameters);
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessForwardsCompatWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessForwardsCompatWebSite/InProcessWebSite.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <!-- UseAppHost is a workaround for https://github.com/aspnet/websdk/issues/422 -->
-    <TestAssetPublishProfile Include="Portable" Properties="UseAppHost=true;TargetFramework=netcoreapp3.0" />
+    <TestAssetPublishProfile Include="Portable" Properties="TargetFramework=netcoreapp3.0" />
     <TestAssetPublishProfile Include="Standalone-x64" Properties="RuntimeIdentifier=win-x64;" />
     <TestAssetPublishProfile Include="Standalone-x86" Properties="RuntimeIdentifier=win-x86;" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessForwardsCompatWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessForwardsCompatWebSite/InProcessWebSite.csproj
@@ -9,10 +9,9 @@
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <!-- UseAppHost is a workaround for https://github.com/aspnet/websdk/issues/422 -->
-    <TestAssetPublishProfile Include="Portable" Properties="UseAppHost=false;TargetFramework=netcoreapp3.0" />
+    <TestAssetPublishProfile Include="Portable" Properties="UseAppHost=true;TargetFramework=netcoreapp3.0" />
     <TestAssetPublishProfile Include="Standalone-x64" Properties="RuntimeIdentifier=win-x64;" />
     <TestAssetPublishProfile Include="Standalone-x86" Properties="RuntimeIdentifier=win-x86;" />
-    <TestAssetPublishProfile Include="AppHost" Properties="RuntimeIdentifier=win-x64;UseAppHost=true;SelfContained=false;" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <!-- UseAppHost is a workaround for https://github.com/aspnet/websdk/issues/422 -->
     <TestAssetPublishProfile Include="Portable" Properties="TargetFramework=netcoreapp3.0" />
     <TestAssetPublishProfile Include="Standalone-x64" Properties="RuntimeIdentifier=win-x64;" />
     <TestAssetPublishProfile Include="Standalone-x86" Properties="RuntimeIdentifier=win-x86;" />

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\..\..\build\testsite.props" />
 
@@ -9,10 +9,9 @@
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <!-- UseAppHost is a workaround for https://github.com/aspnet/websdk/issues/422 -->
-    <TestAssetPublishProfile Include="Portable" Properties="UseAppHost=false;TargetFramework=netcoreapp3.0" />
+    <TestAssetPublishProfile Include="Portable" Properties="TargetFramework=netcoreapp3.0" />
     <TestAssetPublishProfile Include="Standalone-x64" Properties="RuntimeIdentifier=win-x64;" />
     <TestAssetPublishProfile Include="Standalone-x86" Properties="RuntimeIdentifier=win-x86;" />
-    <TestAssetPublishProfile Include="AppHost" Properties="RuntimeIdentifier=win-x64;UseAppHost=true;SelfContained=false;" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore-Internal/issues/1895

The cause for this failure was due to publish changes we made. The published runtimeconfig.json file we created for standalone applications was being copied to the published output for portable exe. This made the app think it was standalone even though it wasn't.

Also, to make the web.config file write a .exe, we were passing in weird arguments (UseAppHost=true, Standalone=false) to force it to happen. By default, the web.config will never point to the portable exe. However, someone can manually add it. It really isn't 

This makes it so the test manually changes the web.config to point to the exe and removes the AppHost publish option as by default portable adds it now.