### PR TITLE
Up the SignalR test timeout to match Kestrel's

### DIFF
--- a/src/SignalR/common/testassets/Tests.Utils/TaskExtensions.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/TaskExtensions.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks
 #endif
     static class TaskExtensions
     {
-        private const int DefaultTimeout = 30*1000;
+        private const int DefaultTimeout = 30 * 1000;
 
         public static Task OrTimeout(this Task task, int milliseconds = DefaultTimeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
         {

--- a/src/SignalR/common/testassets/Tests.Utils/TaskExtensions.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/TaskExtensions.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks
 #endif
     static class TaskExtensions
     {
-        private const int DefaultTimeout = 5000;
+        private const int DefaultTimeout = 30*1000;
 
         public static Task OrTimeout(this Task task, int milliseconds = DefaultTimeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
         {


### PR DESCRIPTION
As per @halter73's suggestion this increases the SignalR test timeout to 30s. 
We've not decided on this but I'll just leave this here for us to discuss...
