### PR TITLE
Copy EndpointFeature when using LongPolling

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -589,10 +589,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             // The response is a dud, you can't do anything with it anyways
             var responseFeature = new HttpResponseFeature();
 
+            var endpointFeature = context.Features.Get<IEndpointFeature>();
+
             var features = new FeatureCollection();
             features.Set<IHttpRequestFeature>(requestFeature);
             features.Set<IHttpResponseFeature>(responseFeature);
             features.Set<IHttpConnectionFeature>(connectionFeature);
+            features.Set<IEndpointFeature>(endpointFeature);
 
             // REVIEW: We could strategically look at adding other features but it might be better
             // if we expose a callback that would allow the user to preserve HttpContext properties.

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Connections.Internal;
 using Microsoft.AspNetCore.Http.Connections.Internal.Transports;
+using Microsoft.AspNetCore.Http.Endpoints;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.SignalR.Tests;
@@ -588,11 +589,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             }
         }
 
-        private class CustomEndpointFeature : IEndpointFeature
-        {
-            public Endpoint Endpoint { get; set; }
-        }
-
         [Fact]
         public async Task HttpContextFeatureForLongpollingWorksBetweenPolls()
         {
@@ -632,9 +628,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Connection.LocalPort = 4563;
                     context.Connection.RemoteIpAddress = IPAddress.IPv6Any;
                     context.Connection.RemotePort = 43456;
-                    IEndpointFeature endpointFeature = new CustomEndpointFeature();
-                    endpointFeature.Endpoint = new Endpoint(null, null, "TestName");
-                    context.Features.Set<IEndpointFeature>(endpointFeature);
+                    context.SetEndpoint(new Endpoint(null, null, "TestName"));
 
                     var builder = new ConnectionBuilder(services.BuildServiceProvider());
                     builder.UseConnectionHandler<HttpContextConnectionHandler>();
@@ -687,7 +681,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     Assert.Equal(Stream.Null, connectionHttpContext.Response.Body);
                     Assert.NotNull(connectionHttpContext.Response.Headers);
                     Assert.Equal("application/xml", connectionHttpContext.Response.ContentType);
-                    endpointFeature = connectionHttpContext.Features.Get<IEndpointFeature>();
+                    var endpointFeature = connectionHttpContext.Features.Get<IEndpointFeature>();
                     Assert.NotNull(endpointFeature);
                     Assert.Equal("TestName", endpointFeature.Endpoint.DisplayName);
                 }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -588,6 +588,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             }
         }
 
+        private class CustomEndpointFeature : IEndpointFeature
+        {
+            public Endpoint Endpoint { get; set; }
+        }
+
         [Fact]
         public async Task HttpContextFeatureForLongpollingWorksBetweenPolls()
         {
@@ -627,6 +632,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Connection.LocalPort = 4563;
                     context.Connection.RemoteIpAddress = IPAddress.IPv6Any;
                     context.Connection.RemotePort = 43456;
+                    IEndpointFeature endpointFeature = new CustomEndpointFeature();
+                    endpointFeature.Endpoint = new Endpoint(null, null, "TestName");
+                    context.Features.Set<IEndpointFeature>(endpointFeature);
 
                     var builder = new ConnectionBuilder(services.BuildServiceProvider());
                     builder.UseConnectionHandler<HttpContextConnectionHandler>();
@@ -679,6 +687,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     Assert.Equal(Stream.Null, connectionHttpContext.Response.Body);
                     Assert.NotNull(connectionHttpContext.Response.Headers);
                     Assert.Equal("application/xml", connectionHttpContext.Response.ContentType);
+                    endpointFeature = connectionHttpContext.Features.Get<IEndpointFeature>();
+                    Assert.NotNull(endpointFeature);
+                    Assert.Equal("TestName", endpointFeature.Endpoint.DisplayName);
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/8679

@JamesNK Is it ok to reference the feature from the original HttpContext? Or should we do some kind of deep copy?

~~TODO: Write a test~~