### PR TITLE
Fix for #7729 to ensure upgradable bundles

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -16,7 +16,7 @@
         <RelatedBundle Action="Upgrade" Id="{EC5CFEAE-D169-3A4A-AA09-F446BBC39AD9}"/>
         <RelatedBundle Action="Upgrade" Id="{1D6E2BA3-B920-3C74-8F3E-F38E6097A297}"/>
         <RelatedBundle Action="Upgrade" Id="{D73B587E-7C85-3418-9B07-6A8469CF7E94}"/>
-        <?elseif $(var.Platform=x64?>
+        <?elseif $(var.Platform)=x64?>
         <RelatedBundle Action="Upgrade" Id="{F5C19B0F-77DF-3353-96D9-3F398FA38CF7}"/>
         <RelatedBundle Action="Upgrade" Id="{DFC9DEC7-307D-39B5-AF9C-4E8CE923B1BA}"/>
         <RelatedBundle Action="Upgrade" Id="{FDCA5106-C69E-34BB-A3B8-A24ADD0B4769}"/>

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-    <Bundle Name="$(var.BundleName)" Version="$(var.Version)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
+    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
             dep:ProviderKey="$(var.BundleProviderKey)">
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=320539"
@@ -9,6 +9,19 @@
                                                     ThemeFile="thm.xml"
                                                     LocalizationFile="thm.wxl"/>
         </BootstrapperApplicationRef>
+
+        <!-- Ensure upgrades from 3.0.0 preview 1, 2, and 3. Conditioned for the 3.0.0 family. -->
+        <?if $(var.Version)=3.0.0.0?>
+        <?if $(var.Platform)=x86?>
+        <RelatedBundle Action="Upgrade" Id="{EC5CFEAE-D169-3A4A-AA09-F446BBC39AD9}"/>
+        <RelatedBundle Action="Upgrade" Id="{1D6E2BA3-B920-3C74-8F3E-F38E6097A297}"/>
+        <RelatedBundle Action="Upgrade" Id="{D73B587E-7C85-3418-9B07-6A8469CF7E94}"/>
+        <?elseif $(var.Platform=x64?>
+        <RelatedBundle Action="Upgrade" Id="{F5C19B0F-77DF-3353-96D9-3F398FA38CF7}"/>
+        <RelatedBundle Action="Upgrade" Id="{DFC9DEC7-307D-39B5-AF9C-4E8CE923B1BA}"/>
+        <RelatedBundle Action="Upgrade" Id="{FDCA5106-C69E-34BB-A3B8-A24ADD0B4769}"/>
+        <?endif?>
+        <?endif?>
 
         <!-- Customizations of the default BA -->
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
      xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-    <Bundle Name="$(var.BundleName)" Version="$(var.Version)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
+    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
             dep:ProviderKey="$(var.BundleProviderKey)">
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=320539"
@@ -10,6 +10,13 @@
                                                     ThemeFile="thm.xml"
                                                     LocalizationFile="thm.wxl"/>
         </BootstrapperApplicationRef>
+
+        <!-- Ensure upgrades from 3.0.0 preview 1 and 2 (Preview 3 was not shipped). Conditioned for the 3.0.0 family. Hosting bundle simships x86/x64 so there's
+             a single set of upgrade codes. -->
+        <?if $(var.Version)=3.0.0.0?>
+        <RelatedBundle Action="Upgrade" Id="{D8BFC3A1-72B1-36C1-9E5A-49FE36A5563B}"/>
+        <RelatedBundle Action="Upgrade" Id="{EA47395A-BC9B-3ECC-8229-229BC9528DF6}"/>
+        <?endif?>
 
         <!-- Customizations of the default BA -->
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />

--- a/src/Installers/Windows/Wix.props
+++ b/src/Installers/Windows/Wix.props
@@ -1,7 +1,10 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Used for generating stable upgrade codes for bundles -->
     <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).0</Version>
+    <!-- Actual upgrade code used in bundles to ensure upgrades withing a version band, e.g. 3.0.0.xxx -->
+    <BundleVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(_BuildNumberShortDate)</BundleVersion>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Lang Condition="'$(Lang)' == ''">ENU</Lang>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -29,7 +29,9 @@
     <!-- Don't need to use the name of the bundle since we have separate namespace GUIDs. The name will also changes based on the milestone and destabalize
          the upgrade code. Bundle upgrades pivot on Major.Minor.Patch changes. For example, 3.0.1-preview 1 can upgrade to 3.0.1-preview 8, but 3.0.1
          cannot upgrade to 3.0.2 or 3.1. -->
-    <BundleGuidInputs>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)</BundleGuidInputs>
+    <PropertyGroup>
+      <BundleGuidInputs>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)</BundleGuidInputs>
+    </PropertyGroup>
     <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleGuidInputs)">
       <Output TaskParameter="Guid" PropertyName="BundleProviderKey" />
     </GenerateGuid>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -32,7 +32,7 @@
     <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)">
       <Output TaskParameter="Guid" PropertyName="BundleProviderKey" />
     </GenerateGuid>
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion);$(AspNetCorePatchVersion);Platform)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);Platform)">
       <Output TaskParameter="Guid" PropertyName="BundleUpgradeCode" />
     </GenerateGuid>
 

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -26,15 +26,18 @@
   </Target>
 
   <Target Name="_GenerateBundleGuids" Condition="'$(OutputType)' == 'bundle'">
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleNameShort);$(GuidInputs)">
+    <!-- Don't need to use the name of the bundle since we have separate namespace GUIDs. The name will also changes based on the milestone and destabalize
+         the upgrade code. Bundle upgrades pivot on Major.Minor.Patch changes. For example, 3.0.1-preview 1 can upgrade to 3.0.1-preview 8, but 3.0.1
+         cannot upgrade to 3.0.2 or 3.1. -->
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)">
       <Output TaskParameter="Guid" PropertyName="BundleProviderKey" />
     </GenerateGuid>
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleNameShort);$(GuidInputs);$(OutputType)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion);$(AspNetCorePatchVersion);Platform)">
       <Output TaskParameter="Guid" PropertyName="BundleUpgradeCode" />
     </GenerateGuid>
 
     <PropertyGroup>
