### PR TITLE
Fix rendering inheritance. Fixes #8192

### DIFF
--- a/src/Components/Blazor/Build/test/ComponentRenderingRazorIntegrationTest.cs
+++ b/src/Components/Blazor/Build/test/ComponentRenderingRazorIntegrationTest.cs
@@ -577,7 +577,6 @@ namespace Test
 
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             for (var i = 0; i < Count; i++)
             {
                 builder.AddContent(i, Template, Value);

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -71,7 +71,6 @@ namespace Microsoft.AspNetCore.Components
     }
     public abstract partial class ComponentBase : Microsoft.AspNetCore.Components.IComponent, Microsoft.AspNetCore.Components.IHandleAfterRender, Microsoft.AspNetCore.Components.IHandleEvent
     {
-        public const string BuildRenderTreeMethodName = "BuildRenderTree";
         public ComponentBase() { }
         protected virtual void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
         protected System.Threading.Tasks.Task Invoke(System.Action workItem) { throw null; }

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -25,11 +25,6 @@ namespace Microsoft.AspNetCore.Components
     /// </summary>
     public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRender
     {
-        /// <summary>
-        /// Specifies the name of the <see cref="RenderTree"/>-building method.
-        /// </summary>
-        public const string BuildRenderTreeMethodName = nameof(BuildRenderTree);
-
         private readonly RenderFragment _renderFragment;
         private RenderHandle _renderHandle;
         private bool _initialized;
@@ -41,7 +36,12 @@ namespace Microsoft.AspNetCore.Components
         /// </summary>
         public ComponentBase()
         {
-            _renderFragment = BuildRenderTree;
+            _renderFragment = builder =>
+            {
+                _hasPendingQueuedRender = false;
+                _hasNeverRendered = false;
+                BuildRenderTree(builder);
+            };
         }
 
         /// <summary>
@@ -52,8 +52,9 @@ namespace Microsoft.AspNetCore.Components
         {
             // Developers can either override this method in derived classes, or can use Razor
             // syntax to define a derived class and have the compiler generate the method.
-            _hasPendingQueuedRender = false;
-            _hasNeverRendered = false;
+
+            // Other code within this class should *not* invoke BuildRenderTree directly,
+            // but instead should invoke the _renderFragment field.
         }
 
         /// <summary>

--- a/src/Components/Components/src/Forms/EditForm.cs
+++ b/src/Components/Components/src/Forms/EditForm.cs
@@ -93,8 +93,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
-
             // If _fixedEditContext changes, tear down and recreate all descendants.
             // This is so we can safely use the IsFixed optimization on CascadingValue,
             // optimizing for the common case where _fixedEditContext never changes.

--- a/src/Components/Components/src/Forms/InputComponents/InputCheckbox.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputCheckbox.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "checkbox");
             builder.AddAttribute(2, "id", Id);

--- a/src/Components/Components/src/Forms/InputComponents/InputDate.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputDate.cs
@@ -19,7 +19,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "date");
             builder.AddAttribute(2, "id", Id);

--- a/src/Components/Components/src/Forms/InputComponents/InputNumber.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputNumber.cs
@@ -58,7 +58,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "number");
             builder.AddAttribute(2, "step", _stepAttributeValue);

--- a/src/Components/Components/src/Forms/InputComponents/InputSelect.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputSelect.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "select");
             builder.AddAttribute(1, "id", Id);
             builder.AddAttribute(2, "class", CssClass);

--- a/src/Components/Components/src/Forms/InputComponents/InputText.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputText.cs
@@ -24,7 +24,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "id", Id);
             builder.AddAttribute(2, "class", CssClass);

--- a/src/Components/Components/src/Forms/InputComponents/InputTextArea.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputTextArea.cs
@@ -24,7 +24,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
             builder.OpenElement(0, "textarea");
             builder.AddAttribute(1, "id", Id);
             builder.AddAttribute(2, "class", CssClass);

--- a/src/Components/Components/src/Forms/ValidationMessage.cs
+++ b/src/Components/Components/src/Forms/ValidationMessage.cs
@@ -64,8 +64,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
-
             foreach (var message in CurrentEditContext.GetValidationMessages(_fieldIdentifier))
             {
                 builder.OpenElement(0, "div");

--- a/src/Components/Components/src/Forms/ValidationSummary.cs
+++ b/src/Components/Components/src/Forms/ValidationSummary.cs
@@ -49,8 +49,6 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            base.BuildRenderTree(builder);
-
             // As an optimization, only evaluate the messages enumerable once, and
             // only produce the enclosing <ul> if there's at least one message
             var messagesEnumerator = CurrentEditContext.GetValidationMessages().GetEnumerator();

--- a/src/Components/Components/test/ComponentBaseTest.cs
+++ b/src/Components/Components/test/ComponentBaseTest.cs
@@ -380,7 +380,6 @@ namespace Microsoft.AspNetCore.Components.Test
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
             {
-                base.BuildRenderTree(builder);
                 builder.OpenElement(0, "p");
                 builder.AddContent(1, Counter);
                 builder.CloseElement();

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -3655,7 +3655,6 @@ namespace Microsoft.AspNetCore.Components.Test
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
             {
-                base.BuildRenderTree(builder);
                 var renderFactory = WhatToRender[TestId];
                 renderFactory(this)(builder);
             }

--- a/src/Components/Components/test/Rendering/HtmlRendererTestBase.cs
+++ b/src/Components/Components/test/Rendering/HtmlRendererTestBase.cs
@@ -482,7 +482,6 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
             {
-                base.BuildRenderTree(builder);
                 builder.OpenElement(0, "p");
                 builder.AddContent(1, Value.ToString());
                 builder.CloseElement();
@@ -513,7 +512,6 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
             {
-                base.BuildRenderTree(builder);
                 builder.OpenElement(0, "p");
                 builder.AddContent(1, Value.ToString());
                 builder.CloseElement();


### PR DESCRIPTION
With this PR, it no longer matters whether a `ComponentBase` component's rendering logic calls `base.BuildRenderTree` or not.

We need to merge this change *before* we change the Razor Components compiler so that it no longer generates the `base.BuildRenderTree` calls.
