### PR TITLE
backport accessTokenProvider fix

### DIFF
--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1213,4 +1213,86 @@ class HubConnectionTest {
             () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Unexpected status code returned from negotiate: 500 Internal server error.", exception.getMessage());
     }
+
+    @Test
+    public void accessTokenProviderReferenceIsKeptAfterNegotiateRedirect() {
+        AtomicReference<String> token = new AtomicReference<>();
+        AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
+
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate", (req) -> {
+                    beforeRedirectToken.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
+                })
+                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                    token.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                            + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                });
+
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransport(transport)
+                .withHttpClient(client)
+                .withAccessTokenProvider(Single.just("User Registered Token"))
+                .build();
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals("Bearer User Registered Token", beforeRedirectToken.get());
+        assertEquals("Bearer newToken", token.get());
+
+        // Clear the tokens to see if they get reset to the proper values
+        beforeRedirectToken.set("");
+        token.set("");
+
+        // Restart the connection to make sure that the orignal accessTokenProvider that we registered is still registered before the redirect.
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop();
+        assertEquals("Bearer User Registered Token", beforeRedirectToken.get());
+        assertEquals("Bearer newToken", token.get());
+    }
+
+    @Test
+    public void authorizationHeaderFromNegotiateGetsClearedAfterStopping() {
+        AtomicReference<String> token = new AtomicReference<>();
+        AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
+
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate", (req) -> {
+                    beforeRedirectToken.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
+                })
+                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                    token.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                            + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                });
+
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransport(transport)
+                .withHttpClient(client)
+                .build();
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals("Bearer newToken", token.get());
+
+        // Clear the tokens to see if they get reset to the proper values
+        beforeRedirectToken.set("");
+        token.set("");
+
+        // Restart the connection to make sure that the orignal accessTokenProvider that we registered is still registered before the redirect.
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop();
+        assertNull(beforeRedirectToken.get());
+        assertEquals("Bearer newToken", token.get());
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/8640


Backporting a fix for issue: https://github.com/aspnet/AspNetCore/issues/8429 into 2.2.x

# Description:
When connecting to the Azure SignalR Service we take the access token from the negotiate response and wrap that in a single and override the user provided `accessTokenProvider` is there was one. That behavior is correct. What is incorrect is that we don't keep a reference to the original passed in `accessTokenProvider` so we can restore it if we restart the connection. 

# Customer Impact
Without this change customers who have provided an accessToken provider and are connecting to the Azure SignalR Service won't be able to restart their connections properly.

# Regression?
Nope

# Risk:
Low. This just makes sure that we can reset the user provided accessTokenProvider if there was one in the event the client is connecting to the Azure SignalR Service.