### PR TITLE
Removed Content Type header for 304 response since no content is being returned

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             // Short circuit if the preconditional headers process to 304 (NotModified) or 412 (PreconditionFailed)
             if (preconditionState == PreconditionState.NotModified)
             {
-                response.StatusCode = StatusCodes.Status304NotModified;                
+                response.StatusCode = StatusCodes.Status304NotModified;
                 return (range: null, rangeLength: 0, serveBody: false);
             }
             else if (preconditionState == PreconditionState.PreconditionFailed)
@@ -87,7 +87,6 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             {
                 // Assuming the request is not a range request, and the response body is not empty, the Content-Length header is set to 
                 // the length of the entire file. 
-
                 // If the request is a valid range request, this header is overwritten with the length of the range as part of the 
                 // range processing (see method SetContentLength).
 

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
@@ -52,10 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             {
                 throw new ArgumentNullException(nameof(result));
             }
-
-            SetContentType(context, result);
-            SetContentDispositionHeader(context, result);
-
+            
             var request = context.HttpContext.Request;
             var httpRequestHeaders = request.GetTypedHeaders();
 
@@ -74,8 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             // Short circuit if the preconditional headers process to 304 (NotModified) or 412 (PreconditionFailed)
             if (preconditionState == PreconditionState.NotModified)
             {
-                response.StatusCode = StatusCodes.Status304NotModified;
-                response.Headers.Remove("Content-Type");
+                response.StatusCode = StatusCodes.Status304NotModified;                
                 return (range: null, rangeLength: 0, serveBody: false);
             }
             else if (preconditionState == PreconditionState.PreconditionFailed)
@@ -84,10 +80,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                 return (range: null, rangeLength: 0, serveBody: false);
             }
 
+            SetContentType(context, result);
+            SetContentDispositionHeader(context, result);
+
             if (fileLength.HasValue)
             {
                 // Assuming the request is not a range request, and the response body is not empty, the Content-Length header is set to 
                 // the length of the entire file. 
+
                 // If the request is a valid range request, this header is overwritten with the length of the range as part of the 
                 // range processing (see method SetContentLength).
 

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
@@ -75,6 +75,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             if (preconditionState == PreconditionState.NotModified)
             {
                 response.StatusCode = StatusCodes.Status304NotModified;
+                response.Headers.Remove("Content-Type");
                 return (range: null, rangeLength: 0, serveBody: false);
             }
             else if (preconditionState == PreconditionState.PreconditionFailed)

--- a/src/Mvc/Mvc.Core/test/FileContentResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/FileContentResultTest.cs
@@ -444,6 +444,7 @@ namespace Microsoft.AspNetCore.Mvc
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
             Assert.Null(httpResponse.ContentLength);
+            Assert.False(httpResponse.Headers.ContainsKey(HeaderNames.ContentType));
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);

--- a/src/Mvc/Mvc.Core/test/FileStreamResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/FileStreamResultTest.cs
@@ -432,13 +432,14 @@ namespace Microsoft.AspNetCore.Mvc
             var httpResponse = actionContext.HttpContext.Response;
             httpResponse.Body.Seek(0, SeekOrigin.Begin);
             var streamReader = new StreamReader(httpResponse.Body);
-            var body = streamReader.ReadToEndAsync().Result;
+            var body = await streamReader.ReadToEndAsync();
             Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
             Assert.Null(httpResponse.ContentLength);
-            Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
+            Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);            
+            Assert.False(httpResponse.Headers.ContainsKey(HeaderNames.ContentType));
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);
-            Assert.False(readStream.CanSeek);
+            Assert.False(readStream.CanSeek);            
         }
 
         [Theory]

--- a/src/Mvc/Mvc.Core/test/FileStreamResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/FileStreamResultTest.cs
@@ -439,7 +439,7 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.False(httpResponse.Headers.ContainsKey(HeaderNames.ContentType));
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);
-            Assert.False(readStream.CanSeek);            
+            Assert.False(readStream.CanSeek);
         }
 
         [Theory]

--- a/src/Mvc/Mvc.Core/test/PhysicalFileResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/PhysicalFileResultTest.cs
@@ -305,6 +305,7 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
+            Assert.False(httpResponse.Headers.ContainsKey(HeaderNames.ContentType));
             Assert.Empty(body);
         }
 

--- a/src/Mvc/Mvc.Core/test/VirtualFileResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/VirtualFileResultTest.cs
@@ -402,6 +402,7 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
+            Assert.False(httpResponse.Headers.ContainsKey(HeaderNames.ContentType));
             Assert.Empty(body);
         }
 


### PR DESCRIPTION
Summary of the changes
 - Removes Content Type header when preconditional headers process to 304 (NotModified)

Addresses #8230 
