### PR TITLE
Fix #8520 - Component parameters not found

### DIFF
--- a/eng/GenAPI.exclusions.txt
+++ b/eng/GenAPI.exclusions.txt
@@ -3,3 +3,19 @@ T:Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame
 # Manually implemented - https://github.com/dotnet/arcade/issues/2066
 T:Microsoft.AspNetCore.Mvc.ApplicationModels.PageParameterModel
 T:Microsoft.AspNetCore.Mvc.ApplicationModels.PagePropertyModel
+# Manually implemented - https://github.com/aspnet/AspNetCore/issues/8825
+T:Microsoft.AspNetCore.Components.CascadingValue`1
+T:Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator
+T:Microsoft.AspNetCore.Components.Forms.EditForm
+T:Microsoft.AspNetCore.Components.Forms.InputBase`1
+T:Microsoft.AspNetCore.Components.Forms.InputCheckbox
+T:Microsoft.AspNetCore.Components.Forms.InputDate`1
+T:Microsoft.AspNetCore.Components.Forms.InputNumber`1
+T:Microsoft.AspNetCore.Components.Forms.InputSelect`1
+T:Microsoft.AspNetCore.Components.Forms.InputText
+T:Microsoft.AspNetCore.Components.Forms.InputTextArea
+T:Microsoft.AspNetCore.Components.Forms.ValidationMessage`1
+T:Microsoft.AspNetCore.Components.Forms.ValidationSummary
+T:Microsoft.AspNetCore.Components.Layouts.LayoutDisplay
+T:Microsoft.AspNetCore.Components.Routing.NavLink
+T:Microsoft.AspNetCore.Components.Routing.Router

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.Manual.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.Manual.cs
@@ -45,3 +45,183 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         public override string ToString() { throw null; }
     }
 }
