### PR TITLE
Start IHostedServices before server

### DIFF
--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -149,13 +149,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             var diagnosticSource = _applicationServices.GetRequiredService<DiagnosticListener>();
             var httpContextFactory = _applicationServices.GetRequiredService<IHttpContextFactory>();
             var hostingApp = new HostingApplication(application, _logger, diagnosticSource, httpContextFactory);
+
+            // Run all IHostedService's
+            await _hostedServiceExecutor.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            // Start server
             await Server.StartAsync(hostingApp, cancellationToken).ConfigureAwait(false);
 
             // Fire IApplicationLifetime.Started
             _applicationLifetime?.NotifyStarted();
-
-            // Fire IHostedService.Start
-            await _hostedServiceExecutor.StartAsync(cancellationToken).ConfigureAwait(false);
 
             _logger.Started();
 


### PR DESCRIPTION
Fix: #8625

Why when we start server, IHostedService's start after it?
It can cause some runtime problems, when we just started and already receiveing and handling requests.

Isn't it would be a great idea to also with for services to start properly, before start receiveing requests