### PR TITLE
Make ResetSendPing and ResetTimeout private methods on HubConnection

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/ref/Microsoft.AspNetCore.SignalR.Client.Core.netstandard2.0.cs
+++ b/src/SignalR/clients/csharp/Client.Core/ref/Microsoft.AspNetCore.SignalR.Client.Core.netstandard2.0.cs
@@ -37,8 +37,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public System.Threading.Tasks.Task<object> InvokeCoreAsync(string methodName, System.Type returnType, object[] args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.IDisposable On(string methodName, System.Type[] parameterTypes, System.Func<object[], object, System.Threading.Tasks.Task> handler, object state) { throw null; }
         public void Remove(string methodName) { }
-        public void ResetSendPing() { }
-        public void ResetTimeout() { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task SendCoreAsync(string methodName, object[] args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1012,12 +1012,12 @@ namespace Microsoft.AspNetCore.SignalR.Client
             }
         }
 
-        public void ResetSendPing()
+        private void ResetSendPing()
         {
             Volatile.Write(ref _nextActivationSendPing, (DateTime.UtcNow + KeepAliveInterval).Ticks);
         }
 
-        public void ResetTimeout()
+        private void ResetTimeout()
         {
             Volatile.Write(ref _nextActivationServerTimeout, (DateTime.UtcNow + ServerTimeout).Ticks);
         }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/7977

Making these methods private as they are only intended for internal use and shouldn't be exposed. Will file an announcement after this is merged since it is a breaking change but it shouldn't be a huge deal.
