### PR TITLE
Skip Kestrel's InMemory.FunctionalTests on macOS

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Moq;
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class BadHttpRequestTests : LoggedTest
     {
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(InvalidRequestLineData))]
         public Task TestInvalidRequestLines(string request, string expectedExceptionMessage)
         {
@@ -27,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 expectedExceptionMessage);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(UnrecognizedHttpVersionData))]
         public Task TestInvalidRequestLinesWithUnrecognizedVersion(string httpVersion)
         {
@@ -37,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(httpVersion));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(InvalidRequestHeaderData))]
         public Task TestInvalidHeaders(string rawHeaders, string expectedExceptionMessage)
         {
@@ -47,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 expectedExceptionMessage);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("Hea\0der: value", "Invalid characters in header name.")]
         [InlineData("Header: va\0lue", "Malformed request: invalid headers.")]
         [InlineData("Head\x80r: value", "Invalid characters in header name.")]
@@ -60,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 expectedExceptionMessage);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("POST")]
         [InlineData("PUT")]
         public Task BadRequestIfMethodRequiresLengthButNoContentLengthOrTransferEncodingInRequest(string method)
@@ -71,7 +72,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_LengthRequired(method));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("POST")]
         [InlineData("PUT")]
         public Task BadRequestIfMethodRequiresLengthButNoContentLengthInHttp10Request(string method)
@@ -82,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_LengthRequiredHttp10(method));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("NaN")]
         [InlineData("-1")]
         public Task BadRequestIfContentLengthInvalid(string contentLength)
@@ -93,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_InvalidContentLength_Detail(contentLength));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("GET *", "OPTIONS")]
         [InlineData("GET www.host.com", "CONNECT")]
         public Task RejectsIncorrectMethods(string request, string allowedMethod)
