### PR TITLE
Add details to the JwtBearer error messages

### DIFF
--- a/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
@@ -284,23 +285,25 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                 // and we want to display the most specific message possible.
                 switch (ex)
                 {
-                    case SecurityTokenInvalidAudienceException _:
-                        messages.Add("The audience is invalid");
+                    case SecurityTokenInvalidAudienceException stia:
+                        messages.Add($"The audience '{stia.InvalidAudience ?? "(null)"}' is invalid");
                         break;
-                    case SecurityTokenInvalidIssuerException _:
-                        messages.Add("The issuer is invalid");
+                    case SecurityTokenInvalidIssuerException stii:
+                        messages.Add($"The issuer '{stii.InvalidIssuer ?? "(null)"}' is invalid");
                         break;
                     case SecurityTokenNoExpirationException _:
                         messages.Add("The token has no expiration");
                         break;
-                    case SecurityTokenInvalidLifetimeException _:
-                        messages.Add("The token lifetime is invalid");
+                    case SecurityTokenInvalidLifetimeException stil:
+                        messages.Add("The token lifetime is invalid; NotBefore: "
+                            + $"'{stil.NotBefore?.ToString(CultureInfo.InvariantCulture) ?? "(null)"}'"
+                            + $", Expires: '{stil.Expires?.ToString(CultureInfo.InvariantCulture) ?? "(null)"}'");
                         break;
-                    case SecurityTokenNotYetValidException _:
-                        messages.Add("The token is not valid yet");
+                    case SecurityTokenNotYetValidException stnyv:
+                        messages.Add($"The token is not valid before '{stnyv.NotBefore.ToString(CultureInfo.InvariantCulture)}'");
                         break;
-                    case SecurityTokenExpiredException _:
-                        messages.Add("The token is expired");
+                    case SecurityTokenExpiredException ste:
+                        messages.Add($"The token expired at '{ste.Expires.ToString(CultureInfo.InvariantCulture)}'");
                         break;
                     case SecurityTokenSignatureKeyNotFoundException _:
                         messages.Add("The signature key was not found");


### PR DESCRIPTION
 #4679 Bearer allows you to include error details in the WwwAuthenticate response header. We didn't want to expose raw exception messages but we did want to provide some hint at what went wrong. Previously we used generic messages based on the exception type because no details were available. Now that the exceptions have some detailed properties we can include those in a well structured format.

@blowdart 