### PR TITLE
[WIP] Reuse previous headers

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -123,6 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public System.IServiceProvider ApplicationServices { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader ConfigurationLoader { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits Limits { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool ReuseRequestHeaders { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure() { throw null; }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure(Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }
         public void ConfigureEndpointDefaults(System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> configureOptions) { }
@@ -498,6 +499,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public readonly Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection Connection;
         public Http1ParsingHandler(Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection connection) { throw null; }
         public void OnHeader(System.Span<byte> name, System.Span<byte> value) { }
+        public void OnHeadersComplete() { }
         public void OnStartLine(Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod method, Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpVersion version, System.Span<byte> target, System.Span<byte> path, System.Span<byte> query, System.Span<byte> customMethod, bool pathEncoded) { }
     }
     public partial class Http1UpgradeMessageBody : Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1MessageBody
@@ -518,6 +520,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public abstract partial class HttpHeaders : Microsoft.AspNetCore.Http.IHeaderDictionary, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>>, System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>>, System.Collections.IEnumerable
     {
         protected System.Collections.Generic.Dictionary<string, Microsoft.Extensions.Primitives.StringValues> MaybeUnknown;
+        protected long _bits;
         protected long? _contentLength;
         protected bool _isReadOnly;
         protected HttpHeaders() { }
@@ -695,6 +698,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public void OnCompleted(System.Func<object, System.Threading.Tasks.Task> callback, object state) { }
         protected virtual void OnErrorAfterResponseStarted() { }
         public void OnHeader(System.Span<byte> name, System.Span<byte> value) { }
+        public void OnHeadersComplete() { }
         protected virtual void OnRequestProcessingEnded() { }
         protected virtual void OnRequestProcessingEnding() { }
         protected abstract void OnReset();
@@ -723,7 +727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     }
     public sealed partial class HttpRequestHeaders : Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders
     {
-        public HttpRequestHeaders() { }
+        public HttpRequestHeaders(Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions serverOptions) { }
         public bool HasConnection { get { throw null; } }
         public bool HasTransferEncoding { get { throw null; } }
         public Microsoft.Extensions.Primitives.StringValues HeaderAccept { get { throw null; } set { } }
@@ -772,13 +776,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public Microsoft.Extensions.Primitives.StringValues HeaderWarning { get { throw null; } set { } }
         public int HostCount { get { throw null; } }
         protected override bool AddValueFast(string key, in Microsoft.Extensions.Primitives.StringValues value) { throw null; }
-        public unsafe void Append(byte* pKeyBytes, int keyLength, string value) { }
-        public void Append(System.Span<byte> name, string value) { }
+        public void Append(System.Span<byte> name, System.Span<byte> value) { }
         protected override void ClearFast() { }
         protected override bool CopyToFast(System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>[] array, int arrayIndex) { throw null; }
         protected override int GetCountFast() { throw null; }
         public Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestHeaders.Enumerator GetEnumerator() { throw null; }
         protected override System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> GetEnumeratorFast() { throw null; }
+        public void OnHeadersComplete() { }
         protected override bool RemoveFast(string key) { throw null; }
         protected override void SetValueFast(string key, in Microsoft.Extensions.Primitives.StringValues value) { }
         protected override bool TryGetValueFast(string key, out Microsoft.Extensions.Primitives.StringValues value) { throw null; }
@@ -940,6 +944,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public partial interface IHttpHeadersHandler
     {
         void OnHeader(System.Span<byte> name, System.Span<byte> value);
+        void OnHeadersComplete();
     }
     public partial interface IHttpOutputAborter
     {
@@ -1131,6 +1136,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         void Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.IHttp2StreamLifetimeHandler.OnStreamCompleted(Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2Stream stream) { }
         void Microsoft.AspNetCore.Server.Kestrel.Core.Internal.IRequestProcessor.Tick(System.DateTimeOffset now) { }
         public void OnHeader(System.Span<byte> name, System.Span<byte> value) { }
+        public void OnHeadersComplete() { }
         public void OnInputOrOutputCompleted() { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task ProcessRequestsAsync<TContext>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<TContext> application) { throw null; }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
@@ -17,6 +17,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public void OnHeader(Span<byte> name, Span<byte> value)
             => Connection.OnHeader(name, value);
 
+        public void OnHeadersComplete()
+            => Connection.OnHeadersComplete();
+
         public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
             => Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     public abstract class HttpHeaders : IHeaderDictionary
     {
+        protected long _bits = 0;
         protected long? _contentLength;
         protected bool _isReadOnly;
         protected Dictionary<string, StringValues> MaybeUnknown;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -241,6 +241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                     }
 
                                     done = true;
+                                    handler.OnHeadersComplete();
                                     return true;
                                 }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -74,6 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
+            HttpRequestHeaders = new HttpRequestHeaders(ServerOptions);
             HttpResponseControl = this;
         }
 
@@ -275,7 +276,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public bool HasFlushedHeaders => _requestProcessingStatus == RequestProcessingStatus.HeadersFlushed;
 
-        protected HttpRequestHeaders HttpRequestHeaders { get; } = new HttpRequestHeaders();
+        protected HttpRequestHeaders HttpRequestHeaders { get; }
 
         protected HttpResponseHeaders HttpResponseHeaders { get; } = new HttpResponseHeaders();
 
@@ -492,9 +493,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 BadHttpRequestException.Throw(RequestRejectionReason.TooManyHeaders);
             }
-            var valueString = value.GetAsciiOrUTF8StringNonNullCharacters();
 
-            HttpRequestHeaders.Append(name, valueString);
+            HttpRequestHeaders.Append(name, value);
+        }
+
+        public void OnHeadersComplete()
+        {
+            HttpRequestHeaders.OnHeadersComplete();
         }
 
         public async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
@@ -13,6 +14,46 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     public sealed partial class HttpRequestHeaders : HttpHeaders
     {
+        private readonly KestrelServerOptions _serverOptions;
+        private long _previousBits = 0;
+
+        public HttpRequestHeaders(KestrelServerOptions serverOptions)
+        {
+            _serverOptions = serverOptions;
+        }
+
+        public void OnHeadersComplete()
+        {
+            var bitsToClear = _previousBits & ~_bits;
+            _previousBits = 0;
+
+            if (bitsToClear != 0)
+            {
+                // Some previous headers were not reused or overwritten, so clear them now.
+                Clear(bitsToClear);
+            }
+        }
+
+        protected override void ClearFast()
+        {
+            if (!_serverOptions.ReuseRequestHeaders)
+            {
+                // If we aren't reusing headers clear them all
+                Clear(_bits);
+            }
+            else
+            {
+                // If we are reusing headers, store the currently set headers for comparision later
+                _previousBits = _bits;
+            }
+
+            // Mark no headers as currently in use
+            _bits = 0;
+            // Clear ContentLength and any unknown headers as we will never reuse them 
+            _contentLength = null;
+            MaybeUnknown?.Clear();
+        }
+
         private static long ParseContentLength(string value)
         {
             if (!HeaderUtilities.TryParseNonNegativeInt64(value, out var parsed))
@@ -24,33 +65,82 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AppendContentLength(Span<byte> value)
+        {
+            if (_contentLength.HasValue)
+            {
+                BadHttpRequestException.Throw(RequestRejectionReason.MultipleContentLengths);
+            }
+
+
+            if (!TryParseNonNegativeInt64(value, out var parsed))
+            {
+                BadHttpRequestException.Throw(RequestRejectionReason.InvalidContentLength, value.GetAsciiOrUTF8StringNonNullCharacters());
+            }
+
+            _contentLength = parsed;
+        }
+
+        private static unsafe bool TryParseNonNegativeInt64(Span<byte> value, out long result)
+        {
+            if (value.Length == 0)
+            {
+                result = 0;
+                return false;
+            }
+
+            var calc = 0L;
+            var i = 0;
+            for (; i < value.Length; i++)
+            {
+                var digit = (long)value[i] - (long)0x30;
+                if ((ulong)digit > 9)
+                {
+                    // Not a digit
+                    break;
+                }
+
+                calc = calc * 10 + digit;
+                if (calc < 0)
+                {
+                    // Overflow
+                    break;
+                }
+            }
+
+            if (i != value.Length)
+            {
+                // Didn't parse correct until end
+                result = 0;
+                return false;
+            }
+
+            result = calc;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void SetValueUnknown(string key, in StringValues value)
         {
             Unknown[key] = value;
         }
 
-        public unsafe void Append(Span<byte> name, string value)
-        {
-            fixed (byte* namePtr = name)
-            {
-                Append(namePtr, name.Length, value);
-            }
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe void AppendUnknownHeaders(byte* pKeyBytes, int keyLength, string value)
+        private unsafe void AppendUnknownHeaders(Span<byte> name, Span<byte> value)
         {
-            string key = new string('\0', keyLength);
+            string key = new string('\0', name.Length);
+            fixed (byte* pKeyBytes = name)
             fixed (char* keyBuffer = key)
             {
-                if (!StringUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, keyLength))
+                if (!StringUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, name.Length))
                 {
                     BadHttpRequestException.Throw(RequestRejectionReason.InvalidCharactersInHeaderName);
                 }
             }
 
+            var valueString = value.GetAsciiOrUTF8StringNonNullCharacters();
             Unknown.TryGetValue(key, out var existing);
-            Unknown[key] = AppendValue(existing, value);
+            Unknown[key] = AppendValue(existing, valueString);
         }
 
         public Enumerator GetEnumerator()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpHeadersHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpHeadersHandler.cs
@@ -8,5 +8,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public interface IHttpHeadersHandler
     {
         void OnHeader(Span<byte> name, Span<byte> value);
+        void OnHeadersComplete();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1092,6 +1092,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
+        public void OnHeadersComplete()
+            => _currentHeadersStream.OnHeadersComplete();
+
         private void ValidateHeader(Span<byte> name, Span<byte> value)
         {
             // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.1

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StringUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StringUtilities.cs
@@ -2,13 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
     internal class StringUtilities
     {
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe bool TryGetAsciiString(byte* input, char* output, int count)
         {
             // Calculate end position
@@ -107,6 +110,127 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             } while (input < end);
 
             return isValid;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        public unsafe static bool BytesOrdinalEqualsStringAndAscii(string previousValue, Span<byte> newValue)
+        {
+            // We just widen the bytes to char for comparision, if either the string or the bytes are not ascii
+            // this will result in non-equality, so we don't need to specifically test for non-ascii.
+            Debug.Assert(previousValue.Length == newValue.Length);
+
+            // Use IntPtr values rather than int, to avoid unnessary 32 -> 64 movs on 64-bit.
+            // Unfortunately this means we also need to cast to byte* for comparisions as IntPtr doesn't
+            // support operator comparisions (e.g. <=, >, etc).
+            // Note: Pointer comparision is unsigned, so we use the compare pattern (offset + length <= count)
+            // rather than (offset <= count - length) which we'd do with signed comparision to avoid overflow.
+            var count = (IntPtr)newValue.Length;
+            var offset = (IntPtr)0;
+
+            ref var bytes = ref MemoryMarshal.GetReference(newValue);
+            ref var str = ref MemoryMarshal.GetReference(previousValue.AsSpan());
+
+            do
+            {
+                // If Vector not-accelerated or remaining less than vector size
+                if (!Vector.IsHardwareAccelerated || (byte*)(offset + Vector<byte>.Count) > (byte*)count)
+                {
+                    if (IntPtr.Size == 8) // Use Intrinsic switch for branch elimination
+                    {
+                        // 64-bit: Loop longs by default
+                        while ((byte*)(offset + sizeof(long)) <= (byte*)count)
+                        {
+                            if (Unsafe.Add(ref str, offset) != (char)Unsafe.Add(ref bytes, offset) ||
+                                Unsafe.Add(ref str, offset + 1) != (char)Unsafe.Add(ref bytes, offset + 1) ||
+                                Unsafe.Add(ref str, offset + 2) != (char)Unsafe.Add(ref bytes, offset + 2) ||
+                                Unsafe.Add(ref str, offset + 3) != (char)Unsafe.Add(ref bytes, offset + 3) ||
+                                Unsafe.Add(ref str, offset + 4) != (char)Unsafe.Add(ref bytes, offset + 4) ||
+                                Unsafe.Add(ref str, offset + 5) != (char)Unsafe.Add(ref bytes, offset + 5) ||
+                                Unsafe.Add(ref str, offset + 6) != (char)Unsafe.Add(ref bytes, offset + 6) ||
+                                Unsafe.Add(ref str, offset + 7) != (char)Unsafe.Add(ref bytes, offset + 7))
+                            {
+                                goto NotEqual;
+                            }
+
+                            offset += sizeof(long);
+                        }
+                        if ((byte*)(offset + sizeof(int)) <= (byte*)count)
+                        {
+                            if (Unsafe.Add(ref str, offset) != (char)Unsafe.Add(ref bytes, offset) ||
+                                Unsafe.Add(ref str, offset + 1) != (char)Unsafe.Add(ref bytes, offset + 1) ||
+                                Unsafe.Add(ref str, offset + 2) != (char)Unsafe.Add(ref bytes, offset + 2) ||
+                                Unsafe.Add(ref str, offset + 3) != (char)Unsafe.Add(ref bytes, offset + 3))
+                            {
+                                goto NotEqual;
+                            }
+
+                            offset += sizeof(int);
+                        }
+                    }
+                    else
+                    {
+                        // 32-bit: Loop ints by default
+                        while ((byte*)(offset + sizeof(int)) <= (byte*)count)
+                        {
+                            if (Unsafe.Add(ref str, offset) != (char)Unsafe.Add(ref bytes, offset) ||
+                                Unsafe.Add(ref str, offset + 1) != (char)Unsafe.Add(ref bytes, offset + 1) ||
+                                Unsafe.Add(ref str, offset + 2) != (char)Unsafe.Add(ref bytes, offset + 2) ||
+                                Unsafe.Add(ref str, offset + 3) != (char)Unsafe.Add(ref bytes, offset + 3))
+                            {
+                                goto NotEqual;
+                            }
+
+                            offset += sizeof(int);
+                        }
+                    }
+                    if ((byte*)(offset + sizeof(short)) <= (byte*)count)
+                    {
+                        if (Unsafe.Add(ref str, offset) != (char)Unsafe.Add(ref bytes, offset) ||
+                            Unsafe.Add(ref str, offset + 1) != (char)Unsafe.Add(ref bytes, offset + 1))
+                        {
+                            goto NotEqual;
+                        }
+
+                        offset += sizeof(short);
+                    }
+                    if ((byte*)offset < (byte*)count)
+                    {
+                        if (Unsafe.Add(ref str, offset) != (char)Unsafe.Add(ref bytes, offset))
+                        {
+                            goto NotEqual;
+                        }
+                    }
+
+                    return true;
+                }
+
+                // do/while as entry condition already checked
+                var AllTrue = new Vector<ushort>(ushort.MaxValue);
+                do
+                {
+                    var vector = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref bytes, offset));
+                    Vector.Widen(vector, out var vector0, out var vector1);
+                    var compare0 = Unsafe.As<char, Vector<ushort>>(ref Unsafe.Add(ref str, offset));
+                    var compare1 = Unsafe.As<char, Vector<ushort>>(ref Unsafe.Add(ref str, offset + Vector<ushort>.Count));
+
+                    if (!AllTrue.Equals(
+                        Vector.BitwiseAnd(
+                            Vector.Equals(compare0, vector0),
+                            Vector.Equals(compare1, vector1))))
+                    {
+                        goto NotEqual;
+                    }
+
+                    offset += Vector<byte>.Count;
+                } while ((byte*)(offset + Vector<byte>.Count) <= (byte*)count);
+
+                // Vector path done, loop back to do non-Vector
+                // If is a exact multiple of vector size, bail now
+            } while ((byte*)offset < (byte*)count);
+
+            return true;
+        NotEqual:
+            return false;
         }
 
         private static readonly char[] s_encode16Chars = "0123456789ABCDEF".ToCharArray();

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -55,6 +55,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public bool AllowSynchronousIO { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value that controls whether the header values materialized as strings will be reused across requests;
+        /// if they match, or if the strings will always be reallocated.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to false.
+        /// </remarks>
+        public bool ReuseRequestHeaders { get; set; } = true;
+
+        /// <summary>
         /// Enables the Listen options callback to resolve and use services registered by the application during startup.
         /// Typically initialized by UseKestrel()"/>.
         /// </summary>

--- a/src/Servers/Kestrel/Core/test/HPackDecoderTests.cs
+++ b/src/Servers/Kestrel/Core/test/HPackDecoderTests.cs
@@ -103,6 +103,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _decodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiStringNonNullCharacters();
         }
 
+        void IHttpHeadersHandler.OnHeadersComplete() { }
+
         [Fact]
         public void DecodesIndexedHeaderField_StaticTable()
         {

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             // Arrange
             var originalRequestHeaders = _http1Connection.RequestHeaders;
-            _http1Connection.RequestHeaders = new HttpRequestHeaders();
+            _http1Connection.RequestHeaders = new HttpRequestHeaders(new KestrelServerOptions());
 
             // Act
             _http1Connection.Reset();

--- a/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void ValidContentLengthsAccepted()
         {
-            ValidContentLengthsAcceptedImpl(new HttpRequestHeaders());
+            ValidContentLengthsAcceptedImpl(new HttpRequestHeaders(new KestrelServerOptions()));
             ValidContentLengthsAcceptedImpl(new HttpResponseHeaders());
         }
 
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void InvalidContentLengthsRejected()
         {
-            InvalidContentLengthsRejectedImpl(new HttpRequestHeaders());
+            InvalidContentLengthsRejectedImpl(new HttpRequestHeaders(new KestrelServerOptions()));
             InvalidContentLengthsRejectedImpl(new HttpResponseHeaders());
         }
 

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -483,6 +483,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Headers[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiStringNonNullCharacters();
             }
 
+            void IHttpHeadersHandler.OnHeadersComplete() { }
+
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
             {
                 Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiStringNonNullCharacters();

--- a/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void InitialDictionaryIsEmpty()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             Assert.Equal(0, headers.Count);
             Assert.False(headers.IsReadOnly);
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void SettingUnknownHeadersWorks()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             headers["custom"] = new[] { "value" };
 
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void SettingKnownHeadersWorks()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             headers["host"] = new[] { "value" };
             headers["content-length"] = new[] { "0" };
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void KnownAndCustomHeaderCountAddedTogether()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             headers["host"] = new[] { "value" };
             headers["custom"] = new[] { "value" };
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void TryGetValueWorksForKnownAndUnknownHeaders()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             StringValues value;
             Assert.False(headers.TryGetValue("host", out value));
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void SameExceptionThrownForMissingKey()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             Assert.Throws<KeyNotFoundException>(() => headers["custom"]);
             Assert.Throws<KeyNotFoundException>(() => headers["host"]);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void EntriesCanBeEnumerated()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
             var v1 = new[] { "localhost" };
             var v2 = new[] { "0" };
             var v3 = new[] { "value" };
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void KeysAndValuesCanBeEnumerated()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
             StringValues v1 = new[] { "localhost" };
             StringValues v2 = new[] { "0" };
             StringValues v3 = new[] { "value" };
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void ContainsAndContainsKeyWork()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
             var kv1 = new KeyValuePair<string, StringValues>("host", new[] { "localhost" });
             var kv2 = new KeyValuePair<string, StringValues>("custom", new[] { "value" });
             var kv3 = new KeyValuePair<string, StringValues>("Content-Length", new[] { "0" });
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void AddWorksLikeSetAndThrowsIfKeyExists()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
 
             StringValues value;
             Assert.False(headers.TryGetValue("host", out value));
@@ -215,7 +215,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void ClearRemovesAllHeaders()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
             headers.Add("host", new[] { "localhost" });
             headers.Add("custom", new[] { "value" });
             headers.Add("Content-Length", new[] { "0" });
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void RemoveTakesHeadersOutOfDictionary()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
             headers.Add("host", new[] { "localhost" });
             headers.Add("custom", new[] { "value" });
             headers.Add("Content-Length", new[] { "0" });
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void CopyToMovesDataIntoArray()
         {
-            IDictionary<string, StringValues> headers = new HttpRequestHeaders();
+            IDictionary<string, StringValues> headers = new HttpRequestHeaders(new KestrelServerOptions());
             headers.Add("host", new[] { "localhost" });
             headers.Add("Content-Length", new[] { "0" });
             headers.Add("custom", new[] { "value" });
@@ -302,12 +302,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void AppendThrowsWhenHeaderNameContainsNonASCIICharacters()
         {
-            var headers = new HttpRequestHeaders();
+            var headers = new HttpRequestHeaders(new KestrelServerOptions());
             const string key = "\u00141\u00F3d\017c";
 
             var encoding = Encoding.GetEncoding("iso-8859-1");
             var exception = Assert.Throws<BadHttpRequestException>(
-                () => headers.Append(encoding.GetBytes(key), "value"));
+                () => headers.Append(encoding.GetBytes(key), Encoding.ASCII.GetBytes("value")));
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
     }

--- a/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
+++ b/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
 
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -398,7 +398,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -426,7 +426,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -452,7 +452,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(), input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection);
                 var mockBodyControl = new Mock<IHttpBodyControlFeature>();
                 mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(true);
                 var reader = new HttpRequestPipeReader();
@@ -476,7 +476,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(), input.Http1Connection);
+                var body = Http1MessageBody.For(httpVersion, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders { HeaderContentLength = "8197" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "8197" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -527,7 +527,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             using (var input = new TestInput())
             {
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
-                    Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked, not-chunked" }, input.Http1Connection));
+                    Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked, not-chunked" }, input.Http1Connection));
 
                 Assert.Equal(StatusCodes.Status400BadRequest, ex.StatusCode);
                 Assert.Equal(CoreStrings.FormatBadRequest_FinalTransferCodingNotChunked("chunked, not-chunked"), ex.Message);
@@ -543,7 +543,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 input.Http1Connection.Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
-                    Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection));
+                    Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection));
 
                 Assert.Equal(StatusCodes.Status411LengthRequired, ex.StatusCode);
                 Assert.Equal(CoreStrings.FormatBadRequest_LengthRequired(((IHttpRequestFeature)input.Http1Connection).Method), ex.Message);
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 input.Http1Connection.Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
-                    Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(), input.Http1Connection));
+                    Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection));
 
                 Assert.Equal(StatusCodes.Status400BadRequest, ex.StatusCode);
                 Assert.Equal(CoreStrings.FormatBadRequest_LengthRequiredHttp10(((IHttpRequestFeature)input.Http1Connection).Method), ex.Message);
