### PR TITLE
Update cmake for SignalR C++ client on Mac OS X

### DIFF
--- a/src/SignalR/clients/cpp/CMakeLists.txt
+++ b/src/SignalR/clients/cpp/CMakeLists.txt
@@ -10,10 +10,14 @@ include
 "${CPPREST_INCLUDE_DIR}")
 
 find_library(CPPREST_SO NAMES "cpprest" PATHS ${CPPREST_LIB_DIR} REQUIRED)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	find_package(Boost COMPONENTS chrono thread REQUIRED)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 add_subdirectory(src/signalrclient)
-add_subdirectory(test)
+#add_subdirectory(test)
+set_property(TARGET signalrclient PROPERTY MACOSX_RPATH ON)

--- a/src/SignalR/clients/cpp/src/signalrclient/CMakeLists.txt
+++ b/src/SignalR/clients/cpp/src/signalrclient/CMakeLists.txt
@@ -23,4 +23,8 @@ set (SOURCES
 
 add_library (signalrclient SHARED ${SOURCES})
 
-target_link_libraries(signalrclient ${CPPREST_SO})
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(signalrclient ${CPPREST_SO} ${Boost_LIBRARIES} libssl.dylib libcrypto.dylib)
+else()
+    target_link_libraries(signalrclient ${CPPREST_SO})
+endif()


### PR DESCRIPTION
Summary of the changes
 - Skip gtest
 - Patch Boost and OpenSSL in `/usr/local/opt`
```sh
brew install cpprestsdk boost openssl
cmake .. -DCMAKE_CXX_FLAGS=-I/usr/local/opt/openssl/include -DCPPREST_INCLUDE_DIR=/usr/local/opt/cpprestsdk/include -DCPPREST_LIB_DIR=/usr/local/opt/cpprestsdk/lib
make
```

Addresses #8066
