### PR TITLE
Update acessTokenProvider selecting logic for restarting connection

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
@@ -16,10 +16,10 @@ class NegotiateResponse {
     private String redirectUrl;
     private String accessToken;
     private String error;
+    private String finalUrl;
 
-    public NegotiateResponse(String negotiatePayload) {
+    public NegotiateResponse(JsonReader reader) {
         try {
-            JsonReader reader = new JsonReader(new StringReader(negotiatePayload));
             reader.beginObject();
 
             do {
@@ -79,6 +79,10 @@ class NegotiateResponse {
         }
     }
 
+    public NegotiateResponse(String url) {
+        this.finalUrl = url;
+    }
+
     public String getConnectionId() {
         return connectionId;
     }
@@ -97,5 +101,13 @@ class NegotiateResponse {
 
     public String getError() {
         return error;
+    }
+
+    public String getFinalUrl(){
+        return finalUrl;
+    }
+
+    public void setFinalUrl(String url) {
+        this.finalUrl = url;
     }
 }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1677,7 +1677,7 @@ class HubConnectionTest {
 
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop();
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals("Bearer User Registered Token", beforeRedirectToken.get());
         assertEquals("Bearer newToken", token.get());
 

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1745,6 +1745,46 @@ class HubConnectionTest {
     }
 
     @Test
+    public void authorizationHeaderFromNegotiateGetsClearedAfterStopping() {
+        AtomicReference<String> token = new AtomicReference<>();
+        AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
+
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate", (req) -> {
+                    beforeRedirectToken.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
+                })
+                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                    token.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                            + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                });
+
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .build();
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals("Bearer newToken", token.get());
+
+        // Clear the tokens to see if they get reset to the proper values
+        beforeRedirectToken.set("");
+        token.set("");
+
+        // Restart the connection to make sure that the orignal accessTokenProvider that we registered is still registered before the redirect.
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop();
+        assertNull(beforeRedirectToken.get());
+        assertEquals("Bearer newToken", token.get());
+    }
+
+    @Test
     public void connectionTimesOutIfServerDoesNotSendMessage() {
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
         hubConnection.setServerTimeout(1);

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
@@ -5,7 +5,10 @@ package com.microsoft.signalr;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.gson.stream.JsonReader;
 import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
 
 
 class NegotiateResponseTest {
@@ -15,7 +18,7 @@ class NegotiateResponseTest {
                 "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}," +
                 "{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]}," +
                 "{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}";
-        NegotiateResponse negotiateResponse = new NegotiateResponse(stringNegotiateResponse);
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertTrue(negotiateResponse.getAvailableTransports().contains("WebSockets"));
         assertTrue(negotiateResponse.getAvailableTransports().contains("ServerSentEvents"));
         assertTrue(negotiateResponse.getAvailableTransports().contains("LongPolling"));
@@ -29,7 +32,7 @@ class NegotiateResponseTest {
         String stringNegotiateResponse = "{\"url\":\"www.example.com\"," +
                 "\"accessToken\":\"some_access_token\"," +
                 "\"availableTransports\":[]}";
-        NegotiateResponse negotiateResponse = new NegotiateResponse(stringNegotiateResponse);
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertTrue(negotiateResponse.getAvailableTransports().isEmpty());
         assertNull(negotiateResponse.getConnectionId());
         assertEquals("some_access_token", negotiateResponse.getAccessToken());
@@ -41,7 +44,7 @@ class NegotiateResponseTest {
     public void NegotiateResponseIgnoresExtraProperties() {
         String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
                 "\"extra\":\"something\"}";
-        NegotiateResponse negotiateResponse = new NegotiateResponse(stringNegotiateResponse);
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
     }
 
@@ -49,7 +52,7 @@ class NegotiateResponseTest {
     public void NegotiateResponseIgnoresExtraComplexProperties() {
         String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
                 "\"extra\":[\"something\"]}";
-        NegotiateResponse negotiateResponse = new NegotiateResponse(stringNegotiateResponse);
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/8429

Making sure we don't lose the reference to the user passed in accessTokenProvider. Before if you got redirected by the service, then restarted your connection the accessTokenProvider regiestered with `withAccessTokenProvider` would be lost.