### PR TITLE
Fix AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/PollingAppOfflineApplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/PollingAppOfflineApplication.cpp
@@ -17,6 +17,8 @@ HRESULT PollingAppOfflineApplication::TryCreateHandler(_In_ IHttpContext* pHttpC
 void
 PollingAppOfflineApplication::CheckAppOffline()
 {
+    SRWSharedLock stopLock(m_stateLock);
+
     if (m_fStopCalled)
     {
         return;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/PollingAppOfflineApplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/PollingAppOfflineApplication.cpp
@@ -17,8 +17,6 @@ HRESULT PollingAppOfflineApplication::TryCreateHandler(_In_ IHttpContext* pHttpC
 void
 PollingAppOfflineApplication::CheckAppOffline()
 {
-    SRWSharedLock stopLock(m_stateLock);
-
     if (m_fStopCalled)
     {
         return;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -155,8 +155,8 @@ APPLICATION_INFO::TryCreateApplication(IHttpContext& pHttpContext, const ShimOpt
             }
             LOG_LAST_ERROR_IF(WaitForSingleObject(eventHandle, INFINITE) != WAIT_OBJECT_0);
         }
-
     }
+
     RETURN_IF_FAILED(m_handlerResolver.GetApplicationFactory(*pHttpContext.GetApplication(), m_pApplicationFactory, options));
     LOG_INFO(L"Creating handler application");
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
@@ -75,11 +75,6 @@ public:
         }
 
         StopInternal(fServerInitiated);
-
-        if (m_pFinishShutdownEvent != nullptr)
-        {
-            LOG_IF_FAILED(SetEvent(m_pFinishShutdownEvent));
-        }
     }
 
     virtual
@@ -144,8 +139,6 @@ private:
     std::wstring m_applicationVirtualPath;
     std::wstring m_applicationConfigPath;
     std::wstring m_applicationId;
-
-    HandleWrapper<NullHandleTraits> m_pFinishShutdownEvent;
 
     static std::wstring ToVirtualPath(const std::wstring& configurationPath)
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
@@ -27,13 +27,11 @@ public:
 
         SRWSharedLock stopLock(m_stopLock);
 
+        // If we have acquired the stopLock, we don't need to acquire the data lock
+        // as m_fStoppedCalled is only set by Stop.
+        if (m_fStopCalled)
         {
-            SRWSharedLock dataLock(m_dataLock);
-
-            if (m_fStopCalled)
-            {
-                return S_FALSE;
-            }
+            return S_FALSE;
         }
 
         TraceContextScope traceScope(pHttpContext->GetTraceContext());

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
@@ -57,14 +57,16 @@ public:
     VOID
     Stop(bool fServerInitiated) override
     {
-        SRWExclusiveLock stopLock(m_stateLock);
-
-        if (m_fStopCalled)
         {
-            return;
-        }
+            SRWExclusiveLock stopLock(m_stateLock);
 
-        m_fStopCalled = true;
+            if (m_fStopCalled)
+            {
+                return;
+            }
+
+            m_fStopCalled = true;
+        }
 
         StopInternal(fServerInitiated);
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/application.h
@@ -25,10 +25,10 @@ public:
     {
         *pRequestHandler = nullptr;
 
-        SRWSharedLock stateLock(m_stateLock);
+        SRWSharedLock stopLock(m_stopLock);
 
         {
-            SRWSharedLock stopLock(m_stopLock);
+            SRWSharedLock dataLock(m_dataLock);
 
             if (m_fStopCalled)
             {
@@ -54,18 +54,18 @@ public:
           m_applicationConfigPath(pHttpApplication.GetAppConfigPath()),
           m_applicationId(pHttpApplication.GetApplicationId())
     {
-        InitializeSRWLock(&m_stateLock);
         InitializeSRWLock(&m_stopLock);
+        InitializeSRWLock(&m_dataLock);
         m_applicationVirtualPath = ToVirtualPath(m_applicationConfigPath);
     }
 
     VOID
     Stop(bool fServerInitiated) override
     {
-        SRWExclusiveLock stateLock(m_stateLock);
+        SRWExclusiveLock stopLock(m_stopLock);
 
         {
-            SRWSharedLock stopLock(m_stopLock);
+            SRWExclusiveLock dataLock(m_dataLock);
             if (m_fStopCalled)
             {
                 return;
@@ -133,8 +133,8 @@ public:
     }
 
 protected:
-    SRWLOCK m_stateLock{};
-    SRWLOCK m_stopLock {};
+    SRWLOCK m_stopLock{};
+    SRWLOCK m_dataLock {};
     bool m_fStopCalled;
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -536,7 +536,7 @@ IN_PROCESS_APPLICATION::CreateHandler(
         DBG_ASSERT(!m_fStopCalled);
         m_requestCount++;
 
-        LOG_INFOF(L"Adding request. Total Request Count %d", m_requestCount.load());
+        LOG_TRACEF(L"Adding request. Total Request Count %d", m_requestCount.load());
 
         *pRequestHandler = new IN_PROCESS_HANDLER(::ReferenceApplication(this), pHttpContext, m_RequestHandler, m_RequestHandlerContext, m_DisconnectHandler, m_AsyncCompletionHandler);
     }
@@ -550,7 +550,7 @@ IN_PROCESS_APPLICATION::HandleRequestCompletion()
 {
     SRWSharedLock lock(m_stateLock);
     m_requestCount--;
-    LOG_INFOF(L"Removing Request %d", m_requestCount.load());
+    LOG_TRACEF(L"Removing Request %d", m_requestCount.load());
 
     if (m_fStopCalled && m_requestCount.load() == 0 && !m_blockManagedCallbacks)
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -285,7 +285,6 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         // At this point CLR thread either finished or timed out, abandon it.
         m_clrThread.detach();
 
-        SRWSharedLock lock(m_stateLock);
         if (m_fStopCalled)
         {
             if (clrThreadExited)
@@ -343,13 +342,9 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
 
 void IN_PROCESS_APPLICATION::QueueStop()
 {
+    if (m_fStopCalled)
     {
-        SRWSharedLock lock(m_stateLock);
-
-        if (m_fStopCalled)
-        {
-            return;
-        }
+        return;
     }
 
     LOG_INFO(L"Queueing in-process stop thread");

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -549,10 +549,11 @@ void
 IN_PROCESS_APPLICATION::HandleRequestCompletion()
 {
     SRWSharedLock lock(m_stateLock);
-    m_requestCount--;
-    LOG_TRACEF(L"Removing Request %d", m_requestCount.load());
+    auto requestCount = --m_requestCount;
 
-    if (m_fStopCalled && m_requestCount.load() == 0 && !m_blockManagedCallbacks)
+    LOG_TRACEF(L"Removing Request %d", requestCount);
+
+    if (m_fStopCalled && requestCount == 0 && !m_blockManagedCallbacks)
     {
         LOG_INFO(L"Drained all requests, notifying managed.");
         m_RequestsDrainedHandler(m_ShutdownHandlerContext);

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -71,6 +71,8 @@ IN_PROCESS_APPLICATION::StopClr()
             shutdownHandler(m_ShutdownHandlerContext);
         }
 
+        SRWSharedLock stopLock(m_stopLock);
+
         auto requestCount = m_requestCount.load();
 
         if (requestCount == 0)
@@ -528,6 +530,8 @@ IN_PROCESS_APPLICATION::CreateHandler(
 {
     try
     {
+        SRWSharedLock stopLock(m_stopLock);
+
         DBG_ASSERT(!m_fStopCalled);
         m_requestCount++;
 
@@ -543,7 +547,7 @@ IN_PROCESS_APPLICATION::CreateHandler(
 void
 IN_PROCESS_APPLICATION::HandleRequestCompletion()
 {
-    SRWSharedLock stopLock(m_stateLock);
+    SRWSharedLock stopLock(m_stopLock);
 
     auto requestCount = --m_requestCount;
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -71,7 +71,7 @@ IN_PROCESS_APPLICATION::StopClr()
             shutdownHandler(m_ShutdownHandlerContext);
         }
 
-        SRWSharedLock stopLock(m_stopLock);
+        SRWSharedLock dataLock(m_dataLock);
 
         auto requestCount = m_requestCount.load();
 
@@ -530,7 +530,7 @@ IN_PROCESS_APPLICATION::CreateHandler(
 {
     try
     {
-        SRWSharedLock stopLock(m_stopLock);
+        SRWSharedLock dataLock(m_dataLock);
 
         DBG_ASSERT(!m_fStopCalled);
         m_requestCount++;
@@ -547,7 +547,7 @@ IN_PROCESS_APPLICATION::CreateHandler(
 void
 IN_PROCESS_APPLICATION::HandleRequestCompletion()
 {
-    SRWSharedLock stopLock(m_stopLock);
+    SRWSharedLock dataLock(m_dataLock);
 
     auto requestCount = --m_requestCount;
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -553,7 +553,6 @@ IN_PROCESS_APPLICATION::CreateHandler(
 void
 IN_PROCESS_APPLICATION::HandleRequestCompletion()
 {
-    LOG_INFOF(L"acquiring lock");
     SRWSharedLock lock(m_stateLock);
     m_requestCount--;
     LOG_INFOF(L"Removing Request %d", m_requestCount.load());

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -543,7 +543,7 @@ IN_PROCESS_APPLICATION::CreateHandler(
 void
 IN_PROCESS_APPLICATION::HandleRequestCompletion()
 {
-    //SRWSharedLock stopLock(m_stateLock);
+    SRWSharedLock stopLock(m_stateLock);
 
     auto requestCount = --m_requestCount;
 
@@ -554,7 +554,6 @@ IN_PROCESS_APPLICATION::HandleRequestCompletion()
         CallRequestsDrained();
     }
 }
-
 
 void IN_PROCESS_APPLICATION::CallRequestsDrained()
 {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -27,8 +27,7 @@ IN_PROCESS_APPLICATION::IN_PROCESS_APPLICATION(
     m_blockManagedCallbacks(true),
     m_waitForShutdown(true),
     m_pConfig(std::move(pConfig)),
-    m_requestCount(0),
-    m_alreadyDrained(false)
+    m_requestCount(0)
 {
     DBG_ASSERT(m_pConfig);
 
@@ -561,10 +560,10 @@ IN_PROCESS_APPLICATION::HandleRequestCompletion()
 
 void IN_PROCESS_APPLICATION::CallRequestsDrained()
 {
-    auto expected = false;
-    if (m_alreadyDrained.compare_exchange_strong(expected, true))
+    if (m_RequestsDrainedHandler != nullptr)
     {
         LOG_INFO(L"Drained all requests, notifying managed.");
         m_RequestsDrainedHandler(m_ShutdownHandlerContext);
+        m_RequestsDrainedHandler = nullptr;
     }
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
@@ -169,7 +169,6 @@ private:
     bool                            m_waitForShutdown;
 
     std::atomic<int>                m_requestCount;
-    std::atomic<bool>               m_alreadyDrained;
 
     std::unique_ptr<InProcessOptions> m_pConfig;
 
@@ -188,7 +187,8 @@ private:
     void
     StopClr();
 
-    void CallRequestsDrained();
+    void
+    CallRequestsDrained();
 
     static
     void

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
@@ -150,8 +150,6 @@ private:
     // The event that gets triggered when worker thread should exit
     HandleWrapper<NullHandleTraits> m_pShutdownEvent;
 
-    HandleWrapper<NullHandleTraits> m_pRequestDrainEvent;
-
     // The request handler callback from managed code
     PFN_REQUEST_HANDLER             m_RequestHandler;
     VOID*                           m_RequestHandlerContext;
@@ -169,7 +167,9 @@ private:
     std::atomic_bool                m_blockManagedCallbacks;
     bool                            m_Initialized;
     bool                            m_waitForShutdown;
+
     std::atomic<int>                m_requestCount;
+    std::atomic<bool>               m_alreadyDrained;
 
     std::unique_ptr<InProcessOptions> m_pConfig;
 
@@ -187,6 +187,8 @@ private:
 
     void
     StopClr();
+
+    void CallRequestsDrained();
 
     static
     void

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
@@ -18,7 +18,7 @@ OUT_OF_PROCESS_APPLICATION::OUT_OF_PROCESS_APPLICATION(
 
 OUT_OF_PROCESS_APPLICATION::~OUT_OF_PROCESS_APPLICATION()
 {
-    SRWExclusiveLock lock(m_stateLock);
+    SRWExclusiveLock lock(m_stopLock);
     if (m_pProcessManager != NULL)
     {
         m_pProcessManager->Shutdown();

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
@@ -51,8 +51,6 @@ __override
 VOID
 OUT_OF_PROCESS_APPLICATION::StopInternal(bool fServerInitiated)
 {
-    SRWExclusiveLock stopLock(m_stateLock);
-
     AppOfflineTrackingApplication::StopInternal(fServerInitiated);
 
     if (m_pProcessManager != NULL)

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
@@ -51,6 +51,8 @@ __override
 VOID
 OUT_OF_PROCESS_APPLICATION::StopInternal(bool fServerInitiated)
 {
+    SRWExclusiveLock stopLock(m_stateLock);
+
     AppOfflineTrackingApplication::StopInternal(fServerInitiated);
 
     if (m_pProcessManager != NULL)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
@@ -134,6 +134,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
                     }
                     catch
                     {
+                        Assert.Contains(TestSink.Writes, context => context.Message.Contains("Drained all requests, notifying managed."));
                         deploymentResult.AssertWorkerProcessStop();
                         return;
                     }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
@@ -218,7 +218,13 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
             AddAppOffline(deploymentResult.ContentRoot);
             await AssertAppOffline(deploymentResult);
-            DeletePublishOutput(deploymentResult);
+
+            // Files should eventually be unlocked, however when AppOffline returns, it doesn't necessarily mean 
+            RetryHelper.RetryOperation(
+                () => DeletePublishOutput(deploymentResult),
+                e => Logger.LogError($"Failed to delete published output: {e.Message}"),
+                retryCount: 3,
+                retryDelayMilliseconds: RetryDelay.Milliseconds);
         }
 
         [ConditionalTheory]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             {
                 var deploymentResult = await DeployApp(HostingModel.InProcess);
 
-                for (int i = 0; i < 100; i++)
+                for (int i = 0; i < 10; i++)
                 {
                     // send first request and add app_offline while app is starting
                     var runningTask = AssertAppOffline(deploymentResult);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             await deploymentResult.AssertRecycledAsync(() => AssertAppOffline(deploymentResult));
         }
 
-        [ConditionalFact(Skip = "https://github.com/aspnet/AspNetCore/issues/6555")]
+        [ConditionalFact]
         [RequiresIIS(IISCapability.ShutdownToken)]
         public async Task AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess()
         {
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             {
                 var deploymentResult = await DeployApp(HostingModel.InProcess);
 
-                for (int i = 0; i < 10; i++)
+                for (int i = 0; i < 100; i++)
                 {
                     // send first request and add app_offline while app is starting
                     var runningTask = AssertAppOffline(deploymentResult);
@@ -140,7 +140,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
                 }
 
                 Assert.True(false);
-
             }
         }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AppOfflineTests.cs
@@ -79,11 +79,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             AddAppOffline(deploymentResult.ContentRoot);
 
             await AssertAppOffline(deploymentResult);
-            RetryHelper.RetryOperation(
-                () => DeletePublishOutput(deploymentResult),
-                e => Logger.LogError($"Failed to delete published output: {e.Message}"),
-                retryCount: 3,
-                retryDelayMilliseconds: RetryDelay.Milliseconds);
+            DeletePublishOutput(deploymentResult);
         }
 
         [ConditionalFact(Skip = "https://github.com/aspnet/IISIntegration/issues/933")]
@@ -161,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         public async Task GracefulShutdownWorksWithMultipleRequestsInFlight_InProcess()
         {
             var deploymentParameters = _fixture.GetBaseDeploymentParameters(_fixture.InProcessTestSite);
-            deploymentParameters.TransformArguments((a, _) => $"{a} RemoveShutdownLimit");
+            deploymentParameters.TransformArguments((a, _) => $"{a} IncreaseShutdownLimit");
 
             var deploymentResult = await DeployAsync(deploymentParameters);
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/EventLogHelpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/EventLogHelpers.cs
@@ -172,6 +172,11 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             }
         }
 
+        public static string InProcessShutdown()
+        {
+            return "Application 'MACHINE/WEBROOT/APPHOST/.*?' has shutdown.";
+        }
+
         public static string InProcessFailedToStop(IISDeploymentResult deploymentResult, string reason)
         {
             return "Failed to gracefully shutdown application 'MACHINE/WEBROOT/APPHOST/.*?'.";

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISCapability.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISCapability.cs
@@ -12,11 +12,10 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         Websockets = 1,
         WindowsAuthentication = 2,
         PoolEnvironmentVariables = 4,
-        ShutdownToken = 8,
-        DynamicCompression = 16,
-        ApplicationInitialization = 32,
-        TracingModule = 64,
-        FailedRequestTracingModule = 128,
-        BasicAuthentication = 256
+        DynamicCompression = 8,
+        ApplicationInitialization = 16,
+        TracingModule = 32,
+        FailedRequestTracingModule = 64,
+        BasicAuthentication = 128
     }
 }

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/RequiresIISAttribute.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/RequiresIISAttribute.cs
@@ -124,12 +124,6 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                 }
             }
 
-            if (capabilities.HasFlag(IISCapability.ShutdownToken))
-            {
-                IsMet = false;
-                SkipReason += "https://github.com/aspnet/IISIntegration/issues/1074";
-            }
-
             foreach (var module in Modules)
             {
                 if (capabilities.HasFlag(module.Capability))

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -64,6 +64,18 @@ namespace TestSite
                         Thread.Sleep(Timeout.Infinite);
                     }
                     break;
+                case "RemoveShutdownLimit":
+                    {
+                        var host = new WebHostBuilder()
+                           .UseIIS()
+                            .UseShutdownTimeout(TimeSpan.FromSeconds(120))
+                           .UseStartup<Startup>()
+                           .Build();
+
+                        host.Run();
+                    }
+
+                    break;
                 case "CheckConsoleFunctions":
                     // Call a bunch of console functions and make sure none return invalid handle.
                     Console.OutputEncoding = Encoding.UTF8;

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -64,11 +64,11 @@ namespace TestSite
                         Thread.Sleep(Timeout.Infinite);
                     }
                     break;
-                case "RemoveShutdownLimit":
+                case "IncreaseShutdownLimit":
                     {
                         var host = new WebHostBuilder()
                            .UseIIS()
-                            .UseShutdownTimeout(TimeSpan.FromSeconds(120))
+                           .UseShutdownTimeout(TimeSpan.FromSeconds(120))
                            .UseStartup<Startup>()
                            .Build();
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -294,11 +294,7 @@ namespace TestSite
             await ctx.Response.WriteAsync(_requestsInFlight.ToString());
 
             var readBuffer = new byte[1];
-            var result = await ctx.Request.Body.ReadAsync(readBuffer, 0, 1);
-            while (result != 0)
-            {
-                result = await ctx.Request.Body.ReadAsync(readBuffer, 0, 1);
-            }
+            await ctx.Request.Body.ReadAsync(readBuffer, 0, 1);
 
             await ctx.Response.WriteAsync("done");
             Interlocked.Decrement(ref _requestsInFlight);

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -221,6 +221,12 @@ namespace TestSite
             await ctx.Response.WriteAsync("Hello World");
         }
 
+        private async Task HelloWorldDelayed(HttpContext ctx)
+        {
+            await ctx.Request.Body.ReadAsync(new byte[1]);
+            await ctx.Response.WriteAsync("Hello World");
+        }
+
         private async Task LargeResponseBody(HttpContext ctx)
         {
             if (int.TryParse(ctx.Request.Query["length"], out var length))

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -24,12 +24,13 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
         private const string DetailedErrorsEnvironmentVariable = "ASPNETCORE_DETAILEDERRORS";
 
         private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
-        private static readonly TimeSpan _retryDelay = TimeSpan.FromMilliseconds(200);
+        private static readonly TimeSpan _retryDelay = TimeSpan.FromMilliseconds(500);
 
         private CancellationTokenSource _hostShutdownToken = new CancellationTokenSource();
 
         private string _configPath;
         private string _debugLogFile;
+        private bool _disposed;
 
         public Process HostProcess { get; set; }
 
@@ -45,6 +46,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
         public override void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
             Dispose(gracefulShutdown: false);
         }
 

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -452,7 +452,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
                 retryCount++;
                 Thread.Sleep(delay);
-                delay *= 2;
+                delay *= 1.5;
             }
 
             throw new AggregateException($"Operation did not succeed after {retryCount} retries", exceptions.ToArray());

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
         private const string DetailedErrorsEnvironmentVariable = "ASPNETCORE_DETAILEDERRORS";
 
         private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
-        private static readonly TimeSpan _retryDelay = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan _retryDelay = TimeSpan.FromMilliseconds(100);
 
         private CancellationTokenSource _hostShutdownToken = new CancellationTokenSource();
 
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             {
                 return;
             }
+
             _disposed = true;
             Dispose(gracefulShutdown: false);
         }
@@ -426,6 +427,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             List<Exception> exceptions = null;
             var sw = Stopwatch.StartNew();
             int retryCount = 0;
+            var delay = _retryDelay;
 
             while (sw.Elapsed < _timeout)
             {
@@ -449,7 +451,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
                 }
 
                 retryCount++;
-                Thread.Sleep(_retryDelay);
+                Thread.Sleep(delay);
+                delay *= 2;
             }
 
             throw new AggregateException($"Operation did not succeed after {retryCount} retries", exceptions.ToArray());


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/6555
The reason an invalid return code was being thrown was due to an issue with our request draining logic which always caused the server to ungracefully shutdown. The return code was due to an invalid handle with console logging.
