### PR TITLE
Allow sync IO for NewtonsoftJsonOutputFormatter

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -111,6 +111,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new ArgumentNullException(nameof(selectedEncoding));
             }
 
+            // Opt into sync IO support until we can work out an alternative https://github.com/aspnet/AspNetCore/issues/6397
+            var syncIOFeature = context.HttpContext.Features.Get<Http.Features.IHttpBodyControlFeature>();
+            if (syncIOFeature != null)
+            {
+                syncIOFeature.AllowSynchronousIO = true;
+            }
+
             var response = context.HttpContext.Response;
             using (var writer = context.WriterFactory(response.Body, selectedEncoding))
             {

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs
@@ -476,10 +476,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var context = new DefaultHttpContext();
             context.Request.ContentType = contentType.ToString();
             context.Request.Headers[HeaderNames.AcceptCharset] = contentType.Charset.ToString();
-            if (responseStream != null)
-            {
-                context.Response.Body = responseStream;
-            }
+            context.Response.Body = responseStream ?? new MemoryStream();
+
             return new ActionContext(context, new RouteData(), new ActionDescriptor());
         }
 

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs
@@ -473,17 +473,14 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             MediaTypeHeaderValue contentType,
             MemoryStream responseStream = null)
         {
-            var request = new Mock<HttpRequest>();
-            var headers = new HeaderDictionary();
-            request.Setup(r => r.ContentType).Returns(contentType.ToString());
-            request.SetupGet(r => r.Headers).Returns(headers);
-            headers[HeaderNames.AcceptCharset] = contentType.Charset.ToString();
-            var response = new Mock<HttpResponse>();
-            response.SetupGet(f => f.Body).Returns(responseStream ?? new MemoryStream());
-            var httpContext = new Mock<HttpContext>();
-            httpContext.SetupGet(c => c.Request).Returns(request.Object);
-            httpContext.SetupGet(c => c.Response).Returns(response.Object);
-            return new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+            var context = new DefaultHttpContext();
+            context.Request.ContentType = contentType.ToString();
+            context.Request.Headers[HeaderNames.AcceptCharset] = contentType.Charset.ToString();
+            if (responseStream != null)
+            {
+                context.Response.Body = responseStream;
+            }
+            return new ActionContext(context, new RouteData(), new ActionDescriptor());
         }
 
         private class TestableJsonOutputFormatter : NewtonsoftJsonOutputFormatter

--- a/src/Mvc/test/Mvc.FunctionalTests/JsonOutputFormatterTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/JsonOutputFormatterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             {
                 Id = 1,
                 Alias = "john",
-                description = "Administrator",
+                description = "This is long so we can test large objects " + new string('a', 1024 * 65),
                 Designation = "Administrator",
                 Name = "John Williams"
             };

--- a/src/Mvc/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
@@ -32,7 +32,7 @@ namespace FormatterWebSite.Controllers
             {
                 Id = 1,
                 Alias = "john",
-                description = "Administrator",
+                description = "This is long so we can test large objects " + new string('a', 1024 * 65),
                 Designation = "Administrator",
                 Name = "John Williams"
             };


### PR DESCRIPTION
 #8302 This was missed before because there were no tests that wrote a large enough body to trigger a sync flush.