+
+// Built-in components: https://github.com/aspnet/AspNetCore/issues/8825
+namespace Microsoft.AspNetCore.Components
+{
+    public partial class CascadingValue<T> : Microsoft.AspNetCore.Components.IComponent
+    {
+        public CascadingValue() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public bool IsFixed { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public T Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
+        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
+    }
+}
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    public partial class DataAnnotationsValidator : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        public DataAnnotationsValidator() { }
+        protected override void OnInit() { }
+    }
+
+    public partial class EditForm : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        public EditForm() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.Forms.EditContext EditContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public object Model { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> OnInvalidSubmit { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> OnSubmit { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> OnValidSubmit { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override void OnParametersSet() { }
+    }
+
+    public abstract partial class InputBase<T> : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        protected InputBase() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string Class { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected string CssClass { get { throw null; } }
+        protected T CurrentValue { get { throw null; } set { } }
+        protected string CurrentValueAsString { get { throw null; } set { } }
+        protected Microsoft.AspNetCore.Components.Forms.EditContext EditContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        protected string FieldClass { get { throw null; } }
+        protected Microsoft.AspNetCore.Components.Forms.FieldIdentifier FieldIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public T Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.EventCallback<T> ValueChanged { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Linq.Expressions.Expression<System.Func<T>> ValueExpression { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected virtual string FormatValueAsString(T value) { throw null; }
+        public override System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
+        protected abstract bool TryParseValueFromString(string value, out T result, out string validationErrorMessage);
+    }
+
+    public partial class InputCheckbox : Microsoft.AspNetCore.Components.Forms.InputBase<bool>
+    {
+        public InputCheckbox() { }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override bool TryParseValueFromString(string value, out bool result, out string validationErrorMessage) { throw null; }
+    }
+
+    public partial class InputDate<T> : Microsoft.AspNetCore.Components.Forms.InputBase<T>
+    {
+        public InputDate() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string ParsingErrorMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override string FormatValueAsString(T value) { throw null; }
+        protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage) { throw null; }
+    }
+
+    public partial class InputNumber<T> : Microsoft.AspNetCore.Components.Forms.InputBase<T>
+    {
+        public InputNumber() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string ParsingErrorMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage) { throw null; }
+    }
+
+    public partial class InputSelect<T> : Microsoft.AspNetCore.Components.Forms.InputBase<T>
+    {
+        public InputSelect() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage) { throw null; }
+    }
+
+    public partial class InputText : Microsoft.AspNetCore.Components.Forms.InputBase<string>
+    {
+        public InputText() { }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override bool TryParseValueFromString(string value, out string result, out string validationErrorMessage) { throw null; }
+    }
+
+    public partial class InputTextArea : Microsoft.AspNetCore.Components.Forms.InputBase<string>
+    {
+        public InputTextArea() { }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override bool TryParseValueFromString(string value, out string result, out string validationErrorMessage) { throw null; }
+    }
+
+    public partial class ValidationMessage<T> : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
+    {
+        public ValidationMessage() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Linq.Expressions.Expression<System.Func<T>> For { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override void OnParametersSet() { }
+        void System.IDisposable.Dispose() { }
+    }
+
+    public partial class ValidationSummary : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
+    {
+        public ValidationSummary() { }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override void OnParametersSet() { }
+        void System.IDisposable.Dispose() { }
+    }
+}
+
+namespace Microsoft.AspNetCore.Components.Layouts
+{
+    public partial class LayoutDisplay : Microsoft.AspNetCore.Components.IComponent
+    {
+        public LayoutDisplay() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Type Page { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Collections.Generic.IDictionary<string, object> PageParameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
+        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
+    }
+}
+
+namespace Microsoft.AspNetCore.Components.Routing
+{
+    public partial class NavLink : Microsoft.AspNetCore.Components.IComponent, System.IDisposable
+    {
+        public NavLink() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string ActiveClass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.Routing.NavLinkMatch Match { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
+    }
+
+    public partial class Router : Microsoft.AspNetCore.Components.IComponent, System.IDisposable
+    {
+        public Router() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Reflection.Assembly AppAssembly { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Type FallbackComponent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; }}
+        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
+        public void Dispose() { }
+        protected virtual void Render(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, System.Type handler, System.Collections.Generic.IDictionary<string, object> parameters) { }
+        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
+    }
+}

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -63,12 +63,6 @@ namespace Microsoft.AspNetCore.Components
         public CascadingParameterAttribute() { }
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
-    public partial class CascadingValue<T> : Microsoft.AspNetCore.Components.IComponent
-    {
-        public CascadingValue() { }
-        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
-        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
-    }
     public abstract partial class ComponentBase : Microsoft.AspNetCore.Components.IComponent, Microsoft.AspNetCore.Components.IHandleAfterRender, Microsoft.AspNetCore.Components.IHandleEvent
     {
         public const string BuildRenderTreeMethodName = "BuildRenderTree";
@@ -617,11 +611,6 @@ namespace Microsoft.AspNetCore.Components
 }
 namespace Microsoft.AspNetCore.Components.Forms
 {
-    public partial class DataAnnotationsValidator : Microsoft.AspNetCore.Components.ComponentBase
-    {
-        public DataAnnotationsValidator() { }
-        protected override void OnInit() { }
-    }
     public sealed partial class EditContext
     {
         public EditContext(object model) { }
@@ -654,12 +643,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         public static string FieldClass(this Microsoft.AspNetCore.Components.Forms.EditContext editContext, in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) { throw null; }
         public static string FieldClass<TField>(this Microsoft.AspNetCore.Components.Forms.EditContext editContext, System.Linq.Expressions.Expression<System.Func<TField>> accessor) { throw null; }
     }
-    public partial class EditForm : Microsoft.AspNetCore.Components.ComponentBase
-    {
-        public EditForm() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override void OnParametersSet() { }
-    }
     public sealed partial class FieldChangedEventArgs
     {
         internal FieldChangedEventArgs() { }
@@ -675,60 +658,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         public static Microsoft.AspNetCore.Components.Forms.FieldIdentifier Create<T>(System.Linq.Expressions.Expression<System.Func<T>> accessor) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-    }
-    public abstract partial class InputBase<T> : Microsoft.AspNetCore.Components.ComponentBase
-    {
-        protected InputBase() { }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        protected string Class { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        protected string CssClass { get { throw null; } }
-        protected T CurrentValue { get { throw null; } set { } }
-        protected string CurrentValueAsString { get { throw null; } set { } }
-        protected Microsoft.AspNetCore.Components.Forms.EditContext EditContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        protected string FieldClass { get { throw null; } }
-        protected Microsoft.AspNetCore.Components.Forms.FieldIdentifier FieldIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        protected string Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        protected virtual string FormatValueAsString(T value) { throw null; }
-        public override System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
-        protected abstract bool TryParseValueFromString(string value, out T result, out string validationErrorMessage);
-    }
-    public partial class InputCheckbox : Microsoft.AspNetCore.Components.Forms.InputBase<bool>
-    {
-        public InputCheckbox() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override bool TryParseValueFromString(string value, out bool result, out string validationErrorMessage) { throw null; }
-    }
-    public partial class InputDate<T> : Microsoft.AspNetCore.Components.Forms.InputBase<T>
-    {
-        public InputDate() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override string FormatValueAsString(T value) { throw null; }
-        protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage) { throw null; }
-    }
-    public partial class InputNumber<T> : Microsoft.AspNetCore.Components.Forms.InputBase<T>
-    {
-        public InputNumber() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage) { throw null; }
-    }
-    public partial class InputSelect<T> : Microsoft.AspNetCore.Components.Forms.InputBase<T>
-    {
-        public InputSelect() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override bool TryParseValueFromString(string value, out T result, out string validationErrorMessage) { throw null; }
-    }
-    public partial class InputText : Microsoft.AspNetCore.Components.Forms.InputBase<string>
-    {
-        public InputText() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override bool TryParseValueFromString(string value, out string result, out string validationErrorMessage) { throw null; }
-    }
-    public partial class InputTextArea : Microsoft.AspNetCore.Components.Forms.InputBase<string>
-    {
-        public InputTextArea() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override bool TryParseValueFromString(string value, out string result, out string validationErrorMessage) { throw null; }
     }
     public sealed partial class ValidationMessageStore
     {
@@ -746,13 +675,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         public static void AddRange(this Microsoft.AspNetCore.Components.Forms.ValidationMessageStore store, System.Linq.Expressions.Expression<System.Func<object>> accessor, System.Collections.Generic.IEnumerable<string> messages) { }
         public static void Clear(this Microsoft.AspNetCore.Components.Forms.ValidationMessageStore store, System.Linq.Expressions.Expression<System.Func<object>> accessor) { }
     }
-    public partial class ValidationMessage<T> : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
-    {
-        public ValidationMessage() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override void OnParametersSet() { }
-        void System.IDisposable.Dispose() { }
-    }
     public sealed partial class ValidationRequestedEventArgs
     {
         internal ValidationRequestedEventArgs() { }
@@ -760,13 +682,6 @@ namespace Microsoft.AspNetCore.Components.Forms
     public sealed partial class ValidationStateChangedEventArgs
     {
         internal ValidationStateChangedEventArgs() { }
-    }
-    public partial class ValidationSummary : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
-    {
-        public ValidationSummary() { }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override void OnParametersSet() { }
-        void System.IDisposable.Dispose() { }
     }
 }
 namespace Microsoft.AspNetCore.Components.Layouts
@@ -782,12 +697,6 @@ namespace Microsoft.AspNetCore.Components.Layouts
         protected LayoutComponentBase() { }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         protected Microsoft.AspNetCore.Components.RenderFragment Body { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    }
-    public partial class LayoutDisplay : Microsoft.AspNetCore.Components.IComponent
-    {
-        public LayoutDisplay() { }
-        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
-        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
     }
 }
 namespace Microsoft.AspNetCore.Components.Rendering
@@ -920,25 +829,10 @@ namespace Microsoft.AspNetCore.Components.RenderTree
 }
 namespace Microsoft.AspNetCore.Components.Routing
 {
-    public partial class NavLink : Microsoft.AspNetCore.Components.IComponent, System.IDisposable
-    {
-        public NavLink() { }
-        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
-        public void Dispose() { }
-        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
-    }
     public enum NavLinkMatch
     {
         All = 1,
         Prefix = 0,
-    }
-    public partial class Router : Microsoft.AspNetCore.Components.IComponent, System.IDisposable
-    {
-        public Router() { }
-        public void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
-        public void Dispose() { }
-        protected virtual void Render(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder, System.Type handler, System.Collections.Generic.IDictionary<string, object> parameters) { }
-        public System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters) { throw null; }
     }
 }
 namespace Microsoft.AspNetCore.Components.Services

