### PR TITLE
Enable the https dev cert for use with Docker for Windows's default networking setup

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
         private const string ServerAuthenticationEnhancedKeyUsageOidFriendlyName = "Server Authentication";
 
         private const string LocalhostHttpsDnsName = "localhost";
+        private const string DockerLocalhostHttpsDnsName = "host.docker.internal";
         private const string LocalhostHttpsDistinguishedName = "CN=" + LocalhostHttpsDnsName;
 
         public const int RSAMinimumKeySizeInBits = 2048;
@@ -155,6 +156,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             var extensions = new List<X509Extension>();
             var sanBuilder = new SubjectAlternativeNameBuilder();
             sanBuilder.AddDnsName(LocalhostHttpsDnsName);
+            sanBuilder.AddDnsName(DockerLocalhostHttpsDnsName);
 
             var keyUsage = new X509KeyUsageExtension(X509KeyUsageFlags.KeyEncipherment, critical: true);
             var enhancedKeyUsage = new X509EnhancedKeyUsageExtension(

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -175,7 +175,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
                 Assert.Contains(
                     httpsCertificate.Extensions.OfType<X509Extension>(),
                     e => e.Critical == true &&
-                        e.Oid.Value == "2.5.29.17");
+                        e.Oid.Value == "2.5.29.17" &&
+                        e.Format(false) == "DNS Name=localhost");
 
                 // ASP.NET HTTPS Development certificate extension
                 Assert.Contains(

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
                     httpsCertificate.Extensions.OfType<X509Extension>(),
                     e => e.Critical == true &&
                         e.Oid.Value == "2.5.29.17" &&
-                        e.Format(false) == "DNS Name=localhost");
+                        e.Format(false) == "DNS Name=localhost, DNS Name=host.docker.internal");
 
                 // ASP.NET HTTPS Development certificate extension
                 Assert.Contains(

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -172,11 +172,12 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
                         keyUsage.Value == "1.3.6.1.5.5.7.3.1");
 
                 // Subject alternative name
+                // Windows uses "DNS Name=" whereas Ubuntu + macOS use "DNS:"
                 Assert.Contains(
                     httpsCertificate.Extensions.OfType<X509Extension>(),
                     e => e.Critical == true &&
                         e.Oid.Value == "2.5.29.17" &&
-                        e.Format(false) == "DNS Name=localhost, DNS Name=host.docker.internal");
+                        e.Format(false).Replace("DNS:", "DNS Name=") == "DNS Name=localhost, DNS Name=host.docker.internal");
 
                 // ASP.NET HTTPS Development certificate extension
                 Assert.Contains(


### PR DESCRIPTION
In Docker for Windows, [Docker recommends that, for development purposes, containers can connect to a service on the host using the DNS name `host.docker.internal`](https://docs.docker.com/docker-for-windows/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host).

This PR changes how the ASP.NET Core https dev cert is generated so that it is additionally valid for that DNS name.