@@ -105,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 $"Allow: {allowedMethod}");
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task BadRequestIfHostHeaderMissing()
         {
             return TestBadRequest(
@@ -114,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.BadRequest_MissingHostHeader);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task BadRequestIfMultipleHostHeaders()
         {
             return TestBadRequest("GET / HTTP/1.1\r\nHost: localhost\r\nHost: localhost\r\n\r\n",
@@ -122,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.BadRequest_MultipleHostHeaders);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(InvalidHostHeaderData))]
         public Task BadRequestIfHostHeaderDoesNotMatchRequestTarget(string requestTarget, string host)
         {
@@ -132,7 +133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_InvalidHostHeader_Detail(host.Trim()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task BadRequestFor10BadHostHeaderFormat()
         {
             return TestBadRequest(
@@ -141,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_InvalidHostHeader_Detail("a=b"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task BadRequestFor11BadHostHeaderFormat()
         {
             return TestBadRequest(
@@ -150,7 +151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 CoreStrings.FormatBadRequest_InvalidHostHeader_Detail("a=b"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BadRequestLogsAreNotHigherThanInformation()
         {
             using (var server = new TestServer(async context =>
@@ -174,7 +175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Contains(TestSink.Writes, w => w.EventId.Id == 17 && w.LogLevel == LogLevel.Information);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TestRequestSplitting()
         {
             using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory)))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/CertificateLoaderTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/CertificateLoaderTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class CertificateLoaderTests : LoggedTest
     {
-        [Theory]
+        [ConditionalTheory]
         [InlineData("no_extensions.pfx")]
         public void IsCertificateAllowedForServerAuth_AllowWithNoExtensions(string testCertName)
         {
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.True(CertificateLoader.IsCertificateAllowedForServerAuth(cert));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("eku.server.pfx")]
         [InlineData("eku.multiple_usages.pfx")]
         public void IsCertificateAllowedForServerAuth_ValidatesEnhancedKeyUsageOnCertificate(string testCertName)
@@ -39,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.True(CertificateLoader.IsCertificateAllowedForServerAuth(cert));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("eku.code_signing.pfx")]
         [InlineData("eku.client.pfx")]
         public void IsCertificateAllowedForServerAuth_RejectsCertificatesMissingServerEku(string testCertName)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -66,7 +67,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             await response.Body.WriteAsync(bytes, 0, bytes.Length);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10TransferEncoding()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -95,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10TransferEncodingPipes()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -124,7 +125,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10KeepAliveTransferEncoding()
         {
             var testContext = new TestServiceContext();
@@ -167,7 +168,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestBodyIsConsumedAutomaticallyIfAppDoesntConsumeItFully()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -222,7 +223,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TrailingHeadersAreParsed()
         {
             var requestCount = 10;
@@ -309,7 +310,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TrailingHeadersAreParsedWithPipe()
         {
             var requestCount = 10;
@@ -398,7 +399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 await server.StopAsync();
             }
         }
-        [Fact]
+        [ConditionalFact]
         public async Task TrailingHeadersCountTowardsHeadersTotalSizeLimit()
         {
             const string transferEncodingHeaderLine = "Transfer-Encoding: chunked";
@@ -443,7 +444,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TrailingHeadersCountTowardsHeaderCountLimit()
         {
             const string transferEncodingHeaderLine = "Transfer-Encoding: chunked";
@@ -485,7 +486,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ExtensionsAreIgnored()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -572,7 +573,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task InvalidLengthResultsIn400()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -616,7 +617,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task InvalidSizedDataResultsIn400()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -662,7 +663,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkedNotFinalTransferCodingResultsIn400()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -766,7 +767,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ClosingConnectionMidChunkPrefixThrows()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -815,7 +816,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkedRequestCallCancelPendingReadWorks()
         {
             var tcs = new TaskCompletionSource<object>();
@@ -873,7 +874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkedRequestCallCompleteThrowsExceptionOnRead()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -924,7 +925,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkedRequestCallCompleteWithExceptionCauses500()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class ChunkedResponseTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task ResponsesAreChunkedAutomatically()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -51,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponsesAreNotChunkedAutomaticallyForHttp10Requests()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -80,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponsesAreChunkedAutomaticallyForHttp11NonKeepAliveRequests()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -117,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SettingConnectionCloseHeaderInAppDoesNotDisableChunking()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -154,7 +155,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroLengthWritesAreIgnored()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -191,7 +192,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroLengthWritesFlushHeaders()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -236,7 +237,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task EmptyResponseBodyHandledCorrectlyWithZeroLengthWrite()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -267,7 +268,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionClosedIfExceptionThrownAfterWrite()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -301,7 +302,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionClosedIfExceptionThrownAfterZeroLengthWrite()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -334,7 +335,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WritesAreFlushedPriorToResponseCompletion()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -381,7 +382,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunksCanBeWrittenManually()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -421,7 +422,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunksWithGetMemoryAfterStartAsyncBeforeFirstFlushStillFlushes()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -467,7 +468,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunksWithGetMemoryBeforeFirstFlushStillFlushes()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -512,7 +513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunksWithGetMemoryLargeWriteBeforeFirstFlush()
         {
             var length = new IntAsRef();
@@ -568,7 +569,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunksWithGetMemoryAndStartAsyncWithInitialFlushWorks()
         {
             var length = new IntAsRef();
@@ -626,7 +627,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunksWithGetMemoryBeforeFlushEdgeCase()
         {
             var length = 0;
@@ -685,7 +686,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkGetMemoryMultipleAdvance()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -729,7 +730,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkGetSpanMultipleAdvance()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -778,7 +779,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkGetMemoryAndWrite()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -821,7 +822,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkGetMemoryAndWriteWithoutStart()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -863,7 +864,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GetMemoryWithSizeHint()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -904,7 +905,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GetMemoryWithSizeHintWithoutStartAsync()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -941,7 +942,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(15)]
         [InlineData(255)]
         public async Task ChunkGetMemoryWithoutStartWithSmallerSizesWork(int writeSize)
@@ -983,7 +984,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(15)]
         [InlineData(255)]
         public async Task ChunkGetMemoryWithStartWithSmallerSizesWork(int writeSize)
@@ -1024,7 +1025,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkedWithBothPipeAndStreamWorks()
         {
             using (var server = new TestServer(async httpContext =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -27,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 { TestApp.EchoAppPipeWriter }
             };
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(EchoAppRequestDelegates))]
         public async Task CanReadAndWriteWithRewritingConnectionAdapter(RequestDelegate requestDelegate)
         {
@@ -60,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(sendString.Length, adapter.BytesRead);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(EchoAppRequestDelegates))]
         public async Task CanReadAndWriteWithAsyncConnectionAdapter(RequestDelegate requestDelegate)
         {
@@ -91,7 +92,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(EchoAppRequestDelegates))]
         public async Task ImmediateFinAfterOnConnectionAsyncClosesGracefully(RequestDelegate requestDelegate)
         {
@@ -114,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(EchoAppRequestDelegates))]
         public async Task ImmediateFinAfterThrowingClosesGracefully(RequestDelegate requestDelegate)
         {
@@ -137,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [CollectDump]
         [MemberData(nameof(EchoAppRequestDelegates))]
         public async Task ImmediateShutdownAfterOnConnectionAsyncDoesNotCrash(RequestDelegate requestDelegate)
@@ -165,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ImmediateShutdownDuringOnConnectionAsyncDoesNotCrash()
         {
             var waitingConnectionAdapter = new WaitingConnectionAdapter();
@@ -195,7 +196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(EchoAppRequestDelegates))]
         public async Task ThrowingSynchronousConnectionAdapterDoesNotCrashServer(RequestDelegate requestDelegate)
         {
@@ -223,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains($"Uncaught exception from the {nameof(IConnectionAdapter.OnConnectionAsync)} method of an {nameof(IConnectionAdapter)}."));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CanFlushAsyncWithConnectionAdapter()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -257,7 +258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CanFlushAsyncWithConnectionAdapterPipeWriter()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class ConnectionLimitTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task ResetsCountWhenConnectionClosed()
         {
             var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             await releasedTcs.Task.DefaultTimeout();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UpgradedConnectionsCountsAgainstDifferentLimit()
         {
             using (var server = CreateServerWithMaxConnections(async context =>
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RejectsConnectionsWhenLimitReached()
         {
             const int max = 10;
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "https://github.com/aspnet/KestrelHttpServer/issues/2282")]
         public async Task ConnectionCountingReturnsToZero()
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/DefaultHeaderTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/DefaultHeaderTests.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class DefaultHeaderTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task TestDefaultHeaders()
         {
             var testContext = new TestServiceContext(LoggerFactory)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/EventSourceTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/EventSourceTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             _listener.EnableEvents(KestrelEventSource.Log, EventLevel.Verbose);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task EmitsConnectionStartAndStop()
         {
             string connectionId = null;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Moq;
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class Http2ConnectionTests : Http2TestBase
     {
-        [Fact]
+        [ConditionalFact]
         public async Task Frame_Received_OverMaxSize_FrameError()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -41,7 +42,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorFrameOverLimit(length, Http2PeerSettings.MinAllowedMaxFrameSize));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ServerSettings_ChangesRequestMaxFrameSize()
         {
             var length = Http2PeerSettings.MinAllowedMaxFrameSize + 10;
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_ReadByStream()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -99,7 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_MaxSize_ReadByStream()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -126,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_GreaterThanInitialWindowSize_ReadByStream()
         {
             var initialStreamWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialStreamWindowSize;
@@ -227,7 +228,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(updateSize, connectionWindowUpdateFrame1.WindowUpdateSizeIncrement);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_RightAtWindowLimit_DoesNotPausePipe()
         {
             var initialStreamWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialStreamWindowSize;
@@ -257,7 +258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_Multiple_ReadByStream()
         {
             await InitializeConnectionAsync(_bufferingApplication);
@@ -289,7 +290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_Multiplexed_ReadByStreams()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -355,7 +356,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_worldBytes.AsSpan().SequenceEqual(stream3DataFrame2.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_Multiplexed_GreaterThanInitialWindowSize_ReadByStream()
         {
             var initialStreamWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialStreamWindowSize;
@@ -471,7 +472,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(updateSize, connectionWindowUpdateFrame.WindowUpdateSizeIncrement);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_Multiplexed_AppMustNotBlockOtherFrames()
         {
             var stream1Read = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -540,7 +541,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(255)]
@@ -569,7 +570,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(255)]
@@ -641,7 +642,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(updateSize, connectionWindowUpdateFrame.WindowUpdateSizeIncrement);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_ButNotConsumedByApp_CountsTowardsInputFlowControl()
         {
             var initialConnectionWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize;
@@ -777,7 +778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(updateSize, connectionWindowUpdateFrame.WindowUpdateSizeIncrement);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_StreamIdZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -791,7 +792,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdZero(Http2FrameType.DATA));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_StreamIdEven_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -805,7 +806,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdEven(Http2FrameType.DATA, streamId: 2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_PaddingEqualToFramePayloadLength_ConnectionError()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -820,7 +821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorPaddingTooLong(Http2FrameType.DATA));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_PaddingGreaterThanFramePayloadLength_ConnectionError()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -835,7 +836,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorPaddingTooLong(Http2FrameType.DATA));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_FrameLengthZeroPaddingZero_ConnectionError()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -850,7 +851,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.DATA, expectedLength: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -865,7 +866,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.DATA, streamId: 1, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_StreamIdle_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -879,7 +880,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdle(Http2FrameType.DATA, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_StreamHalfClosedRemote_ConnectionError()
         {
             // Use _waitForAbortApplication so we know the stream will still be active when we send the illegal DATA frame
@@ -896,7 +897,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.DATA, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_StreamClosed_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -925,7 +926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_StreamClosedImplicitly_ConnectionError()
         {
             // http://httpwg.org/specs/rfc7540.html#rfc.section.5.1.1
@@ -957,7 +958,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_NoStreamWindowSpace_ConnectionError()
         {
             var initialWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialStreamWindowSize;
@@ -979,7 +980,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorFlowControlWindowExceeded);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_NoConnectionWindowSpace_ConnectionError()
         {
             var initialWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize;
@@ -1008,7 +1009,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorFlowControlWindowExceeded);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Sent_DespiteConnectionOutputFlowControl_IfEmptyAndEndsStream()
         {
             // Zero-length data frames are allowed to be sent even if there is no space available in the flow control window.
@@ -1093,7 +1094,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForAllStreamsAsync();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Sent_DespiteStreamOutputFlowControl_IfEmptyAndEndsStream()
         {
             // Zero-length data frames are allowed to be sent even if there is no space available in the flow control window.
@@ -1118,7 +1119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_Decoded()
         {
             await InitializeConnectionAsync(_readHeadersApplication);
@@ -1139,7 +1140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(255)]
@@ -1163,7 +1164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_WithPriority_Decoded()
         {
             await InitializeConnectionAsync(_readHeadersApplication);
@@ -1184,7 +1185,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(255)]
@@ -1208,7 +1209,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task HEADERS_Received_WithTrailers_Discarded(bool sendData)
@@ -1260,7 +1261,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_ContainsExpect100Continue_100ContinueSent()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -1292,7 +1293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_AppCannotBlockOtherFrames()
         {
             var firstRequestReceived = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1349,7 +1350,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_OverMaxStreamLimit_Refused()
         {
             CreateConnection();
@@ -1379,7 +1380,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_StreamIdZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1393,7 +1394,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdZero(Http2FrameType.HEADERS));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_StreamIdEven_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1407,7 +1408,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdEven(Http2FrameType.HEADERS, streamId: 2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_StreamClosed_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1437,7 +1438,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_StreamHalfClosedRemote_ConnectionError()
         {
             // Use _waitForAbortApplication so we know the stream will still be active when we send the illegal DATA frame
@@ -1454,7 +1455,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.HEADERS, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_StreamClosedImplicitly_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1480,7 +1481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(1)]
         [InlineData(255)]
         public async Task HEADERS_Received_PaddingEqualToFramePayloadLength_ConnectionError(byte padLength)
@@ -1497,7 +1498,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorPaddingTooLong(Http2FrameType.HEADERS));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_PaddingFieldMissing_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1511,7 +1512,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.HEADERS, expectedLength: 1));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(1, 2)]
         [InlineData(254, 255)]
         public async Task HEADERS_Received_PaddingGreaterThanFramePayloadLength_ConnectionError(int frameLength, byte padLength)
@@ -1527,7 +1528,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorPaddingTooLong(Http2FrameType.HEADERS));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1542,7 +1543,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.HEADERS, streamId: 3, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_WithPriority_StreamDependencyOnSelf_ConnectionError()
         {
             await InitializeConnectionAsync(_readHeadersApplication);
@@ -1556,7 +1557,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamSelfDependency(Http2FrameType.HEADERS, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_IncompleteHeaderBlock_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1570,7 +1571,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.HPackErrorIncompleteHeaderBlock);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_IntegerOverLimit_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1598,7 +1599,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.HPackErrorIntegerTooBig);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(IllegalTrailerData))]
         public async Task HEADERS_Received_WithTrailers_ContainsIllegalTrailer_ConnectionError(byte[] trailers, string expectedErrorMessage)
         {
@@ -1614,7 +1615,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: expectedErrorMessage);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(Http2HeadersFrameFlags.NONE)]
         [InlineData(Http2HeadersFrameFlags.END_HEADERS)]
         public async Task HEADERS_Received_WithTrailers_EndStreamNotSet_ConnectionError(Http2HeadersFrameFlags flags)
@@ -1631,7 +1632,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorHeadersWithTrailersNoEndStream);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(UpperCaseHeaderNameData))]
         public async Task HEADERS_Received_HeaderNameContainsUpperCaseCharacter_ConnectionError(byte[] headerBlock)
         {
@@ -1645,7 +1646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorHeaderNameUppercase);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_HeaderBlockContainsUnknownPseudoHeaderField_ConnectionError()
         {
             var headers = new[]
@@ -1659,7 +1660,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorUnknownPseudoHeaderField);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_HeaderBlockContainsResponsePseudoHeaderField_ConnectionError()
         {
             var headers = new[]
@@ -1673,14 +1674,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorResponsePseudoHeaderField);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(DuplicatePseudoHeaderFieldData))]
         public Task HEADERS_Received_HeaderBlockContainsDuplicatePseudoHeaderField_ConnectionError(IEnumerable<KeyValuePair<string, string>> headers)
         {
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorDuplicatePseudoHeaderField);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectMissingPseudoHeaderFieldData))]
         public async Task HEADERS_Received_HeaderBlockDoesNotContainMandatoryPseudoHeaderField_MethodIsCONNECT_NoError(IEnumerable<KeyValuePair<string, string>> headers)
         {
@@ -1700,7 +1701,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(PseudoHeaderFieldAfterRegularHeadersData))]
         public Task HEADERS_Received_HeaderBlockContainsPseudoHeaderFieldAfterRegularHeaders_ConnectionError(IEnumerable<KeyValuePair<string, string>> headers)
         {
@@ -1718,7 +1719,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: expectedErrorMessage);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(MissingPseudoHeaderFieldData))]
         public async Task HEADERS_Received_HeaderBlockDoesNotContainMandatoryPseudoHeaderField_StreamError(IEnumerable<KeyValuePair<string, string>> headers)
         {
@@ -1739,7 +1740,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_HeaderBlockOverLimit_ConnectionError()
         {
             // > 32kb
@@ -1761,7 +1762,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_HeadersExceedMaxTotalSize);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_TooManyHeaders_ConnectionError()
         {
             // > MaxRequestHeaderCount (100)
@@ -1780,7 +1781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_TooManyHeaders);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_InvalidCharacters_ConnectionError()
         {
             var headers = new[]
@@ -1794,7 +1795,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_MalformedRequestInvalidHeaders);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_HeaderBlockContainsConnectionHeader_ConnectionError()
         {
             var headers = new[]
@@ -1808,7 +1809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.Http2ErrorConnectionSpecificHeaderField);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsNotTrailers_ConnectionError()
         {
             var headers = new[]
@@ -1822,7 +1823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.Http2ErrorConnectionSpecificHeaderField);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsTrailers_NoError()
         {
             var headers = new[]
@@ -1849,7 +1850,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PRIORITY_Received_StreamIdZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1863,7 +1864,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdZero(Http2FrameType.PRIORITY));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PRIORITY_Received_StreamIdEven_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1877,7 +1878,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdEven(Http2FrameType.PRIORITY, streamId: 2));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(4)]
         [InlineData(6)]
         public async Task PRIORITY_Received_LengthNotFive_ConnectionError(int length)
@@ -1893,7 +1894,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.PRIORITY, expectedLength: 5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PRIORITY_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1908,7 +1909,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.PRIORITY, streamId: 1, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PRIORITY_Received_StreamDependencyOnSelf_ConnectionError()
         {
             await InitializeConnectionAsync(_readHeadersApplication);
@@ -1922,7 +1923,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamSelfDependency(Http2FrameType.PRIORITY, 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_ContinuesAppsAwaitingConnectionOutputFlowControl()
         {
             var writeTasks = new Task[4];
@@ -2042,7 +2043,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Contains(3, _abortedStreamIds);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_ContinuesAppsAwaitingStreamOutputFlowControl()
         {
             var writeTasks = new Task[6];
@@ -2126,7 +2127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Contains(5, _abortedStreamIds);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_ReturnsSpaceToConnectionInputFlowControlWindow()
         {
             var initialConnectionWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize;
@@ -2160,7 +2161,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(updateSize, connectionWindowUpdateFrame.WindowUpdateSizeIncrement);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_StreamIdZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2174,7 +2175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdZero(Http2FrameType.RST_STREAM));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_StreamIdEven_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2188,7 +2189,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdEven(Http2FrameType.RST_STREAM, streamId: 2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_StreamIdle_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2202,7 +2203,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdle(Http2FrameType.RST_STREAM, streamId: 1));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(3)]
         [InlineData(5)]
         public async Task RST_STREAM_Received_LengthNotFour_ConnectionError(int length)
@@ -2221,7 +2222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.RST_STREAM, expectedLength: 4));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2237,7 +2238,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         // Compare to h2spec http2/5.1/8
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_IncompleteRequest_AdditionalDataFrames_ConnectionAborted()
         {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2261,7 +2262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.DATA, 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_IncompleteRequest_AdditionalTrailerFrames_ConnectionAborted()
         {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2285,7 +2286,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.HEADERS, 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_IncompleteRequest_AdditionalResetFrame_ConnectionAborted()
         {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2308,7 +2309,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.RST_STREAM, 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_IncompleteRequest_AdditionalWindowUpdateFrame_ConnectionAborted()
         {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2331,7 +2332,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.WINDOW_UPDATE, 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_KestrelDefaults_Sent()
         {
             CreateConnection();
@@ -2377,7 +2378,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Custom_Sent()
         {
             CreateConnection();
@@ -2427,7 +2428,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_Sends_ACK()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2435,7 +2436,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_ACK_Received_DoesNotSend_ACK()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2448,7 +2449,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_StreamIdNotZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2462,7 +2463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdNotZero(Http2FrameType.SETTINGS));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(Http2SettingsParameter.SETTINGS_ENABLE_PUSH, 2, Http2ErrorCode.PROTOCOL_ERROR)]
         [InlineData(Http2SettingsParameter.SETTINGS_ENABLE_PUSH, uint.MaxValue, Http2ErrorCode.PROTOCOL_ERROR)]
         [InlineData(Http2SettingsParameter.SETTINGS_INITIAL_WINDOW_SIZE, (uint)int.MaxValue + 1, Http2ErrorCode.FLOW_CONTROL_ERROR)]
@@ -2485,7 +2486,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorSettingsParameterOutOfRange(parameter));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2500,7 +2501,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.SETTINGS, streamId: 0, headersStreamId: 1));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(1)]
         [InlineData(16 * 1024 - 9)] // Min. max. frame size minus header length
         public async Task SETTINGS_Received_WithACK_LengthNotZero_ConnectionError(int length)
@@ -2516,7 +2517,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorSettingsAckLengthNotZero);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(1)]
         [InlineData(5)]
         [InlineData(7)]
@@ -2535,7 +2536,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorSettingsLengthNotMultipleOfSix);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_WithInitialWindowSizePushingStreamWindowOverMax_ConnectionError()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -2559,7 +2560,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorInitialWindowSizeInvalid);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_ChangesAllowedResponseMaxFrameSize()
         {
             CreateConnection();
@@ -2616,7 +2617,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_ClientMaxFrameSizeCannotExceedServerMaxFrameSize()
         {
             var serverMaxFrame = Http2PeerSettings.MinAllowedMaxFrameSize + 1024;
@@ -2655,7 +2656,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SETTINGS_Received_ChangesHeaderTableSize()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2673,7 +2674,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PUSH_PROMISE_Received_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2687,7 +2688,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorPushPromiseReceived);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PING_Received_SendsACK()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2701,7 +2702,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PING_Received_WithACK_DoesNotSendACK()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2711,7 +2712,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PING_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2726,7 +2727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.PING, streamId: 0, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PING_Received_StreamIdNotZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2740,7 +2741,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdNotZero(Http2FrameType.PING));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(7)]
@@ -2758,7 +2759,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.PING, expectedLength: 8));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GOAWAY_Received_ConnectionStops()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -2768,7 +2769,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionStopAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GOAWAY_Received_SetsConnectionStateToClosingAndWaitForAllStreamsToComplete()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -2814,7 +2815,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _closedStateReached.Task.DefaultTimeout();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GOAWAY_Received_ContinuesAppsAwaitingConnectionOutputFlowControl()
         {
             var writeTasks = new Task[6];
@@ -2917,7 +2918,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Contains(5, _abortedStreamIds);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GOAWAY_Received_ContinuesAppsAwaitingStreamOutputFlowControl()
         {
             var writeTasks = new Task[6];
@@ -2994,7 +2995,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Contains(5, _abortedStreamIds);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GOAWAY_Received_StreamIdNotZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3008,7 +3009,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdNotZero(Http2FrameType.GOAWAY));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GOAWAY_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3023,7 +3024,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.GOAWAY, streamId: 0, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_StreamIdEven_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3037,7 +3038,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdEven(Http2FrameType.WINDOW_UPDATE, streamId: 2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3052,7 +3053,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.WINDOW_UPDATE, streamId: 1, headersStreamId: 1));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0, 3)]
         [InlineData(0, 5)]
         [InlineData(1, 3)]
