### PR TITLE
Blazor: Decode URL segments in RouteContext

### DIFF
--- a/src/Components/Components/src/Routing/RouteContext.cs
+++ b/src/Components/Components/src/Routing/RouteContext.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace Microsoft.AspNetCore.Components.Routing
 {
@@ -15,6 +16,11 @@ namespace Microsoft.AspNetCore.Components.Routing
             // This is a simplification. We are assuming there are no paths like /a//b/. A proper routing
             // implementation would be more sophisticated.
             Segments = path.Trim('/').Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+            // Individual segments are URL-decoded in order to support arbitrary characters, assuming UTF-8 encoding.
+            for (int i = 0; i < Segments.Length; i++)
+            {
+                Segments[i] = WebUtility.UrlDecode(Segments[i]);
+            }
         }
 
         public string[] Segments { get; }

--- a/src/Components/Components/src/Routing/RouteContext.cs
+++ b/src/Components/Components/src/Routing/RouteContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 
 namespace Microsoft.AspNetCore.Components.Routing
 {
@@ -19,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             // Individual segments are URL-decoded in order to support arbitrary characters, assuming UTF-8 encoding.
             for (int i = 0; i < Segments.Length; i++)
             {
-                Segments[i] = WebUtility.UrlDecode(Segments[i]);
+                Segments[i] = Uri.UnescapeDataString(Segments[i]);
             }
         }
 

--- a/src/Components/Components/test/Routing/RouteTableTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableTests.cs
@@ -68,6 +68,20 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
         }
 
         [Fact]
+        public void CanMatchEncodedSegments()
+        {
+            // Arrange
+            var routeTable = new TestRouteTableBuilder().AddRoute("/some/ünicõdē/🛣/").Build();
+            var context = new RouteContext("/some/%C3%BCnic%C3%B5d%C4%93/%F0%9F%9B%A3");
+
+            // Act
+            routeTable.Route(context);
+
+            // Assert
+            Assert.NotNull(context.Handler);
+        }
+
+        [Fact]
         public void DoesNotMatchIfSegmentsDontMatch()
         {
             // Arrange
@@ -122,6 +136,9 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
         [Theory]
         [InlineData("/value1", "value1")]
         [InlineData("/value2/", "value2")]
+        [InlineData("/d%C3%A9j%C3%A0%20vu", "déjà vu")]
+        [InlineData("/d%C3%A9j%C3%A0%20vu/", "déjà vu")]
+        [InlineData("/d%C3%A9j%C3%A0+vu", "déjà vu")]
         public void CanMatchParameterTemplate(string path, string expectedValue)
         {
             // Arrange

--- a/src/Components/Components/test/Routing/RouteTableTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
         [InlineData("/value2/", "value2")]
         [InlineData("/d%C3%A9j%C3%A0%20vu", "déjà vu")]
         [InlineData("/d%C3%A9j%C3%A0%20vu/", "déjà vu")]
-        [InlineData("/d%C3%A9j%C3%A0+vu", "déjà vu")]
+        [InlineData("/d%C3%A9j%C3%A0+vu", "déjà+vu")]
         public void CanMatchParameterTemplate(string path, string expectedValue)
         {
             // Arrange


### PR DESCRIPTION
Change `RouteContext`, to URL-decode every route segment. This happens before they are matched in `RouteEntry`, so both static route segments and route parameters are handled.

The current implementation of `TemplateParser` seems pretty relaxed and only splits on the character `/`, so unless we want to support route segments containing escaped `/` characters, the change on `RouteContext` should be enough.

Addresses #5510
