### PR TITLE
Use examined rather than consumed for content length of body.

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -31,8 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             if (_inputLength == 0)
             {
-                _readResult = new ReadResult(default, isCanceled: false, isCompleted: true);
-                return _readResult;
+                _readResult = new ReadResult(_readResult.Buffer, isCanceled: false, isCompleted: true);
             }
 
             TryStart();
@@ -170,7 +169,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return;
             }
 
-            var dataLength = _readResult.Buffer.Slice(_readResult.Buffer.Start, consumed).Length;
+            // Need prevExamined....
+            var dataLength = _readResult.Buffer.Slice(_readResult.Buffer.Start, examined).Length;
 
             _inputLength -= dataLength;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -120,12 +120,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             if (_readCompleted)
             {
+                _isReading = true;
                 readResult = _readResult;
                 return true;
             }
 
             TryStart();
-
 
             if (!_context.Input.TryRead(out _readResult))
             {
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
 
-            // Only set _isReading if we are returing a ReadResult.
+            // Only set _isReading if we are returing true.
             _isReading = true;
 
             CreateReadResultFromConnectionReadResult();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -164,6 +164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             return OnConsumeAsync();
         }
+        
         private void ThrowIfCompleted()
         {
             if (_completed)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -208,12 +208,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _context.Input.AdvanceTo(consumed, examined);
 
             var newlyExamined = examinedLength - _totalExaminedInPreviousReadResult;
-            if (newlyExamined > 0)
-            {
-                OnDataRead(newlyExamined);
-                _totalExaminedInPreviousReadResult += newlyExamined;
-                _inputLength -= newlyExamined;
-            }
+
+            // Newly examined can never be negative, pipereader.AdvanceTo will throw.
+            OnDataRead(newlyExamined);
+            _totalExaminedInPreviousReadResult += newlyExamined;
+            _inputLength -= newlyExamined;
 
             _totalExaminedInPreviousReadResult -= consumedLength;
         }

--- a/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
+++ b/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
@@ -778,10 +778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 // Add some input and read it to start PumpAsync
                 input.Add("a");
-                var readResult = await body.ReadAsync();
-                Assert.Equal(1, readResult.Buffer.Length);
 
-                body.AdvanceTo(readResult.Buffer.End);
                 // Time out on the next read
                 input.Http1Connection.SendTimeoutResponse();
 

--- a/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
+++ b/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
@@ -778,8 +778,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 // Add some input and read it to start PumpAsync
                 input.Add("a");
-                Assert.Equal(1, (await body.ReadAsync()).Buffer.Length);
+                var readResult = await body.ReadAsync();
+                Assert.Equal(1, readResult.Buffer.Length);
 
+                body.AdvanceTo(readResult.Buffer.End);
                 // Time out on the next read
                 input.Http1Connection.SendTimeoutResponse();
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -734,11 +734,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             using (var server = new TestServer(async httpContext =>
             {
-                var readResult = await httpContext.Request.BodyPipe.ReadAsync();
+                var readResult = await httpContext.Request.BodyReader.ReadAsync();
                 // This will hang if 0 content length is not assumed by the server
                 Assert.Equal(5, readResult.Buffer.Length);
-                httpContext.Request.BodyPipe.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
-                readResult = await httpContext.Request.BodyPipe.ReadAsync();
+                httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+                readResult = await httpContext.Request.BodyReader.ReadAsync();
                 Assert.Equal(5, readResult.Buffer.Length);
 
             }, testContext))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -814,6 +814,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
+        [Fact]
+        public async Task ContentLengthDoesNotConsumeEntireBufferDoesNotThrow()
+        {
+            var testContext = new TestServiceContext(LoggerFactory);
+            using (var server = new TestServer(async httpContext =>
+            {
+                var readResult = await httpContext.Request.BodyReader.ReadAsync();
+
+                httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+
+                readResult = await httpContext.Request.BodyReader.ReadAsync();
+                httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Slice(1).Start, readResult.Buffer.End);
+            }, testContext))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.SendAll(
+                        "POST / HTTP/1.0",
+                        "Host:",
+                        "Content-Length: 5",
+                        "",
+                        "funny");
+
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Connection: close",
+                        $"Date: {testContext.DateHeaderValue}",
+                        "Content-Length: 0",
+                        "",
+                        "");
+                }
+
+                await server.StopAsync();
+            }
+        }
+
 
         [Fact]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes()

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -850,7 +850,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-
         [Fact]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes()
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -778,9 +778,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
 
-                // Check AdvanceTo(Start, Start) doesn't cause negative issues.
                 readResult = await httpContext.Request.BodyReader.ReadAsync();
-                httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.Start);
+                httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
                 tcs2.SetResult(null);
 
                 readResult = await httpContext.Request.BodyReader.ReadAsync();


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore/issues/8142

I still think I need  #8198 to resolve this.