### PR TITLE
Kill java after build

### DIFF
--- a/eng/scripts/KillProcesses.ps1
+++ b/eng/scripts/KillProcesses.ps1
@@ -22,6 +22,7 @@ _kill vctip.exe
 _kill chrome.exe
 _kill h2spec.exe
 _kill WerFault.exe
+_kill java.exe
 if (Get-Command iisreset -ErrorAction ignore) {
     iisreset /restart
 }


### PR DESCRIPTION
To prevent leaving java processes (such as Selenium) around lets add java to the list of processes that we kill when leaving an agent. Only on windows because we don't run Selenium on other OSs.