--- a/src/Components/Components/src/CascadingValue.cs
+++ b/src/Components/Components/src/CascadingValue.cs
@@ -21,12 +21,12 @@ namespace Microsoft.AspNetCore.Components
         /// <summary>
         /// The content to which the value should be provided.
         /// </summary>
-        [Parameter] private RenderFragment ChildContent { get; set; }
+        [Parameter] public RenderFragment ChildContent { get; private set; }
 
         /// <summary>
         /// The value to be provided.
         /// </summary>
-        [Parameter] private T Value { get; set; }
+        [Parameter] public T Value { get; private set; }
 
         /// <summary>
         /// Optionally gives a name to the provided value. Descendant components
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Components
         /// If no name is specified, then descendant components will receive the
         /// value based the type of value they are requesting.
         /// </summary>
-        [Parameter] private string Name { get; set; }
+        [Parameter] public string Name { get; private set; }
 
         /// <summary>
         /// If true, indicates that <see cref="Value"/> will not change. This is a
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components
         /// change notifications. Set this flag only if you will not change
         /// <see cref="Value"/> during the component's lifetime.
         /// </summary>
-        [Parameter] private bool IsFixed { get; set; }
+        [Parameter] public bool IsFixed { get; private set; }
 
         object ICascadingValueComponent.CurrentValue => Value;
 

