### PR TITLE
fixing possible NRE, when viewContext is null

### DIFF
--- a/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
@@ -644,9 +644,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         public virtual HtmlString SetAntiforgeryCookieAndHeader()
         {
             var viewContext = ViewContext;
-            var antiforgery = viewContext?.HttpContext.RequestServices.GetRequiredService<IAntiforgery>();
-            antiforgery.SetCookieTokenAndHeader(viewContext?.HttpContext);
-
+            if (viewContext != null)
+            {
+                var antiforgery = viewContext.HttpContext.RequestServices.GetRequiredService<IAntiforgery>();
+                antiforgery.SetCookieTokenAndHeader(viewContext.HttpContext);
+            }
             return HtmlString.Empty;
         }
 


### PR DESCRIPTION
This change addresses a NRE in RazorPageBase.

When `ViewContext` is null this line assigns null to `antiforgery`:

https://github.com/aspnet/AspNetCore/blob/bd6faa5ca1f43f78ea708a92d3ff44608e23381b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs#L647

... and then the next line attempts to call the `SetCookieTokenAndHeader` instance method, on this null value:

https://github.com/aspnet/AspNetCore/blob/bd6faa5ca1f43f78ea708a92d3ff44608e23381b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs#L648