### PR TITLE
Fix for deletion of tempdata cookie with __Host as prefix

### DIFF
--- a/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
+++ b/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
@@ -285,6 +285,7 @@ namespace Microsoft.AspNetCore.Internal
                     Path = options.Path,
                     Domain = options.Domain,
                     SameSite = options.SameSite,
+                    Secure = options.Secure,
                     IsEssential = options.IsEssential,
                     Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                 });
@@ -300,6 +301,7 @@ namespace Microsoft.AspNetCore.Internal
                         Path = options.Path,
                         Domain = options.Domain,
                         SameSite = options.SameSite,
+                        Secure = options.Secure,
                         IsEssential = options.IsEssential,
                         Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                     });


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Ensure secure flag is retained when deleting a cookie

Addresses #8426

I won't be signing the CLA, if this is required for a PR to be merged feel free to close this PR and just copy the changes.
It would be great if this could also be fixed on 2.1 LTS.