@@ -571,7 +571,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -594,7 +594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
 
                 input.Add("Hello");
 
@@ -611,7 +611,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
 
                 input.Add("Hello");
 
@@ -633,7 +633,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             using (var input = new TestInput())
             {
                 // note the http1connection request body pipe reader should be the same.
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = headerConnection }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = headerConnection }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -660,7 +660,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var headerConnection = "Upgrade, Keep-Alive";
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = headerConnection, ContentLength = 0 }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = headerConnection, ContentLength = 0 }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -682,7 +682,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "2" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "2" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -710,7 +710,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 input.Http1ConnectionContext.TimeoutControl = mockTimeoutControl.Object;
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
 
                 // Add some input and read it to start PumpAsync
                 input.Add("a");
@@ -739,7 +739,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var mockLogger = new Mock<IKestrelTrace>();
                 input.Http1Connection.ServiceContext.Log = mockLogger.Object;
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
 
                 // Add some input and read it to start PumpAsync
                 input.Add("a");
@@ -771,7 +771,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 input.Http1ConnectionContext.TimeoutControl = mockTimeoutControl.Object;
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -803,7 +803,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 input.Http1Connection.ConnectionIdFeature = "ConnectionId";
                 input.Http1Connection.TraceIdentifier = "RequestId";
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "2" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "2" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -834,7 +834,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 input.Http1Connection.ConnectionIdFeature = "ConnectionId";
                 input.Http1Connection.TraceIdentifier = "RequestId";
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "2" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "2" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), reader);
                 reader.StartAcceptingReads(body);
