### PR TITLE
SignInManager should respect IdentityOptions

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -608,7 +608,7 @@ namespace Microsoft.AspNetCore.Identity
                 }
             }
 
-            var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            var providerKey = auth.Principal.FindFirstValue(Options.ClaimsIdentity.UserIdClaimType);
             var provider = items[LoginProviderKey] as string;
             if (providerKey == null || provider == null)
             {


### PR DESCRIPTION
GetExternalLoginInfoAsync should not be using `ClaimTypes.NameIdentifier` directly. There is an option to configure this via `Options.ClaimsIdentity.UserIdClaim`