-      <DefineConstants>$(DefineConstants);BundleProviderKey=$(BundleProviderKey);BundleUpgradeCode=$(BundleUpgradeCode)</DefineConstants>
+      <DefineConstants>$(DefineConstants);BundleVersion=$(BundleVersion);BundleProviderKey=$(BundleProviderKey);BundleUpgradeCode=$(BundleUpgradeCode)</DefineConstants>
     </PropertyGroup>
   </Target>
 

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -29,10 +29,11 @@
     <!-- Don't need to use the name of the bundle since we have separate namespace GUIDs. The name will also changes based on the milestone and destabalize
          the upgrade code. Bundle upgrades pivot on Major.Minor.Patch changes. For example, 3.0.1-preview 1 can upgrade to 3.0.1-preview 8, but 3.0.1
          cannot upgrade to 3.0.2 or 3.1. -->
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)">
+    <BundleGuidInputs>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)</BundleGuidInputs>
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleGuidInputs)">
       <Output TaskParameter="Guid" PropertyName="BundleProviderKey" />
     </GenerateGuid>
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);Platform)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleGuidInputs)">
       <Output TaskParameter="Guid" PropertyName="BundleUpgradeCode" />
     </GenerateGuid>
 


### PR DESCRIPTION
- Stabilize bundle UpgradeCodes to Major.Minor.Patch (split on x86, x64). 
- Add build version to the bundle version - this ensures higher generated version numbers, e.g. 3.0.0.10200 and 3.0.0.10250

Addresses #7729
