### PR TITLE
Support conditional compression

### DIFF
--- a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
+++ b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
@@ -131,6 +131,12 @@ namespace Microsoft.AspNetCore.Http.Features
         public T Fetch(Microsoft.AspNetCore.Http.Features.IFeatureCollection features) { throw null; }
         public T Update(Microsoft.AspNetCore.Http.Features.IFeatureCollection features, T feature) { throw null; }
     }
+    public enum HttpsCompressionMode
+    {
+        Compress = 2,
+        Default = 0,
+        DoNotCompress = 1,
+    }
     public partial interface IFeatureCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, object>>, System.Collections.IEnumerable
     {
         bool IsReadOnly { get; }
@@ -206,6 +212,10 @@ namespace Microsoft.AspNetCore.Http.Features
     public partial interface IHttpResponseTrailersFeature
     {
         Microsoft.AspNetCore.Http.IHeaderDictionary Trailers { get; set; }
+    }
+    public partial interface IHttpsCompressionFeature
+    {
+        Microsoft.AspNetCore.Http.Features.HttpsCompressionMode Mode { get; set; }
     }
     public partial interface IHttpSendFileFeature
     {

--- a/src/Http/Http.Features/src/HttpsCompressionMode.cs
+++ b/src/Http/Http.Features/src/HttpsCompressionMode.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    /// <summary>
+    /// Use to dynamically control response compression for HTTPS requests.
+    /// </summary>
+    public enum HttpsCompressionMode
+    {
+        /// <summary>
+        /// No value has been specified, use the configured defaults.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Opts out of compression over HTTPS. Enabling compression on HTTPS requests for remotely manipulable content
+        /// may expose security problems.
+        /// </summary>
+        DoNotCompress,
+
+        /// <summary>
+        /// Opts into compression over HTTPS. Enabling compression on HTTPS requests for remotely manipulable content
+        /// may expose security problems.
+        /// </summary>
+        Compress,
+    }
+}

--- a/src/Http/Http.Features/src/HttpsCompressionMode.cs
+++ b/src/Http/Http.Features/src/HttpsCompressionMode.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Http.Features
         /// <summary>
         /// No value has been specified, use the configured defaults.
         /// </summary>
-        Default,
+        Default = 0,
 
         /// <summary>
         /// Opts out of compression over HTTPS. Enabling compression on HTTPS requests for remotely manipulable content

--- a/src/Http/Http.Features/src/IHttpsCompressionFeature.cs
+++ b/src/Http/Http.Features/src/IHttpsCompressionFeature.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    /// <summary>
+    /// Configures response compression behavior for HTTPS on a per-request basis.
+    /// </summary>
+    public interface IHttpsCompressionFeature
+    {
+        /// <summary>
+        /// The <see cref="HttpsCompressionMode"/> to use.
+        /// </summary>
+        HttpsCompressionMode Mode { get; set; }
+    }
+}

--- a/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
+++ b/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
     /// <summary>
     /// Stream wrapper that create specific compression stream only if necessary.
     /// </summary>
-    internal class BodyWrapperStream : Stream, IHttpBufferingFeature, IHttpSendFileFeature, IHttpResponseStartFeature
+    internal class BodyWrapperStream : Stream, IHttpBufferingFeature, IHttpSendFileFeature, IHttpResponseStartFeature, IHttpsCompressionFeature
     {
         private readonly HttpContext _context;
         private readonly Stream _bodyOriginalStream;
@@ -45,6 +45,8 @@ namespace Microsoft.AspNetCore.ResponseCompression
         {
             return _compressionStream?.DisposeAsync() ?? new ValueTask();
         }
+
+        HttpsCompressionMode IHttpsCompressionFeature.Mode { get; set; }
 
         public override bool CanRead => false;
 

--- a/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
+++ b/src/Middleware/ResponseCompression/src/BodyWrapperStream.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             return _compressionStream?.DisposeAsync() ?? new ValueTask();
         }
 
-        HttpsCompressionMode IHttpsCompressionFeature.Mode { get; set; }
+        HttpsCompressionMode IHttpsCompressionFeature.Mode { get; set; } = HttpsCompressionMode.Default;
 
         public override bool CanRead => false;
 

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs
@@ -55,11 +55,13 @@ namespace Microsoft.AspNetCore.ResponseCompression
             var originalBufferFeature = context.Features.Get<IHttpBufferingFeature>();
             var originalSendFileFeature = context.Features.Get<IHttpSendFileFeature>();
             var originalStartFeature = context.Features.Get<IHttpResponseStartFeature>();
+            var originalCompressionFeature = context.Features.Get<IHttpsCompressionFeature>();
 
             var bodyWrapperStream = new BodyWrapperStream(context, bodyStream, _provider,
                 originalBufferFeature, originalSendFileFeature, originalStartFeature);
             context.Response.Body = bodyWrapperStream;
             context.Features.Set<IHttpBufferingFeature>(bodyWrapperStream);
