### PR TITLE
Pass the formatter context to the CreateJsonSerializer. It gives ability to override and create serializer specific to the context

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/ref/Microsoft.AspNetCore.Mvc.NewtonsoftJson.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/ref/Microsoft.AspNetCore.Mvc.NewtonsoftJson.netcoreapp3.0.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public virtual Microsoft.AspNetCore.Mvc.Formatters.InputFormatterExceptionPolicy ExceptionPolicy { get { throw null; } }
         protected Newtonsoft.Json.JsonSerializerSettings SerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         protected virtual Newtonsoft.Json.JsonSerializer CreateJsonSerializer() { throw null; }
+        protected virtual Newtonsoft.Json.JsonSerializer CreateJsonSerializer(Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext context) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.Formatters.InputFormatterResult> ReadRequestBodyAsync(Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext context, System.Text.Encoding encoding) { throw null; }
         protected virtual void ReleaseJsonSerializer(Newtonsoft.Json.JsonSerializer serializer) { }
@@ -34,6 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public NewtonsoftJsonOutputFormatter(Newtonsoft.Json.JsonSerializerSettings serializerSettings, System.Buffers.ArrayPool<char> charPool) { }
         protected Newtonsoft.Json.JsonSerializerSettings SerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         protected virtual Newtonsoft.Json.JsonSerializer CreateJsonSerializer() { throw null; }
+        protected virtual Newtonsoft.Json.JsonSerializer CreateJsonSerializer(Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context) { throw null; }
         protected virtual Newtonsoft.Json.JsonWriter CreateJsonWriter(System.IO.TextWriter writer) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.Task WriteResponseBodyAsync(Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context, System.Text.Encoding selectedEncoding) { throw null; }

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -247,6 +247,25 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// Called during deserialization to get the <see cref="JsonSerializer"/>. The formatter context
         /// that is passed gives an ability to create serializer specific to the context. 
         /// </summary>
+        /// <returns>The <see cref="JsonSerializer"/> used during deserialization.</returns>
+        /// <remarks>
+        /// This method works in tandem with <see cref="ReleaseJsonSerializer(JsonSerializer)"/> to
+        /// manage the lifetimes of <see cref="JsonSerializer"/> instances.
+        /// </remarks>
+        protected virtual JsonSerializer CreateJsonSerializer()
+        {
+            if (_jsonSerializerPool == null)
+            {
+                _jsonSerializerPool = _objectPoolProvider.Create(new JsonSerializerObjectPolicy(SerializerSettings));
+            }
+
+            return _jsonSerializerPool.Get();
+        }
+
+        /// <summary>
+        /// Called during deserialization to get the <see cref="JsonSerializer"/>. The formatter context
+        /// that is passed gives an ability to create serializer specific to the context. 
+        /// </summary>
         /// <param name="context">A context object used by an input formatter for deserializing the request body into an object.</param>
         /// <returns>The <see cref="JsonSerializer"/> used during deserialization.</returns>
         /// <remarks>
@@ -255,12 +274,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// </remarks>
         protected virtual JsonSerializer CreateJsonSerializer(InputFormatterContext context)
         {
-            if (_jsonSerializerPool == null)
-            {
-                _jsonSerializerPool = _objectPoolProvider.Create(new JsonSerializerObjectPolicy(SerializerSettings));
-            }
-
-            return _jsonSerializerPool.Get();
+            return CreateJsonSerializer();
         }
 
         /// <summary>

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     }
 
                     var type = context.ModelType;
-                    var jsonSerializer = CreateJsonSerializer();
+                    var jsonSerializer = CreateJsonSerializer(context);
                     jsonSerializer.Error += ErrorHandler;
                     object model;
                     try
@@ -244,14 +244,16 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         /// <summary>
-        /// Called during deserialization to get the <see cref="JsonSerializer"/>.
+        /// Called during deserialization to get the <see cref="JsonSerializer"/>. The formatter context
+        /// that is passed gives an ability to create serializer specific to the context. 
         /// </summary>
