### PR TITLE
Rename Pipe properties

### DIFF
--- a/src/Http/Http.Abstractions/ref/Microsoft.AspNetCore.Http.Abstractions.netcoreapp3.0.cs
+++ b/src/Http/Http.Abstractions/ref/Microsoft.AspNetCore.Http.Abstractions.netcoreapp3.0.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Http
     {
         protected HttpRequest() { }
         public abstract System.IO.Stream Body { get; set; }
-        public abstract System.IO.Pipelines.PipeReader BodyPipe { get; set; }
+        public abstract System.IO.Pipelines.PipeReader BodyReader { get; set; }
         public abstract long? ContentLength { get; set; }
         public abstract string ContentType { get; set; }
         public abstract Microsoft.AspNetCore.Http.IRequestCookieCollection Cookies { get; set; }
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Http
     {
         protected HttpResponse() { }
         public abstract System.IO.Stream Body { get; set; }
-        public abstract System.IO.Pipelines.PipeWriter BodyPipe { get; set; }
+        public abstract System.IO.Pipelines.PipeWriter BodyWriter { get; set; }
         public abstract long? ContentLength { get; set; }
         public abstract string ContentType { get; set; }
         public abstract Microsoft.AspNetCore.Http.IResponseCookies Cookies { get; }

--- a/src/Http/Http.Abstractions/src/Extensions/HttpResponseWritingExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/HttpResponseWritingExtensions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Http
 
             Write(response, text, encoding);
 
-            var flushAsyncTask = response.BodyPipe.FlushAsync(cancellationToken);
+            var flushAsyncTask = response.BodyWriter.FlushAsync(cancellationToken);
             if (flushAsyncTask.IsCompletedSuccessfully)
             {
                 // Most implementations of ValueTask reset state in GetResult, so call it before returning a completed task.
@@ -88,12 +88,12 @@ namespace Microsoft.AspNetCore.Http
         {
             await startAsyncTask;
             Write(response, text, encoding);
-            await response.BodyPipe.FlushAsync(cancellationToken);
+            await response.BodyWriter.FlushAsync(cancellationToken);
         }
 
         private static void Write(this HttpResponse response, string text, Encoding encoding)
         {
-            var pipeWriter = response.BodyPipe;
+            var pipeWriter = response.BodyWriter;
             var encodedLength = encoding.GetByteCount(text);
             var destination = pipeWriter.GetSpan(encodedLength);
 

--- a/src/Http/Http.Abstractions/src/HttpRequest.cs
+++ b/src/Http/Http.Abstractions/src/HttpRequest.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Gets or sets the request body pipe <see cref="PipeReader"/>.
         /// </summary>
-        public abstract PipeReader BodyPipe { get; set; }
+        public abstract PipeReader BodyReader { get; set; }
 
         /// <summary>
         /// Checks the Content-Type header for form types.

--- a/src/Http/Http.Abstractions/src/HttpResponse.cs
+++ b/src/Http/Http.Abstractions/src/HttpResponse.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Gets or sets the response body pipe <see cref="PipeWriter"/>
         /// </summary>
-        public abstract PipeWriter BodyPipe { get; set; }
+        public abstract PipeWriter BodyWriter { get; set; }
 
         /// <summary>
         /// Gets or sets the value for the <c>Content-Length</c> response header.

--- a/src/Http/Http.Abstractions/test/HttpResponseWritingExtensionsTests.cs
+++ b/src/Http/Http.Abstractions/test/HttpResponseWritingExtensionsTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Http
             var streamPipeWriter = new StreamPipeWriter(outputStream, minimumSegmentSize: 0, memoryPool);
 
             HttpContext context = new DefaultHttpContext();
-            context.Response.BodyPipe = streamPipeWriter;
+            context.Response.BodyWriter = streamPipeWriter;
 
             var inputString = "昨日すき焼きを食べました";
             var expected = encoding.GetBytes(inputString);

--- a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
+++ b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Http.Features
     }
     public partial interface IRequestBodyPipeFeature
     {
-        System.IO.Pipelines.PipeReader RequestBodyPipe { get; set; }
+        System.IO.Pipelines.PipeReader RequestBodyReader { get; set; }
     }
     public partial interface IRequestCookiesFeature
     {
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Http.Features
     }
     public partial interface IResponseBodyPipeFeature
     {
-        System.IO.Pipelines.PipeWriter ResponseBodyPipe { get; set; }
+        System.IO.Pipelines.PipeWriter ResponseBodyWriter { get; set; }
     }
     public partial interface IResponseCookiesFeature
     {

--- a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
+++ b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Http.Features
     }
     public partial interface IRequestBodyPipeFeature
     {
-        System.IO.Pipelines.PipeReader RequestBodyReader { get; set; }
+        System.IO.Pipelines.PipeReader Reader { get; set; }
     }
     public partial interface IRequestCookiesFeature
     {
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Http.Features
     }
     public partial interface IResponseBodyPipeFeature
     {
-        System.IO.Pipelines.PipeWriter ResponseBodyWriter { get; set; }
+        System.IO.Pipelines.PipeWriter Writer { get; set; }
     }
     public partial interface IResponseCookiesFeature
     {

--- a/src/Http/Http.Features/src/IRequestBodyPipeFeature.cs
+++ b/src/Http/Http.Features/src/IRequestBodyPipeFeature.cs
@@ -13,6 +13,6 @@ namespace Microsoft.AspNetCore.Http.Features
         /// <summary>
         /// A <see cref="PipeReader"/> representing the request body, if any.
         /// </summary>
-        PipeReader RequestBodyReader { get; set; }
+        PipeReader Reader { get; set; }
     }
 }

--- a/src/Http/Http.Features/src/IRequestBodyPipeFeature.cs
+++ b/src/Http/Http.Features/src/IRequestBodyPipeFeature.cs
@@ -13,6 +13,6 @@ namespace Microsoft.AspNetCore.Http.Features
         /// <summary>
         /// A <see cref="PipeReader"/> representing the request body, if any.
         /// </summary>
-        PipeReader RequestBodyPipe { get; set; }
+        PipeReader RequestBodyReader { get; set; }
     }
 }

