### PR TITLE
Don't explicitly set ValidationProblemDetails status code

### DIFF
--- a/src/Mvc/Mvc.Core/src/DependencyInjection/ApiBehaviorOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/ApiBehaviorOptionsSetup.cs
@@ -105,10 +105,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         internal static IActionResult ProblemDetailsInvalidModelStateResponse(ActionContext context)
         {
-            var problemDetails = new ValidationProblemDetails(context.ModelState)
-            {
-                Status = StatusCodes.Status400BadRequest,
-            };
+            var problemDetails = new ValidationProblemDetails(context.ModelState);
 
             ProblemDetailsClientErrorFactory.SetTraceId(context, problemDetails);
 

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
@@ -90,6 +90,9 @@ namespace Microsoft.Extensions.DependencyInjection
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(new[] { "application/problem+json", "application/problem+xml" }, badRequest.ContentTypes.OrderBy(c => c));
 
+            // Make sure the result status code is set on the problem details instance.
+            badRequest.OnFormatting(actionContext);
+            
             var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
             Assert.Equal(400, problemDetails.Status);
         }


### PR DESCRIPTION
Re: https://github.com/aspnet/AspNetCore/issues/6145#issuecomment-461640112

Wrapping it in a `BadRequestObjectResult` below will make sure it has the correct status code set:

https://github.com/aspnet/AspNetCore/blob/aa89639d629899985b27b4ad749f707efc8892cd/src/Mvc/Mvc.Core/src/ObjectResult.cs#L61-L64