### PR TITLE
Expose ConnectionId  on .NET Client

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/ref/Microsoft.AspNetCore.SignalR.Client.Core.netstandard2.0.cs
+++ b/src/SignalR/clients/csharp/Client.Core/ref/Microsoft.AspNetCore.SignalR.Client.Core.netstandard2.0.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public static readonly System.TimeSpan DefaultServerTimeout;
         public HubConnection(Microsoft.AspNetCore.SignalR.Client.IConnectionFactory connectionFactory, Microsoft.AspNetCore.SignalR.Protocol.IHubProtocol protocol, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public HubConnection(Microsoft.AspNetCore.SignalR.Client.IConnectionFactory connectionFactory, Microsoft.AspNetCore.SignalR.Protocol.IHubProtocol protocol, System.IServiceProvider serviceProvider, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public string ConnectionId { get { throw null; } }
         public System.TimeSpan HandshakeTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.TimeSpan KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.TimeSpan ServerTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -123,12 +123,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// <remarks>
         /// This value will change if the connection is stopped and restarted.
         /// </remarks>
-        public string ConnectionId {
-            get
-            {
-                return _connectionId;
-            }
-        }
+        public string ConnectionId => _connectionId;
 
         /// <summary>
         /// Indicates the state of the <see cref="HubConnection"/> to the server.

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -54,6 +54,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private long _nextActivationSendPing;
         private bool _disposed;
         private bool _hasInherentKeepAlive;
+        private string _connectionId;
 
         private CancellationToken _uploadStreamToken;
 
@@ -115,6 +116,19 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// Gets or sets the timeout for the initial handshake.
         /// </summary>
         public TimeSpan HandshakeTimeout { get; set; } = DefaultHandshakeTimeout;
+
+        /// <summary>
+        /// Get the connections current connection Id.
+        /// </summary>
+        /// <remarks>
+        /// This value will change if the connection is stopped and restarted.
+        /// </remarks>
+        public string ConnectionId {
+            get
+            {
+                return _connectionId;
+            }
+        }
 
         /// <summary>
         /// Indicates the state of the <see cref="HubConnection"/> to the server.
@@ -338,6 +352,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
                 // Start the connection
                 var connection = await _connectionFactory.ConnectAsync(_protocol.TransferFormat);
+                _connectionId = connection.ConnectionId;
                 var startingConnectionState = new ConnectionState(connection, this);
                 _hasInherentKeepAlive = connection.Features.Get<IConnectionInherentKeepAliveFeature>()?.HasInherentKeepAlive ?? false;
 

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -118,11 +118,10 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public TimeSpan HandshakeTimeout { get; set; } = DefaultHandshakeTimeout;
 
         /// <summary>
-        /// Get the connections current connection Id.
+        /// Gets the connection's current Id. This value will be cleared when the connection is stopped and will have a new value every time the connection is (re)established.
+        /// This value will be null if the negotiation step is skipped via HttpConnectionOptions or if the WebSockets transport is explicitly specified because the
+        /// client skips negotiation in that case as well.
         /// </summary>
-        /// <remarks>
-        /// This value will change if the connection is stopped and restarted.
-        /// </remarks>
         public string ConnectionId => _connectionId;
 
         /// <summary>

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -420,6 +420,8 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     (_serviceProvider as IDisposable)?.Dispose();
                     _disposed = true;
                 }
+
+                _connectionId = null;
             }
             finally
             {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -177,7 +177,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     connectionIdFromServer = await connection.InvokeAsync<string>(nameof(TestHub.GetCallerConnectionId)).OrTimeout();
                     Assert.NotEqual(originalClientConnectionId, connectionIdFromServer);
                     Assert.Equal(connection.ConnectionId, connectionIdFromServer);
-
                 }
                 catch (Exception ex)
                 {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -158,6 +158,41 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         [LogLevel(LogLevel.Trace)]
+        public async Task CanAccessConnectionIdFromHubConnection(string protocolName, HttpTransportType transportType, string path)
+        {
+            var protocol = HubProtocols[protocolName];
+            using (StartServer<Startup>(out var server))
+            {
+                var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory);
+                try
+                {
+                    Assert.Null(connection.ConnectionId);
+                    await connection.StartAsync().OrTimeout();
+                    var originalClientConnectionId = connection.ConnectionId;
+                    var connectionIdFromServer = await connection.InvokeAsync<string>(nameof(TestHub.GetCallerConnectionId)).OrTimeout();
+                    Assert.Equal(connection.ConnectionId, connectionIdFromServer);
+                    await connection.StopAsync().OrTimeout();
+                    await connection.StartAsync().OrTimeout();
+                    connectionIdFromServer = await connection.InvokeAsync<string>(nameof(TestHub.GetCallerConnectionId)).OrTimeout();
+                    Assert.NotEqual(originalClientConnectionId, connectionIdFromServer);
+                    Assert.Equal(connection.ConnectionId, connectionIdFromServer);
+
+                }
+                catch (Exception ex)
+                {
+                    LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                    throw;
+                }
+                finally
+                {
+                    await connection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+        [LogLevel(LogLevel.Trace)]
         public async Task CanStartConnectionFromClosedEvent(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
@@ -449,7 +484,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory);
                 try
                 {
-                    await connection.StartAsync().OrTimeout();
+                 await connection.StartAsync().OrTimeout();
 
                     var cts = new CancellationTokenSource();
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -172,6 +172,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     var connectionIdFromServer = await connection.InvokeAsync<string>(nameof(TestHub.GetCallerConnectionId)).OrTimeout();
                     Assert.Equal(connection.ConnectionId, connectionIdFromServer);
                     await connection.StopAsync().OrTimeout();
+                    Assert.Null(connection.ConnectionId);
                     await connection.StartAsync().OrTimeout();
                     connectionIdFromServer = await connection.InvokeAsync<string>(nameof(TestHub.GetCallerConnectionId)).OrTimeout();
                     Assert.NotEqual(originalClientConnectionId, connectionIdFromServer);
@@ -484,7 +485,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory);
                 try
                 {
-                 await connection.StartAsync().OrTimeout();
+                    await connection.StartAsync().OrTimeout();
 
                     var cts = new CancellationTokenSource();
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -219,7 +219,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         Task Echo(string message);
         Task Send(string message);
         Task NoClientHandler();
-        Task SendCallerConnectionId(string connectionId);
     }
 
     public class VersionHub : Hub

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -36,6 +36,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             await Clients.Client(Context.ConnectionId).SendAsync("NoClientHandler");
         }
 
+        public string GetCallerConnectionId()
+        {
+            return Context.ConnectionId;
+        }
+
         public ChannelReader<string> StreamEcho(ChannelReader<string> source) => TestHubMethodsImpl.StreamEcho(source);
 
         public string GetUserIdentifier()
@@ -110,6 +115,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             await Clients.Client(Context.ConnectionId).NoClientHandler();
         }
 
+        public string GetCallerConnectionId()
+        {
+            return Context.ConnectionId;
+        }
+
         public ChannelReader<string> StreamEcho(ChannelReader<string> source) => TestHubMethodsImpl.StreamEcho(source);
     }
 
@@ -133,6 +143,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         public async Task CallHandlerThatDoesntExist()
         {
             await Clients.Client(Context.ConnectionId).NoClientHandler();
+        }
+
+        public string GetCallerConnectionId()
+        {
+            return Context.ConnectionId;
         }
 
         public ChannelReader<string> StreamEcho(ChannelReader<string> source) => TestHubMethodsImpl.StreamEcho(source);
@@ -204,6 +219,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         Task Echo(string message);
         Task Send(string message);
         Task NoClientHandler();
+        Task SendCallerConnectionId(string connectionId);
     }
 
     public class VersionHub : Hub


### PR DESCRIPTION
Exposing the ConnectionId on the .NET Client.

Part of: #8681