### PR TITLE
Hook auth options validation into validation feature

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationBuilder.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationBuilder.cs
@@ -25,9 +25,8 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         public virtual IServiceCollection Services { get; }
 
-
         private AuthenticationBuilder AddSchemeHelper<TOptions, THandler>(string authenticationScheme, string displayName, Action<TOptions> configureOptions)
-            where TOptions : class, new()
+            where TOptions : AuthenticationSchemeOptions, new()
             where THandler : class, IAuthenticationHandler
         {
             Services.Configure<AuthenticationOptions>(o =>
@@ -41,6 +40,10 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 Services.Configure(authenticationScheme, configureOptions);
             }
+            Services.AddOptions<TOptions>(authenticationScheme).Validate(o => {
+                o.Validate(authenticationScheme);
+                return true;
+            });
             Services.AddTransient<THandler>();
             return this;
         }

--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -83,7 +83,6 @@ namespace Microsoft.AspNetCore.Authentication
             Context = context;
 
             Options = OptionsMonitor.Get(Scheme.Name) ?? new TOptions();
-            Options.Validate(Scheme.Name);
 
             await InitializeEventsAsync();
             await InitializeHandlerAsync();

--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Authentication
             Scheme = scheme;
             Context = context;
 
-            Options = OptionsMonitor.Get(Scheme.Name) ?? new TOptions();
+            Options = OptionsMonitor.Get(Scheme.Name);
 
             await InitializeEventsAsync();
             await InitializeHandlerAsync();


### PR DESCRIPTION
@Tratcher reminded by that issue today, basically we just move the call to Validate from the auth handler to options itself