### PR TITLE
Refresh process in back compat test

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/BackwardsCompatibilityTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/BackwardsCompatibilityTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         {
 
             var response = await _fixture.Client.GetAsync("/HelloWorld");
+            _fixture.DeploymentResult.HostProcess.Refresh();
             var handles = _fixture.DeploymentResult.HostProcess.Modules;
 
             foreach (ProcessModule handle in handles)


### PR DESCRIPTION
This is occasionally failing on aspnetci. Going to try calling refresh on the process and see if that helps.