### PR TITLE
Reuse previous materialized strings

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -121,6 +121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal.SchedulingMode ApplicationSchedulingMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.IServiceProvider ApplicationServices { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader ConfigurationLoader { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool DisableStringReuse { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits Limits { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure() { throw null; }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure(Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -122,6 +122,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public System.IServiceProvider ApplicationServices { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader ConfigurationLoader { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits Limits { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool ReuseRequestHeaders { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure() { throw null; }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure(Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }
         public void ConfigureEndpointDefaults(System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> configureOptions) { }
@@ -251,6 +252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public partial interface IHttpHeadersHandler
     {
         void OnHeader(System.Span<byte> name, System.Span<byte> value);
+        void OnHeadersComplete();
     }
     public partial interface IHttpParser<TRequestHandler> where TRequestHandler : Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler, Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpRequestLineHandler
     {

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -122,7 +122,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public System.IServiceProvider ApplicationServices { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader ConfigurationLoader { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits Limits { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public bool ReuseRequestHeaders { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure() { throw null; }
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure(Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }
         public void ConfigureEndpointDefaults(System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> configureOptions) { }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else
                     {
-                        // Same as pervious
+                        // Same as previous
                         QueryString = _parsedQueryString;
                     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private const byte ByteAsterisk = (byte)'*';
         private const byte ByteForwardSlash = (byte)'/';
         private const string Asterisk = "*";
+        private const string ForwardSlash = "/";
 
         private readonly HttpConnectionContext _context;
         private readonly IHttpParser<Http1ParsingHandler> _parser;
@@ -268,6 +269,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             _requestTargetForm = HttpRequestTarget.OriginForm;
 
+            if (target.Length == 1)
+            {
+                // If target.Length == 1 it can only be a forward slash (e.g. home page)
+                // and we know RawTarget and Path are the same and QueryString is Empty
+                RawTarget = ForwardSlash;
+                Path = ForwardSlash;
+                QueryString = string.Empty;
+                // Clear parsedData as we won't check it if we come via this path again,
+                // an setting to null is fast as it doesn't need to use a GC write barrier.
+                _parsedRawTarget = _parsedPath = _parsedQueryString = null;
+                return;
+            }
+
             // URIs are always encoded/escaped to ASCII https://tools.ietf.org/html/rfc3986#page-11
             // Multibyte Internationalized Resource Identifiers (IRIs) are first converted to utf8;
             // then encoded/escaped to ASCII  https://www.ietf.org/rfc/rfc3987.txt "Mapping of IRIs to URIs"
@@ -275,9 +289,45 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             try
             {
                 // Read raw target before mutating memory.
-                RawTarget = target.GetAsciiStringNonNullCharacters();
-                QueryString = query.GetAsciiStringNonNullCharacters();
-                Path = PathNormalizer.DecodePath(path, pathEncoded, RawTarget, query.Length);
+                var previousValue = _parsedRawTarget;
+                if (previousValue == null || previousValue.Length != target.Length ||
+                    !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
+                {
+                    // The previous string does not match what the bytes would convert to,
+                    // so we will need to generate a new string.
+                    RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
+
+                    previousValue = _parsedQueryString;
+                    if (previousValue == null || previousValue.Length != query.Length ||
+                        !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, query))
+                    {
+                        // The previous string does not match what the bytes would convert to,
+                        // so we will need to generate a new string.
+                        QueryString = _parsedQueryString = query.GetAsciiStringNonNullCharacters();
+                    }
+                    else
+                    {
+                        // Same as pervious
+                        QueryString = _parsedQueryString;
+                    }
+
+                    if (path.Length == 1)
+                    {
+                        // If path.Length == 1 it can only be a forward slash (e.g. home page)
+                        Path = _parsedPath = ForwardSlash;
+                    }
+                    else
+                    {
+                        Path = _parsedPath = PathNormalizer.DecodePath(path, pathEncoded, RawTarget, query.Length);
+                    }
+                }
+                else
+                {
+                    // As RawTarget is the same we can reuse the previous parsed values.
+                    RawTarget = _parsedRawTarget;
+                    Path = _parsedPath;
+                    QueryString = _parsedQueryString;
+                }
             }
             catch (InvalidOperationException)
             {
@@ -312,9 +362,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             //
             // Allowed characters in the 'host + port' section of authority.
             // See https://tools.ietf.org/html/rfc3986#section-3.2
-            RawTarget = target.GetAsciiStringNonNullCharacters();
+            var previousValue = _parsedRawTarget;
+            if (previousValue == null || previousValue.Length != target.Length ||
+                !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
+            {
+                // The previous string does not match what the bytes would convert to,
+                // so we will need to generate a new string.
+                RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
+            }
+            else
+            {
+                // Reuse previous value
+                RawTarget = _parsedRawTarget;
+            }
+
             Path = string.Empty;
             QueryString = string.Empty;
+            // Clear parsedData for path and queryString as we won't check it if we come via this path again,
+            // an setting to null is fast as it doesn't need to use a GC write barrier.
+            _parsedPath = _parsedQueryString = null;
         }
 
         private void OnAsteriskFormTarget(HttpMethod method)
@@ -331,6 +397,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             RawTarget = Asterisk;
             Path = string.Empty;
             QueryString = string.Empty;
+            // Clear parsedData as we won't check it if we come via this path again,
+            // an setting to null is fast as it doesn't need to use a GC write barrier.
+            _parsedRawTarget = _parsedPath = _parsedQueryString = null;
         }
 
         private void OnAbsoluteFormTarget(Span<byte> target, Span<byte> query)
@@ -346,21 +415,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             //    a server MUST accept the absolute-form in requests, even though
             //    HTTP/1.1 clients will only send them in requests to proxies.
 
-            RawTarget = target.GetAsciiStringNonNullCharacters();
-
-            // Validation of absolute URIs is slow, but clients
-            // should not be sending this form anyways, so perf optimization
-            // not high priority
-
-            if (!Uri.TryCreate(RawTarget, UriKind.Absolute, out var uri))
+            var previousValue = _parsedRawTarget;
+            if (previousValue == null || previousValue.Length != target.Length ||
+                !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
             {
-                ThrowRequestTargetRejected(target);
-            }
+                // The previous string does not match what the bytes would convert to,
+                // so we will need to generate a new string.
+                RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
 
-            _absoluteRequestTarget = uri;
-            Path = uri.LocalPath;
-            // don't use uri.Query because we need the unescaped version
-            QueryString = query.GetAsciiStringNonNullCharacters();
+                // Validation of absolute URIs is slow, but clients
+                // should not be sending this form anyways, so perf optimization
+                // not high priority
+
+                if (!Uri.TryCreate(RawTarget, UriKind.Absolute, out var uri))
+                {
+                    ThrowRequestTargetRejected(target);
+                }
+
+                _absoluteRequestTarget = uri;
+                Path = _parsedPath = uri.LocalPath;
+                // don't use uri.Query because we need the unescaped version
+                previousValue = _parsedQueryString;
+                if (previousValue == null || previousValue.Length != query.Length ||
+                    !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, query))
+                {
+                    // The previous string does not match what the bytes would convert to,
+                    // so we will need to generate a new string.
+                    QueryString = _parsedQueryString = query.GetAsciiStringNonNullCharacters();
+                }
+            }
+            else
+            {
+                // As RawTarget is the same we can reuse the previous values.
+                RawTarget = _parsedRawTarget;
+                Path = _parsedPath;
+                QueryString = _parsedQueryString;
+            }
         }
 
         internal void EnsureHostHeaderExists()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -288,9 +288,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             try
             {
+                var disableStringReuse = ServerOptions.DisableStringReuse;
                 // Read raw target before mutating memory.
                 var previousValue = _parsedRawTarget;
-                if (DisableStringReuse || previousValue == null || previousValue.Length != target.Length ||
+                if (disableStringReuse ||
+                    previousValue == null || previousValue.Length != target.Length ||
                     !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
                 {
                     // The previous string does not match what the bytes would convert to,
@@ -298,7 +300,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
 
                     previousValue = _parsedQueryString;
-                    if (DisableStringReuse || previousValue == null || previousValue.Length != query.Length ||
+                    if (disableStringReuse ||
+                        previousValue == null || previousValue.Length != query.Length ||
                         !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, query))
                     {
                         // The previous string does not match what the bytes would convert to,
@@ -362,8 +365,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             //
             // Allowed characters in the 'host + port' section of authority.
             // See https://tools.ietf.org/html/rfc3986#section-3.2
+
             var previousValue = _parsedRawTarget;
-            if (DisableStringReuse || previousValue == null || previousValue.Length != target.Length ||
+            if (ServerOptions.DisableStringReuse ||
+                previousValue == null || previousValue.Length != target.Length ||
                 !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
             {
                 // The previous string does not match what the bytes would convert to,
@@ -415,8 +420,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             //    a server MUST accept the absolute-form in requests, even though
             //    HTTP/1.1 clients will only send them in requests to proxies.
 
+            var disableStringReuse = ServerOptions.DisableStringReuse;
             var previousValue = _parsedRawTarget;
-            if (DisableStringReuse || previousValue == null || previousValue.Length != target.Length ||
+            if (disableStringReuse ||
+                previousValue == null || previousValue.Length != target.Length ||
                 !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
             {
                 // The previous string does not match what the bytes would convert to,
@@ -436,7 +443,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 Path = _parsedPath = uri.LocalPath;
                 // don't use uri.Query because we need the unescaped version
                 previousValue = _parsedQueryString;
-                if (DisableStringReuse || previousValue == null || previousValue.Length != query.Length ||
+                if (disableStringReuse ||
+                    previousValue == null || previousValue.Length != query.Length ||
                     !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, query))
                 {
                     // The previous string does not match what the bytes would convert to,

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 // Read raw target before mutating memory.
                 var previousValue = _parsedRawTarget;
-                if (previousValue == null || previousValue.Length != target.Length ||
+                if (DisableStringReuse || previousValue == null || previousValue.Length != target.Length ||
                     !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
                 {
                     // The previous string does not match what the bytes would convert to,
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
 
                     previousValue = _parsedQueryString;
-                    if (previousValue == null || previousValue.Length != query.Length ||
+                    if (DisableStringReuse || previousValue == null || previousValue.Length != query.Length ||
                         !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, query))
                     {
                         // The previous string does not match what the bytes would convert to,
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // Allowed characters in the 'host + port' section of authority.
             // See https://tools.ietf.org/html/rfc3986#section-3.2
             var previousValue = _parsedRawTarget;
-            if (previousValue == null || previousValue.Length != target.Length ||
+            if (DisableStringReuse || previousValue == null || previousValue.Length != target.Length ||
                 !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
             {
                 // The previous string does not match what the bytes would convert to,
@@ -416,7 +416,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             //    HTTP/1.1 clients will only send them in requests to proxies.
 
             var previousValue = _parsedRawTarget;
-            if (previousValue == null || previousValue.Length != target.Length ||
+            if (DisableStringReuse || previousValue == null || previousValue.Length != target.Length ||
                 !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, target))
             {
                 // The previous string does not match what the bytes would convert to,
@@ -436,12 +436,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 Path = _parsedPath = uri.LocalPath;
                 // don't use uri.Query because we need the unescaped version
                 previousValue = _parsedQueryString;
-                if (previousValue == null || previousValue.Length != query.Length ||
+                if (DisableStringReuse || previousValue == null || previousValue.Length != query.Length ||
                     !StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, query))
                 {
                     // The previous string does not match what the bytes would convert to,
                     // so we will need to generate a new string.
                     QueryString = _parsedQueryString = query.GetAsciiStringNonNullCharacters();
+                }
+                else
+                {
+                    QueryString = _parsedQueryString;
                 }
             }
             else

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
@@ -17,6 +17,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public void OnHeader(Span<byte> name, Span<byte> value)
             => Connection.OnHeader(name, value);
 
+        public void OnHeadersComplete()
+            => Connection.OnHeadersComplete();
+
         public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
             => Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal abstract class HttpHeaders : IHeaderDictionary
     {
+        protected long _bits = 0;
         protected long? _contentLength;
         protected bool _isReadOnly;
         protected Dictionary<string, StringValues> MaybeUnknown;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -241,6 +241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                     }
 
                                     done = true;
+                                    handler.OnHeadersComplete();
                                     return true;
                                 }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -25,9 +25,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal abstract partial class HttpProtocol : IDefaultHttpContextContainer, IHttpResponseControl
     {
-        private const string DisableStringReuseSwitch = "Switch.Microsoft.AspNetCore.Kestrel.DisableStringReuse";
-        protected static readonly bool DisableStringReuse = GetDisableStringReuseSwitch();
-
         private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");
         private static readonly byte[] _bytesConnectionKeepAlive = Encoding.ASCII.GetBytes("\r\nConnection: keep-alive");
         private static readonly byte[] _bytesTransferEncodingChunked = Encoding.ASCII.GetBytes("\r\nTransfer-Encoding: chunked");
@@ -77,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
-            HttpRequestHeaders = new HttpRequestHeaders(reuseHeaderValues: !DisableStringReuse);
+            HttpRequestHeaders = new HttpRequestHeaders(reuseHeaderValues: !ServerOptions.DisableStringReuse);
             HttpResponseControl = this;
         }
 
@@ -1503,16 +1500,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 HandleNonBodyResponseWrite();
                 return await Output.FlushAsync(cancellationToken);
             }
-        }
-
-        private static bool GetDisableStringReuseSwitch()
-        {
-            if (AppContext.TryGetSwitch(DisableStringReuseSwitch, out var disableStringReuse))
-            {
-                return disableStringReuse;
-            }
-
-            return false;
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -25,8 +25,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal abstract partial class HttpProtocol : IDefaultHttpContextContainer, IHttpResponseControl
     {
-        private const string DisableHeaderStringSwitch = "Switch.Microsoft.AspNetCore.Kestrel.DisableStringReuse";
-        protected static readonly bool DisableStringReuse = GetDisableHeaderStringSwitch();
+        private const string DisableStringReuseSwitch = "Switch.Microsoft.AspNetCore.Kestrel.DisableStringReuse";
+        protected static readonly bool DisableStringReuse = GetDisableStringReuseSwitch();
 
         private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");
         private static readonly byte[] _bytesConnectionKeepAlive = Encoding.ASCII.GetBytes("\r\nConnection: keep-alive");
@@ -1505,11 +1505,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        private static bool GetDisableHeaderStringSwitch()
+        private static bool GetDisableStringReuseSwitch()
         {
-            if (AppContext.TryGetSwitch(DisableHeaderStringSwitch, out var disableHeaderReuse))
+            if (AppContext.TryGetSwitch(DisableStringReuseSwitch, out var disableStringReuse))
             {
-                return disableHeaderReuse;
+                return disableStringReuse;
             }
 
             return false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -25,8 +25,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal abstract partial class HttpProtocol : IDefaultHttpContextContainer, IHttpResponseControl
     {
-        private const string DisableHeaderReuseSwitch = "Switch.Microsoft.AspNetCore.Kestrel.DisableHeaderReuse";
-        private static readonly bool DisableHeaderReuse = GetDisableHeaderReuseSwitch();
+        private const string DisableHeaderStringSwitch = "Switch.Microsoft.AspNetCore.Kestrel.DisableStringReuse";
+        protected static readonly bool DisableStringReuse = GetDisableHeaderStringSwitch();
 
         private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");
         private static readonly byte[] _bytesConnectionKeepAlive = Encoding.ASCII.GetBytes("\r\nConnection: keep-alive");
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
-            HttpRequestHeaders = new HttpRequestHeaders(reuseHeaderValues: !DisableHeaderReuse);
+            HttpRequestHeaders = new HttpRequestHeaders(reuseHeaderValues: !DisableStringReuse);
             HttpResponseControl = this;
         }
 
@@ -1505,9 +1505,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        private static bool GetDisableHeaderReuseSwitch()
+        private static bool GetDisableHeaderStringSwitch()
         {
-            if (AppContext.TryGetSwitch(DisableHeaderReuseSwitch, out var disableHeaderReuse))
+            if (AppContext.TryGetSwitch(DisableHeaderStringSwitch, out var disableHeaderReuse))
             {
                 return disableHeaderReuse;
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers.Text;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -13,6 +14,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal sealed partial class HttpRequestHeaders : HttpHeaders
     {
+        private readonly bool _reuseHeaderValues;
+        private long _previousBits = 0;
+
+        public HttpRequestHeaders(bool reuseHeaderValues = true)
+        {
+            _reuseHeaderValues = reuseHeaderValues;
+        }
+
+        public void OnHeadersComplete()
+        {
+            var bitsToClear = _previousBits & ~_bits;
+            _previousBits = 0;
+
+            if (bitsToClear != 0)
+            {
+                // Some previous headers were not reused or overwritten.
+
+                // While they cannot be accessed by the current request (as they were not supplied by it)
+                // there is no point in holding on to them, so clear them now,
+                // to allow them to get collected by the GC.
+                Clear(bitsToClear);
+            }
+        }
+
+        protected override void ClearFast()
+        {
+            if (!_reuseHeaderValues)
+            {
+                // If we aren't reusing headers clear them all
+                Clear(_bits);
+            }
+            else
+            {
+                // If we are reusing headers, store the currently set headers for comparison later
+                _previousBits = _bits;
+            }
+
+            // Mark no headers as currently in use
+            _bits = 0;
+            // Clear ContentLength and any unknown headers as we will never reuse them 
+            _contentLength = null;
+            MaybeUnknown?.Clear();
+        }
+
         private static long ParseContentLength(string value)
         {
             if (!HeaderUtilities.TryParseNonNegativeInt64(value, out var parsed))
@@ -24,33 +69,44 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AppendContentLength(Span<byte> value)
+        {
+            if (_contentLength.HasValue)
+            {
+                BadHttpRequestException.Throw(RequestRejectionReason.MultipleContentLengths);
+            }
+
+            if (!Utf8Parser.TryParse(value, out long parsed, out var consumed) ||
+                parsed < 0 ||
+                consumed != value.Length)
+            {
+                BadHttpRequestException.Throw(RequestRejectionReason.InvalidContentLength, value.GetAsciiOrUTF8StringNonNullCharacters());
+            }
+
+            _contentLength = parsed;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void SetValueUnknown(string key, StringValues value)
         {
             Unknown[key] = value;
         }
 
-        public unsafe void Append(Span<byte> name, string value)
-        {
-            fixed (byte* namePtr = name)
-            {
-                Append(namePtr, name.Length, value);
-            }
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe void AppendUnknownHeaders(byte* pKeyBytes, int keyLength, string value)
+        private unsafe void AppendUnknownHeaders(Span<byte> name, string valueString)
         {
-            string key = new string('\0', keyLength);
+            string key = new string('\0', name.Length);
+            fixed (byte* pKeyBytes = name)
             fixed (char* keyBuffer = key)
             {
-                if (!StringUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, keyLength))
+                if (!StringUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, name.Length))
                 {
                     BadHttpRequestException.Throw(RequestRejectionReason.InvalidCharactersInHeaderName);
                 }
             }
 
             Unknown.TryGetValue(key, out var existing);
-            Unknown[key] = AppendValue(existing, value);
+            Unknown[key] = AppendValue(existing, valueString);
         }
 
         public Enumerator GetEnumerator()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpHeadersHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpHeadersHandler.cs
@@ -8,5 +8,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public interface IHttpHeadersHandler
     {
         void OnHeader(Span<byte> name, Span<byte> value);
+        void OnHeadersComplete();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1092,6 +1092,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
+        public void OnHeadersComplete()
+            => _currentHeadersStream.OnHeadersComplete();
+
         private void ValidateHeader(Span<byte> name, Span<byte> value)
         {
             // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.1

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StringUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StringUtilities.cs
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 }
 
                 // Create a comparision vector for all bits being equal
-                var AllTrue = new Vector<ushort>(ushort.MaxValue);
+                var AllTrue = new Vector<short>(-1);
                 // do/while as entry condition already checked, remaining length must be Vector<byte>.Count or larger.
                 do
                 {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StringUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StringUtilities.cs
@@ -2,13 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+using System.Text;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
     internal class StringUtilities
     {
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe bool TryGetAsciiString(byte* input, char* output, int count)
         {
             // Calculate end position
@@ -107,6 +113,257 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             } while (input < end);
 
             return isValid;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        public unsafe static bool BytesOrdinalEqualsStringAndAscii(string previousValue, Span<byte> newValue)
+        {
+            // previousValue is a previously materialized string which *must* have already passed validation.
+            Debug.Assert(IsValidHeaderString(previousValue));
+
+            // Ascii bytes => Utf-16 chars will be the same length.
+            // The caller should have already compared lengths before calling this method.
+            // However; let's double check, and early exit if they are not the same length.
+            if (previousValue.Length != newValue.Length)
+            {
+                // Lengths don't match, so there cannot be an exact ascii conversion between the two.
+                goto NotEqual;
+            }
+
+            // Use IntPtr values rather than int, to avoid unnecessary 32 -> 64 movs on 64-bit.
+            // Unfortunately this means we also need to cast to byte* for comparisons as IntPtr doesn't
+            // support operator comparisons (e.g. <=, >, etc).
+            //
+            // Note: Pointer comparison is unsigned, so we use the compare pattern (offset + length <= count)
+            // rather than (offset <= count - length) which we'd do with signed comparison to avoid overflow.
+            // This isn't problematic as we know the maximum length is max string length (from test above)
+            // which is a signed value so half the size of the unsigned pointer value so we can safely add
+            // a Vector<byte>.Count to it without overflowing.
+            var count = (IntPtr)newValue.Length;
+            var offset = (IntPtr)0;
+
+            // Get references to the first byte in the span, and the first char in the string.
+            ref var bytes = ref MemoryMarshal.GetReference(newValue);
+            ref var str = ref MemoryMarshal.GetReference(previousValue.AsSpan());
+
+            do
+            {
+                // If Vector not-accelerated or remaining less than vector size
+                if (!Vector.IsHardwareAccelerated || (byte*)(offset + Vector<byte>.Count) > (byte*)count)
+                {
+                    if (IntPtr.Size == 8) // Use Intrinsic switch for branch elimination
+                    {
+                        // 64-bit: Loop longs by default
+                        while ((byte*)(offset + sizeof(long)) <= (byte*)count)
+                        {
+                            if (!WidenFourAsciiBytesToUtf16AndComapreToChars(
+                                    ref Unsafe.Add(ref str, offset),
+                                    Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref bytes, offset))) ||
+                                !WidenFourAsciiBytesToUtf16AndComapreToChars(
+                                    ref Unsafe.Add(ref str, offset + 4),
+                                    Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref bytes, offset + 4))))
+                            {
+                                goto NotEqual;
+                            }
+
+                            offset += sizeof(long);
+                        }
+                        if ((byte*)(offset + sizeof(int)) <= (byte*)count)
+                        {
+                            if (!WidenFourAsciiBytesToUtf16AndComapreToChars(
+                                ref Unsafe.Add(ref str, offset),
+                                Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref bytes, offset))))
+                            {
+                                goto NotEqual;
+                            }
+
+                            offset += sizeof(int);
+                        }
+                    }
+                    else
+                    {
+                        // 32-bit: Loop ints by default
+                        while ((byte*)(offset + sizeof(int)) <= (byte*)count)
+                        {
+                            if (!WidenFourAsciiBytesToUtf16AndComapreToChars(
+                                ref Unsafe.Add(ref str, offset),
+                                Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref bytes, offset))))
+                            {
+                                goto NotEqual;
+                            }
+
+                            offset += sizeof(int);
+                        }
+                    }
+                    if ((byte*)(offset + sizeof(short)) <= (byte*)count)
+                    {
+                        if (!WidenTwoAsciiBytesToUtf16AndComapreToChars(
+                            ref Unsafe.Add(ref str, offset),
+                            Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref bytes, offset))))
+                        {
+                            goto NotEqual;
+                        }
+
+                        offset += sizeof(short);
+                    }
+                    if ((byte*)offset < (byte*)count)
+                    {
+                        var ch = (char)Unsafe.Add(ref bytes, offset);
+                        if (((ch & 0x80) != 0) || Unsafe.Add(ref str, offset) != ch)
+                        {
+                            goto NotEqual;
+                        }
+                    }
+
+                    // End of input reached, there are no inequalities via widening; so the input bytes are both ascii
+                    // and a match to the string if it was converted via Encoding.ASCII.GetString(...)
+                    return true;
+                }
+
+                // Create a comparision vector for all bits being equal
+                var AllTrue = new Vector<ushort>(ushort.MaxValue);
+                // do/while as entry condition already checked, remaining length must be Vector<byte>.Count or larger.
+                do
+                {
+                    // Read a Vector length from the input as bytes
+                    var vector = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.Add(ref bytes, offset));
+                    // Widen the bytes directly to chars (ushort) as if they were ascii.
+                    // As widening doubles the size we get two vectors back.
+                    Vector.Widen(vector, out var vector0, out var vector1);
+                    // Read two char vectors from the string to perform the match.
+                    var compare0 = Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref str, offset)));
+                    var compare1 = Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref str, offset + Vector<ushort>.Count)));
+
+                    // If the string is not ascii, then the widened bytes cannot match
+                    // as each widened byte element as chars will be in the range 0-255
+                    // so cannot match any higher unicode values.
+
+                    // Compare to our all bits true comparision vector
+                    if (!AllTrue.Equals(
+                        // BitwiseAnd the two equals together
+                        Vector.BitwiseAnd(
+                            // Check equality for the two widened vectors
+                            Vector.Equals(compare0, vector0),
+                            Vector.Equals(compare1, vector1))))
+                    {
+                        goto NotEqual;
+                    }
+
+                    offset += Vector<byte>.Count;
+                } while ((byte*)(offset + Vector<byte>.Count) <= (byte*)count);
+
+                // Vector path done, loop back to do non-Vector
+                // If is a exact multiple of vector size, bail now
+            } while ((byte*)offset < (byte*)count);
+
+            // If we get here (input is exactly a multiple of Vector length) then there are no inequalities via widening;
+            // so the input bytes are both ascii and a match to the string if it was converted via Encoding.ASCII.GetString(...)
+            return true;
+        NotEqual:
+            return false;
+        }
+
+        /// <summary>
+        /// Given a DWORD which represents a buffer of 4 bytes, widens the buffer into 4 WORDs and
+        /// compares them to the WORD buffer with machine endianness.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+        private static bool WidenFourAsciiBytesToUtf16AndComapreToChars(ref char charStart, uint value)
+        {
+            if (!AllBytesInUInt32AreAscii(value))
+            {
+                return false;
+            }
+
+            if (Bmi2.X64.IsSupported)
+            {
+                // BMI2 will work regardless of the processor's endianness.
+                return Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref charStart)) ==
+                    Bmi2.X64.ParallelBitDeposit(value, 0x00FF00FF_00FF00FFul);
+            }
+            else
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return charStart == (char)(byte)value &&
+                        Unsafe.Add(ref charStart, 1) == (char)(byte)(value >> 8) &&
+                        Unsafe.Add(ref charStart, 2) == (char)(byte)(value >> 16) &&
+                        Unsafe.Add(ref charStart, 3) == (char)(value >> 24);
+                }
+                else
+                {
+                    return Unsafe.Add(ref charStart, 3) == (char)(byte)value &&
+                        Unsafe.Add(ref charStart, 2) == (char)(byte)(value >> 8) &&
+                        Unsafe.Add(ref charStart, 1) == (char)(byte)(value >> 16) &&
+                        charStart == (char)(value >> 24);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Given a WORD which represents a buffer of 2 bytes, widens the buffer into 2 WORDs and
+        /// compares them to the WORD buffer with machine endianness.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+        private static bool WidenTwoAsciiBytesToUtf16AndComapreToChars(ref char charStart, ushort value)
+        {
+            if (!AllBytesInUInt16AreAscii(value))
+            {
+                return false;
+            }
+
+            if (Bmi2.IsSupported)
+            {
+                // BMI2 will work regardless of the processor's endianness.
+                return Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref charStart)) ==
+                    Bmi2.ParallelBitDeposit(value, 0x00FF00FFu);
+            }
+            else
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return charStart == (char)(byte)value &&
+                        Unsafe.Add(ref charStart, 1) == (char)(byte)(value >> 8);
+                }
+                else
+                {
+                    return Unsafe.Add(ref charStart, 1) == (char)(byte)value &&
+                        charStart == (char)(byte)(value >> 8);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> iff all bytes in <paramref name="value"/> are ASCII.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllBytesInUInt32AreAscii(uint value)
+        {
+            return ((value & 0x80808080u) == 0);
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> iff all bytes in <paramref name="value"/> are ASCII.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllBytesInUInt16AreAscii(ushort value)
+        {
+            return ((value & 0x8080u) == 0);
+        }
+
+        private unsafe static bool IsValidHeaderString(string value)
+        {
+            // Method for Debug.Assert to ensure BytesOrdinalEqualsStringAndAscii
+            // is not called with an unvalidated string comparitor.
+            try
+            {
+                if (value is null) return false;
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetByteCount(value);
+                return !value.Contains('\0');
+            }
+            catch (DecoderFallbackException) {
+                return false;
+            }
         }
 
         private static readonly char[] s_encode16Chars = "0123456789ABCDEF".ToCharArray();

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -55,6 +55,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public bool AllowSynchronousIO { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value that controls whether the string values materialized
+        /// will be reused across requests; if they match, or if the strings will always be reallocated.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to false.
+        /// </remarks>
+        public bool DisableStringReuse { get; set; } = false;
+
+        /// <summary>
         /// Enables the Listen options callback to resolve and use services registered by the application during startup.
         /// Typically initialized by UseKestrel()"/>.
         /// </summary>

--- a/src/Servers/Kestrel/Core/test/AsciiDecoding.cs
+++ b/src/Servers/Kestrel/Core/test/AsciiDecoding.cs
@@ -24,16 +24,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 .Concat(byteRange)
                 .ToArray();
 
-            var s = new Span<byte>(byteArray).GetAsciiStringNonNullCharacters();
+            var span = new Span<byte>(byteArray);
 
-            Assert.Equal(s.Length, byteArray.Length);
-
-            for (var i = 1; i < byteArray.Length; i++)
+            for (var i = 0; i <= byteArray.Length; i++)
             {
-                var sb = (byte)s[i];
-                var b = byteArray[i];
+                // Test all the lengths to hit all the different length paths e.g. Vector, long, short, char
+                Test(span.Slice(i));
+            }
 
-                Assert.Equal(sb, b);
+            static void Test(Span<byte> asciiBytes)
+            {
+                var s = asciiBytes.GetAsciiStringNonNullCharacters();
+
+                Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, asciiBytes));
+                Assert.Equal(s.Length, asciiBytes.Length);
+
+                for (var i = 0; i < asciiBytes.Length; i++)
+                {
+                    var sb = (byte)s[i];
+                    var b = asciiBytes[i];
+
+                    Assert.Equal(sb, b);
+                }
             }
         }
 
@@ -59,8 +71,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var byteRange = Enumerable.Range(0, 16384 + 64).Select(x => (byte)((x & 0x7f) | 0x01)).ToArray();
             var expectedByteRange = byteRange.Concat(byteRange).ToArray();
-            
-            var s = new Span<byte>(expectedByteRange).GetAsciiStringNonNullCharacters();
+
+            var span = new Span<byte>(expectedByteRange);
+            var s = span.GetAsciiStringNonNullCharacters();
 
             Assert.Equal(expectedByteRange.Length, s.Length);
 
@@ -68,8 +81,74 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 var sb = (byte)((s[i] & 0x7f) | 0x01);
                 var b = expectedByteRange[i];
+            }
 
-                Assert.Equal(sb, b);
+            Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, span));
+        }
+
+        [Fact]
+        private void DifferentLengthsAreNotEqual()
+        {
+            var byteRange = Enumerable.Range(0, 4096).Select(x => (byte)((x & 0x7f) | 0x01)).ToArray();
+            var expectedByteRange = byteRange.Concat(byteRange).ToArray();
+
+            for (var i = 1; i < byteRange.Length; i++)
+            {
+                var span = new Span<byte>(expectedByteRange);
+                var s = span.GetAsciiStringNonNullCharacters();
+
+                Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, span));
+
+                // One off end
+                Assert.False(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, span.Slice(0, span.Length - 1)));
+                Assert.False(StringUtilities.BytesOrdinalEqualsStringAndAscii(s.Substring(0, s.Length - 1), span));
+
+                // One off start
+                Assert.False(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, span.Slice(1, span.Length - 1)));
+                Assert.False(StringUtilities.BytesOrdinalEqualsStringAndAscii(s.Substring(1, s.Length - 1), span));
+            }
+        }
+
+        [Fact]
+        private void AsciiBytesEqualAsciiStrings()
+        {
+            var byteRange = Enumerable.Range(1, 127).Select(x => (byte)x);
+
+            var byteArray = byteRange
+                .Concat(byteRange)
+                .Concat(byteRange)
+                .Concat(byteRange)
+                .Concat(byteRange)
+                .Concat(byteRange)
+                .ToArray();
+
+            var span = new Span<byte>(byteArray);
+
+            for (var i = 0; i <= byteArray.Length; i++)
+            {
+                // Test all the lengths to hit all the different length paths e.g. Vector, long, short, char
+                Test(span.Slice(i));
+            }
+
+            static void Test(Span<byte> asciiBytes)
+            {
+                var s = asciiBytes.GetAsciiStringNonNullCharacters();
+
+                // Should start as equal
+                Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, asciiBytes));
+
+                for (var i = 0; i < asciiBytes.Length; i++)
+                {
+                    var b = asciiBytes[i];
+
+                    // Change one byte, ensure is not equal
+                    asciiBytes[i] = (byte)(b + 1);
+                    Assert.False(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, asciiBytes));
+
+                    // Change byte back for next iteration, ensure is equal again
+                    asciiBytes[i] = b;
+                    Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, asciiBytes));
+                }
             }
         }
     }

--- a/src/Servers/Kestrel/Core/test/HPackDecoderTests.cs
+++ b/src/Servers/Kestrel/Core/test/HPackDecoderTests.cs
@@ -103,6 +103,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _decodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiStringNonNullCharacters();
         }
 
+        void IHttpHeadersHandler.OnHeadersComplete() { }
+
         [Fact]
         public void DecodesIndexedHeaderField_StaticTable()
         {

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -483,6 +483,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Headers[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiStringNonNullCharacters();
             }
 
+            void IHttpHeadersHandler.OnHeadersComplete() { }
+
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
             {
                 Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiStringNonNullCharacters();

--- a/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.Extensions.Primitives;
 using Xunit;
+using static CodeGenerator.KnownHeaders;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
@@ -307,8 +309,314 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var encoding = Encoding.GetEncoding("iso-8859-1");
             var exception = Assert.Throws<BadHttpRequestException>(
-                () => headers.Append(encoding.GetBytes(key), "value"));
+                () => headers.Append(encoding.GetBytes(key), Encoding.ASCII.GetBytes("value")));
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void ValueReuseOnlyWhenAllowed(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValue = "Hello";
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+
+            for (var i = 0; i < 6; i++)
+            {
+                var prevName = ChangeNameCase(header.Name, variant: i);
+                var nextName = ChangeNameCase(header.Name, variant: i + 1);
+
+                var values = GetHeaderValues(headers, prevName, nextName, HeaderValue, HeaderValue);
+
+                Assert.Equal(HeaderValue, values.PrevHeaderValue);
+                Assert.NotSame(HeaderValue, values.PrevHeaderValue);
+
+                Assert.Equal(HeaderValue, values.NextHeaderValue);
+                Assert.NotSame(HeaderValue, values.NextHeaderValue);
+
+                Assert.Equal(values.PrevHeaderValue, values.NextHeaderValue);
+                if (reuseValue)
+                {
+                    // When materalized string is reused previous and new should be the same object
+                    Assert.Same(values.PrevHeaderValue, values.NextHeaderValue);
+                }
+                else
+                {
+                    // When materalized string is not reused previous and new should be the different objects
+                    Assert.NotSame(values.PrevHeaderValue, values.NextHeaderValue);
+            }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void ValueReuseChangedValuesOverwrite(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValue1 = "Hello1";
+            const string HeaderValue2 = "Hello2";
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+
+            for (var i = 0; i < 6; i++)
+            {
+                var prevName = ChangeNameCase(header.Name, variant: i);
+                var nextName = ChangeNameCase(header.Name, variant: i + 1);
+
+                var values = GetHeaderValues(headers, prevName, nextName, HeaderValue1, HeaderValue2);
+
+                Assert.Equal(HeaderValue1, values.PrevHeaderValue);
+                Assert.NotSame(HeaderValue1, values.PrevHeaderValue);
+
+                Assert.Equal(HeaderValue2, values.NextHeaderValue);
+                Assert.NotSame(HeaderValue2, values.NextHeaderValue);
+
+                Assert.NotEqual(values.PrevHeaderValue, values.NextHeaderValue);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void ValueReuseMissingValuesClear(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValue1 = "Hello1";
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+
+            for (var i = 0; i < 6; i++)
+            {
+                var prevName = ChangeNameCase(header.Name, variant: i);
+                var nextName = ChangeNameCase(header.Name, variant: i + 1);
+
+                var values = GetHeaderValues(headers, prevName, nextName, HeaderValue1, nextValue: null);
+
+                Assert.Equal(HeaderValue1, values.PrevHeaderValue);
+                Assert.NotSame(HeaderValue1, values.PrevHeaderValue);
+
+                Assert.Equal(string.Empty, values.NextHeaderValue);
+
+                Assert.NotEqual(values.PrevHeaderValue, values.NextHeaderValue);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void ValueReuseNeverWhenNotAscii(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValue = "Hello \u03a0";
+
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+
+            for (var i = 0; i < 6; i++)
+            {
+                var prevName = ChangeNameCase(header.Name, variant: i);
+                var nextName = ChangeNameCase(header.Name, variant: i + 1);
+
+                var values = GetHeaderValues(headers, prevName, nextName, HeaderValue, HeaderValue);
+
+                Assert.Equal(HeaderValue, values.PrevHeaderValue);
+                Assert.NotSame(HeaderValue, values.PrevHeaderValue);
+
+                Assert.Equal(HeaderValue, values.NextHeaderValue);
+                Assert.NotSame(HeaderValue, values.NextHeaderValue);
+
+                Assert.Equal(values.PrevHeaderValue, values.NextHeaderValue);
+
+                Assert.NotSame(values.PrevHeaderValue, values.NextHeaderValue);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void ValueReuseLatin1NotConfusedForUtf16AndStillRejected(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValueUtf16Latin1CrossOver = "Hello \u00a3";
+
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+            headers.Reset();
+
+            var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
+            var prevSpan = Encoding.UTF8.GetBytes(HeaderValueUtf16Latin1CrossOver).AsSpan();
+
+            headers.Append(headerName, prevSpan);
+            headers.OnHeadersComplete();
+            var prevHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
+
+            Assert.Equal(HeaderValueUtf16Latin1CrossOver, prevHeaderValue);
+            Assert.NotSame(HeaderValueUtf16Latin1CrossOver, prevHeaderValue);
+
+            headers.Reset();
+
+            Assert.Throws<InvalidOperationException>(() => {
+                var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
+                var nextSpan = Encoding.GetEncoding("iso-8859-1").GetBytes(HeaderValueUtf16Latin1CrossOver).AsSpan();
+                headers.Append(headerName, nextSpan);
+            });
+        }
+
+        [Fact]
+        public void ValueReuseNeverWhenUnknownHeader()
+        {
+            const string HeaderName = "An-Unknown-Header";
+            const string HeaderValue = "Hello";
+
+            var headers = new HttpRequestHeaders(reuseHeaderValues: true);
+
+            for (var i = 0; i < 6; i++)
+            {
+                var prevName = ChangeNameCase(HeaderName, variant: i);
+                var nextName = ChangeNameCase(HeaderName, variant: i + 1);
+
+                var values = GetHeaderValues(headers, prevName, nextName, HeaderValue, HeaderValue);
+
+                Assert.Equal(HeaderValue, values.PrevHeaderValue);
+                Assert.NotSame(HeaderValue, values.PrevHeaderValue);
+
+                Assert.Equal(HeaderValue, values.NextHeaderValue);
+                Assert.NotSame(HeaderValue, values.NextHeaderValue);
+
+                Assert.Equal(values.PrevHeaderValue, values.NextHeaderValue);
+
+                Assert.NotSame(values.PrevHeaderValue, values.NextHeaderValue);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void ValueReuseEmptyAfterReset(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValue = "Hello";
+
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+            var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
+            var prevSpan = Encoding.UTF8.GetBytes(HeaderValue).AsSpan();
+
+            headers.Append(headerName, prevSpan);
+            headers.OnHeadersComplete();
+            var prevHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
+
+            Assert.NotNull(prevHeaderValue);
+            Assert.NotEqual(string.Empty, prevHeaderValue);
+            Assert.Equal(HeaderValue, prevHeaderValue);
+            Assert.NotSame(HeaderValue, prevHeaderValue);
+            Assert.Single(headers);
+            var count = headers.Count;
+            Assert.Equal(1, count);
+
+            headers.Reset();
+
+            // Empty after reset
+            var nextHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
+
+            Assert.NotNull(nextHeaderValue);
+            Assert.Equal(string.Empty, nextHeaderValue);
+            Assert.NotEqual(HeaderValue, nextHeaderValue);
+            Assert.Empty(headers);
+            count = headers.Count;
+            Assert.Equal(0, count);
+
+            headers.OnHeadersComplete();
+
+            // Still empty after complete
+            nextHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
+
+            Assert.NotNull(nextHeaderValue);
+            Assert.Equal(string.Empty, nextHeaderValue);
+            Assert.NotEqual(HeaderValue, nextHeaderValue);
+            Assert.Empty(headers);
+            count = headers.Count;
+            Assert.Equal(0, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(KnownRequestHeaders))]
+        public void MultiValueReuseEmptyAfterReset(bool reuseValue, KnownHeader header)
+        {
+            const string HeaderValue1 = "Hello1";
+            const string HeaderValue2 = "Hello2";
+
+            var headers = new HttpRequestHeaders(reuseHeaderValues: reuseValue);
+            var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
+            var prevSpan1 = Encoding.UTF8.GetBytes(HeaderValue1).AsSpan();
+            var prevSpan2 = Encoding.UTF8.GetBytes(HeaderValue2).AsSpan();
+
+            headers.Append(headerName, prevSpan1);
+            headers.Append(headerName, prevSpan2);
+            headers.OnHeadersComplete();
+            var prevHeaderValue = ((IHeaderDictionary)headers)[header.Name];
+
+            Assert.Equal(2, prevHeaderValue.Count);
+
+            Assert.NotEqual(string.Empty, prevHeaderValue.ToString());
+            Assert.Single(headers);
+            var count = headers.Count;
+            Assert.Equal(1, count);
+
+            headers.Reset();
+
+            // Empty after reset
+            var nextHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
+
+            Assert.NotNull(nextHeaderValue);
+            Assert.Equal(string.Empty, nextHeaderValue);
+            Assert.Empty(headers);
+            count = headers.Count;
+            Assert.Equal(0, count);
+
+            headers.OnHeadersComplete();
+
+            // Still empty after complete
+            nextHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
+
+            Assert.NotNull(nextHeaderValue);
+            Assert.Equal(string.Empty, nextHeaderValue);
+            Assert.Empty(headers);
+            count = headers.Count;
+            Assert.Equal(0, count);
+        }
+
+        private static (string PrevHeaderValue, string NextHeaderValue) GetHeaderValues(HttpRequestHeaders headers, string prevName, string nextName, string prevValue, string nextValue)
+        {
+            headers.Reset();
+            var headerName = Encoding.ASCII.GetBytes(prevName).AsSpan();
+            var prevSpan = Encoding.UTF8.GetBytes(prevValue).AsSpan();
+
+            headers.Append(headerName, prevSpan);
+            headers.OnHeadersComplete();
+            var prevHeaderValue = ((IHeaderDictionary)headers)[prevName].ToString();
+
+            headers.Reset();
+
+            if (nextValue != null)
+            {
+                headerName = Encoding.ASCII.GetBytes(prevName).AsSpan();
+                var nextSpan = Encoding.UTF8.GetBytes(nextValue).AsSpan();
+                headers.Append(headerName, nextSpan);
+            }
+
+            headers.OnHeadersComplete();
+
+            var newHeaderValue = ((IHeaderDictionary)headers)[nextName].ToString();
+
+            return (prevHeaderValue, newHeaderValue);
+        }
+
+        private static string ChangeNameCase(string name, int variant)
+        {
+            switch ((variant / 2) % 3)
+            {
+                case 0:
+                    return name;
+                case 1:
+                    return name.ToLowerInvariant();
+                case 2:
+                    return name.ToUpperInvariant();
+            }
+
+            // Never reached
+            Assert.False(true);
+            return name;
+        }
+
+        // Content-Length is numeric not a string, so we exclude it from the string reuse tests
+        public static IEnumerable<object[]> KnownRequestHeaders =>
+            RequestHeaders.Where(h => h.Name != "Content-Length").Select(h => new object[] { true, h }).Concat(
+            RequestHeaders.Where(h => h.Name != "Content-Length").Select(h => new object[] { false, h }));
     }
 }

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -10,6 +10,7 @@
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
     <Compile Include="$(SharedSourceRoot)Buffers.Testing\*.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />
+    <Compile Include="$(KestrelSharedSourceRoot)KnownHeaders.cs" LinkBase="shared" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -1,0 +1,536 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
+{
+    public class StartLineTests : IDisposable
+    {
+        private readonly static IKestrelTrace _trace = Mock.Of<IKestrelTrace>();
+
+        private IDuplexPipe Transport { get; }
+        private MemoryPool<byte> MemoryPool { get; }
+        private Http1Connection Http1Connection { get; }
+        private Http1ParsingHandler ParsingHandler {get;}
+        private IHttpParser<Http1ParsingHandler> Parser { get; }
+
+        [Fact]
+        public void InOriginForm()
+        {
+            var rawTarget = "/path%20with%20spaces?q=123&w=xyzw1";
+            var path = "/path with spaces";
+            var query = "?q=123&w=xyzw1";
+            Http1Connection.Reset();
+            // RawTarget, Path, QueryString are null after reset
+            Assert.Null(Http1Connection.RawTarget);
+            Assert.Null(Http1Connection.Path);
+            Assert.Null(Http1Connection.QueryString);
+
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"POST {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            Assert.NotSame(path, Http1Connection.Path);
+            Assert.NotSame(query, Http1Connection.QueryString);
+        }
+
+        [Fact]
+        public void InAuthorityForm()
+        {
+            var rawTarget = "example.com:1234";
+            var path = string.Empty;
+            var query = string.Empty;
+            Http1Connection.Reset();
+            // RawTarget, Path, QueryString are null after reset
+            Assert.Null(Http1Connection.RawTarget);
+            Assert.Null(Http1Connection.Path);
+            Assert.Null(Http1Connection.QueryString);
+
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            // Empty strings, so interned and the same.
+            Assert.Same(path, Http1Connection.Path);
+            Assert.Same(query, Http1Connection.QueryString);
+        }
+
+        [Fact]
+        public void InAbsoluteForm()
+        {
+            var rawTarget = "http://localhost/path1?q=123&w=xyzw";
+            var path = "/path1";
+            var query = "?q=123&w=xyzw";
+            Http1Connection.Reset();
+            // RawTarget, Path, QueryString are null after reset
+            Assert.Null(Http1Connection.RawTarget);
+            Assert.Null(Http1Connection.Path);
+            Assert.Null(Http1Connection.QueryString);
+
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            Assert.NotSame(path, Http1Connection.Path);
+            Assert.NotSame(query, Http1Connection.QueryString);
+        }
+
+        [Fact]
+        public void InAsteriskForm()
+        {
+            var rawTarget = "*";
+            var path = string.Empty;
+            var query = string.Empty;
+            Http1Connection.Reset();
+            // RawTarget, Path, QueryString are null after reset
+            Assert.Null(Http1Connection.RawTarget);
+            Assert.Null(Http1Connection.Path);
+            Assert.Null(Http1Connection.QueryString);
+
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"OPTIONS {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // Asterisk is interned string, so the same.
+            Assert.Same(rawTarget, Http1Connection.RawTarget);
+            // Empty strings, so interned and the same.
+            Assert.Same(path, Http1Connection.Path);
+            Assert.Same(query, Http1Connection.QueryString);
+        }
+
+        [Fact]
+        public void DifferentFormsWorkTogether()
+        {
+            // InOriginForm
+            var rawTarget = "/a%20path%20with%20spaces?q=123&w=xyzw12";
+            var path = "/a path with spaces";
+            var query = "?q=123&w=xyzw12";
+            Http1Connection.Reset();
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"POST {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            Assert.NotSame(path, Http1Connection.Path);
+            Assert.NotSame(query, Http1Connection.QueryString);
+
+            InAuthorityForm();
+
+            InOriginForm();
+            InAbsoluteForm();
+
+            InOriginForm();
+            InAsteriskForm();
+
+            InAuthorityForm();
+            InAsteriskForm();
+
+            InAbsoluteForm();
+            InAuthorityForm();
+
+            InAbsoluteForm();
+            InAsteriskForm();
+
+            InAbsoluteForm();
+            InAuthorityForm();
+        }
+
+        [Theory]
+        [InlineData("/abs/path", "/abs/path", "")]
+        [InlineData("/", "/", "")]
+        [InlineData("/path", "/path", "")]
+        [InlineData("/?q=123&w=xyz", "/", "?q=123&w=xyz")]
+        [InlineData("/path?q=123&w=xyz", "/path", "?q=123&w=xyz")]
+        [InlineData("/path%20with%20space?q=abc%20123", "/path with space", "?q=abc%20123")]
+        public void OriginForms(string rawTarget, string path, string query)
+        {
+            Http1Connection.Reset();
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            var prevRequestUrl = Http1Connection.RawTarget;
+            var prevPath = Http1Connection.Path;
+            var prevQuery = Http1Connection.QueryString;
+
+            // Identical requests keep same materialized string values
+            for (var i = 0; i < 5; i++)
+            {
+                Http1Connection.Reset();
+                // RawTarget, Path, QueryString are null after reset
+                Assert.Null(Http1Connection.RawTarget);
+                Assert.Null(Http1Connection.Path);
+                Assert.Null(Http1Connection.QueryString);
+
+                // Parser decodes % encoding in place, so we need to recreate the ROS
+                ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+                // Equal the inputs.
+                Assert.Equal(rawTarget, Http1Connection.RawTarget);
+                Assert.Equal(path, Http1Connection.Path);
+                Assert.Equal(query, Http1Connection.QueryString);
+
+                // But not the same as the inputs.
+
+                Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+                Assert.NotSame(path, Http1Connection.Path);
+                // string.Empty is used for empty strings, so should be the same.
+                Assert.True(query.Length == 0 || !ReferenceEquals(query, Http1Connection.QueryString));
+
+                // However, materalized strings are reused if generated for previous requests.
+
+                Assert.Same(prevRequestUrl, Http1Connection.RawTarget);
+                Assert.Same(prevPath, Http1Connection.Path);
+                Assert.Same(prevQuery, Http1Connection.QueryString);
+
+                prevRequestUrl = Http1Connection.RawTarget;
+                prevPath = Http1Connection.Path;
+                prevQuery = Http1Connection.QueryString;
+            }
+
+            // Different OriginForm request changes values
+
+            rawTarget = "/path1?q=123&w=xyzw";
+            path = "/path1";
+            query = "?q=123&w=xyzw";
+
+            Http1Connection.Reset();
+            ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            Assert.NotSame(path, Http1Connection.Path);
+            Assert.NotSame(query, Http1Connection.QueryString);
+
+            // Not equal previous request.
+            Assert.NotEqual(prevRequestUrl, Http1Connection.RawTarget);
+            Assert.NotEqual(prevPath, Http1Connection.Path);
+            Assert.NotEqual(prevQuery, Http1Connection.QueryString);
+
+            DifferentFormsWorkTogether();
+        }
+
+        [Theory]
+        [InlineData("http://localhost/abs/path", "/abs/path", "")]
+        [InlineData("https://localhost/abs/path", "/abs/path", "")] // handles mismatch scheme
+        [InlineData("https://localhost:22/abs/path", "/abs/path", "")] // handles mismatched ports
+        [InlineData("https://differenthost/abs/path", "/abs/path", "")] // handles mismatched hostname
+        [InlineData("http://localhost/", "/", "")]
+        [InlineData("http://root@contoso.com/path", "/path", "")]
+        [InlineData("http://root:password@contoso.com/path", "/path", "")]
+        [InlineData("https://localhost/", "/", "")]
+        [InlineData("http://localhost", "/", "")]
+        [InlineData("http://127.0.0.1/", "/", "")]
+        [InlineData("http://[::1]/", "/", "")]
+        [InlineData("http://[::1]:8080/", "/", "")]
+        [InlineData("http://localhost?q=123&w=xyz", "/", "?q=123&w=xyz")]
+        [InlineData("http://localhost/?q=123&w=xyz", "/", "?q=123&w=xyz")]
+        [InlineData("http://localhost/path?q=123&w=xyz", "/path", "?q=123&w=xyz")]
+        [InlineData("http://localhost/path%20with%20space?q=abc%20123", "/path with space", "?q=abc%20123")]
+        public void AbsoluteForms(string rawTarget, string path, string query)
+        {
+            Http1Connection.Reset();
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            var prevRequestUrl = Http1Connection.RawTarget;
+            var prevPath = Http1Connection.Path;
+            var prevQuery = Http1Connection.QueryString;
+
+            // Identical requests keep same materialized string values
+            for (var i = 0; i < 5; i++)
+            {
+                Http1Connection.Reset();
+                // RawTarget, Path, QueryString are null after reset
+                Assert.Null(Http1Connection.RawTarget);
+                Assert.Null(Http1Connection.Path);
+                Assert.Null(Http1Connection.QueryString);
+
+                ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+                // Equal the inputs.
+                Assert.Equal(rawTarget, Http1Connection.RawTarget);
+                Assert.Equal(path, Http1Connection.Path);
+                Assert.Equal(query, Http1Connection.QueryString);
+
+                // But not the same as the inputs.
+
+                Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+                Assert.NotSame(path, Http1Connection.Path);
+                // string.Empty is used for empty strings, so should be the same.
+                Assert.True(query.Length == 0 || !ReferenceEquals(query, Http1Connection.QueryString));
+
+                // However, materalized strings are reused if generated for previous requests.
+
+                Assert.Same(prevRequestUrl, Http1Connection.RawTarget);
+                Assert.Same(prevPath, Http1Connection.Path);
+                Assert.Same(prevQuery, Http1Connection.QueryString);
+
+                prevRequestUrl = Http1Connection.RawTarget;
+                prevPath = Http1Connection.Path;
+                prevQuery = Http1Connection.QueryString;
+            }
+
+            // Different Absolute Form request changes values
+
+            rawTarget = "http://localhost/path1?q=123&w=xyzw";
+            path = "/path1";
+            query = "?q=123&w=xyzw";
+
+            Http1Connection.Reset();
+            ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            Assert.NotSame(path, Http1Connection.Path);
+            Assert.NotSame(query, Http1Connection.QueryString);
+
+            // Not equal previous request.
+            Assert.NotEqual(prevRequestUrl, Http1Connection.RawTarget);
+            Assert.NotEqual(prevPath, Http1Connection.Path);
+            Assert.NotEqual(prevQuery, Http1Connection.QueryString);
+
+            DifferentFormsWorkTogether();
+        }
+
+        [Fact]
+        public void AsteriskForms()
+        {
+            var rawTarget = "*";
+            var path = string.Empty;
+            var query = string.Empty;
+
+            Http1Connection.Reset();
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"OPTIONS {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            var prevRequestUrl = Http1Connection.RawTarget;
+            var prevPath = Http1Connection.Path;
+            var prevQuery = Http1Connection.QueryString;
+
+            // Identical requests keep same materialized string values
+            for (var i = 0; i < 5; i++)
+            {
+                Http1Connection.Reset();
+                // RawTarget, Path, QueryString are null after reset
+                Assert.Null(Http1Connection.RawTarget);
+                Assert.Null(Http1Connection.Path);
+                Assert.Null(Http1Connection.QueryString);
+
+                ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"OPTIONS {rawTarget} HTTP/1.1\r\n"));
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+                // Equal the inputs.
+                Assert.Equal(rawTarget, Http1Connection.RawTarget);
+                Assert.Equal(path, Http1Connection.Path);
+                Assert.Equal(query, Http1Connection.QueryString);
+
+                // Also same as the inputs (interned strings).
+
+                Assert.Same(rawTarget, Http1Connection.RawTarget);
+                Assert.Same(path, Http1Connection.Path);
+                Assert.Same(query, Http1Connection.QueryString);
+
+                // Materalized strings are reused if generated for previous requests.
+
+                Assert.Same(prevRequestUrl, Http1Connection.RawTarget);
+                Assert.Same(prevPath, Http1Connection.Path);
+                Assert.Same(prevQuery, Http1Connection.QueryString);
+
+                prevRequestUrl = Http1Connection.RawTarget;
+                prevPath = Http1Connection.Path;
+                prevQuery = Http1Connection.QueryString;
+            }
+
+            // Different request changes values (can't be Astrisk Form as all the same)
+            rawTarget = "http://localhost/path1?q=123&w=xyzw";
+            path = "/path1";
+            query = "?q=123&w=xyzw";
+
+            Http1Connection.Reset();
+            ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
+            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            Assert.NotSame(path, Http1Connection.Path);
+            Assert.NotSame(query, Http1Connection.QueryString);
+
+            // Not equal previous request.
+            Assert.NotEqual(prevRequestUrl, Http1Connection.RawTarget);
+            Assert.NotEqual(prevPath, Http1Connection.Path);
+            Assert.NotEqual(prevQuery, Http1Connection.QueryString);
+
+            DifferentFormsWorkTogether();
+        }
+
+        [Theory]
+        [InlineData("localhost", "", "")]
+        [InlineData("localhost:22", "", "")] // handles mismatched ports
+        [InlineData("differenthost", "", "")] // handles mismatched hostname
+        [InlineData("127.0.0.1", "", "")]
+        [InlineData("[::1]", "", "")]
+        [InlineData("[::1]:8080", "", "")]
+        public void AuthorityForms(string rawTarget, string path, string query)
+        {
+            Http1Connection.Reset();
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+            var prevRequestUrl = Http1Connection.RawTarget;
+            var prevPath = Http1Connection.Path;
+            var prevQuery = Http1Connection.QueryString;
+
+            // Identical requests keep same materialized string values
+            for (var i = 0; i < 5; i++)
+            {
+                Http1Connection.Reset();
+                // RawTarget, Path, QueryString are null after reset
+                Assert.Null(Http1Connection.RawTarget);
+                Assert.Null(Http1Connection.Path);
+                Assert.Null(Http1Connection.QueryString);
+
+                ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+
+                // Equal the inputs.
+                Assert.Equal(rawTarget, Http1Connection.RawTarget);
+                Assert.Equal(path, Http1Connection.Path);
+                Assert.Equal(query, Http1Connection.QueryString);
+
+                // RawTarget not the same as the input.
+                Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+                // Others same as the inputs, empty strings.
+                Assert.Same(path, Http1Connection.Path);
+                Assert.Same(query, Http1Connection.QueryString);
+
+                // However, materalized strings are reused if generated for previous requests.
+
+                Assert.Same(prevRequestUrl, Http1Connection.RawTarget);
+                Assert.Same(prevPath, Http1Connection.Path);
+                Assert.Same(prevQuery, Http1Connection.QueryString);
+
+                prevRequestUrl = Http1Connection.RawTarget;
+                prevPath = Http1Connection.Path;
+                prevQuery = Http1Connection.QueryString;
+            }
+
+            // Different Authority Form request changes values
+            rawTarget = "example.org:2345";
+            path = "";
+            query = "";
+
+            Http1Connection.Reset();
+            ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
+            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+
+            // Equal the inputs.
+            Assert.Equal(rawTarget, Http1Connection.RawTarget);
+            Assert.Equal(path, Http1Connection.Path);
+            Assert.Equal(query, Http1Connection.QueryString);
+
+            // But not the same as the inputs.
+            Assert.NotSame(rawTarget, Http1Connection.RawTarget);
+            // Empty interned strings
+            Assert.Same(path, Http1Connection.Path);
+            Assert.Same(query, Http1Connection.QueryString);
+
+            // Not equal previous request.
+            Assert.NotEqual(prevRequestUrl, Http1Connection.RawTarget);
+
+            DifferentFormsWorkTogether();
+        }
+
+        public StartLineTests()
+        {
+            MemoryPool = KestrelMemoryPool.Create();
+            var options = new PipeOptions(MemoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
+            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            Transport = pair.Transport;
+
+            var serviceContext = new ServiceContext
+            {
+                ServerOptions = new KestrelServerOptions(),
+                Log = _trace,
+                HttpParser = new HttpParser<Http1ParsingHandler>()
+            };
+
+            Http1Connection = new Http1Connection(context: new HttpConnectionContext
+            {
+                ServiceContext = serviceContext,
+                ConnectionFeatures = new FeatureCollection(),
+                MemoryPool = MemoryPool,
+                Transport = Transport,
+                TimeoutControl = new TimeoutControl(timeoutHandler: null)
+            });
+
+            Parser = new HttpParser<Http1ParsingHandler>(showErrorDetails: true);
+            ParsingHandler = new Http1ParsingHandler(Http1Connection);
+        }
+
+        public void Dispose()
+        {
+            Transport.Input.Complete();
+            Transport.Output.Complete();
+
+            MemoryPool.Dispose();
+        }
+    }
+}

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
@@ -107,6 +107,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             public void OnHeader(Span<byte> name, Span<byte> value)
                 => RequestHandler.Connection.OnHeader(name, value);
 
+            public void OnHeadersComplete()
+                => RequestHandler.Connection.OnHeadersComplete();
+
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
                 => RequestHandler.Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
         }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
@@ -72,6 +72,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
         }
 
+        public void OnHeadersComplete()
+        {
+        }
+
         private struct Adapter : IHttpRequestLineHandler, IHttpHeadersHandler
         {
             public HttpParserBenchmark RequestHandler;
@@ -83,6 +87,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             public void OnHeader(Span<byte> name, Span<byte> value)
                 => RequestHandler.OnHeader(name, value);
+
+            public void OnHeadersComplete()
+                => RequestHandler.OnHeadersComplete();
 
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
                 => RequestHandler.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             handler.OnHeader(new Span<byte>(_hostHeaderName), new Span<byte>(_hostHeaderValue));
             handler.OnHeader(new Span<byte>(_acceptHeaderName), new Span<byte>(_acceptHeaderValue));
             handler.OnHeader(new Span<byte>(_connectionHeaderName), new Span<byte>(_connectionHeaderValue));
+            handler.OnHeadersComplete();
 
             consumedBytes = 0;
             consumed = buffer.Start;

--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -125,6 +125,12 @@ namespace PlatformBenchmarks
         {
         }
 
+#if NETCOREAPP3_0
+        public void OnHeadersComplete()
+        {
+        }
+#endif
+
         public async ValueTask OnReadCompletedAsync()
         {
             await Writer.FlushAsync();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -406,6 +406,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _decodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters();
         }
 
+        void IHttpHeadersHandler.OnHeadersComplete() { }
+
         protected void CreateConnection()
         {
             var limits = _serviceContext.ServerOptions.Limits;

--- a/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
+++ b/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(KestrelSharedSourceRoot)KnownHeaders.cs" />
+  </ItemGroup>
+    
+  <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
   </ItemGroup>


### PR DESCRIPTION
For each request from the browser a lot of repeated headers are sent that are identical to the previous request. This results in a lot of string allocations, especially for `Accept`, `Cookie` and `User-Agent` when materializing these values.

This change drops the sustained allocations to zero bytes/s for middleware with Json TE headers (e.g. 320MB less per 1M requests); will also drop header string allocation for MVC etc by the same amount.

![image](https://user-images.githubusercontent.com/1142958/55302126-9fa78080-5437-11e9-9976-77ad6fac8fa9.png)

Which fits with the goals of aspnet applications being able to run under lower memory conditions (See: ["Proposal for .NET Core GC Support for Docker Limits"](https://github.com/dotnet/designs/blob/261698cb9c56bab0bc7b54b938fa097d729a144f/proposed/support-for-docker-limits.md))

![image](https://user-images.githubusercontent.com/1142958/54391486-de4de480-469c-11e9-83af-5bd60cfaf02f.png)

This PR introduces `DisableStringReuse` which went `false` to reduces allocations for repeated request headers.

```csharp
public partial class KestrelServerOptions
{
/// <summary>
/// Gets or sets a value that controls whether the string values materialized
/// will be reused across requests; if they match, or if the strings will always be reallocated.
/// </summary>
/// <remarks>
/// Defaults to false.
/// </remarks>
public bool DisableStringReuse { get; set; } = false;
}
```

Pre
```
               Method |              |       Mean |        Op/s |   Gen 0 | Allocated |
--------------------- |------------- |-----------:|------------:|--------:|----------:|
 PlaintextTechEmpower |              |   650.1 ns | 1,538,199.2 |  8.3008 |    168 KB |
           LiveAspNet |              | 1,487.8 ns |   672,119.6 | 26.3672 |    504 KB |
```
Post
```
               Method | ReuseHeaders |       Mean |        Op/s |   Gen 0 | Allocated |
--------------------- |------------- |-----------:|------------:|--------:|----------:|
 PlaintextTechEmpower |        False |   593.3 ns | 1,685,440.5 |  7.3242 |    144 KB |
           LiveAspNet |        False | 1,092.5 ns |   915,301.9 | 22.4609 |    440 KB |
                      |              |            |             |         |           |
 PlaintextTechEmpower |         True |   526.0 ns | 1,901,193.1 |       - |       0 B |
           LiveAspNet |         True |   871.9 ns | 1,146,875.8 |       - |       0 B |
```
This change drops ~320MB of allocations for ~1M requests of non-pipelined Json TE benchmark
```
wrk -c 128 -t 4 -d 45 -H "Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7" -H "Connection: keep-alive" http://127.0.0.1:5001
```

Addresses #8372