### PR TITLE
Update to newer Blazor.Mono. Fixes #6726

### DIFF
--- a/build/runtimes.props
+++ b/build/runtimes.props
@@ -1,6 +1,9 @@
 <Project>
 
   <ItemGroup>
+    <!-- BaselineGenerator is netcoreapp2.1. Other build tools may also require 2.x. -->
+    <DotNetCoreRuntime Include="2.2.1" />
+
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)"
       Feed="$(DotNetAssetRootUrl)"
       FeedCredential="$(DotNetAssetRootAccessTokenSuffix)" />

--- a/build/runtimes.props
+++ b/build/runtimes.props
@@ -1,9 +1,6 @@
 <Project>
 
   <ItemGroup>
-    <!-- Workaround https://github.com/aspnet/AspNetCore/issues/6726. Required because illink (part of Microsoft.AspNetCore.Blazor.Mono) depends on .NET Core 2.x -->
-    <DotNetCoreRuntime Include="2.2.1" />
-
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)"
       Feed="$(DotNetAssetRootUrl)"
       FeedCredential="$(DotNetAssetRootAccessTokenSuffix)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -164,7 +164,7 @@
     <SystemIdentityModelTokensJwtPackageVersion>5.3.0</SystemIdentityModelTokensJwtPackageVersion>
     <WindowsAzureStoragePackageVersion>8.1.4</WindowsAzureStoragePackageVersion>
     <!-- Dependencies for Blazor. -->
-    <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.8.0-preview-20190204.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
+    <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.10.0-preview-20190325.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from 2.1/2.2 branches used for site extension build -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>

--- a/src/Components/Blazor/Build/test/RuntimeDependenciesResolverTest.cs
+++ b/src/Components/Blazor/Build/test/RuntimeDependenciesResolverTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 "System.Data.dll",
                 "System.Diagnostics.Debug.dll",
                 "System.Diagnostics.Tracing.dll",
-                "System.Drawing.dll",
+                "System.Drawing.Common.dll",
                 "System.IO.Compression.dll",
                 "System.IO.Compression.FileSystem.dll",
                 "System.Linq.dll",

--- a/src/Components/Blazor/testassets/MonoSanityClient/Examples.cs
+++ b/src/Components/Blazor/testassets/MonoSanityClient/Examples.cs
@@ -11,6 +11,14 @@ namespace MonoSanityClient
 {
     public static class Examples
     {
+        static Examples()
+        {
+            // We have to populate GetHttpMessageHandler with something (like the real
+            // Blazor web assembly host does), otherwise HttpClientHandler's constructor
+            // gets into an infinite loop.
+            FakeHttpMessageHandler.Attach();
+        }
+
         public static string AddNumbers(int a, int b)
             => (a + b).ToString();
 

--- a/src/Components/Blazor/testassets/MonoSanityClient/FakeHttpMessageHandler.cs
+++ b/src/Components/Blazor/testassets/MonoSanityClient/FakeHttpMessageHandler.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MonoSanityClient
+{
+    class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        public static void Attach()
+        {
+            var getHttpMessageHandlerField = typeof(HttpClient).GetField(
+                "GetHttpMessageHandler",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Func<HttpMessageHandler> handlerFactory = () => new FakeHttpMessageHandler();
+            getHttpMessageHandlerField.SetValue(null, handlerFactory);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new NotImplementedException($"{nameof(FakeHttpMessageHandler)} cannot {nameof(SendAsync)}.");
+    }
+}


### PR DESCRIPTION
This corresponds to the package built from this: https://github.com/aspnet/Blazor/pull/1801

The net result is:

 * Default compressed Blazor app size **increases by 25KB** compared with the previous Mono binaries we've been using since 0.8. This size delta is small enough not to be a problem (though of course we're always looking for size reductions in the future :smile:)
 * Runtime perf effect:
    * In Firefox, the startup time **decreases by about 10%**, but other benchmarks show basically no change
    * In Chrome, the startup time is not significantly affected, but other benchmarks show **improvements in the 10%-30% range**, which is pretty impressive. Rendering large batches and formatting large JSON payloads see the biggest speed-ups.

**Sidenote:** Independently of any changes to Mono, since about a month ago, Chrome has overtaken Firefox as being fastest to execute .NET on WebAssembly. This is because Firefox's speed hasn't changed much during this time, whereas Chrome has become almost twice as fast. I don't know what optimizations they have shipped but they are really working.