### PR TITLE
Attempt to make MaxRequestBufferSizeTests.LargeUpload less flaky

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class MaxRequestBufferSizeTests : LoggedTest
     {
-        private const int _dataLength = 20 * 1024 * 1024;
+        private const int _dataLength = 100 * 1024 * 1024;
 
         private static readonly string[] _requestLines = new[]
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -277,6 +277,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     }
 
                     options.Limits.MinRequestBodyDataRate = null;
+                    options.Limits.MaxRequestBodySize = _dataLength;
                 })
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .Configure(app => app.Run(async context =>


### PR DESCRIPTION
This is for the release/2.1 branch, but should probably be ported forward to master so the test can be unskipped.

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1775 (hopefully)
See https://github.com/aspnet/AspNetCore-Internal/issues/1970 for the master version.