--- a/src/Components/Components/src/Forms/EditForm.cs
+++ b/src/Components/Components/src/Forms/EditForm.cs
@@ -29,19 +29,19 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// also supply <see cref="Model"/>, since the model value will be taken
         /// from the <see cref="EditContext.Model"/> property.
         /// </summary>
-        [Parameter] EditContext EditContext { get; set; }
+        [Parameter] public EditContext EditContext { get; private set; }
 
         /// <summary>
         /// Specifies the top-level model object for the form. An edit context will
         /// be constructed for this model. If using this parameter, do not also supply
         /// a value for <see cref="EditContext"/>.
         /// </summary>
-        [Parameter] object Model { get; set; }
+        [Parameter] public object Model { get; private set; }
 
         /// <summary>
         /// Specifies the content to be rendered inside this <see cref="EditForm"/>.
         /// </summary>
-        [Parameter] RenderFragment<EditContext> ChildContent { get; set; }
+        [Parameter] public RenderFragment<EditContext> ChildContent { get; private set; }
 
         /// <summary>
         /// A callback that will be invoked when the form is submitted.
@@ -49,19 +49,19 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// If using this parameter, you are responsible for triggering any validation
         /// manually, e.g., by calling <see cref="EditContext.Validate"/>.
         /// </summary>
-        [Parameter] EventCallback<EditContext> OnSubmit { get; set; }
+        [Parameter] public EventCallback<EditContext> OnSubmit { get; private set; }
 
         /// <summary>
         /// A callback that will be invoked when the form is submitted and the
         /// <see cref="EditContext"/> is determined to be valid.
         /// </summary>
-        [Parameter] EventCallback<EditContext> OnValidSubmit { get; set; }
+        [Parameter] public EventCallback<EditContext> OnValidSubmit { get; private set; }
 
         /// <summary>
         /// A callback that will be invoked when the form is submitted and the
         /// <see cref="EditContext"/> is determined to be invalid.
         /// </summary>
-        [Parameter] EventCallback<EditContext> OnInvalidSubmit { get; set; }
+        [Parameter] public EventCallback<EditContext> OnInvalidSubmit { get; private set; }
 
         /// <inheritdoc />
         protected override void OnParametersSet()

--- a/src/Components/Components/src/Forms/InputComponents/InputBase.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputBase.cs
@@ -24,12 +24,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <summary>
         /// Gets a value for the component's 'id' attribute.
         /// </summary>
-        [Parameter] protected string Id { get; private set; }
+        [Parameter] public string Id { get; private set; }
 
         /// <summary>
         /// Gets a value for the component's 'class' attribute.
         /// </summary>
-        [Parameter] protected string Class { get; private set; }
+        [Parameter] public string Class { get; private set; }
 
         /// <summary>
         /// Gets or sets the value of the input. This should be used with two-way binding.
@@ -37,17 +37,17 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <example>
         /// bind-Value="@model.PropertyName"
         /// </example>
-        [Parameter] T Value { get; set; }
+        [Parameter] public T Value { get; private set; }
 
         /// <summary>
         /// Gets or sets a callback that updates the bound value.
         /// </summary>
-        [Parameter] EventCallback<T> ValueChanged { get; set; }
+        [Parameter] public EventCallback<T> ValueChanged { get; private set; }
 
         /// <summary>
         /// Gets or sets an expression that identifies the bound value.
         /// </summary>
-        [Parameter] Expression<Func<T>> ValueExpression { get; set; }
+        [Parameter] public Expression<Func<T>> ValueExpression { get; private set; }
 
         /// <summary>
         /// Gets the associated <see cref="Microsoft.AspNetCore.Components.Forms.EditContext"/>.