+        /// <param name="context">A context object used by an input formatter for deserializing the request body into an object.</param>
         /// <returns>The <see cref="JsonSerializer"/> used during deserialization.</returns>
         /// <remarks>
         /// This method works in tandem with <see cref="ReleaseJsonSerializer(JsonSerializer)"/> to
         /// manage the lifetimes of <see cref="JsonSerializer"/> instances.
         /// </remarks>
-        protected virtual JsonSerializer CreateJsonSerializer()
+        protected virtual JsonSerializer CreateJsonSerializer(InputFormatterContext context)
         {
             if (_jsonSerializerPool == null)
             {

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -85,10 +85,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         /// <summary>
-        /// Called during serialization to create the <see cref="JsonSerializer"/>.
+        /// Called during serialization to create the <see cref="JsonSerializer"/>.The formatter context
+        /// that is passed gives an ability to create serializer specific to the context. 
         /// </summary>
+        /// <param name="context">A context object for <see cref="IOutputFormatter.WriteAsync(OutputFormatterWriteContext)"/>.</param>
         /// <returns>The <see cref="JsonSerializer"/> used during serialization and deserialization.</returns>
-        protected virtual JsonSerializer CreateJsonSerializer()
+        protected virtual JsonSerializer CreateJsonSerializer(OutputFormatterWriteContext context)
         {
             if (_serializer == null)
             {
@@ -116,7 +118,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 using (var jsonWriter = CreateJsonWriter(writer))
                 {
-                    var jsonSerializer = CreateJsonSerializer();
+                    var jsonSerializer = CreateJsonSerializer(context);
                     jsonSerializer.Serialize(jsonWriter, context.Object);
                 }
 

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -88,9 +88,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// Called during serialization to create the <see cref="JsonSerializer"/>.The formatter context
         /// that is passed gives an ability to create serializer specific to the context. 
         /// </summary>
-        /// <param name="context">A context object for <see cref="IOutputFormatter.WriteAsync(OutputFormatterWriteContext)"/>.</param>
         /// <returns>The <see cref="JsonSerializer"/> used during serialization and deserialization.</returns>
-        protected virtual JsonSerializer CreateJsonSerializer(OutputFormatterWriteContext context)
+        protected virtual JsonSerializer CreateJsonSerializer()
         {
             if (_serializer == null)
             {
@@ -98,6 +97,17 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
 
             return _serializer;
+        }
+
+        /// <summary>
+        /// Called during serialization to create the <see cref="JsonSerializer"/>.The formatter context
+        /// that is passed gives an ability to create serializer specific to the context. 
+        /// </summary>
+        /// <param name="context">A context object for <see cref="IOutputFormatter.WriteAsync(OutputFormatterWriteContext)"/>.</param>
+        /// <returns>The <see cref="JsonSerializer"/> used during serialization and deserialization.</returns>
+        protected virtual JsonSerializer CreateJsonSerializer(OutputFormatterWriteContext context)
+        {
+            return CreateJsonSerializer();
         }
 
         /// <inheritdoc />

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -474,7 +474,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var formatter = new TestableJsonInputFormatter(settings);
 
             // Act
-            var actual = formatter.CreateJsonSerializer();
+            var actual = formatter.CreateJsonSerializer(null);
 
             // Assert
             Assert.Same(settings.ContractResolver, actual.ContractResolver);
@@ -578,7 +578,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             public new JsonSerializerSettings SerializerSettings => base.SerializerSettings;
 
-            public new JsonSerializer CreateJsonSerializer() => base.CreateJsonSerializer();
+            public new JsonSerializer CreateJsonSerializer(InputFormatterContext _) => base.CreateJsonSerializer(null);
         }
 
         private static ILogger GetLogger()


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Pass the formatter context to overridable CreateJsonSerializer. This allows users to override it and create serializer customized to the context.

Addresses:
  In our scenario, we need to select serializer based on the request properties like api version. With context parameter, we can just override CreateJsonSerializer and plug the custom serializer based on the request.