### PR TITLE
Restore MvcJsonOptions

### DIFF
--- a/src/Mvc/Mvc.Formatters.Json/src/Microsoft.AspNetCore.Mvc.Formatters.Json.csproj
+++ b/src/Mvc/Mvc.Formatters.Json/src/Microsoft.AspNetCore.Mvc.Formatters.Json.csproj
@@ -10,5 +10,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
   </ItemGroup>
 </Project>

--- a/src/Mvc/Mvc.Formatters.Json/src/Properties/AssemblyInfo.cs
+++ b/src/Mvc/Mvc.Formatters.Json/src/Properties/AssemblyInfo.cs
@@ -5,4 +5,4 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc;
 
 [assembly: TypeForwardedTo(typeof(JsonResult))]
-
+[assembly: TypeForwardedTo(typeof(MvcJsonOptions))]

--- a/src/Mvc/Mvc.NewtonsoftJson/src/DependencyInjection/MvcJsonOptionsSetup.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/DependencyInjection/MvcJsonOptionsSetup.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Sets up options for <see cref="MvcJsonOptions"/>.
+    /// </summary>
+    internal class MvcJsonOptionsSetup : IConfigureOptions<MvcNewtonsoftJsonOptions>
+    {
+        private readonly MvcJsonOptions _jsonOptions;
+
+        public MvcJsonOptionsSetup(IOptions<MvcJsonOptions> jsonOptions)
+        {
+            if (jsonOptions == null)
+            {
+                throw new ArgumentNullException(nameof(jsonOptions));
+            }
+
+            _jsonOptions = jsonOptions.Value;
+        }
+
+        public void Configure(MvcNewtonsoftJsonOptions options)
+        {
+            // Allow MvcJsonOptions to proxy MvcNewtonsoftJsonOptions for back-compat.
+            // See https://github.com/aspnet/AspNetCore/issues/8254
+            _jsonOptions.Proxy = options;
+        }
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Mvc/Mvc.NewtonsoftJson/src/DependencyInjection/NewtonsoftJsonMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/DependencyInjection/NewtonsoftJsonMvcCoreBuilderExtensions.cs
@@ -72,6 +72,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, NewtonsoftJsonMvcOptionsSetup>());
             services.TryAddEnumerable(
+                ServiceDescriptor.Transient<IConfigureOptions<MvcNewtonsoftJsonOptions>, MvcJsonOptionsSetup>());
+            services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IApiDescriptionProvider, JsonPatchOperationsArrayProvider>());
             services.TryAddSingleton<IActionResultExecutor<JsonResult>, JsonResultExecutor>();
 

--- a/src/Mvc/Mvc.NewtonsoftJson/src/MvcJsonOptions.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/MvcJsonOptions.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Provides programmatic configuration for JSON in the MVC framework.
+    /// </summary>
+    [Obsolete("This class is obsolete. Use the MvcNewtonsoftJsonOptions class instead.")]
+    public class MvcJsonOptions : IEnumerable<ICompatibilitySwitch>
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="MvcJsonOptions"/>.
+        /// </summary>
+        public MvcJsonOptions()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a flag to determine whether error messages from JSON deserialization by the
+        /// will be added to the <see cref="ModelStateDictionary"/>. If <see langword="false"/>, a
+        /// generic error message will be used instead.
+        /// </summary>
+        /// <value>
+        /// The default value is <see langword="true"/>.
+        /// </value>
+        /// <remarks>
+        /// Error messages in the <see cref="ModelStateDictionary"/> are often communicated to clients, either in HTML
+        /// or using <see cref="BadRequestObjectResult"/>. In effect, this setting controls whether clients can receive
+        /// detailed error messages about submitted JSON data.
+        /// </remarks>
+        [Obsolete("This property is obsolete. Use the MvcNewtonsoftJsonOptions.AllowInputFormatterExceptionMessages property instead.")]
+        public bool AllowInputFormatterExceptionMessages
+        {
+            get => Proxy.AllowInputFormatterExceptionMessages;
+            set => Proxy.AllowInputFormatterExceptionMessages = value;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JsonSerializerSettings"/> that are used by this application.
+        /// </summary>
+        [Obsolete("This property is obsolete. Use the MvcNewtonsoftJsonOptions.SerializerSettings property instead.")]
+        public JsonSerializerSettings SerializerSettings => Proxy.SerializerSettings;
+
+        /// <summary>
+        /// Gets or sets the <see cref="MvcNewtonsoftJsonOptions"/> to proxy values for.
+        /// </summary>
+        internal MvcNewtonsoftJsonOptions Proxy { get; set; }
+
+        IEnumerator<ICompatibilitySwitch> IEnumerable<ICompatibilitySwitch>.GetEnumerator()
+        {
+            return ((IEnumerable<ICompatibilitySwitch>)Proxy).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<ICompatibilitySwitch>)Proxy).GetEnumerator();
+    }
+}

--- a/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
+++ b/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
@@ -12,7 +12,6 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Cors" />
     <Reference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Localization" />
     <Reference Include="Microsoft.AspNetCore.Mvc.RazorPages" />
     <Reference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />


### PR DESCRIPTION
Restore the `MvcJsonOptions` type as a type-forwarded proxy for backwards compatibility with libraries such as NSwag and Swashbuckle.AspNetCore.

This is mainly just a jumping off point for some discussion, as I don't think I've got the references quite right. The application would also _have_ to reference `Microsoft.AspNetCore.Mvc.NewtonsoftJson` to fix the runtime exception, rather than it just coming for free with MVC itself.

Addresses #8254.
