### PR TITLE
Testing broken pipelines on ci no. 2

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -305,7 +305,7 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>00000</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19127.11">
+    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19156.2">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>00000</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview4.19156.2</SystemComponentModelAnnotationsPackageVersion>
     <SystemDataSqlClientPackageVersion>4.7.0-preview4.19156.2</SystemDataSqlClientPackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19156.2</SystemDiagnosticsEventLogPackageVersion>
-    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19127.11</SystemIOPipelinesPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19156.2</SystemIOPipelinesPackageVersion>
     <SystemNetHttpWinHttpHandlerPackageVersion>4.6.0-preview4.19156.2</SystemNetHttpWinHttpHandlerPackageVersion>
     <SystemNetWebSocketsWebSocketProtocolPackageVersion>4.6.0-preview4.19156.2</SystemNetWebSocketsWebSocketProtocolPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19156.2</SystemReflectionMetadataPackageVersion>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -182,6 +182,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     finally
                     {
+                        var cObj = consumed.GetObject();
+                        var cIndex = consumed.GetInteger();
+
+                        var eObj = examined.GetObject();
+                        var eIndex = examined.GetInteger();
+
+                        _context.ServiceContext.Log.LogDebug($"AdvanceTo({cObj?.GetHashCode().ToString() ?? "null"}, {cIndex}, {eObj?.GetHashCode().ToString() ?? "null"}, {eIndex})");
                         _context.Input.AdvanceTo(consumed, examined);
                     }
 


### PR DESCRIPTION
Is [this check](https://github.com/dotnet/corefx/blob/1382754add40c899c141803c1cdb03c335d60095/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs#L492) enough?

If examined and consumed are canonically the same, but examined points to the BufferSegment before the one pointed to by consumed, the examined BufferSegment would get returned. Considering _bufferSegmentPool is used like a stack, GetLength could quickly be called with a _lastExamined segment that's been reused and been given a new RunningIndex.