@@ -859,7 +859,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var mockTimeoutControl = new Mock<ITimeoutControl>();
                 input.Http1ConnectionContext.TimeoutControl = mockTimeoutControl.Object;
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "12" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "12" }, input.Http1Connection);
 
                 // Add some input and read it to start PumpAsync
                 var readTask1 = body.ReadAsync();
@@ -895,7 +895,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 input.Http1ConnectionContext.TimeoutControl = mockTimeoutControl.Object;
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
 
                 Assert.False(startRequestBodyCalled);
 
@@ -920,7 +920,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var mockTimeoutControl = new Mock<ITimeoutControl>();
                 input.Http1ConnectionContext.TimeoutControl = mockTimeoutControl.Object;
 
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
 
                 // Add some input and read it to start PumpAsync
                 input.Add("a");
@@ -952,7 +952,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -973,7 +973,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -994,7 +994,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1015,7 +1015,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1038,7 +1038,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1057,7 +1057,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1084,7 +1084,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1110,7 +1110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1133,7 +1133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1156,7 +1156,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1179,7 +1179,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1204,7 +1204,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1229,7 +1229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderContentLength = "5" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderContentLength = "5" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1255,7 +1255,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderTransferEncoding = "chunked" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1281,7 +1281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders { HeaderConnection = "upgrade" }, input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()) { HeaderConnection = "upgrade" }, input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 
@@ -1308,7 +1308,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection);
+                var body = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(new KestrelServerOptions()), input.Http1Connection);
                 var reader = new HttpRequestPipeReader();
                 reader.StartAcceptingReads(body);
 

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
@@ -107,6 +107,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             public void OnHeader(Span<byte> name, Span<byte> value)
                 => RequestHandler.Connection.OnHeader(name, value);
 