--- a/src/Http/Http.Features/src/IResponseBodyPipeFeature.cs
+++ b/src/Http/Http.Features/src/IResponseBodyPipeFeature.cs
@@ -14,6 +14,6 @@ namespace Microsoft.AspNetCore.Http.Features
         /// <summary>
         /// A <see cref="PipeWriter"/> representing the response body, if any.
         /// </summary>
-        PipeWriter ResponseBodyPipe { get; set; }
+        PipeWriter ResponseBodyWriter { get; set; }
     }
 }

--- a/src/Http/Http.Features/src/IResponseBodyPipeFeature.cs
+++ b/src/Http/Http.Features/src/IResponseBodyPipeFeature.cs
@@ -14,6 +14,6 @@ namespace Microsoft.AspNetCore.Http.Features
         /// <summary>
         /// A <see cref="PipeWriter"/> representing the response body, if any.
         /// </summary>
-        PipeWriter ResponseBodyWriter { get; set; }
+        PipeWriter Writer { get; set; }
     }
 }

--- a/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
+++ b/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Http.Features
     public partial class RequestBodyPipeFeature : Microsoft.AspNetCore.Http.Features.IRequestBodyPipeFeature
     {
         public RequestBodyPipeFeature(Microsoft.AspNetCore.Http.HttpContext context) { }
-        public System.IO.Pipelines.PipeReader RequestBodyPipe { get { throw null; } set { } }
+        public System.IO.Pipelines.PipeReader RequestBodyReader { get { throw null; } set { } }
     }
     public partial class RequestCookiesFeature : Microsoft.AspNetCore.Http.Features.IRequestCookiesFeature
     {
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Http.Features
     public partial class ResponseBodyPipeFeature : Microsoft.AspNetCore.Http.Features.IResponseBodyPipeFeature
     {
         public ResponseBodyPipeFeature(Microsoft.AspNetCore.Http.HttpContext context) { }
-        public System.IO.Pipelines.PipeWriter ResponseBodyPipe { get { throw null; } set { } }
+        public System.IO.Pipelines.PipeWriter ResponseBodyWriter { get { throw null; } set { } }
     }
     public partial class ResponseCookiesFeature : Microsoft.AspNetCore.Http.Features.IResponseCookiesFeature
     {
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Http.Internal
     {
         public DefaultHttpRequest(Microsoft.AspNetCore.Http.DefaultHttpContext context) { }
         public override System.IO.Stream Body { get { throw null; } set { } }
-        public override System.IO.Pipelines.PipeReader BodyPipe { get { throw null; } set { } }
+        public override System.IO.Pipelines.PipeReader BodyReader { get { throw null; } set { } }
         public override long? ContentLength { get { throw null; } set { } }
         public override string ContentType { get { throw null; } set { } }
         public override Microsoft.AspNetCore.Http.IRequestCookieCollection Cookies { get { throw null; } set { } }
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Http.Internal
     {
         public DefaultHttpResponse(Microsoft.AspNetCore.Http.DefaultHttpContext context) { }
         public override System.IO.Stream Body { get { throw null; } set { } }
-        public override System.IO.Pipelines.PipeWriter BodyPipe { get { throw null; } set { } }
+        public override System.IO.Pipelines.PipeWriter BodyWriter { get { throw null; } set { } }
         public override long? ContentLength { get { throw null; } set { } }
         public override string ContentType { get { throw null; } set { } }
         public override Microsoft.AspNetCore.Http.IResponseCookies Cookies { get { throw null; } }

--- a/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
+++ b/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Http.Features
     public partial class RequestBodyPipeFeature : Microsoft.AspNetCore.Http.Features.IRequestBodyPipeFeature
     {
         public RequestBodyPipeFeature(Microsoft.AspNetCore.Http.HttpContext context) { }
-        public System.IO.Pipelines.PipeReader RequestBodyReader { get { throw null; } set { } }
+        public System.IO.Pipelines.PipeReader Reader { get { throw null; } set { } }
     }
     public partial class RequestCookiesFeature : Microsoft.AspNetCore.Http.Features.IRequestCookiesFeature
     {
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Http.Features
     public partial class ResponseBodyPipeFeature : Microsoft.AspNetCore.Http.Features.IResponseBodyPipeFeature
     {
         public ResponseBodyPipeFeature(Microsoft.AspNetCore.Http.HttpContext context) { }
-        public System.IO.Pipelines.PipeWriter ResponseBodyWriter { get { throw null; } set { } }
+        public System.IO.Pipelines.PipeWriter Writer { get { throw null; } set { } }
     }
     public partial class ResponseCookiesFeature : Microsoft.AspNetCore.Http.Features.IResponseCookiesFeature
     {

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Http.Features
                 if (HasApplicationFormContentType(contentType))
                 {
                     var encoding = FilterEncoding(contentType.Encoding);
-                    var formReader = new FormPipeReader(_request.BodyPipe, encoding)
+                    var formReader = new FormPipeReader(_request.BodyReader, encoding)
                     {
                         ValueCountLimit = _options.ValueCountLimit,
                         KeyLengthLimit = _options.KeyLengthLimit,

--- a/src/Http/Http/src/Features/RequestBodyPipeFeature.cs
+++ b/src/Http/Http/src/Features/RequestBodyPipeFeature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Features
             _context = context;
         }
 
-        public PipeReader RequestBodyReader
+        public PipeReader Reader
         {
             get
             {

--- a/src/Http/Http/src/Features/RequestBodyPipeFeature.cs
+++ b/src/Http/Http/src/Features/RequestBodyPipeFeature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Features
             _context = context;
         }
 
-        public PipeReader RequestBodyPipe
+        public PipeReader RequestBodyReader
         {
             get
             {

--- a/src/Http/Http/src/Features/ResponseBodyPipeFeature.cs
+++ b/src/Http/Http/src/Features/ResponseBodyPipeFeature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Features
             _context = context;
         }
 
-        public PipeWriter ResponseBodyPipe
+        public PipeWriter ResponseBodyWriter
         {
             get
             {

--- a/src/Http/Http/src/Features/ResponseBodyPipeFeature.cs
+++ b/src/Http/Http/src/Features/ResponseBodyPipeFeature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Features
             _context = context;
         }
 
-        public PipeWriter ResponseBodyWriter
+        public PipeWriter Writer
         {
             get
             {

--- a/src/Http/Http/src/Internal/DefaultHttpRequest.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpRequest.cs
@@ -173,8 +173,8 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public override PipeReader BodyReader
         {
-            get { return RequestBodyPipeFeature.RequestBodyReader; }
-            set { RequestBodyPipeFeature.RequestBodyReader = value; }
+            get { return RequestBodyPipeFeature.Reader; }
+            set { RequestBodyPipeFeature.Reader = value; }
         }
 
         struct FeatureInterfaces

--- a/src/Http/Http/src/Internal/DefaultHttpRequest.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpRequest.cs
@@ -171,10 +171,10 @@ namespace Microsoft.AspNetCore.Http.Internal
             set { RouteValuesFeature.RouteValues = value; }
         }
 
-        public override PipeReader BodyPipe
+        public override PipeReader BodyReader
         {
-            get { return RequestBodyPipeFeature.RequestBodyPipe; }
-            set { RequestBodyPipeFeature.RequestBodyPipe = value; }
+            get { return RequestBodyPipeFeature.RequestBodyReader; }
+            set { RequestBodyPipeFeature.RequestBodyReader = value; }
         }
 
         struct FeatureInterfaces

--- a/src/Http/Http/src/Internal/DefaultHttpResponse.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpResponse.cs
@@ -111,8 +111,8 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public override PipeWriter BodyWriter
         {
-            get { return ResponseBodyPipeFeature.ResponseBodyWriter; }
-            set { ResponseBodyPipeFeature.ResponseBodyWriter = value; }
+            get { return ResponseBodyPipeFeature.Writer; }
+            set { ResponseBodyPipeFeature.Writer = value; }
         }
 
         public override void OnStarting(Func<object, Task> callback, object state)

--- a/src/Http/Http/src/Internal/DefaultHttpResponse.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpResponse.cs
@@ -109,10 +109,10 @@ namespace Microsoft.AspNetCore.Http.Internal
             get { return HttpResponseFeature.HasStarted; }
         }
 
-        public override PipeWriter BodyPipe
+        public override PipeWriter BodyWriter
         {
-            get { return ResponseBodyPipeFeature.ResponseBodyPipe; }
-            set { ResponseBodyPipeFeature.ResponseBodyPipe = value; }
+            get { return ResponseBodyPipeFeature.ResponseBodyWriter; }
+            set { ResponseBodyPipeFeature.ResponseBodyWriter = value; }
         }
 
         public override void OnStarting(Func<object, Task> callback, object state)

--- a/src/Http/Http/test/Features/FormFeatureTests.cs
+++ b/src/Http/Http/test/Features/FormFeatureTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Http.Features
             await pipe.Writer.WriteAsync(formContent);
             pipe.Writer.Complete();
 
-            context.Request.BodyPipe = pipe.Reader;
+            context.Request.BodyReader = pipe.Reader;
 
             IFormFeature formFeature = new FormFeature(context.Request, new FormOptions() { BufferBody = bufferRequest });
             context.Features.Set<IFormFeature>(formFeature);

--- a/src/Http/Http/test/Features/RequestBodyPipeFeatureTests.cs
+++ b/src/Http/Http/test/Features/RequestBodyPipeFeatureTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.AspNetCore.Http.Features
             var expectedStream = new MemoryStream();
             context.Request.Body = expectedStream;
 
-            var provider = new RequestBodyPipeFeature(context);
+            var feature = new RequestBodyPipeFeature(context);
 
-            var pipeBody = provider.RequestBodyPipe;
+            var pipeBody = feature.Reader;
 
             Assert.True(pipeBody is StreamPipeReader);
             Assert.Equal(expectedStream, (pipeBody as StreamPipeReader).InnerStream);
@@ -32,9 +32,9 @@ namespace Microsoft.AspNetCore.Http.Features
         public async Task RequestBodyReadCanWorkWithPipe()
         {
             var expectedString = "abcdef";
-            var provider = InitializeFeatureWithData(expectedString);
+            var feature = InitializeFeatureWithData(expectedString);
 
-            var data = await provider.RequestBodyPipe.ReadAsync();
+            var data = await feature.Reader.ReadAsync();
             Assert.Equal(expectedString, GetStringFromReadResult(data));
         }
 
@@ -43,12 +43,12 @@ namespace Microsoft.AspNetCore.Http.Features
         {
             var context = new DefaultHttpContext();
 
-            var provider = new RequestBodyPipeFeature(context);
+            var feature = new RequestBodyPipeFeature(context);
 
             var pipeReader = new Pipe().Reader;
-            provider.RequestBodyPipe = pipeReader;
+            feature.Reader = pipeReader;
 
-            Assert.Equal(pipeReader, provider.RequestBodyPipe);
+            Assert.Equal(pipeReader, feature.Reader);
         }
 
         [Fact]
@@ -56,25 +56,25 @@ namespace Microsoft.AspNetCore.Http.Features
         {
             var context = new DefaultHttpContext();
 
-            var provider = new RequestBodyPipeFeature(context);
+            var feature = new RequestBodyPipeFeature(context);
 
             var expectedPipeReader = new Pipe().Reader;
-            provider.RequestBodyPipe = expectedPipeReader;
+            feature.Reader = expectedPipeReader;
 
             // Because the user set the RequestBodyPipe, this will return the user set pipeReader
             context.Request.Body = new MemoryStream();
 
-            Assert.Equal(expectedPipeReader, provider.RequestBodyPipe);
+            Assert.Equal(expectedPipeReader, feature.Reader);
         }
 
         [Fact]
         public async Task RequestBodyDoesNotAffectUserSetPipe()
         {
             var expectedString = "abcdef";
-            var provider = InitializeFeatureWithData("hahaha");
-            provider.RequestBodyPipe = await GetPipeReaderWithData(expectedString);
+            var feature = InitializeFeatureWithData("hahaha");
+            feature.Reader = await GetPipeReaderWithData(expectedString);
 
-            var data = await provider.RequestBodyPipe.ReadAsync();
+            var data = await feature.Reader.ReadAsync();
             Assert.Equal(expectedString, GetStringFromReadResult(data));
         }
 
@@ -85,14 +85,14 @@ namespace Microsoft.AspNetCore.Http.Features
 
             context.Request.Body = new MemoryStream();
 
-            var provider = new RequestBodyPipeFeature(context);
+            var feature = new RequestBodyPipeFeature(context);
 
-            var pipeBody = provider.RequestBodyPipe;
+            var pipeBody = feature.Reader;
 
             // Requery the PipeReader after setting the body again.
             var expectedStream = new MemoryStream();
             context.Request.Body = expectedStream;
-            pipeBody = provider.RequestBodyPipe;
+            pipeBody = feature.Reader;
 
             Assert.True(pipeBody is StreamPipeReader);
             Assert.Equal(expectedStream, (pipeBody as StreamPipeReader).InnerStream);
@@ -103,12 +103,12 @@ namespace Microsoft.AspNetCore.Http.Features
         {
             var context = new DefaultHttpContext();
             context.Request.Body = new MemoryStream(Encoding.ASCII.GetBytes("hahaha"));
-            var provider = new RequestBodyPipeFeature(context);
-            var _ = provider.RequestBodyPipe;
+            var feature = new RequestBodyPipeFeature(context);
+            var _ = feature.Reader;
 
             var expectedString = "abcdef";
             context.Request.Body = new MemoryStream(Encoding.ASCII.GetBytes(expectedString));
-            var data = await provider.RequestBodyPipe.ReadAsync();
+            var data = await feature.Reader.ReadAsync();
             Assert.Equal(expectedString, GetStringFromReadResult(data));
         }
 

--- a/src/Http/Http/test/Features/ResponseBodyPipeFeatureTests.cs
+++ b/src/Http/Http/test/Features/ResponseBodyPipeFeatureTests.cs
@@ -16,9 +16,9 @@ namespace Microsoft.AspNetCore.Http.Features
             var expectedStream = new MemoryStream();
             context.Response.Body = expectedStream;
 
-            var provider = new ResponseBodyPipeFeature(context);
+            var feature = new ResponseBodyPipeFeature(context);
 
-            var pipeBody = provider.ResponseBodyPipe;
+            var pipeBody = feature.Writer;
 
             Assert.True(pipeBody is StreamPipeWriter);
             Assert.Equal(expectedStream, (pipeBody as StreamPipeWriter).InnerStream);
@@ -28,12 +28,12 @@ namespace Microsoft.AspNetCore.Http.Features
         public void ResponseBodySetPipeReaderReturnsSameValue()
         {
             var context = new DefaultHttpContext();
-            var provider = new ResponseBodyPipeFeature(context);
+            var feature = new ResponseBodyPipeFeature(context);
 
             var pipeWriter = new Pipe().Writer;
-            provider.ResponseBodyPipe = pipeWriter;
+            feature.Writer = pipeWriter;
 
-            Assert.Equal(pipeWriter, provider.ResponseBodyPipe);
+            Assert.Equal(pipeWriter, feature.Writer);
         }
 
         [Fact]
@@ -43,11 +43,11 @@ namespace Microsoft.AspNetCore.Http.Features
             var expectedStream = new MemoryStream();
             context.Response.Body = new MemoryStream();
 
-            var provider = new ResponseBodyPipeFeature(context);
+            var feature = new ResponseBodyPipeFeature(context);
 
-            var pipeBody = provider.ResponseBodyPipe;
+            var pipeBody = feature.Writer;
             context.Response.Body = expectedStream;
-            pipeBody = provider.ResponseBodyPipe;
+            pipeBody = feature.Writer;
 
             Assert.True(pipeBody is StreamPipeWriter);
             Assert.Equal(expectedStream, (pipeBody as StreamPipeWriter).InnerStream);

--- a/src/Http/Http/test/Internal/DefaultHttpRequestTests.cs
+++ b/src/Http/Http/test/Internal/DefaultHttpRequestTests.cs
@@ -244,41 +244,41 @@ namespace Microsoft.AspNetCore.Http.Internal
         }
 
         [Fact]
-        public void BodyPipe_CanGet()
+        public void BodyReader_CanGet()
         {
             var context = new DefaultHttpContext();
-            var bodyPipe = context.Request.BodyPipe;
+            var bodyPipe = context.Request.BodyReader;
             Assert.NotNull(bodyPipe);
         }
 
         [Fact]
-        public void BodyPipe_CanSet()
+        public void BodyReader_CanSet()
         {
             var pipeReader = new Pipe().Reader;
             var context = new DefaultHttpContext();
 
-            context.Request.BodyPipe = pipeReader;
+            context.Request.BodyReader = pipeReader;
 
-            Assert.Equal(pipeReader, context.Request.BodyPipe);
+            Assert.Equal(pipeReader, context.Request.BodyReader);
         }
 
         [Fact]
-        public void BodyPipe_WrapsStream()
+        public void BodyReader_WrapsStream()
         {
             var context = new DefaultHttpContext();
             var expectedStream = new MemoryStream();
             context.Request.Body = expectedStream;
 
-            var bodyPipe = context.Request.BodyPipe as StreamPipeReader;
+            var bodyPipe = context.Request.BodyReader as StreamPipeReader;
 
             Assert.Equal(expectedStream, bodyPipe.InnerStream);
         }
 
         [Fact]
-        public void BodyPipe_ThrowsWhenSettingNull()
+        public void BodyReader_ThrowsWhenSettingNull()
         {
             var context = new DefaultHttpContext();
-            Assert.Throws<ArgumentNullException>(() => context.Request.BodyPipe = null);
+            Assert.Throws<ArgumentNullException>(() => context.Request.BodyReader = null);
         }
 
         private class CustomRouteValuesFeature : IRouteValuesFeature

--- a/src/Http/Http/test/Internal/DefaultHttpResponseTests.cs
+++ b/src/Http/Http/test/Internal/DefaultHttpResponseTests.cs
@@ -65,41 +65,41 @@ namespace Microsoft.AspNetCore.Http.Internal
         }
 
         [Fact]
-        public void BodyPipe_CanGet()
+        public void BodyWriter_CanGet()
         {
             var response = new DefaultHttpContext();
-            var bodyPipe = response.Response.BodyPipe;
+            var bodyPipe = response.Response.BodyWriter;
 
             Assert.NotNull(bodyPipe);
         }
 
         [Fact]
-        public void BodyPipe_CanSet()
+        public void BodyWriter_CanSet()
         {
             var response = new DefaultHttpContext();
             var pipeWriter = new Pipe().Writer;
-            response.Response.BodyPipe = pipeWriter;
+            response.Response.BodyWriter = pipeWriter;
 
-            Assert.Equal(pipeWriter, response.Response.BodyPipe);
+            Assert.Equal(pipeWriter, response.Response.BodyWriter);
         }
 
         [Fact]
-        public void BodyPipe_WrapsStream()
+        public void BodyWriter_WrapsStream()
         {
             var context = new DefaultHttpContext();
             var expectedStream = new MemoryStream();
             context.Response.Body = expectedStream;
 
-            var bodyPipe = context.Response.BodyPipe as StreamPipeWriter;
+            var bodyPipe = context.Response.BodyWriter as StreamPipeWriter;
 
             Assert.Equal(expectedStream, bodyPipe.InnerStream);
         }
 
         [Fact]
-        public void BodyPipe_ThrowsWhenSettingNull()
+        public void BodyWriter_ThrowsWhenSettingNull()
         {
             var context = new DefaultHttpContext();
-            Assert.Throws<ArgumentNullException>(() => context.Response.BodyPipe = null);
+            Assert.Throws<ArgumentNullException>(() => context.Response.BodyWriter = null);
         }
 
         [Fact]

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
@@ -94,8 +94,8 @@ namespace JwtBearerSample
                         response.ContentType = "application/json";
                         response.Headers[HeaderNames.CacheControl] = "no-cache";
                         await response.StartAsync();
-                        Serialize(Todos, response.BodyPipe);
-                        await response.BodyPipe.FlushAsync();
+                        Serialize(Todos, response.BodyWriter);
+                        await response.BodyWriter.FlushAsync();
                     }
                 });
             });

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -639,8 +639,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         string Microsoft.AspNetCore.Http.Features.IHttpResponseFeature.ReasonPhrase { get { throw null; } set { } }
         int Microsoft.AspNetCore.Http.Features.IHttpResponseFeature.StatusCode { get { throw null; } set { } }
         bool Microsoft.AspNetCore.Http.Features.IHttpUpgradeFeature.IsUpgradableRequest { get { throw null; } }
-        System.IO.Pipelines.PipeReader Microsoft.AspNetCore.Http.Features.IRequestBodyPipeFeature.RequestBodyReader { get { throw null; } set { } }
-        System.IO.Pipelines.PipeWriter Microsoft.AspNetCore.Http.Features.IResponseBodyPipeFeature.ResponseBodyWriter { get { throw null; } set { } }
+        System.IO.Pipelines.PipeReader Microsoft.AspNetCore.Http.Features.IRequestBodyPipeFeature.Reader { get { throw null; } set { } }
+        System.IO.Pipelines.PipeWriter Microsoft.AspNetCore.Http.Features.IResponseBodyPipeFeature.Writer { get { throw null; } set { } }
         Microsoft.AspNetCore.Http.DefaultHttpContext Microsoft.AspNetCore.Http.IDefaultHttpContextContainer.HttpContext { get { throw null; } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpOutputProducer Output { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public string Path { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -639,8 +639,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         string Microsoft.AspNetCore.Http.Features.IHttpResponseFeature.ReasonPhrase { get { throw null; } set { } }
         int Microsoft.AspNetCore.Http.Features.IHttpResponseFeature.StatusCode { get { throw null; } set { } }
         bool Microsoft.AspNetCore.Http.Features.IHttpUpgradeFeature.IsUpgradableRequest { get { throw null; } }
-        System.IO.Pipelines.PipeReader Microsoft.AspNetCore.Http.Features.IRequestBodyPipeFeature.RequestBodyPipe { get { throw null; } set { } }
-        System.IO.Pipelines.PipeWriter Microsoft.AspNetCore.Http.Features.IResponseBodyPipeFeature.ResponseBodyPipe { get { throw null; } set { } }
+        System.IO.Pipelines.PipeReader Microsoft.AspNetCore.Http.Features.IRequestBodyPipeFeature.RequestBodyReader { get { throw null; } set { } }
+        System.IO.Pipelines.PipeWriter Microsoft.AspNetCore.Http.Features.IResponseBodyPipeFeature.ResponseBodyWriter { get { throw null; } set { } }
         Microsoft.AspNetCore.Http.DefaultHttpContext Microsoft.AspNetCore.Http.IDefaultHttpContextContainer.HttpContext { get { throw null; } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpOutputProducer Output { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public string Path { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        PipeReader IRequestBodyPipeFeature.RequestBodyPipe
+        PipeReader IRequestBodyPipeFeature.RequestBodyReader
         {
             get
             {
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        PipeWriter IResponseBodyPipeFeature.ResponseBodyPipe
+        PipeWriter IResponseBodyPipeFeature.ResponseBodyWriter
         {
             get
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        PipeReader IRequestBodyPipeFeature.RequestBodyReader
+        PipeReader IRequestBodyPipeFeature.Reader
         {
             get
             {
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        PipeWriter IResponseBodyPipeFeature.ResponseBodyWriter
+        PipeWriter IResponseBodyPipeFeature.Writer
         {
             get
             {

--- a/src/Servers/Kestrel/shared/test/TestApp.cs
+++ b/src/Servers/Kestrel/shared/test/TestApp.cs
@@ -50,10 +50,10 @@ namespace Microsoft.AspNetCore.Testing
             {
                 await request.Body.ReadUntilEndAsync(buffer).DefaultTimeout();
                 await response.StartAsync();
-                var memory = response.BodyPipe.GetMemory(buffer.Length);
+                var memory = response.BodyWriter.GetMemory(buffer.Length);
                 buffer.CopyTo(memory);
-                response.BodyPipe.Advance(buffer.Length);
-                await response.BodyPipe.FlushAsync();
+                response.BodyWriter.Advance(buffer.Length);
+                await response.BodyWriter.FlushAsync();
             }
         }
 
@@ -68,10 +68,10 @@ namespace Microsoft.AspNetCore.Testing
             response.Headers["Content-Length"] = bytes.Length.ToString();
             await response.StartAsync();
 
-            var memory = response.BodyPipe.GetMemory(bytes.Length);
+            var memory = response.BodyWriter.GetMemory(bytes.Length);
             bytes.CopyTo(memory);
-            response.BodyPipe.Advance(bytes.Length);
-            await response.BodyPipe.FlushAsync();
+            response.BodyWriter.Advance(bytes.Length);
+            await response.BodyWriter.FlushAsync();
         }
     }
 }

--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                         for (int i = 0; i < 1024; i++)
                         {
-                            await context.Response.BodyPipe.WriteAsync(new Memory<byte>(bytes, 0, bytes.Length));
+                            await context.Response.BodyWriter.WriteAsync(new Memory<byte>(bytes, 0, bytes.Length));
                         }
                     });
                 });
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     for (var i = 0; i < 1000; i++)
                     {
-                        await context.Response.BodyPipe.WriteAsync(new Memory<byte>(scratchBuffer, 0, scratchBuffer.Length), context.RequestAborted);
+                        await context.Response.BodyWriter.WriteAsync(new Memory<byte>(scratchBuffer, 0, scratchBuffer.Length), context.RequestAborted);
                         await Task.Delay(10);
                     }
                 }
@@ -500,7 +500,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     for (; i < chunks; i++)
                     {
-                        await context.Response.BodyPipe.WriteAsync(new Memory<byte>(chunkData, 0, chunkData.Length), context.RequestAborted);
+                        await context.Response.BodyWriter.WriteAsync(new Memory<byte>(chunkData, 0, chunkData.Length), context.RequestAborted);
                         await Task.Yield();
                     }
 
@@ -607,7 +607,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     for (var i = 0; i < chunks; i++)
                     {
-                        await context.Response.BodyPipe.WriteAsync(new Memory<byte>(chunkData, 0, chunkData.Length), context.RequestAborted);
+                        await context.Response.BodyWriter.WriteAsync(new Memory<byte>(chunkData, 0, chunkData.Length), context.RequestAborted);
                     }
                 }
                 catch (OperationCanceledException)
@@ -771,7 +771,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 for (var i = 0; i < chunkCount; i++)
                 {
-                    await context.Response.BodyPipe.WriteAsync(new Memory<byte>(chunkData, 0, chunkData.Length), context.RequestAborted);
+                    await context.Response.BodyWriter.WriteAsync(new Memory<byte>(chunkData, 0, chunkData.Length), context.RequestAborted);
                 }
 
                 appFuncCompleted.SetResult(null);
@@ -848,7 +848,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 context.Response.Headers[$"X-Custom-Header"] = headerStringValues;
                 context.Response.ContentLength = 0;
 
-                await context.Response.BodyPipe.FlushAsync();
+                await context.Response.BodyWriter.FlushAsync();
             }
 
             using (var server = new TestServer(App, testContext, listenOptions))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -42,15 +42,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var response = httpContext.Response;
             while (true)
             {
-                var readResult = await request.BodyPipe.ReadAsync();
+                var readResult = await request.BodyReader.ReadAsync();
                 if (readResult.IsCompleted)
                 {
                     break;
                 }
                 // Need to copy here.
-                await response.BodyPipe.WriteAsync(readResult.Buffer.ToArray());
+                await response.BodyWriter.WriteAsync(readResult.Buffer.ToArray());
 
-                request.BodyPipe.AdvanceTo(readResult.Buffer.End);
+                request.BodyReader.AdvanceTo(readResult.Buffer.End);
             }
         }
 
@@ -322,8 +322,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 while (true)
                 {
-                    var result = await request.BodyPipe.ReadAsync();
-                    request.BodyPipe.AdvanceTo(result.Buffer.End);
+                    var result = await request.BodyReader.ReadAsync();
+                    request.BodyReader.AdvanceTo(result.Buffer.End);
                     if (result.IsCompleted)
                     {
                         break;
@@ -828,12 +828,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 Assert.Equal("POST", request.Method);
 
-                var readResult = await request.BodyPipe.ReadAsync();
-                request.BodyPipe.AdvanceTo(readResult.Buffer.End);
+                var readResult = await request.BodyReader.ReadAsync();
+                request.BodyReader.AdvanceTo(readResult.Buffer.End);
 
-                var requestTask = httpContext.Request.BodyPipe.ReadAsync();
+                var requestTask = httpContext.Request.BodyReader.ReadAsync();
 
-                httpContext.Request.BodyPipe.CancelPendingRead();
+                httpContext.Request.BodyReader.CancelPendingRead();
 
                 Assert.True((await requestTask).IsCanceled);
 
@@ -841,7 +841,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 response.Headers["Content-Length"] = new[] { "11" };
 
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
 
             }, testContext))
             {
@@ -885,16 +885,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 Assert.Equal("POST", request.Method);
 
-                var readResult = await request.BodyPipe.ReadAsync();
-                request.BodyPipe.AdvanceTo(readResult.Buffer.End);
+                var readResult = await request.BodyReader.ReadAsync();
+                request.BodyReader.AdvanceTo(readResult.Buffer.End);
 
-                httpContext.Request.BodyPipe.Complete();
+                httpContext.Request.BodyReader.Complete();
 
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await request.BodyPipe.ReadAsync());
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await request.BodyReader.ReadAsync());
 
                 response.Headers["Content-Length"] = new[] { "11" };
 
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
 
             }, testContext))
             {
@@ -937,14 +937,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 Assert.Equal("POST", request.Method);
 
-                var readResult = await request.BodyPipe.ReadAsync();
-                request.BodyPipe.AdvanceTo(readResult.Buffer.End);
+                var readResult = await request.BodyReader.ReadAsync();
+                request.BodyReader.AdvanceTo(readResult.Buffer.End);
 
-                httpContext.Request.BodyPipe.Complete(new Exception());
+                httpContext.Request.BodyReader.Complete(new Exception());
 
                 response.Headers["Content-Length"] = new[] { "11" };
 
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
 
             }, testContext))
             {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello "), 0, 6));
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("World!"), 0, 6));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello "), 0, 6));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("World!"), 0, 6));
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -162,9 +162,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello "), 0, 6));
-                await response.BodyPipe.WriteAsync(new Memory<byte>(new byte[0], 0, 0));
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("World!"), 0, 6));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello "), 0, 6));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(new byte[0], 0, 0));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("World!"), 0, 6));
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -244,7 +244,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.BodyPipe.WriteAsync(new Memory<byte>(new byte[0], 0, 0));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(new byte[0], 0, 0));
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World!"), 0, 12));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello World!"), 0, 12));
                 throw new Exception();
             }, testContext))
             {
@@ -309,7 +309,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.BodyPipe.WriteAsync(new Memory<byte>(new byte[0], 0, 0));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(new byte[0], 0, 0));
                 throw new Exception();
             }, testContext))
             {
@@ -344,12 +344,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             using (var server = new TestServer(async httpContext =>
             {
                 var response = httpContext.Response;
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello "), 0, 6));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("Hello "), 0, 6));
 
                 // Don't complete response until client has received the first chunk.
                 await flushWh.Task.DefaultTimeout();
 
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("World!"), 0, 6));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("World!"), 0, 6));
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -391,9 +391,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 var response = httpContext.Response;
                 response.Headers["Transfer-Encoding"] = "chunked";
 
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("6\r\nHello \r\n"), 0, 11));
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("6\r\nWorld!\r\n"), 0, 11));
-                await response.BodyPipe.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("0\r\n\r\n"), 0, 5));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("6\r\nHello \r\n"), 0, 11));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("6\r\nWorld!\r\n"), 0, 11));
+                await response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("0\r\n\r\n"), 0, 5));
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -430,17 +430,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 await response.StartAsync();
-                var memory = response.BodyPipe.GetMemory();
+                var memory = response.BodyWriter.GetMemory();
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
-                memory = response.BodyPipe.GetMemory();
+                memory = response.BodyWriter.GetMemory();
                 var secondPartOfResponse = Encoding.ASCII.GetBytes("World!");
                 secondPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