@@ -3070,7 +3071,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.WINDOW_UPDATE, expectedLength: 4));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnConnection_SizeIncrementZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3084,7 +3085,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorWindowUpdateIncrementZero);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnStream_SizeIncrementZero_ConnectionError()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -3099,7 +3100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorWindowUpdateIncrementZero);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_StreamIdle_ConnectionError()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -3113,7 +3114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamIdle(Http2FrameType.WINDOW_UPDATE, streamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnConnection_IncreasesWindowAboveMaxValue_ConnectionError()
         {
             var maxIncrement = (int)(Http2PeerSettings.MaxWindowSize - Http2PeerSettings.DefaultInitialWindowSize);
@@ -3130,7 +3131,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.Http2ErrorWindowUpdateSizeInvalid);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnStream_IncreasesWindowAboveMaxValue_StreamError()
         {
             var maxIncrement = (int)(Http2PeerSettings.MaxWindowSize - Http2PeerSettings.DefaultInitialWindowSize);
@@ -3149,7 +3150,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnConnection_Respected()
         {
             var expectedFullFrameCountBeforeBackpressure = Http2PeerSettings.DefaultInitialWindowSize / _maxData.Length;
@@ -3240,7 +3241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnStream_Respected()
         {
             var initialWindowSize = _helloWorldBytes.Length / 2;
@@ -3281,7 +3282,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan(initialWindowSize, initialWindowSize).SequenceEqual(dataFrame2.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WINDOW_UPDATE_Received_OnStream_Respected_WhenInitialWindowSizeReducedMidStream()
         {
             // This only affects the stream windows. The connection-level window is always initialized at 64KiB.
@@ -3337,7 +3338,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan(9, 3).SequenceEqual(dataFrame3.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CONTINUATION_Received_Decoded()
         {
             await InitializeConnectionAsync(_readHeadersApplication);
@@ -3358,7 +3359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CONTINUATION_Received_WithTrailers_Discarded(bool sendData)
@@ -3419,7 +3420,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CONTINUATION_Received_StreamIdMismatch_ConnectionError()
         {
             await InitializeConnectionAsync(_readHeadersApplication);
@@ -3434,7 +3435,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(Http2FrameType.CONTINUATION, streamId: 3, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CONTINUATION_Received_IncompleteHeaderBlock_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3449,7 +3450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.HPackErrorIncompleteHeaderBlock);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(IllegalTrailerData))]
         public async Task CONTINUATION_Received_WithTrailers_ContainsIllegalTrailer_ConnectionError(byte[] trailers, string expectedErrorMessage)
         {
@@ -3466,7 +3467,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: expectedErrorMessage);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(MissingPseudoHeaderFieldData))]
         public async Task CONTINUATION_Received_HeaderBlockDoesNotContainMandatoryPseudoHeaderField_StreamError(IEnumerable<KeyValuePair<string, string>> headers)
         {
@@ -3489,7 +3490,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectMissingPseudoHeaderFieldData))]
         public async Task CONTINUATION_Received_HeaderBlockDoesNotContainMandatoryPseudoHeaderField_MethodIsCONNECT_NoError(IEnumerable<KeyValuePair<string, string>> headers)
         {
@@ -3510,7 +3511,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CONTINUATION_Sent_WhenHeadersLargerThanFrameLength()
         {
             await InitializeConnectionAsync(_largeHeadersApplication);
@@ -3554,7 +3555,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(_4kHeaderValue, _decodedHeaders["h"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UnknownFrameType_Received_Ignored()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3571,7 +3572,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(0, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UnknownFrameType_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3586,7 +3587,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedErrorMessage: CoreStrings.FormatHttp2ErrorHeadersInterleaved(frameType: 42, streamId: 1, headersStreamId: 1));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionErrorAbortsAllStreams()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -3611,7 +3612,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Contains(5, _abortedStreamIds);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionResetLoggedWithActiveStreams()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -3624,7 +3625,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is ConnectionResetException);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionResetNotLoggedWithNoActiveStreams()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -3635,7 +3636,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.DoesNotContain(TestApplicationErrorLogger.Messages, m => m.Exception is ConnectionResetException);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnInputOrOutputCompletedCompletesOutput()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3648,7 +3649,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(result.Buffer.IsEmpty);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AbortSendsFinalGOAWAY()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3659,7 +3660,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             VerifyGoAway(await ReceiveFrameAsync(), int.MaxValue, Http2ErrorCode.INTERNAL_ERROR);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CompletionSendsFinalGOAWAY()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -3671,7 +3672,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             VerifyGoAway(await ReceiveFrameAsync(), 0, Http2ErrorCode.NO_ERROR);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StopProcessingNextRequestSendsGracefulGOAWAYAndWaitsForStreamsToComplete()
         {
             var task = Task.CompletedTask;
@@ -3719,7 +3720,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(result.IsCompleted);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StopProcessingNextRequestSendsGracefulGOAWAYThenFinalGOAWAYWhenAllStreamsComplete()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -3751,7 +3752,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             VerifyGoAway(await ReceiveFrameAsync(), 1, Http2ErrorCode.NO_ERROR);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AcceptNewStreamsDuringClosingConnection()
         {
             await InitializeConnectionAsync(_echoApplication);
@@ -3797,7 +3798,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionStopAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task IgnoreNewStreamsDuringClosedConnection()
         {
             // Remove callback that completes _pair.Application.Output on abort.
@@ -3817,7 +3818,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(result.Buffer.IsEmpty);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void IOExceptionDuringFrameProcessingLoggedAsInfo()
         {
             CreateConnection();
@@ -3834,7 +3835,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Same(ioException, logMessage.Exception);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void UnexpectedExceptionDuringFrameProcessingLoggedAWarning()
         {
             CreateConnection();
@@ -3851,7 +3852,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Same(exception, logMessage.Exception);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(Http2FrameType.DATA)]
         [InlineData(Http2FrameType.WINDOW_UPDATE)]
         [InlineData(Http2FrameType.HEADERS)]
@@ -3904,7 +3905,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(Http2FrameType.DATA)]
         [InlineData(Http2FrameType.WINDOW_UPDATE)]
         [InlineData(Http2FrameType.HEADERS)]
@@ -3946,7 +3947,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(Http2FrameType.DATA)]
         [InlineData(Http2FrameType.HEADERS)]
         [InlineData(Http2FrameType.CONTINUATION)]
@@ -4019,7 +4020,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(Http2FrameType.DATA)]
         [InlineData(Http2FrameType.HEADERS)]
         public async Task AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterClientReset(Http2FrameType finalFrameType)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class Http2StreamTests : Http2TestBase
     {
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_EmptyMethod_Reset()
         {
             var headers = new[]
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_InvalidCustomMethod_Reset()
         {
             var headers = new[]
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_CustomMethod_Accepted()
         {
             var headers = new[]
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_CONNECTMethod_Accepted()
         {
             await InitializeConnectionAsync(_echoMethod);
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_OPTIONSStar_LeftOutOfPath()
         {
             await InitializeConnectionAsync(_echoPath);
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_OPTIONSSlash_Accepted()
         {
             await InitializeConnectionAsync(_echoPath);
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_PathAndQuery_Separated()
         {
             await InitializeConnectionAsync(context =>
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("/", "/")]
         [InlineData("/a%5E", "/a^")]
         [InlineData("/a%E2%82%AC", "/a€")]
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(HeaderNames.Path, "/")]
         [InlineData(HeaderNames.Scheme, "http")]
         public async Task HEADERS_Received_CONNECTMethod_WithSchemeOrPath_Reset(string headerName, string value)
@@ -289,7 +289,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_SchemeMismatch_Reset()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_MissingAuthority_200Status()
         {
             var headers = new[]
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_EmptyAuthority_200Status()
         {
             var headers = new[]
@@ -371,7 +371,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders["content-length"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_MissingAuthorityFallsBackToHost_200Status()
         {
             var headers = new[]
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("abc", _decodedHeaders[HeaderNames.Host]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_EmptyAuthorityIgnoredOverHost_200Status()
         {
             var headers = new[]
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("abc", _decodedHeaders[HeaderNames.Host]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_AuthorityOverridesHost_200Status()
         {
             var headers = new[]
@@ -475,7 +475,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("def", _decodedHeaders[HeaderNames.Host]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_AuthorityOverridesInvalidHost_200Status()
         {
             var headers = new[]
@@ -510,7 +510,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("def", _decodedHeaders[HeaderNames.Host]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_InvalidAuthority_Reset()
         {
             var headers = new[]
@@ -530,7 +530,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_InvalidAuthorityWithValidHost_Reset()
         {
             var headers = new[]
@@ -551,7 +551,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_TwoHosts_StreamReset()
         {
             var headers = new[]
@@ -572,7 +572,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_Received_MaxRequestLineSize_Reset()
         {
             // Default 8kb limit
@@ -594,7 +594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_SingleDataFrame_Verified()
         {
             var headers = new[]
@@ -635,7 +635,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_ReceivedInContinuation_SingleDataFrame_Verified()
         {
             await InitializeConnectionAsync(async context =>
@@ -680,7 +680,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_MultipleDataFrame_Verified()
         {
             var headers = new[]
@@ -728,7 +728,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_MultipleDataFrame_ReadViaPipe_Verified()
         {
             var headers = new[]
@@ -775,7 +775,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_MultipleDataFrame_ReadViaPipeAndStream_Verified()
         {
             var tcs = new TaskCompletionSource<object>();
@@ -832,7 +832,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_NoDataFrames_Reset()
         {
             var headers = new[]
@@ -851,7 +851,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_ReceivedInContinuation_NoDataFrames_Reset()
         {
             var headers = new[]
@@ -874,7 +874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_SingleDataFrameOverSize_Reset()
         {
             IOException thrownEx = null;
@@ -909,7 +909,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.IsType<Http2StreamErrorException>(thrownEx.InnerException);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_SingleDataFrameUnderSize_Reset()
         {
             IOException thrownEx = null;
@@ -944,7 +944,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.IsType<Http2StreamErrorException>(thrownEx.InnerException);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_MultipleDataFramesOverSize_Reset()
         {
             IOException thrownEx = null;
@@ -980,7 +980,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.IsType<Http2StreamErrorException>(thrownEx.InnerException);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Received_MultipleDataFramesUnderSize_Reset()
         {
             IOException thrownEx = null;
@@ -1064,7 +1064,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact] // TODO https://github.com/aspnet/AspNetCore/issues/7034
+        [ConditionalFact] // TODO https://github.com/aspnet/AspNetCore/issues/7034
         public async Task ContentLength_Response_FirstWriteMoreBytesWritten_Throws_Sends500()
         {
             var headers = new[]
@@ -1102,7 +1102,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("11", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Response_MoreBytesWritten_ThrowsAndResetsStream()
         {
             var headers = new[]
@@ -1141,7 +1141,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("11", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Response_NoBytesWritten_Sends500()
         {
             var headers = new[]
@@ -1179,7 +1179,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_Response_NoBytesWritten_Sends200()
         {
             var headers = new[]
@@ -1213,7 +1213,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_ContentLength_Response_NoBytesWritten_Sends200()
         {
             var headers = new[]
@@ -1249,7 +1249,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_OnStartingThrowsAfterStartAsyncIsCalled()
         {
             InvalidOperationException ex = null;
@@ -1288,7 +1288,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_StartsResponse()
         {
 
@@ -1324,7 +1324,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_WithoutFinalFlushDoesNotFlushUntilResponseEnd()
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1374,7 +1374,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_FlushStillFlushesBody()
         {
             var headers = new[]
@@ -1412,7 +1412,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_WithContentLengthAndEmptyWriteCallsFinalFlush()
         {
 
@@ -1450,7 +1450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_SingleWriteCallsFinalFlush()
         {
             var headers = new[]
@@ -1493,7 +1493,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_ContentLength_ThrowsException_DataIsFlushed_ConnectionReset()
         {
             var headers = new[]
@@ -1528,7 +1528,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("11", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsync_ThrowsException_DataIsFlushed()
         {
             var headers = new[]
@@ -1561,7 +1561,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLength_Response_TooFewBytesWritten_Resets()
         {
             var headers = new[]
@@ -1599,7 +1599,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("11", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task MaxRequestBodySize_ContentLengthUnder_200()
         {
             _serviceContext.ServerOptions.Limits.MaxRequestBodySize = 15;
@@ -1641,7 +1641,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task MaxRequestBodySize_ContentLengthOver_413()
         {
             BadHttpRequestException exception = null;
@@ -1690,7 +1690,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.NotNull(exception);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task MaxRequestBodySize_NoContentLength_Under_200()
         {
             _serviceContext.ServerOptions.Limits.MaxRequestBodySize = 15;
@@ -1731,7 +1731,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task MaxRequestBodySize_NoContentLength_Over_413()
         {
             BadHttpRequestException exception = null;
@@ -1781,7 +1781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.NotNull(exception);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task MaxRequestBodySize_AppCanLowerLimit(bool includeContentLength)
@@ -1843,7 +1843,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.NotNull(exception);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task MaxRequestBodySize_AppCanRaiseLimit(bool includeContentLength)
@@ -1896,7 +1896,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseTrailers_WithoutData_Sent()
         {
             await InitializeConnectionAsync(context =>
@@ -1934,7 +1934,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseTrailers_WithData_Sent()
         {
             await InitializeConnectionAsync(async context =>
@@ -1976,7 +1976,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseTrailers_WithContinuation_Sent()
         {
             var largeHeader = new string('a', 1024 * 3);
@@ -2042,7 +2042,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(largeHeader, _decodedHeaders["CustomName5"]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseTrailers_WithNonAscii_Throws()
         {
             await InitializeConnectionAsync(async context =>
@@ -2078,7 +2078,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseTrailers_TooLong_Throws()
         {
             await InitializeConnectionAsync(async context =>
@@ -2113,7 +2113,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Contains(CoreStrings.HPackErrorNotEnoughBuffer, message.Exception.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ApplicationException_BeforeFirstWrite_Sends500()
         {
             var headers = new[]
@@ -2150,7 +2150,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ApplicationException_AfterFirstWrite_Resets()
         {
             var headers = new[]
@@ -2187,7 +2187,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_AbortsStream()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -2200,7 +2200,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_AbortsStream_FlushedHeadersNotSent()
         {
             await InitializeConnectionAsync(_waitForAbortFlushingApplication);
@@ -2213,7 +2213,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_Received_AbortsStream_FlushedDataNotSent()
         {
             await InitializeConnectionAsync(_waitForAbortWithDataApplication);
@@ -2226,7 +2226,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_WaitingForRequestBody_RequestBodyThrows()
         {
             var sem = new SemaphoreSlim(0);
@@ -2268,7 +2268,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RST_STREAM_IncompleteRequest_RequestBodyThrows()
         {
             var sem = new SemaphoreSlim(0);
@@ -2312,7 +2312,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestAbort_SendsRstStream()
         {
             await InitializeConnectionAsync(async context =>
@@ -2352,7 +2352,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestAbort_AfterDataSent_SendsRstStream()
         {
             await InitializeConnectionAsync(async context =>
@@ -2404,7 +2404,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestAbort_ThrowsOperationCanceledExceptionFromSubsequentRequestBodyStreamRead()
         {
             OperationCanceledException thrownEx = null;
@@ -2431,7 +2431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(CoreStrings.ConnectionAbortedByApplication, thrownEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestAbort_ThrowsOperationCanceledExceptionFromOngoingRequestBodyStreamRead()
         {
             OperationCanceledException thrownEx = null;
@@ -2462,7 +2462,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         // Sync writes after async writes could block the write loop if the callback is not dispatched.
         // https://github.com/aspnet/KestrelHttpServer/issues/2878
-        [Fact]
+        [ConditionalFact]
         public async Task Write_DoesNotBlockWriteLoop()
         {
             const int windowSize = (int)Http2PeerSettings.DefaultMaxFrameSize;
@@ -2509,7 +2509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseWithHeadersTooLarge_AbortsConnection()
         {
             var appFinished = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2538,7 +2538,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 CoreStrings.HPackErrorNotEnoughBuffer);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_PreCancelledCancellationToken_DoesNotAbort()
         {
             var headers = new[]
@@ -2575,7 +2575,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_CancellationTokenTriggeredDueToFlowControl_SendRST()
         {
             var cts = new CancellationTokenSource();
@@ -2623,7 +2623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GetMemoryAdvance_Works()
         {
             var headers = new[]
@@ -2669,7 +2669,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GetMemoryAdvance_WithStartAsync_Works()
         {
             var headers = new[]
@@ -2715,7 +2715,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_GetMemoryLargeWriteBeforeFirstFlush()
         {
             var headers = new[]
@@ -2767,7 +2767,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(Encoding.ASCII.GetBytes(new string('a', 4102)), dataFrame.PayloadSequence.ToArray());
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_WithGetMemoryWithInitialFlushWorks()
         {
             var headers = new[]
@@ -2820,7 +2820,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(Encoding.ASCII.GetBytes(new string('a', 4102)), dataFrame.PayloadSequence.ToArray());
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_GetMemoryMultipleAdvance()
         {
             var headers = new[]
@@ -2866,7 +2866,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_GetSpanMultipleAdvance()
         {
             var headers = new[]
@@ -2916,7 +2916,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_GetMemoryAndWrite()
         {
             var headers = new[]
@@ -2962,7 +2962,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_GetMemoryWithSizeHintAlwaysReturnsSameSize()
         {
             var headers = new[]
@@ -3004,7 +3004,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_GetMemoryWithSizeHintAlwaysReturnsSameSizeStartAsync()
         {
             var headers = new[]
@@ -3047,7 +3047,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WriteAsync_BothPipeAndStreamWorks()
         {
             var headers = new[]
@@ -3111,7 +3111,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthWithGetSpanWorks()
         {
             var headers = new[]
@@ -3162,7 +3162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("12", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthWithGetMemoryWorks()
         {
             var headers = new[]
@@ -3208,7 +3208,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("12", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyCanWrite()
         {
             var headers = new[]
@@ -3248,7 +3248,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("12", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyAndResponsePipeWorks()
         {
             var headers = new[]
@@ -3312,7 +3312,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("54", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyPipeCompleteWithoutExceptionDoesNotThrow()
         {
             var headers = new[]
@@ -3347,7 +3347,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyPipeCompleteWithoutExceptionWritesDoNotThrow()
         {
             var headers = new[]
@@ -3384,7 +3384,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyPipeCompleteWithExceptionThrows()
         {
             var expectedException = new Exception();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class Http2TimeoutTests : Http2TestBase
     {
-        [Fact]
+        [ConditionalFact]
         public async Task Preamble_NotReceivedInitially_WithinKeepAliveTimeout_ClosesConnection()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockTimeoutHandler.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_NotReceivedInitially_WithinKeepAliveTimeout_ClosesConnection()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockTimeoutHandler.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_NotReceivedAfterFirstRequest_WithinKeepAliveTimeout_ClosesConnection()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockTimeoutHandler.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HEADERS_ReceivedWithoutAllCONTINUATIONs_WithinRequestHeadersTimeout_AbortsConnection()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseDrain_SlowerThanMinimumDataRate_AbortsConnection()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Theory(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1879")]
+        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1879")]
         [InlineData(Http2FrameType.DATA)]
         [InlineData(Http2FrameType.CONTINUATION)]
         public async Task AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires(Http2FrameType finalFrameType)
@@ -323,7 +323,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Sent_TooSlowlyDueToSocketBackPressureOnLargeWrite_AbortsConnectionAfterRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -381,7 +381,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Sent_TooSlowlyDueToFlowControlOnSmallWrite_AbortsConnectionAfterGracePeriod()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -435,7 +435,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Sent_TooSlowlyDueToOutputFlowControlOnLargeWrite_AbortsConnectionAfterRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -491,7 +491,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Sent_TooSlowlyDueToOutputFlowControlOnMultipleStreams_AbortsConnectionAfterAdditiveRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_TooSlowlyOnSmallRead_AbortsConnectionAfterGracePeriod()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -608,7 +608,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_TooSlowlyOnLargeRead_AbortsConnectionAfterRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -661,7 +661,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_TooSlowlyOnMultipleStreams_AbortsConnectionAfterAdditiveRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -730,7 +730,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_TooSlowlyOnSecondStream_AbortsConnectionAfterNonAdditiveRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -800,7 +800,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DATA_Received_SlowlyDueToConnectionFlowControl_DoesNotAbortConnection()
         {
             var initialConnectionWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -16,25 +17,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class HttpProtocolSelectionTests : TestApplicationErrorLoggerLoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public Task Server_NoProtocols_Error()
         {
             return TestError<InvalidOperationException>(HttpProtocols.None, CoreStrings.EndPointRequiresAtLeastOneProtocol);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task Server_Http1AndHttp2_Cleartext_Http1Default()
         {
             return TestSuccess(HttpProtocols.Http1AndHttp2, "GET / HTTP/1.1\r\nHost:\r\n\r\n", "HTTP/1.1 200 OK");
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task Server_Http1Only_Cleartext_Success()
         {
             return TestSuccess(HttpProtocols.Http1, "GET / HTTP/1.1\r\nHost:\r\n\r\n", "HTTP/1.1 200 OK");
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task Server_Http2Only_Cleartext_Success()
         {
             // Expect a SETTINGS frame with default settings then a connection-level WINDOW_UPDATE frame.

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionAdapterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
         private static X509Certificate2 _x509Certificate2NoExt = TestResources.GetTestCertificate("no_extensions.pfx");
 
-        [Fact]
+        [ConditionalFact]
         public async Task CanReadAndWriteWithHttpsConnectionAdapter()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HandshakeDetailsAreAvailable()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequireCertificateFailsWhenNoCertificate()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AllowCertificateContinuesWhenNoCertificate()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void ThrowsWhenNoServerCertificateIsProvided()
         {
             Assert.Throws<ArgumentException>(() => new HttpsConnectionAdapter(
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 );
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UsesProvidedServerCertificate()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UsesProvidedServerCertificateSelector()
         {
             var selectorCalled = 0;
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UsesProvidedServerCertificateSelectorEachTime()
         {
             var selectorCalled = 0;
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UsesProvidedServerCertificateSelectorValidatesEkus()
         {
             var selectorCalled = 0;
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UsesProvidedServerCertificateSelectorOverridesServerCertificate()
         {
             var selectorCalled = 0;
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UsesProvidedServerCertificateSelectorFailsIfYouReturnNull()
         {
             var selectorCalled = 0;
@@ -368,7 +368,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(HttpProtocols.Http1)]
         [InlineData(HttpProtocols.Http1AndHttp2)] // Make sure Http/1.1 doesn't regress with Http/2 enabled.
         public async Task CertificatePassedToHttpContext(HttpProtocols httpProtocols)
@@ -409,7 +409,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HttpsSchemePassedToRequestFeature()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -428,7 +428,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotSupportTls10()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -459,7 +459,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory(Skip = "https://github.com/aspnet/AspNetCore/issues/7265")]
+        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/7265")]
         [InlineData(ClientCertificateMode.AllowCertificate)]
         [InlineData(ClientCertificateMode.RequireCertificate)]
         public async Task ClientCertificateValidationGetsCalledWithNotNullParameters(ClientCertificateMode mode)
@@ -497,7 +497,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [SkipOnHelix]
         [InlineData(ClientCertificateMode.AllowCertificate)]
         [InlineData(ClientCertificateMode.RequireCertificate)]
@@ -528,7 +528,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(ClientCertificateMode.AllowCertificate)]
         [InlineData(ClientCertificateMode.RequireCertificate)]
         public async Task RejectsConnectionOnSslPolicyErrorsWhenNoValidation(ClientCertificateMode mode)
@@ -557,7 +557,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CertificatePassedToHttpContextIsNotDisposed()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
@@ -598,7 +598,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("no_extensions.pfx")]
         public void AcceptsCertificateWithoutExtensions(string testCertName)
         {
@@ -613,7 +613,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             });
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("eku.server.pfx")]
         [InlineData("eku.multiple_usages.pfx")]
         public void ValidatesEnhancedKeyUsageOnCertificate(string testCertName)
@@ -631,7 +631,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             });
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("eku.code_signing.pfx")]
         [InlineData("eku.client.pfx")]
         public void ThrowsForCertificatesMissingServerEku(string testCertName)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
@@ -37,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             return serverOptions;
         }
 
-        [Fact]
+        [ConditionalFact]
         public void UseHttpsDefaultsToDefaultCert()
         {
             var serverOptions = CreateServerOptions();
@@ -62,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.False(serverOptions.IsDevCertLoaded);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void ConfigureHttpsDefaultsNeverLoadsDefaultCert()
         {
             var serverOptions = CreateServerOptions();
@@ -86,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Null(serverOptions.DefaultCertificate);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void ConfigureCertSelectorNeverLoadsDefaultCert()
         {
             var serverOptions = CreateServerOptions();
@@ -115,7 +116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Null(serverOptions.DefaultCertificate);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task EmptyRequestLoggedAsDebug()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();
@@ -143,7 +144,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 userMessage: string.Join(Environment.NewLine, loggerProvider.ErrorLogger.ErrorMessages));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ClientHandshakeFailureLoggedAsDebug()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();
@@ -173,7 +174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         // Regression test for https://github.com/aspnet/KestrelHttpServer/issues/1103#issuecomment-246971172
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotThrowObjectDisposedExceptionOnConnectionAbort()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();
@@ -219,7 +220,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.False(loggerProvider.ErrorLogger.ObjectDisposedExceptionLogged);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -263,7 +264,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         // Regression test for https://github.com/aspnet/KestrelHttpServer/issues/1693
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotThrowObjectDisposedExceptionOnEmptyConnection()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();
@@ -290,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         // Regression test for https://github.com/aspnet/KestrelHttpServer/pull/1197
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionFilterDoesNotLeakBlock()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();
@@ -311,7 +312,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HandshakeTimesOutAndIsLoggedAsDebug()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();
@@ -356,7 +357,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(LogLevel.Debug, loggerProvider.FilterLogger.LastLogLevel);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ClientAttemptingToUseUnsupportedProtocolIsLoggedAsDebug()
         {
             var loggerProvider = new HandshakeErrorLoggerProvider();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -23,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
         private readonly TaskCompletionSource<object> _firstRequestReceived = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionClosedWhenKeepAliveTimeoutExpires()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -50,7 +51,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionKeptAliveBetweenRequests()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -78,7 +79,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionNotTimedOutWhileRequestBeingSent()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -118,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         private async Task ConnectionNotTimedOutWhileAppIsRunning()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -158,7 +159,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         private async Task ConnectionTimesOutWhenOpenedButNoRequestSent()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -178,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         private async Task KeepAliveTimeoutDoesNotApplyToUpgradedConnections()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/LoggingConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/LoggingConnectionAdapterTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class LoggingConnectionAdapterTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task LoggingConnectionAdapterCanBeAddedBeforeAndAfterHttpsAdapter()
         {
             using (var server = new TestServer(context =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -16,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class MaxRequestBodySizeTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task RejectsRequestWithContentLengthHeaderExceedingGlobalLimit()
         {
             // 4 GiB
@@ -55,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RejectsRequestWithContentLengthHeaderExceedingPerRequestLimit()
         {
             // 8 GiB
@@ -102,7 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotRejectRequestWithContentLengthHeaderExceedingGlobalLimitIfLimitDisabledPerRequest()
         {
             using (var server = new TestServer(async context =>
@@ -143,7 +144,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotRejectBodylessGetRequestWithZeroMaxRequestBodySize()
         {
             using (var server = new TestServer(context => context.Request.Body.CopyToAsync(Stream.Null),
@@ -176,7 +177,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SettingMaxRequestBodySizeAfterReadingFromRequestBodyThrows()
         {
             var perRequestMaxRequestBodySize = 0x10;
@@ -220,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.MaxRequestBodySizeCannotBeModifiedAfterRead, invalidOpEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SettingMaxRequestBodySizeAfterUpgradingRequestThrows()
         {
             InvalidOperationException invalidOpEx = null;
@@ -260,7 +261,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.MaxRequestBodySizeCannotBeModifiedForUpgradedRequests, invalidOpEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task EveryReadFailsWhenContentLengthHeaderExceedsGlobalLimit()
         {
             BadHttpRequestException requestRejectedEx1 = null;
@@ -302,7 +303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx2.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChunkFramingAndExtensionsCountTowardsRequestBodySize()
         {
             var chunkedPayload = "5;random chunk extension\r\nHello\r\n6\r\n World\r\n0\r\n\r\n";
@@ -348,7 +349,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TrailingHeadersDoNotCountTowardsRequestBodySize()
         {
             var chunkedPayload = $"5;random chunk extension\r\nHello\r\n6\r\n World\r\n0\r\n";
@@ -391,7 +392,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PerRequestMaxRequestBodySizeGetsReset()
         {
             var chunkedPayload = "5;random chunk extension\r\nHello\r\n6\r\n World\r\n0\r\n\r\n";
@@ -463,7 +464,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task EveryReadFailsWhenChunkedPayloadExceedsGlobalLimit()
         {
             BadHttpRequestException requestRejectedEx1 = null;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestLineSizeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestLineSizeTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class MaxRequestLineSizeTests : LoggedTest
     {
-        [Theory]
+        [ConditionalTheory]
         [InlineData("GET / HTTP/1.1\r\nHost:\r\n\r\n", 16)]
         [InlineData("GET / HTTP/1.1\r\nHost:\r\n\r\n", 17)]
         [InlineData("GET / HTTP/1.1\r\nHost:\r\n\r\n", 137)]
@@ -48,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("GET / HTTP/1.1\r\n")]
         [InlineData("POST /abc/de HTTP/1.1\r\n")]
         [InlineData("PUT /abc/de?f=ghi HTTP/1.1\r\n")]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 
 [assembly: ShortClassName]
 [assembly: LogLevel(LogLevel.Trace)]
+[assembly: OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "https://github.com/aspnet/AspNetCore/issues/8164")]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestBodyTimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestBodyTimeoutTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class RequestBodyTimeoutTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task RequestTimesOutWhenRequestBodyNotReceivedAtSpecifiedMinimumRate()
         {
             var gracePeriod = TimeSpan.FromSeconds(5);
@@ -92,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestTimesOutWhenNotDrainedWithinDrainTimeoutPeriod()
         {
             // This test requires a real clock since we can't control when the drain timeout is set
@@ -141,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Contains(TestSink.Writes, w => w.EventId.Id == 33 && w.LogLevel == LogLevel.Information);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionClosedEvenIfAppSwallowsException()
         {
             var gracePeriod = TimeSpan.FromSeconds(5);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestHeaderLimitsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestHeaderLimitsTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class RequestHeaderLimitsTests : LoggedTest
     {
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0, 1)]
         [InlineData(0, 1337)]
         [InlineData(1, 0)]
@@ -47,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(0, 1)]
         [InlineData(0, 1337)]
         [InlineData(1, 1)]
@@ -80,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(1)]
         [InlineData(5)]
         public async Task ServerRejectsRequestWithHeaderTotalSizeOverLimit(int headerCount)
@@ -104,7 +105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(2, 1)]
         [InlineData(5, 1)]
         [InlineData(5, 4)]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestHeadersTimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestHeadersTimeoutTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -19,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         private static readonly TimeSpan LongDelay = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan ShortDelay = TimeSpan.FromSeconds(LongDelay.TotalSeconds / 10);
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("Host:\r\n")]
         [InlineData("Host:\r\nContent-Length: 1\r\n")]
         [InlineData("Host:\r\nContent-Length: 1\r\n\r")]
@@ -46,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestHeadersTimeoutCanceledAfterHeadersReceived()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -76,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("P")]
         [InlineData("POST / HTTP/1.1\r")]
         public async Task ConnectionAbortedWhenRequestLineNotReceivedInTime(string requestLine)
@@ -100,7 +101,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TimeoutNotResetOnEachRequestLineCharacterReceived()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTargetProcessingTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTargetProcessingTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class RequestTargetProcessingTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task RequestPathIsNotNormalized()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -46,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("/")]
         [InlineData("/.")]
         [InlineData("/..")]
@@ -92,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(HttpMethod.Options, "*")]
         [InlineData(HttpMethod.Connect, "host")]
         public async Task NonPathRequestTargetSetInRawTarget(HttpMethod method, string requestTarget)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class RequestTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task StreamsAreNotPersistedAcrossRequests()
         {
             var requestBodyPersisted = false;
@@ -58,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PipesAreNotPersistedBySettingStreamPipeWriterAcrossRequests()
         {
             var responseBodyPersisted = false;
@@ -84,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PipesAreNotPersistedAcrossRequests()
         {
             var responseBodyPersisted = false;
@@ -109,7 +110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestBodyReadAsyncCanBeCancelled()
         {
             var helloTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -178,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader()
         {
             var dataRead = false;
@@ -214,7 +215,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.True(dataRead);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("http://localhost/abs/path", "/abs/path", null)]
         [InlineData("https://localhost/abs/path", "/abs/path", null)] // handles mismatch scheme
         [InlineData("https://localhost:22/abs/path", "/abs/path", null)] // handles mismatched ports
@@ -284,7 +285,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AppCanSetTraceIdentifier()
         {
             const string knownId = "xyz123";
@@ -300,7 +301,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TraceIdentifierIsUnique()
         {
             const int identifierLength = 22;
@@ -357,7 +358,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http11KeptAliveByDefault()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -393,7 +394,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10NotKeptAliveByDefault()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -433,7 +434,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10KeepAlive()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -468,7 +469,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10KeepAliveNotHonoredIfResponseContentLengthNotSet()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -508,7 +509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http10KeepAliveHonoredIfResponseContentLengthSet()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -565,7 +566,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Expect100ContinueHonored()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -598,7 +599,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroContentLengthAssumedOnNonKeepAliveRequestsWithoutContentLengthOrTransferEncodingHeader()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -645,7 +646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroContentLengthAssumedOnNonKeepAliveRequestsWithoutContentLengthOrTransferEncodingHeaderPipeReader()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -693,7 +694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthReadAsyncPipeReader()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -727,7 +728,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes()
         {
             var testContext = new TestServiceContext(LoggerFactory)
@@ -759,7 +760,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestHeadersAreResetOnEachRequest()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -810,7 +811,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UpgradeRequestIsNotKeptAliveOrChunked()
         {
             const string message = "Hello World";
@@ -848,7 +849,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HeadersAndStreamsAreReusedAcrossRequests()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -925,7 +926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(HostHeaderData))]
         public async Task MatchesValidRequestTargetAndHostHeader(string request, string hostHeader)
         {
@@ -944,7 +945,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ServerConsumesKeepAliveContentLengthRequest()
         {
             // The app doesn't read the request body, so it should be consumed by the server
@@ -986,7 +987,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ServerConsumesKeepAliveChunkedRequest()
         {
             // The app doesn't read the request body, so it should be consumed by the server
@@ -1035,7 +1036,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonKeepAliveRequestNotConsumedByAppCompletes()
         {
             // The app doesn't read the request body, so it should be consumed by the server
@@ -1062,7 +1063,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UpgradedRequestNotConsumedByAppCompletes()
         {
             // The app doesn't read the request body, so it should be consumed by the server
@@ -1096,7 +1097,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotEnforceRequestBodyMinimumDataRateOnUpgradedRequest()
         {
             var appEvent = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1156,7 +1157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousReadsDisallowedByDefault()
         {
             using (var server = new TestServer(async context =>
@@ -1207,7 +1208,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousReadsAllowedByOptIn()
         {
             using (var server = new TestServer(async context =>
@@ -1251,7 +1252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousReadsCanBeDisallowedGlobally()
         {
             var testContext = new TestServiceContext(LoggerFactory)
@@ -1296,7 +1297,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousReadsCanBeAllowedGlobally()
         {
             var testContext = new TestServiceContext(LoggerFactory)
@@ -1338,7 +1339,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthRequestCallCancelPendingReadWorks()
         {
             var tcs = new TaskCompletionSource<object>();
@@ -1390,7 +1391,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthRequestCallCompleteThrowsExceptionOnRead()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -1435,7 +1436,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthCallCompleteWithExceptionCauses500()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             }
         };
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionAdapterData))]
         public async Task ConnectionClosedWhenResponseNotDrainedAtMinimumDataRate(ListenOptions listenOptions)
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -29,7 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task OnCompleteCalledEvenWhenOnStartingNotCalled()
         {
             var onStartingCalled = false;
@@ -69,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnStartingThrowsWhenSetAfterResponseHasAlreadyStarted()
         {
             InvalidOperationException ex = null;
@@ -105,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnStartingThrowsWhenSetAfterStartAsyncIsCalled()
         {
             InvalidOperationException ex = null;
@@ -138,7 +139,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyWriteAsyncCanBeCancelled()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -206,7 +207,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task ResponseStatusCodeSetBeforeHttpContextDisposeAppException()
         {
             return ResponseStatusCodeSetBeforeHttpContextDispose(
@@ -220,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 expectedServerStatusCode: HttpStatusCode.InternalServerError);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task ResponseStatusCodeSetBeforeHttpContextDisposeRequestAborted()
         {
             return ResponseStatusCodeSetBeforeHttpContextDispose(
@@ -235,7 +236,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 expectedServerStatusCode: 0);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task ResponseStatusCodeSetBeforeHttpContextDisposeRequestAbortedAppException()
         {
             return ResponseStatusCodeSetBeforeHttpContextDispose(
@@ -250,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 expectedServerStatusCode: 0);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task ResponseStatusCodeSetBeforeHttpContextDisposedRequestMalformed()
         {
             return ResponseStatusCodeSetBeforeHttpContextDispose(
@@ -265,7 +266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 sendMalformedRequest: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task ResponseStatusCodeSetBeforeHttpContextDisposedRequestMalformedRead()
         {
             return ResponseStatusCodeSetBeforeHttpContextDispose(
@@ -280,7 +281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 sendMalformedRequest: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public Task ResponseStatusCodeSetBeforeHttpContextDisposedRequestMalformedReadIgnored()
         {
             return ResponseStatusCodeSetBeforeHttpContextDispose(
@@ -301,7 +302,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 sendMalformedRequest: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnCompletedExceptionShouldNotPreventAResponse()
         {
             using (var server = new TestServer(async context =>
@@ -332,7 +333,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnCompletedShouldNotBlockAResponse()
         {
             var delayTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -370,7 +371,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task InvalidChunkedEncodingInRequestShouldNotBlockOnCompleted()
         {
             var onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -407,7 +408,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         // https://github.com/aspnet/KestrelHttpServer/pull/1111/files#r80584475 explains the reason for this test.
-        [Fact]
+        [ConditionalFact]
         public async Task NoErrorResponseSentWhenAppSwallowsBadRequestException()
         {
             BadHttpRequestException readException = null;
@@ -442,7 +443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TransferEncodingChunkedSetOnUnknownLengthHttp11Response()
         {
             using (var server = new TestServer(async httpContext =>
@@ -475,7 +476,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(StatusCodes.Status204NoContent)]
         [InlineData(StatusCodes.Status304NotModified)]
         public async Task TransferEncodingChunkedNotSetOnNonBodyResponse(int statusCode)
@@ -503,7 +504,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthZeroSetOn205Response()
         {
             using (var server = new TestServer(httpContext =>
@@ -530,7 +531,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(StatusCodes.Status204NoContent)]
         [InlineData(StatusCodes.Status304NotModified)]
         public async Task AttemptingToWriteFailsForNonBodyResponse(int statusCode)
@@ -576,7 +577,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AttemptingToWriteFailsFor205Response()
         {
             var responseWriteTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -621,7 +622,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TransferEncodingNotSetOnHeadResponse()
         {
             using (var server = new TestServer(httpContext =>
@@ -646,7 +647,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyNotWrittenOnHeadResponseAndLoggedOnlyOnce()
         {
             const string response = "hello, world";
@@ -688,7 +689,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 kestrelTrace.ConnectionHeadResponseBodyWrite(It.IsAny<string>(), response.Length), Times.Once);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowsAndClosesConnectionWhenAppWritesMoreThanContentLengthWrite()
         {
             var serviceContext = new TestServiceContext(LoggerFactory)
@@ -730,7 +731,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowsAndClosesConnectionWhenAppWritesMoreThanContentLengthWriteAsync()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -765,7 +766,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 logMessage.Exception.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task InternalServerErrorAndConnectionClosedOnWriteWithMoreThanContentLengthAndResponseNotStarted()
         {
             var serviceContext = new TestServiceContext(LoggerFactory)
@@ -804,7 +805,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 logMessage.Exception.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task InternalServerErrorAndConnectionClosedOnWriteAsyncWithMoreThanContentLengthAndResponseNotStarted()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -840,7 +841,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 logMessage.Exception.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WhenAppWritesLessThanContentLengthErrorLogged()
         {
             var logTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -894,7 +895,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         ex.Message.Equals($"Response Content-Length mismatch: too few bytes written (12 of 13).", StringComparison.Ordinal))));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WhenAppWritesLessThanContentLengthButRequestIsAbortedErrorNotLogged()
         {
             var requestAborted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -943,7 +944,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             mockTrace.Verify(trace => trace.ApplicationError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<InvalidOperationException>()), Times.Never);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WhenAppSetsContentLengthButDoesNotWriteBody500ResponseSentAndConnectionDoesNotClose()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -983,7 +984,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.All(error, message => message.Message.Equals("Response Content-Length mismatch: too few bytes written (0 of 5)."));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task WhenAppSetsContentLengthToZeroAndDoesNotWriteNoErrorIsThrown(bool flushResponse)
@@ -1024,7 +1025,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         // If a message is received with both a Transfer-Encoding and a
         // Content-Length header field, the Transfer-Encoding overrides the
         // Content-Length.
-        [Fact]
+        [ConditionalFact]
         public async Task WhenAppSetsTransferEncodingAndContentLengthWritingLessIsNotAnError()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -1061,7 +1062,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         // If a message is received with both a Transfer-Encoding and a
         // Content-Length header field, the Transfer-Encoding overrides the
         // Content-Length.
-        [Fact]
+        [ConditionalFact]
         public async Task WhenAppSetsTransferEncodingAndContentLengthWritingMoreIsNotAnError()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -1094,7 +1095,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Empty(TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HeadResponseCanContainContentLengthHeader()
         {
             using (var server = new TestServer(httpContext =>
@@ -1121,7 +1122,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HeadResponseBodyNotWrittenWithAsyncWrite()
         {
             var flushed = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1153,7 +1154,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task HeadResponseBodyNotWrittenWithSyncWrite()
         {
             var flushed = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1187,7 +1188,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroLengthWritesFlushHeaders()
         {
             var flushed = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1222,7 +1223,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AppCanWriteOwnBadRequestResponse()
         {
             var expectedResponse = string.Empty;
@@ -1264,7 +1265,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("gzip")]
         [InlineData("chunked, gzip")]
         public async Task ConnectionClosedWhenChunkedIsNotFinalTransferCoding(string responseTransferEncoding)
@@ -1310,7 +1311,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("gzip")]
         [InlineData("chunked, gzip")]
         public async Task ConnectionClosedWhenChunkedIsNotFinalTransferCodingEvenIfConnectionKeepAliveSetInResponse(string responseTransferEncoding)
@@ -1357,7 +1358,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("chunked")]
         [InlineData("gzip, chunked")]
         public async Task ConnectionKeptAliveWhenChunkedIsFinalTransferCoding(string responseTransferEncoding)
@@ -1401,7 +1402,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task FirstWriteVerifiedAfterOnStarting()
         {
             var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
@@ -1444,7 +1445,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task FirstWriteVerifiedAfterOnStartingWithResponseBody()
         {
             var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
@@ -1487,7 +1488,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SubsequentWriteVerifiedAfterOnStarting()
         {
             var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
@@ -1533,7 +1534,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SubsequentWriteVerifiedAfterOnStartingWithResponseBody()
         {
             var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
@@ -1579,7 +1580,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task FirstWriteAsyncVerifiedAfterOnStarting()
         {
             using (var server = new TestServer(httpContext =>
@@ -1620,7 +1621,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SubsequentWriteAsyncVerifiedAfterOnStarting()
         {
             using (var server = new TestServer(async httpContext =>
@@ -1664,7 +1665,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WhenResponseAlreadyStartedResponseEndedBeforeConsumingRequestBody()
         {
             using (var server = new TestServer(async httpContext =>
@@ -1702,7 +1703,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task WhenResponseNotStartedResponseEndedBeforeConsumingRequestBody()
         {
             using (var server = new TestServer(httpContext => Task.CompletedTask,
@@ -1734,7 +1735,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestDrainingFor100ContinueDoesNotBlockResponse()
         {
             var foundMessage = false;
@@ -1804,7 +1805,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.True(foundMessage, "Expected log not found");
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Sending100ContinueDoesNotPreventAutomatic400Responses()
         {
             using (var server = new TestServer(httpContext =>
@@ -1849,7 +1850,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Sending100ContinueAndResponseSendsChunkTerminatorBeforeConsumingRequestBody()
         {
             using (var server = new TestServer(async httpContext =>
@@ -1897,7 +1898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Http11ResponseSentToHttp10Request()
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
@@ -1922,7 +1923,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroContentLengthSetAutomaticallyAfterNoWrites()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -1955,7 +1956,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroContentLengthSetAutomaticallyForNonKeepAliveRequests()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2000,7 +2001,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroContentLengthNotSetAutomaticallyForHeadRequests()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2024,7 +2025,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ZeroContentLengthNotSetAutomaticallyForCertainStatusCodes()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2074,7 +2075,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ConnectionClosedAfter101Response()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2121,7 +2122,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowingResultsIn500Response()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2173,7 +2174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowingInOnStartingResultsInFailedWritesAnd500Response()
         {
             var callback1Called = false;
@@ -2232,7 +2233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(2, TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnStartingThrowsInsideOnStartingCallbacksRuns()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2278,7 +2279,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnCompletedThrowsInsideOnCompletedCallbackRuns()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2325,7 +2326,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowingInOnCompletedIsLogged()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2375,7 +2376,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.True(onCompletedCalled2);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowingAfterWritingKillsConnection()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2417,7 +2418,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowingAfterPartialWriteKillsConnection()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2460,7 +2461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public async Task NoErrorsLoggedWhenServerEndsConnectionBeforeClient()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2492,7 +2493,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Empty(TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NoResponseSentWhenConnectionIsClosedByServerBeforeClientFinishesSendingRequest()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2516,7 +2517,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AppAbortIsLogged()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2542,7 +2543,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Single(TestApplicationErrorLogger.Messages.Where(m => m.Message.Contains(CoreStrings.ConnectionAbortedByApplication)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AppAbortViaIConnectionLifetimeFeatureIsLogged()
         {
             // Ensure the response doesn't get flush before the abort is observed by scheduling inline.
@@ -2572,7 +2573,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Single(TestApplicationErrorLogger.Messages.Where(m => m.Message.Contains("The connection was aborted by the application via IConnectionLifetimeFeature.Abort().")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseHeadersAreResetOnEachRequest()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2623,7 +2624,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncDefaultToChunkedResponse()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2653,7 +2654,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncWithContentLengthAndEmptyWriteStillCallsFinalFlush()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2682,7 +2683,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncAndEmptyWriteStillCallsFinalFlush()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2713,7 +2714,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncWithSingleChunkedWriteStillWritesSuffix()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2746,7 +2747,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncWithoutFlushStartsResponse()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2777,7 +2778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncThrowExceptionThrowsConnectionAbortedException()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2806,7 +2807,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncWithContentLengthThrowExceptionThrowsConnectionAbortedException()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2836,7 +2837,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncWithoutFlushingDoesNotFlush()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2875,7 +2876,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncWithContentLengthWritingWorks()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2906,7 +2907,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StartAsyncAndFlushWorks()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -2938,7 +2939,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnStartingCallbacksAreCalledInLastInFirstOutOrder()
         {
             const string response = "hello, world";
@@ -2990,7 +2991,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(2, callOrder.Pop());
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OnCompletedCallbacksAreCalledInLastInFirstOutOrder()
         {
             const string response = "hello, world";
@@ -3042,7 +3043,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(2, callOrder.Pop());
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousWritesDisallowedByDefault()
         {
             using (var server = new TestServer(async context =>
@@ -3072,7 +3073,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousWritesAllowedByOptIn()
         {
             using (var server = new TestServer(context =>
@@ -3098,7 +3099,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousWritesCanBeAllowedGlobally()
         {
             var testContext = new TestServiceContext(LoggerFactory)
@@ -3134,7 +3135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SynchronousWritesCanBeDisallowedGlobally()
         {
             var testContext = new TestServiceContext(LoggerFactory)
@@ -3174,7 +3175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonZeroContentLengthFor304StatusCodeIsAllowed()
         {
             using (var server = new TestServer(httpContext =>
@@ -3204,7 +3205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AdvanceNegativeValueThrowsArgumentOutOfRangeException()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -3239,7 +3240,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AdvanceNegativeValueThrowsArgumentOutOfRangeExceptionWithStart()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -3271,7 +3272,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AdvanceWithTooLargeOfAValueThrowInvalidOperationException()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -3305,7 +3306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthWithoutStartAsyncWithGetSpanWorks()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -3345,7 +3346,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ContentLengthWithGetMemoryWorks()
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -3386,7 +3387,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyCanWrite()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3413,7 +3414,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyAndResponsePipeWorks()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3456,7 +3457,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyWriterCompleteWithoutExceptionDoesNotThrow()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3483,7 +3484,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseBodyWriterCompleteWithoutExceptionWritesDoNotThrow()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3512,7 +3513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseAdvanceStateIsResetWithMultipleReqeusts()
         {
             var secondRequest = false;
@@ -3565,7 +3566,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseStartCalledAndAutoChunkStateIsResetWithMultipleReqeusts()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3615,7 +3616,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseStartCalledStateIsResetWithMultipleReqeusts()
         {
             var flip = false;
@@ -3677,7 +3678,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseIsLeasedMemoryInvalidStateIsResetWithMultipleReqeusts()
         {
             var secondRequest = false;
@@ -3723,7 +3724,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponsePipeWriterCompleteWithException()
         {
             var expectedException = new Exception();
@@ -3753,7 +3754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseCompleteGetMemoryReturnsRentedMemory()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3786,7 +3787,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseCompleteGetMemoryReturnsRentedMemoryWithoutStartAsync()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3816,7 +3817,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseGetMemoryAndStartAsyncMemoryReturnsNewMemory()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3853,7 +3854,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseGetMemoryAndStartAsyncAdvanceThrows()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3886,7 +3887,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseCompleteGetMemoryAdvanceInLoopDoesNotThrow()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3922,7 +3923,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseSetBodyAndPipeBodyIsWrapped()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3952,7 +3953,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseSetBodyToSameValueTwiceGetPipeMultipleTimesDifferentObject()
         {
             using (var server = new TestServer(async httpContext =>
@@ -3986,7 +3987,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseSetPipeToSameValueTwiceGetBodyMultipleTimesDifferent()
         {
             using (var server = new TestServer(async httpContext =>
@@ -4020,7 +4021,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseSetPipeAndBodyWriterIsWrapped()
         {
             using (var server = new TestServer(async httpContext =>
@@ -4051,7 +4052,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseWriteToBodyWriterAndStreamAllBlocksDisposed()
         {
             using (var server = new TestServer(async httpContext =>
@@ -4087,7 +4088,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseStreamWrappingWorks()
         {
             using (var server = new TestServer(async httpContext =>
@@ -4126,7 +4127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ResponsePipeWrappingWorks()
         {
             using (var server = new TestServer(async httpContext =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Server.Kestrel.Tests;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 {
     public class UpgradeTests : LoggedTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task ResponseThrowsAfterUpgrade()
         {
             var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -55,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RequestBodyAlwaysEmptyAfterUpgrade()
         {
             const string send = "Custom protocol send";
@@ -111,7 +112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UpgradeCannotBeCalledMultipleTimes()
         {
             var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -153,7 +154,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.UpgradeCannotBeCalledMultipleTimes, ex.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RejectsRequestWithContentLengthAndUpgrade()
         {
             using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory)))
@@ -179,7 +180,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AcceptsRequestWithNoContentLengthAndUpgrade()
         {
             using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory)))
@@ -204,7 +205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RejectsRequestWithChunkedEncodingAndUpgrade()
         {
             using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory)))
@@ -229,7 +230,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ThrowsWhenUpgradingNonUpgradableRequest()
         {
             var upgradeTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -263,7 +264,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.CannotUpgradeNonUpgradableRequest, ex.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task RejectsUpgradeWhenLimitReached()
         {
             const int limit = 10;
@@ -315,7 +316,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.UpgradedConnectionLimitReached, exception.Message);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task DoesNotThrowOnFin()
         {
             var appCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
- until we figure out what's going on (I hope)

Addresses #8164 

We're still seeing issues in Helix like https://dev.azure.com/dnceng/public/_build/results?buildId=122553