+            public void OnHeadersComplete()
+                => RequestHandler.Connection.OnHeadersComplete();
+
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
                 => RequestHandler.Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
         }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
@@ -24,6 +24,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         public Http1Connection Connection { get; set; }
 
+        [Params(true, false)]
+        public bool ReuseHeaders { get; set; }
+
         [GlobalSetup]
         public void Setup()
         {
@@ -33,7 +36,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             var serviceContext = new ServiceContext
             {
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions() { ReuseRequestHeaders = ReuseHeaders },
                 HttpParser = NullParser<Http1ParsingHandler>.Instance
             };
 

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
@@ -72,6 +72,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
         }
 
+        public void OnHeadersComplete()
+        {
+        }
+
         private struct Adapter : IHttpRequestLineHandler, IHttpHeadersHandler
         {
             public HttpParserBenchmark RequestHandler;
@@ -83,6 +87,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             public void OnHeader(Span<byte> name, Span<byte> value)
                 => RequestHandler.OnHeader(name, value);
+
+            public void OnHeadersComplete()
+                => RequestHandler.OnHeadersComplete();
 
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
                 => RequestHandler.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             handler.OnHeader(new Span<byte>(_hostHeaderName), new Span<byte>(_hostHeaderValue));
             handler.OnHeader(new Span<byte>(_acceptHeaderName), new Span<byte>(_acceptHeaderValue));
             handler.OnHeader(new Span<byte>(_connectionHeaderName), new Span<byte>(_connectionHeaderValue));
+            handler.OnHeadersComplete();
 
             consumedBytes = 0;
             consumed = buffer.Start;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -406,6 +406,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _decodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters();
         }
 
