### PR TITLE
Add overload for Configure that gets WebHostBuilderContext

### DIFF
--- a/src/Hosting/Hosting/ref/Microsoft.AspNetCore.Hosting.netcoreapp3.0.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.AspNetCore.Hosting.netcoreapp3.0.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Hosting
     public static partial class WebHostBuilderExtensions
     {
         public static Microsoft.AspNetCore.Hosting.IWebHostBuilder Configure(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder, System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder> configureApp) { throw null; }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder Configure(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.AspNetCore.Builder.IApplicationBuilder> configureApp) { throw null; }
         public static Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureAppConfiguration(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder, System.Action<Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate) { throw null; }
         public static Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Logging.ILoggingBuilder> configureLogging) { throw null; }
         public static Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder, System.Action<Microsoft.Extensions.Logging.ILoggingBuilder> configureLogging) { throw null; }

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -303,13 +303,14 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             builder.Build(instance)(container);
         }
 
-        public IWebHostBuilder Configure(Action<IApplicationBuilder> configure)
+        public IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
             _builder.ConfigureServices((context, services) =>
             {
                 services.Configure<GenericWebHostServiceOptions>(options =>
                 {
-                    options.ConfigureApplication = configure;
+                    var webhostBuilderContext = GetWebHostBuilderContext(context);
+                    options.ConfigureApplication = app => configure(webhostBuilderContext, app);
                 });
             });
 

--- a/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             return _builder.UseDefaultServiceProvider(configure);
         }
 
-        public IWebHostBuilder Configure(Action<IApplicationBuilder> configure)
+        public IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
             return _builder.Configure(configure);
         }

--- a/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal interface ISupportsStartup
     {
-        IWebHostBuilder Configure(Action<IApplicationBuilder> configure);
+        IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure);
         IWebHostBuilder UseStartup(Type startupType);
     }
 }

--- a/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Hosting
             return hostBuilder.Configure(configureApp, configureApp.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name);
         }
 
-        static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, IApplicationBuilder> configureApp, string startupAssemblyName)
+        private static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, IApplicationBuilder> configureApp, string startupAssemblyName)
         {
             if (configureApp == null)
             {

--- a/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
@@ -23,12 +23,26 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<IApplicationBuilder> configureApp)
         {
+            return hostBuilder.Configure((_, app) => configureApp(app), configureApp.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name);
+        }
+
+        /// <summary>
+        /// Specify the startup method to be used to configure the web application.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
+        /// <param name="configureApp">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, IApplicationBuilder> configureApp)
+        {
+            return hostBuilder.Configure(configureApp, configureApp.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name);
+        }
+
+        static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, IApplicationBuilder> configureApp, string startupAssemblyName)
+        {
             if (configureApp == null)
             {
                 throw new ArgumentNullException(nameof(configureApp));
             }
-
-            var startupAssemblyName = configureApp.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name;
 
             hostBuilder.UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName);
 
@@ -38,11 +52,11 @@ namespace Microsoft.AspNetCore.Hosting
                 return supportsStartup.Configure(configureApp);
             }
 
-            return hostBuilder.ConfigureServices(services =>
+            return hostBuilder.ConfigureServices((context, services) =>
             {
                 services.AddSingleton<IStartup>(sp =>
                 {
-                    return new DelegateStartup(sp.GetRequiredService<IServiceProviderFactory<IServiceCollection>>(), configureApp);
+                    return new DelegateStartup(sp.GetRequiredService<IServiceProviderFactory<IServiceCollection>>(), (app => configureApp(context, app)));
                 });
             });
         }

--- a/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
+++ b/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
             return new GenericWebHost(_hostBuilder.Build());
         }
 
-        public IWebHostBuilder Configure(Action<IApplicationBuilder> configure)
+        public IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
             _builder.Configure(configure);
             return this;


### PR DESCRIPTION
Adds an overload for Configure that gets the WebHostBuilderContext to avoid having to assign `IHostingEnvironment` and `IConfiguration` to static fields like shown in https://docs.microsoft.com/en-us/aspnet/core/fundamentals/startup?view=aspnetcore-2.2#convenience-methods

I stopped expanding this further down to `IStartup` and `IStartupFilter`. I'll leave the breaking change decision to you folks

Addresses #5903
