### PR TITLE
Small HubConnection cleanup

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -830,6 +830,8 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 throw new InvalidOperationException("The server disconnected before the handshake was completed");
             }
 
+            var input = startingConnectionState.Connection.Transport.Input;
+
             try
             {
                 using (var handshakeCts = new CancellationTokenSource(HandshakeTimeout))
@@ -837,7 +839,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 {
                     while (true)
                     {
-                        var result = await startingConnectionState.Connection.Transport.Input.ReadAsync(cts.Token);
+                        var result = await input.ReadAsync(cts.Token);
 
                         var buffer = result.Buffer;
                         var consumed = buffer.Start;
@@ -878,7 +880,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                         }
                         finally
                         {
-                            startingConnectionState.Connection.Transport.Input.AdvanceTo(consumed, examined);
+                            input.AdvanceTo(consumed, examined);
                         }
                     }
                 }
@@ -924,11 +926,13 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 }
             }
 
+            var input = connectionState.Connection.Transport.Input;
+
             try
             {
                 while (true)
                 {
-                    var result = await connectionState.Connection.Transport.Input.ReadAsync();
+                    var result = await input.ReadAsync();
                     var buffer = result.Buffer;
 
                     try
@@ -979,7 +983,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                         // The buffer was sliced up to where it was consumed, so we can just advance to the start.
                         // We mark examined as `buffer.End` so that if we didn't receive a full frame, we'll wait for more data
                         // before yielding the read again.
-                        connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start, buffer.End);
+                        input.AdvanceTo(buffer.Start, buffer.End);
                     }
                 }
             }


### PR DESCRIPTION
- Use a single reader, single writer channel for the receive loop
- Await the timer task in the receive loop
