### PR TITLE
Chunked request parsing does not properly update examined

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -305,7 +305,7 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>00000</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19127.11">
+    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19156.2">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>00000</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview4.19156.2</SystemComponentModelAnnotationsPackageVersion>
     <SystemDataSqlClientPackageVersion>4.7.0-preview4.19156.2</SystemDataSqlClientPackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19156.2</SystemDiagnosticsEventLogPackageVersion>
-    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19127.11</SystemIOPipelinesPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19156.2</SystemIOPipelinesPackageVersion>
     <SystemNetHttpWinHttpHandlerPackageVersion>4.6.0-preview4.19156.2</SystemNetHttpWinHttpHandlerPackageVersion>
     <SystemNetWebSocketsWebSocketProtocolPackageVersion>4.6.0-preview4.19156.2</SystemNetWebSocketsWebSocketProtocolPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19156.2</SystemReflectionMetadataPackageVersion>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -323,6 +323,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return;
             }
 
+            // Assigned this before calculating the chunk size since that can throw
+            examined = reader.Position;
+
             var chunkSize = CalculateChunkSize(ch1, 0);
             ch1 = ch2;
 
@@ -359,6 +362,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 chunkSize = CalculateChunkSize(ch1, chunkSize);
                 ch1 = ch2;
             }
+
+            // Set examined so that we capture the progress that way made
+            examined = reader.Position;
 
             // At this point, 10 bytes have been consumed which is enough to parse the max value "7FFFFFFF\r\n".
             BadHttpRequestException.Throw(RequestRejectionReason.BadChunkSizeData);


### PR DESCRIPTION
Chunked request parsing does not properly update examined
- The chunked parsing logic didn't properly update the examined position when parsing the chunked prefix. This started to throw because Pipe now throws if examined is set to the position before the previous.