-                await response.BodyPipe.FlushAsync();
+                await response.BodyWriter.FlushAsync();
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -478,20 +478,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 var response = httpContext.Response;
                 await response.StartAsync();
 
-                var memory = response.BodyPipe.GetMemory();
+                var memory = response.BodyWriter.GetMemory();
                 length.Value = memory.Length;
                 semaphore.Release();
 
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes(new string('a', memory.Length));
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(memory.Length);
+                response.BodyWriter.Advance(memory.Length);
 
-                memory = response.BodyPipe.GetMemory();
+                memory = response.BodyWriter.GetMemory();
                 var secondPartOfResponse = Encoding.ASCII.GetBytes("World!");
                 secondPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
-                await response.BodyPipe.FlushAsync();
+                await response.BodyWriter.FlushAsync();
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -534,22 +534,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
 
-                await response.BodyPipe.FlushAsync();
+                await response.BodyWriter.FlushAsync();
 
-                var memory = response.BodyPipe.GetMemory();
+                var memory = response.BodyWriter.GetMemory();
                 length.Value = memory.Length;
                 semaphore.Release();
 
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes(new string('a', memory.Length));
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(memory.Length);
+                response.BodyWriter.Advance(memory.Length);
 
-                memory = response.BodyPipe.GetMemory();
+                memory = response.BodyWriter.GetMemory();
                 var secondPartOfResponse = Encoding.ASCII.GetBytes("World!");
                 secondPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