+            context.Features.Set<IHttpsCompressionFeature>(bodyWrapperStream);
             if (originalSendFileFeature != null)
             {
                 context.Features.Set<IHttpSendFileFeature>(bodyWrapperStream);
@@ -79,6 +81,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             {
                 context.Response.Body = bodyStream;
                 context.Features.Set(originalBufferFeature);
+                context.Features.Set(originalCompressionFeature);
                 if (originalSendFileFeature != null)
                 {
                     context.Features.Set(originalSendFileFeature);

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionOptions.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionOptions.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.ResponseCompression
 {
@@ -22,8 +23,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
 
         /// <summary>
         /// Indicates if responses over HTTPS connections should be compressed. The default is 'false'.
-        /// Enabling compression on HTTPS connections may expose security problems.
+        /// Enabling compression on HTTPS requests for remotely manipulable content may expose security problems.
         /// </summary>
+        /// <remarks>
+        /// This can be overridden per request using <see cref="IHttpsCompressionFeature"/>.
+        /// </remarks>
         public bool EnableForHttps { get; set; } = false;
 
         /// <summary>

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionProvider.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionProvider.cs
@@ -173,6 +173,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
         {
             var httpsMode = context.Features.Get<IHttpsCompressionFeature>()?.Mode ?? HttpsCompressionMode.Default;
 
+            // Check if the app has opted into or out of compression over HTTPS
             if (context.Request.IsHttps
                 && (httpsMode == HttpsCompressionMode.DoNotCompress
                     || !(_enableForHttps || httpsMode == HttpsCompressionMode.Compress)))

--- a/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
+++ b/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
@@ -55,6 +55,7 @@ namespace Microsoft.AspNetCore.Builder
         public StaticFileOptions(Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions sharedOptions) : base (default(Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions)) { }
         public Microsoft.AspNetCore.StaticFiles.IContentTypeProvider ContentTypeProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string DefaultContentType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Http.Features.HttpsCompressionMode HttpsCompression { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Action<Microsoft.AspNetCore.StaticFiles.StaticFileResponseContext> OnPrepareResponse { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool ServeUnknownFileTypes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/Middleware/StaticFiles/samples/StaticFileSample/Startup.cs
+++ b/src/Middleware/StaticFiles/samples/StaticFileSample/Startup.cs
@@ -12,11 +12,14 @@ namespace StaticFilesSample
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDirectoryBrowser();
+            services.AddResponseCompression();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment host)
         {
             Console.WriteLine("webroot: " + host.WebRootPath);
+
+            app.UseResponseCompression();
 
             app.UseFileServer(new FileServerOptions
             {

--- a/src/Middleware/StaticFiles/samples/StaticFileSample/StaticFileSample.csproj
+++ b/src/Middleware/StaticFiles/samples/StaticFileSample/StaticFileSample.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.ResponseCompression" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />

--- a/src/Middleware/StaticFiles/src/StaticFileContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileContext.cs
@@ -322,6 +322,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         public async Task SendAsync()
         {
+            SetCompressionMode();
             ApplyResponseHeaders(Constants.Status200Ok);
             string physicalPath = _fileInfo.PhysicalPath;
             var sendFile = _context.Features.Get<IHttpSendFileFeature>();
@@ -366,6 +367,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
             _responseHeaders.ContentRange = ComputeContentRange(_range, out var start, out var length);
             _response.ContentLength = length;
+            SetCompressionMode();
             ApplyResponseHeaders(Constants.Status206PartialContent);
 
             string physicalPath = _fileInfo.PhysicalPath;
@@ -403,6 +405,16 @@ namespace Microsoft.AspNetCore.StaticFiles
             long end = range.To.Value;
             length = end - start + 1;
             return new ContentRangeHeaderValue(start, end, _length);
+        }
+
+        // Only called when we expect to serve the body.
+        private void SetCompressionMode()
+        {
+            var responseCompressionFeature = _context.Features.Get<IHttpsCompressionFeature>();
+            if (responseCompressionFeature != null)
+            {
+                responseCompressionFeature.Mode = _options.HttpsCompression;
+            }
         }
     }
 }

--- a/src/Middleware/StaticFiles/src/StaticFileOptions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.AspNetCore.StaticFiles.Infrastructure;
 
@@ -45,6 +46,14 @@ namespace Microsoft.AspNetCore.Builder
         /// Default: false.
         /// </summary>
         public bool ServeUnknownFileTypes { get; set; }
+
+        /// <summary>
+        /// Indicates if files should be compressed for HTTPS requests. The default value is <see cref="HttpsCompressionMode.Compress"/>.
+        /// </summary>
+        /// <remarks>
+        /// Enabling compression on HTTPS requests for remotely manipulable content may expose security problems.
+        /// </remarks>
+        public HttpsCompressionMode HttpsCompression { get; set; } = HttpsCompressionMode.Compress;
 
         /// <summary>
         /// Called after the status code and headers have been set, but before the body has been written.

--- a/src/Middleware/StaticFiles/src/StaticFileOptions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileOptions.cs
@@ -48,7 +48,8 @@ namespace Microsoft.AspNetCore.Builder
         public bool ServeUnknownFileTypes { get; set; }
 
         /// <summary>
-        /// Indicates if files should be compressed for HTTPS requests. The default value is <see cref="HttpsCompressionMode.Compress"/>.
+        /// Indicates if files should be compressed for HTTPS requests when the Response Compression middleware is available.
+        /// The default value is <see cref="HttpsCompressionMode.Compress"/>.
         /// </summary>
         /// <remarks>
         /// Enabling compression on HTTPS requests for remotely manipulable content may expose security problems.


### PR DESCRIPTION
 #6925 @DamianEdwards @glennc @blowdart this allows ResponseCompression's EnableForHttps setting to be overridden per request (opt in or opt out). StaticFiles opts in by default.