### PR TITLE
Fix React template typos

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/App.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/App.js
@@ -23,7 +23,7 @@ export default class App extends Component {
 ////#endif
 ////#if (IndividualLocalAuth)
         <AuthorizeRoute path='/fetch-data' component={FetchData} />
-        <Route path={ApplicationPaths.ApiAuthorizationPrefix} Component={ApiAuthorizationRoutes} />
+        <Route path={ApplicationPaths.ApiAuthorizationPrefix} component={ApiAuthorizationRoutes} />
 ////#endif
       </Layout>
     );

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/FetchData.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/FetchData.js
@@ -56,7 +56,7 @@ export class FetchData extends Component {
 
   async populateWeatherData() {
     ////#if (IndividualLocalAuth)
-    const token = authService.getAccessToken();
+    const token = await authService.getAccessToken();
     const response = await fetch('api/SampleData/WeatherForecasts', {
       headers: !token ? {} : { 'Authorization': `Bearer ${token}` }
     });

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/ApiAuthorizationConstants.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/ApiAuthorizationConstants.js
@@ -24,7 +24,7 @@ const prefix = '/authentication';
 export const ApplicationPaths = {
   DefaultLoginRedirectPath: '/',
   ApiAuthorizationClientConfigurationUrl: `/_configuration/${ApplicationName}`,
-  ApiAuthorizationPrefix = prefix,
+  ApiAuthorizationPrefix: prefix,
   Login: `${prefix}/${LoginActions.Login}`,
   LoginFailed: `${prefix}/${LoginActions.LoginFailed}`,
   LoginCallback: `${prefix}/${LoginActions.LoginCallback}`,

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/ApiAuthorizationRoutes.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/ApiAuthorizationRoutes.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { Route } from 'react-router';
-import { Login } from './components/api-authorization/Login'
-import { Logout } from './components/api-authorization/Logout'
+import { Login } from './Login'
+import { Logout } from './Logout'
 import { ApplicationPaths, LoginActions, LogoutActions } from './ApiAuthorizationConstants';
 
 export default class ApiAuthorizationRoutes extends Component {


### PR DESCRIPTION
Summary of the changes
 - Changed word `Component` to `component` in `<Route path={...} Component={...} />` in `App.js`
 - Applied patches suggested in [comment](https://github.com/aspnet/AspNetCore/issues/8283#issuecomment-471271010)
- Added `await` in `const token = authService.getAccessToken();` to ensure `token` resolves itself

Addresses #8381 #8380 #8405 #8398
