### PR TITLE
Disable framework exception on back compat tests

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/Inprocess/StdOutRedirectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/Inprocess/StdOutRedirectionTests.cs
@@ -25,6 +25,7 @@ namespace IIS.FunctionalTests.Inprocess
         }
 
         [ConditionalFact]
+        [RequiresNewShim]
         public async Task FrameworkNotFoundExceptionLogged_Pipe()
         {
             var deploymentParameters = _fixture.GetBaseDeploymentParameters(_fixture.InProcessTestSite);
@@ -42,7 +43,8 @@ namespace IIS.FunctionalTests.Inprocess
                 "The specified framework 'Microsoft.NETCore.App', version '2.9.9' was not found.");
         }
 
-        [ConditionalFact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1814")]
+        [ConditionalFact]
+        [RequiresNewShim]
         public async Task FrameworkNotFoundExceptionLogged_File()
         {
             var deploymentParameters =


### PR DESCRIPTION
Currently trying to debug why these tests are failing for back compat on aspnetci. Doesn't reallllly make sense. 

Anyways, the skip condition before was too coarse, re enabling tests for non-back compat scenarios.