-                await response.BodyPipe.FlushAsync();
+                await response.BodyWriter.FlushAsync();
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -592,14 +592,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 await response.StartAsync();
 
-                var memory = response.BodyPipe.GetMemory(4096);
+                var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
                 var secondPartOfResponse = Encoding.ASCII.GetBytes("World!");
                 secondPartOfResponse.CopyTo(memory.Slice(6));
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -637,14 +637,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 // To avoid using span in an async method
                 void NonAsyncMethod()
                 {
-                    var span = response.BodyPipe.GetSpan(4096);
+                    var span = response.BodyWriter.GetSpan(4096);
                     var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
                     fisrtPartOfResponse.CopyTo(span);
-                    response.BodyPipe.Advance(6);
+                    response.BodyWriter.Advance(6);
 
                     var secondPartOfResponse = Encoding.ASCII.GetBytes("World!");
                     secondPartOfResponse.CopyTo(span.Slice(6));
-                    response.BodyPipe.Advance(6);
+                    response.BodyWriter.Advance(6);
                 }
 
                 await response.StartAsync();
@@ -686,10 +686,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 await response.StartAsync();
 
-                var memory = response.BodyPipe.GetMemory(4096);
+                var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("Hello ");
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
                 await response.WriteAsync("World!");
             }, testContext))
