### PR TITLE
Handle SIGTERM exit code

### DIFF
--- a/src/Hosting/Hosting/src/Internal/WebHostLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHostLifetime.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private readonly string _shutdownMessage;
 
         private bool _disposed = false;
+        private bool _exitedGracefully = false;
 
         public WebHostLifetime(CancellationTokenSource cts, ManualResetEventSlim resetEvent, string shutdownMessage)
         {
@@ -22,6 +23,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             AppDomain.CurrentDomain.ProcessExit += ProcessExit;
             Console.CancelKeyPress += CancelKeyPress;
+        }
+
+        internal void SetExitedGracefully()
+        {
+            _exitedGracefully = true;
         }
 
         public void Dispose()
@@ -46,6 +52,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private void ProcessExit(object sender, EventArgs eventArgs)
         {
             Shutdown();
+            if (_exitedGracefully)
+            {
+                // On Linux if the shutdown is triggered by SIGTERM then that's signaled with the 143 exit code.
+                // Suppress that since we shut down gracefully. https://github.com/aspnet/AspNetCore/issues/6526
+                Environment.ExitCode = 0;
+            }
         }
 
         private void Shutdown()

--- a/src/Hosting/Hosting/src/WebHostExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostExtensions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Hosting
                     try
                     {
                         await host.WaitForTokenShutdownAsync(cts.Token);
+                        lifetime.SetExitedGracefully();
                     }
                     finally
                     {
@@ -91,6 +92,7 @@ namespace Microsoft.AspNetCore.Hosting
                     try
                     {
                         await host.RunAsync(cts.Token, "Application started. Press Ctrl+C to shut down.");
+                        lifetime.SetExitedGracefully();
                     }
                     finally
                     {

--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Windows)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
-        [OSSkipCondition(OperatingSystems.Linux)] // https://github.com/aspnet/AspNetCore-Internal/issues/1687
         public async Task ShutdownTestRun()
         {
             await ExecuteShutdownTest(nameof(ShutdownTestRun), "Run");


### PR DESCRIPTION
 #6526 There was a corefx change in 3.0 where on Linux if the shutdown is triggered by SIGTERM then that's signaled with the 143 exit code. Suppress that if we shut down gracefully.

Generic host will need a similar treatment.

@tmds 