### PR TITLE
Fix jasmine timeout

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
@@ -5,7 +5,7 @@ import { HttpTransportType, IHubProtocol, JsonHubProtocol } from "@aspnet/signal
 import { MessagePackHubProtocol } from "@aspnet/signalr-protocol-msgpack";
 
 // On slower CI machines, these tests sometimes take longer than 5s
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 1000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20 * 1000;
 
 export let ENDPOINT_BASE_URL: string = "";
 export let ENDPOINT_BASE_HTTPS_URL: string = "";

--- a/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
@@ -17,9 +17,6 @@ const commonOptions: IHttpConnectionOptions = {
     logger: TestLogger.instance,
 };
 
-// On slower CI machines, these tests sometimes take longer than 5s
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 1000;
-
 describe("connection", () => {
     it("can connect to the server without specifying transport explicitly", (done) => {
         const message = "Hello World!";

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -18,9 +18,6 @@ const TESTHUBENDPOINT_HTTPS_URL = ENDPOINT_BASE_HTTPS_URL ? (ENDPOINT_BASE_HTTPS
 
 const TESTHUB_NOWEBSOCKETS_ENDPOINT_URL = ENDPOINT_BASE_URL + "/testhub-nowebsockets";
 
-// On slower CI machines, these tests sometimes take longer than 5s
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 1000;
-
 const commonOptions: IHttpConnectionOptions = {
     logMessageContent: true,
 };


### PR DESCRIPTION
Issue: https://github.com/aspnet/AspNetCore-Internal/issues/1961
We were manually setting the timeout in the HubConnection and Connection tests to 10 seconds. We had logic to set it to 20 seconds but it was getting written over. The logs were explicitly saying that the timeout allowed was only 10 seconds. I did a manual sauce labs build of this and it passed but I want to have it on the daily cadence to see if it brings stability. 
