### PR TITLE
use fields to avoid hard coded state classes

### DIFF
--- a/src/Components/Components/src/Forms/EditContext.cs
+++ b/src/Components/Components/src/Forms/EditContext.cs
@@ -13,6 +13,12 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// </summary>
     public sealed class EditContext
     {
+        public static string ModifiedClass = "modified";
+        public static string ValidClass = "valid";
+        public static string InvalidClass = "invalid";
+        public static string ValidationMessageClass = "validation-message";
+        public static string ValidationErrorsClass = "validation-errors";
+
         // Note that EditContext tracks state for any FieldIdentifier you give to it, plus
         // the underlying storage is sparse. As such, none of the APIs have a "field not found"
         // error state. If you give us an unrecognized FieldIdentifier, that just means we

--- a/src/Components/Components/src/Forms/EditContextFieldClassExtensions.cs
+++ b/src/Components/Components/src/Forms/EditContextFieldClassExtensions.cs
@@ -35,11 +35,13 @@ namespace Microsoft.AspNetCore.Components.Forms
             var isValid = !editContext.GetValidationMessages(fieldIdentifier).Any();
             if (editContext.IsModified(fieldIdentifier))
             {
-                return isValid ? "modified valid" : "modified invalid";
+                return isValid ?
+                    EditContext.ModifiedClass + " " + EditContext.ValidClass :
+                    EditContext.ModifiedClass + " " + EditContext.InvalidClass;
             }
             else
             {
-                return isValid ? "valid" : "invalid";
+                return isValid ? EditContext.ValidClass : EditContext.InvalidClass;
             }
         }
     }

--- a/src/Components/Components/src/Forms/ValidationMessage.cs
+++ b/src/Components/Components/src/Forms/ValidationMessage.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             foreach (var message in CurrentEditContext.GetValidationMessages(_fieldIdentifier))
             {
                 builder.OpenElement(0, "div");
-                builder.AddAttribute(1, "class", "validation-message");
+                builder.AddAttribute(1, "class", EditContext.ValidationMessageClass);
                 builder.AddContent(2, message);
                 builder.CloseElement();
             }

--- a/src/Components/Components/src/Forms/ValidationSummary.cs
+++ b/src/Components/Components/src/Forms/ValidationSummary.cs
@@ -57,12 +57,12 @@ namespace Microsoft.AspNetCore.Components.Forms
             if (messagesEnumerator.MoveNext())
             {
                 builder.OpenElement(0, "ul");
-                builder.AddAttribute(1, "class", "validation-errors");
+                builder.AddAttribute(1, "class", EditContext.ValidationErrorsClass);
 
                 do
                 {
                     builder.OpenElement(2, "li");
-                    builder.AddAttribute(3, "class", "validation-message");
+                    builder.AddAttribute(3, "class", EditContext.ValidationMessageClass);
                     builder.AddContent(4, messagesEnumerator.Current);
                     builder.CloseElement();
                 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
- add static read-write fields to EditContext to hold validation state classes
- use these classes to apply field validation state
- user could customize their own classes