@@ -728,12 +728,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 await response.StartAsync();
 
-                var memory = response.BodyPipe.GetMemory(0);
+                var memory = response.BodyWriter.GetMemory(0);
 
                 // Headers are already written to memory, sliced appropriately
                 Assert.Equal(4005, memory.Length);
 
-                memory = response.BodyPipe.GetMemory(1000000);
+                memory = response.BodyWriter.GetMemory(1000000);
                 Assert.Equal(4005, memory.Length);
             }, testContext))
             {
@@ -771,10 +771,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 await response.StartAsync();
 
-                var memory = response.BodyPipe.GetMemory(4096);
+                var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes(new string('a', writeSize));
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(writeSize);
+                response.BodyWriter.Advance(writeSize);
             }, testContext))
             {
                 using (var connection = server.CreateConnection())
@@ -807,16 +807,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 await response.StartAsync();
-                var memory = response.BodyPipe.GetMemory(4096);
+                var memory = response.BodyWriter.GetMemory(4096);
                 var fisrtPartOfResponse = Encoding.ASCII.GetBytes("hello,");
                 fisrtPartOfResponse.CopyTo(memory);
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
                 var secondPartOfResponse = Encoding.ASCII.GetBytes(" world");
                 secondPartOfResponse.CopyTo(memory.Slice(6));
-                response.BodyPipe.Advance(6);
+                response.BodyWriter.Advance(6);
 
                 await response.Body.WriteAsync(Encoding.ASCII.GetBytes("hello, world"));
-                await response.BodyPipe.WriteAsync(Encoding.ASCII.GetBytes("hello, world"));
+                await response.BodyWriter.WriteAsync(Encoding.ASCII.GetBytes("hello, world"));
                 await response.WriteAsync("hello, world");
 
             }, new TestServiceContext(LoggerFactory)))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
@@ -269,9 +269,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             using (var server = new TestServer(async context =>
             {
-                await context.Response.BodyPipe.WriteAsync(Encoding.ASCII.GetBytes("Hello "));
-                await context.Response.BodyPipe.FlushAsync();
-                await context.Response.BodyPipe.WriteAsync(Encoding.ASCII.GetBytes("World!"));
+                await context.Response.BodyWriter.WriteAsync(Encoding.ASCII.GetBytes("Hello "));
+                await context.Response.BodyWriter.FlushAsync();
+                await context.Response.BodyWriter.WriteAsync(Encoding.ASCII.GetBytes("World!"));
             }, serviceContext, listenOptions))
             {
                 using (var connection = server.CreateConnection())


### PR DESCRIPTION
- Rename BodyPipe to BodyReader and BodyWriter on the request and response directly

It's a much better name

cc @JamesNK @JunTaoLuo 