### PR TITLE
Include blazor 0.9.0 patches in master

### DIFF
--- a/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHostExtensions.cs
+++ b/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHostExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Blazor.Hosting
 {
     /// <summary>
@@ -19,7 +21,16 @@ namespace Microsoft.AspNetCore.Blazor.Hosting
         /// </remarks>
         public static void Run(this IWebAssemblyHost host)
         {
-            host.StartAsync().GetAwaiter().GetResult();
+            // Behave like async void, because we don't yet support async-main properly on WebAssembly.
+            // However, don't actualy make this method async, because we rely on startup being synchronous
+            // for things like attaching navigation event handlers.
+            host.StartAsync().ContinueWith(task =>
+            {
+                if (task.Exception != null)
+                {
+                    Console.WriteLine(task.Exception);
+                }
+            });
         }
     }
 }

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
@@ -14,7 +14,11 @@ namespace BlazorHosted_CSharp.Server
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().AddNewtonsoftJson();
-            services.AddResponseCompression();
+            services.AddResponseCompression(opts =>
+            {
+                opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
+                    new[] { "application/octet-stream" });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
These two commits were part of the Blazor 0.9.0 out-of-band release and, as such, should be included in the `master` branch so they remain part of the ongoing product.

They should really have been merged to `master` at the same time they were first made.