### PR TITLE
[BRT] Mitigating flaky SignalR tests

### DIFF
--- a/eng/targets/Cpp.Common.targets
+++ b/eng/targets/Cpp.Common.targets
@@ -13,6 +13,7 @@
   <Target Name="Restore" />
   <Target Name="ResolveNuGetPackageAssets" />
   <Target Name="Test" Condition="'$(IsTestProject)' == 'true'" >
-    <Exec Command="&quot;$(TargetPath)&quot;" />
+    <Warning Condition="'$(TestProjectSkipReason)' != ''" Text="Skipped $(MSBuildProjectFileName): $(TestProjectSkipReason)" />
+    <Exec Condition="'$(TestProjectSkipReason)' == ''" Command="&quot;$(TargetPath)&quot;" />
   </Target>
 </Project>

--- a/src/SignalR/clients/cpp/test/signalrclienttests/Build/VS/signalrclienttests.vcxproj
+++ b/src/SignalR/clients/cpp/test/signalrclienttests/Build/VS/signalrclienttests.vcxproj
@@ -95,5 +95,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
+    <TestProjectSkipReason>Flaky, due to https://github.com/aspnet/AspNetCore/issues/8421</TestProjectSkipReason>
   </PropertyGroup>
 </Project>

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1227,9 +1227,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 yield return new object[] { HttpTransportType.WebSockets };
             }
             yield return new object[] { HttpTransportType.ServerSentEvents };
-
-            // Disabled due to: https://github.com/aspnet/AspNetCore/issues/6597
-            //yield return new object[] { HttpTransportType.LongPolling };
+            yield return new object[] { HttpTransportType.LongPolling };
         }
     }
 }

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     var cts = new CancellationTokenSource();
                     cts.Cancel();
 
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>connection.StreamAsChannelAsync<int>("Stream", 5, cts.Token).OrTimeout());
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => connection.StreamAsChannelAsync<int>("Stream", 5, cts.Token).OrTimeout());
                 }
                 catch (Exception ex)
                 {
@@ -1227,7 +1227,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 yield return new object[] { HttpTransportType.WebSockets };
             }
             yield return new object[] { HttpTransportType.ServerSentEvents };
-            yield return new object[] { HttpTransportType.LongPolling };
+
+            // Disabled due to: https://github.com/aspnet/AspNetCore/issues/6597
+            //yield return new object[] { HttpTransportType.LongPolling };
         }
     }
 }


### PR DESCRIPTION
mitigates:
* #8421 - SignalR C++ Client tests failing randomly
* #6597 - Flakiness in SignalR Long Polling Tests