--- a/src/Components/Components/src/Forms/InputComponents/InputDate.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputDate.cs
@@ -14,7 +14,10 @@ namespace Microsoft.AspNetCore.Components.Forms
     {
         const string dateFormat = "yyyy-MM-dd"; // Compatible with HTML date inputs
 
-        [Parameter] string ParsingErrorMessage { get; set; } = "The {0} field must be a date.";
+        /// <summary>
+        /// Gets or sets the error message used when displaying an a parsing error.
+        /// </summary>
+        [Parameter] public string ParsingErrorMessage { get; private set; } = "The {0} field must be a date.";
 
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)

--- a/src/Components/Components/src/Forms/InputComponents/InputNumber.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputNumber.cs
@@ -53,7 +53,10 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
         }
 
-        [Parameter] string ParsingErrorMessage { get; set; } = "The {0} field must be a number.";
+        /// <summary>
+        /// Gets or sets the error message used when displaying an a parsing error.
+        /// </summary>
+        [Parameter] public string ParsingErrorMessage { get; private set; } = "The {0} field must be a number.";
 
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)

--- a/src/Components/Components/src/Forms/InputComponents/InputSelect.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputSelect.cs
@@ -11,7 +11,10 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// </summary>
     public class InputSelect<T> : InputBase<T>
     {
-        [Parameter] RenderFragment ChildContent { get; set; }
+        /// <summary>
+        /// Gets or sets the child content to be rendering inside the select element.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; private set; }
 
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)

--- a/src/Components/Components/src/Forms/ValidationMessage.cs
+++ b/src/Components/Components/src/Forms/ValidationMessage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <summary>
         /// Specifies the field for which validation messages should be displayed.
         /// </summary>
-        [Parameter] Expression<Func<T>> For { get; set; }
+        [Parameter] public Expression<Func<T>> For { get; private set; }
 
         /// <summary>`
         /// Constructs an instance of <see cref="ValidationSummary"/>.

--- a/src/Components/Components/src/Layouts/LayoutDisplay.cs
+++ b/src/Components/Components/src/Layouts/LayoutDisplay.cs
@@ -26,13 +26,13 @@ namespace Microsoft.AspNetCore.Components.Layouts
         /// The type must implement <see cref="IComponent"/>.
         /// </summary>
         [Parameter]
-        Type Page { get; set; }
+        public Type Page { get; private set; }
 
         /// <summary>
         /// Gets or sets the parameters to pass to the page.
         /// </summary>
         [Parameter]
-        IDictionary<string, object> PageParameters { get; set; }
+        public IDictionary<string, object> PageParameters { get; private set; }
 
         /// <inheritdoc />
         public void Configure(RenderHandle renderHandle)

--- a/src/Components/Components/src/Routing/NavLink.cs
+++ b/src/Components/Components/src/Routing/NavLink.cs
@@ -40,13 +40,13 @@ namespace Microsoft.AspNetCore.Components.Routing
         /// current route matches the NavLink href.
         /// </summary>
         [Parameter]
-        string ActiveClass { get; set; }
+        public string ActiveClass { get; private set; }
 
         /// <summary>
         /// Gets or sets a value representing the URL matching behavior.
         /// </summary>
         [Parameter]
-        NavLinkMatch Match { get; set; }
+        public NavLinkMatch Match { get; private set; }
 
         [Inject] private IUriHelper UriHelper { get; set; }
 

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -29,12 +29,12 @@ namespace Microsoft.AspNetCore.Components.Routing
         /// Gets or sets the assembly that should be searched, along with its referenced
         /// assemblies, for components matching the URI.
         /// </summary>
-        [Parameter] private Assembly AppAssembly { get; set; }
+        [Parameter] public Assembly AppAssembly { get; private set; }
         
         /// <summary>
         /// Gets or sets the type of the component that should be used as a fallback when no match is found for the requested route.
         /// </summary>
-        [Parameter] private Type FallbackComponent { get; set; }
+        [Parameter] public Type FallbackComponent { get; private set; }
 
         private RouteTable Routes { get; set; }
 


### PR DESCRIPTION
This resolves the issue blocking use of component parameters from our
ref assemblies. Making properties public with private get is our
recommended guidance for wanting documentation to work in the IDE, and
it will be required when you ship ref assemblies - since ref assemblies
only contain public members.