+        void IHttpHeadersHandler.OnHeadersComplete() { }
+
         protected void CreateConnection()
         {
             var limits = _serviceContext.ServerOptions.Limits;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -774,7 +774,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 if (firstRequest)
                 {
                     originalRequestHeaders = requestFeature.Headers;
-                    requestFeature.Headers = new HttpRequestHeaders();
+                    requestFeature.Headers = new HttpRequestHeaders(new KestrelServerOptions());
                     firstRequest = false;
                 }
                 else


### PR DESCRIPTION
Introduces `ReuseRequestHeaders` to reduce allocations for repeated request headers.

```csharp
public partial class KestrelServerOptions
{
    /// <summary>
    /// Gets or sets a value that controls whether the header values materialized as strings
    /// will be reused across requests; if they match, or if the strings will always be reallocated.
    /// </summary>
    /// <remarks>
    /// Defaults to false.
    /// </remarks>
    public bool ReuseRequestHeaders { get; set; } = true;
}
```

Pre
```
               Method |              |       Mean |        Op/s |   Gen 0 | Allocated |
--------------------- |------------- |-----------:|------------:|--------:|----------:|
 PlaintextTechEmpower |              |   650.1 ns | 1,538,199.2 |  8.3008 |    168 KB |
           LiveAspNet |              | 1,487.8 ns |   672,119.6 | 26.3672 |    504 KB |
```
Post
```
               Method | ReuseHeaders |       Mean |        Op/s |   Gen 0 | Allocated |
--------------------- |------------- |-----------:|------------:|--------:|----------:|
 PlaintextTechEmpower |        False |   674.1 ns | 1,483,548.6 |  8.3008 |    168 KB |
           LiveAspNet |        False | 1,480.9 ns |   675,282.8 | 25.3906 |    504 KB |
                      |              |            |             |         |           |
 PlaintextTechEmpower |         True |   617.2 ns | 1,620,152.6 |  0.4883 |     24 KB |
           LiveAspNet |         True | 1,296.2 ns |   771,458.6 |  1.9531 |     88 KB |
```

Allocations still remain for request line (path etc)

Addresses #8372


WIP as needs tests