### PR TITLE
Swap installer names

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
@@ -41,14 +41,14 @@
 
  <ItemGroup>
     <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj">
-      <Name>AspNetCoreV2WoW64</Name>
+      <Name>AspNetCoreV2</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SetPlatform>Platform=x64</SetPlatform>
     </ProjectReference>
     <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj">
-      <Name>AspNetCoreV2HandlerWoW64</Name>
+      <Name>AspNetCoreV2Handler</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -56,14 +56,14 @@
     </ProjectReference>
 
     <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj">
-      <Name>AspNetCoreV2</Name>
+      <Name>AspNetCoreV2WoW64</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SetPlatform>Platform=Win32</SetPlatform>
     </ProjectReference>
     <ProjectReference Include="$(_ServerIISBasePath)AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj">
-      <Name>AspNetCoreV2Handler</Name>
+      <Name>AspNetCoreV2HandlerWoW64</Name>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>


### PR DESCRIPTION
Fixes the windows hosting bundle build. The wrong variable was being set for each installer.

