### PR TITLE
Remove Out-Of-Process test site fixture and make deployer check physical 

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
@@ -5,41 +5,54 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {
-    [Collection(IISCompressionSiteCollection.Name)]
-    public abstract class CompressionTests : FixtureLoggedTest
+    [Collection(PublishedSitesCollection.Name)]
+    public class CompressionOutOfProcessTests : IISFunctionalTestBase
     {
-        private readonly IISTestSiteFixture _fixture;
-
-        [Collection(IISTestSiteCollection.Name)]
-        public class InProc: CompressionTests
+        public CompressionOutOfProcessTests(PublishedSitesFixture fixture) : base(fixture)
         {
-            public InProc(IISTestSiteFixture fixture) : base(fixture) { }
-        }
-
-        [Collection(OutOfProcessTestSiteCollection.Name)]
-        public class OutOfProcess: CompressionTests
-        {
-            public OutOfProcess(OutOfProcessTestSiteFixture fixture) : base(fixture) { }
-        }
-
-        protected CompressionTests(IISTestSiteFixture fixture) : base(fixture)
-        {
-            _fixture = fixture;
         }
 
         [ConditionalFact]
-        public async Task PassesThroughCompression()
+        public async Task PassesThroughCompressionOutOfProcess()
         {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
             var request = new HttpRequestMessage(HttpMethod.Get, "/CompressedData");
 
             request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
 
-            var response = await _fixture.Client.SendAsync(request);
+            var response = await deploymentResult.HttpClient.SendAsync(request);
+            Assert.Equal("gzip", response.Content.Headers.ContentEncoding.Single());
+            Assert.Equal(
+                new byte[] {
+                    0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x04, 0x0A, 0x63, 0x60, 0xA0, 0x3D, 0x00, 0x00,
+                    0xCA, 0xC6, 0x88, 0x99, 0x64, 0x00, 0x00, 0x00 },
+                await response.Content.ReadAsByteArrayAsync());
+        }
+
+        
+        [ConditionalFact]
+        public async Task PassesThroughCompressionInProcess()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/CompressedData");
+
+            request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+            var response = await deploymentResult.HttpClient.SendAsync(request);
             Assert.Equal("gzip", response.Content.Headers.ContentEncoding.Single());
             Assert.Equal(
                 new byte[] {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
@@ -13,9 +13,9 @@ using Xunit;
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
-    public class CompressionOutOfProcessTests : IISFunctionalTestBase
+    public class CompressionTests : IISFunctionalTestBase
     {
-        public CompressionOutOfProcessTests(PublishedSitesFixture fixture) : base(fixture)
+        public CompressionTests(PublishedSitesFixture fixture) : base(fixture)
         {
         }
 
@@ -40,7 +40,6 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                 await response.Content.ReadAsByteArrayAsync());
         }
 
-        
         [ConditionalFact]
         public async Task PassesThroughCompressionInProcess()
         {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ServerAbortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ServerAbortTests.cs
@@ -4,51 +4,52 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {
-    public abstract class ServerAbortTests: FixtureLoggedTest
+    [Collection(PublishedSitesCollection.Name)]
+    public class ServerAbortOutOfProcessTests : IISFunctionalTestBase
     {
-        private readonly IISTestSiteFixture _fixture;
-
-        [Collection(IISTestSiteCollection.Name)]
-        public class InProc: ServerAbortTests
+        public ServerAbortOutOfProcessTests(PublishedSitesFixture fixture) : base(fixture)
         {
-            public InProc(IISTestSiteFixture fixture) : base(fixture) { }
-        }
-
-        [Collection(OutOfProcessTestSiteCollection.Name)]
-        public class OutOfProcess: ServerAbortTests
-        {
-            public OutOfProcess(OutOfProcessTestSiteFixture fixture) : base(fixture) { }
-        }
-
-        protected ServerAbortTests(IISTestSiteFixture fixture) : base(fixture)
-        {
-            _fixture = fixture;
         }
 
         [ConditionalFact]
-        public async Task ClosesConnectionOnServerAbort()
+        public async Task ClosesConnectionOnServerAbortOutOfProcess()
         {
             try
             {
-                var response = await _fixture.Client.GetAsync("/Abort").DefaultTimeout();
+                var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
 
-                // 502 is expected for outofproc but not for inproc
-                if (_fixture.DeploymentResult.DeploymentParameters.HostingModel == HostingModel.OutOfProcess)
-                {
-                    Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
-                    // 0x80072f78 ERROR_HTTP_INVALID_SERVER_RESPONSE The server returned an invalid or unrecognized response
-                    Assert.Contains("0x80072f78", await response.Content.ReadAsStringAsync());
-                }
-                else
-                {
-                    Assert.True(false, "Should not reach here");
-                }
+                var deploymentResult = await DeployAsync(deploymentParameters);
+
+                var response = await deploymentResult.HttpClient.GetAsync("/Abort").DefaultTimeout();
+
+                Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+                // 0x80072f78 ERROR_HTTP_INVALID_SERVER_RESPONSE The server returned an invalid or unrecognized response
+                Assert.Contains("0x80072f78", await response.Content.ReadAsStringAsync());
+            }
+            catch (HttpRequestException)
+            {
+                // Connection reset is expected both for outofproc and inproc
+            }
+        }
+
+        [ConditionalFact]
+        public async Task ClosesConnectionOnServerAbortInProcess()
+        {
+            try
+            {
+                var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);
+
+                var deploymentResult = await DeployAsync(deploymentParameters);
+                var response = await deploymentResult.HttpClient.GetAsync("/Abort").DefaultTimeout();
+
+                Assert.True(false, "Should not reach here");
             }
             catch (HttpRequestException)
             {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ServerAbortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ServerAbortTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             }
             catch (HttpRequestException)
             {
-                // Connection reset is expected both for outofproc and inproc
+                // Connection reset is expected
             }
         }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISTestSiteCollection.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISTestSiteCollection.cs
@@ -13,17 +13,4 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
     {
         public const string Name = nameof(IISTestSiteCollection);
     }
-
-    [CollectionDefinition(Name)]
-    public class OutOfProcessTestSiteCollection : ICollectionFixture<OutOfProcessTestSiteFixture>
-    {
-        public const string Name = nameof(OutOfProcessTestSiteCollection);
-    }
-
-    [CollectionDefinition(Name)]
-    public class OutOfProcessV1TestSiteCollection : ICollectionFixture<OutOfProcessV1TestSiteFixture>
-    {
-        public const string Name = nameof(OutOfProcessV1TestSiteCollection);
-    }
-
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISTestSiteFixture.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISTestSiteFixture.cs
@@ -11,33 +11,6 @@ using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {
-    public class OutOfProcessTestSiteFixture : IISTestSiteFixture
-    {
-        public OutOfProcessTestSiteFixture() : base(Configure)
-        {
-        }
-
-        private static void Configure(IISDeploymentParameters deploymentParameters)
-        {
-            deploymentParameters.ApplicationPublisher = new PublishedApplicationPublisher(Helpers.GetOutOfProcessTestSitesName());;
-            deploymentParameters.HostingModel = HostingModel.OutOfProcess;
-        }
-    }
-
-    public class OutOfProcessV1TestSiteFixture : IISTestSiteFixture
-    {
-        public OutOfProcessV1TestSiteFixture() : base(Configure)
-        {
-        }
-
-        private static void Configure(IISDeploymentParameters deploymentParameters)
-        {
-            deploymentParameters.ApplicationPublisher = new PublishedApplicationPublisher(Helpers.GetOutOfProcessTestSitesName());;
-            deploymentParameters.ApplicationPath = Helpers.GetOutOfProcessTestSitesName();
-            deploymentParameters.HostingModel = HostingModel.OutOfProcess;
-        }
-    }
-
     public class IISTestSiteFixture : IDisposable
     {
         private ApplicationDeployer _deployer;

--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/BackwardsCompatibilityTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/BackwardsCompatibilityTests.cs
@@ -22,8 +22,10 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         [ConditionalFact]
         public async Task CheckBackwardsCompatibilityIsUsed()
         {
-
             var response = await _fixture.Client.GetAsync("/HelloWorld");
+
+            Assert.True(response.IsSuccessStatusCode);
+
             _fixture.DeploymentResult.HostProcess.Refresh();
             var handles = _fixture.DeploymentResult.HostProcess.Modules;
 

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -241,9 +241,10 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
                 var site = serverManager.Sites.Single();
                 var appPool = serverManager.ApplicationPools.Single();
 
-                if (site.Applications.Single().VirtualDirectories.Single().PhysicalPath != contentRoot)
+                var actualPath = site.Applications.Single().VirtualDirectories.Single().PhysicalPath;
+                if (actualPath != contentRoot)
                 {
-                    throw new InvalidOperationException("Wrong physical path");
+                    throw new InvalidOperationException($"Wrong physical path. Expected: {contentRoot} Actual: {actualPath}");
                 }
 
                 if (appPool.State != ObjectState.Started && appPool.State != ObjectState.Starting)

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -218,11 +218,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
                 AddTemporaryAppHostConfig(contentRoot, port);
 
-                WaitUntilSiteStarted();
+                WaitUntilSiteStarted(contentRoot);
             }
         }
 
-        private void WaitUntilSiteStarted()
+        private void WaitUntilSiteStarted(string contentRoot)
         {
             ServiceController serviceController = new ServiceController("w3svc");
             Logger.LogInformation("W3SVC status " + serviceController.Status);
@@ -240,6 +240,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             {
                 var site = serverManager.Sites.Single();
                 var appPool = serverManager.ApplicationPools.Single();
+
+                if (site.Applications.Single().VirtualDirectories.Single().PhysicalPath != contentRoot)
+                {
+                    throw new InvalidOperationException("Wrong physical path");
+                }
 
                 if (appPool.State != ObjectState.Started && appPool.State != ObjectState.Starting)
                 {

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
                 var site = serverManager.Sites.Single();
                 var appPool = serverManager.ApplicationPools.Single();
 
-                var actualPath = site.Applications.Single().VirtualDirectories.Single().PhysicalPath;
+                var actualPath = site.Applications.FirstOrDefault().VirtualDirectories.Single().PhysicalPath;
                 if (actualPath != contentRoot)
                 {
                     throw new InvalidOperationException($"Wrong physical path. Expected: {contentRoot} Actual: {actualPath}");


### PR DESCRIPTION
For https://github.com/aspnet/AspNetCore-Internal/issues/1998, https://github.com/aspnet/AspNetCore-Internal/issues/1999, https://github.com/aspnet/aspnetcore, etc. On Win7, we are seeing the IIS server start with an incorrect physicalPath. We trusted that the IIS ServerManager would switch applicationhost.configs correctly, but it seems like there is a race between modifying the redirection.config and starting the site.

I also removed the OutOfProcess test site fixture. It was only used for 2 tests and it made it increasingly difficult to debug issues.
