### PR TITLE
Components: don't block the SignalR loop during init. Fixes #8274

### DIFF
--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Components.Server
         /// <summary>
         /// Intended for framework use only. Applications should not call this method directly.
         /// </summary>
-        public async Task<string> StartCircuit(string uriAbsolute, string baseUriAbsolute)
+        public string StartCircuit(string uriAbsolute, string baseUriAbsolute)
         {
             var circuitClient = new CircuitClientProxy(Clients.Caller, Context.ConnectionId);
 
@@ -76,8 +76,7 @@ namespace Microsoft.AspNetCore.Components.Server
 
             circuitHost.UnhandledException += CircuitHost_UnhandledException;
 
-            // If initialization fails, this will throw. The caller will fail if they try to call into any interop API.
-            await circuitHost.InitializeAsync(Context.ConnectionAborted);
+            circuitHost.Initialize(Context.ConnectionAborted);
 
             _circuitRegistry.Register(circuitHost);
 

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -76,7 +76,11 @@ namespace Microsoft.AspNetCore.Components.Server
 
             circuitHost.UnhandledException += CircuitHost_UnhandledException;
 
-            circuitHost.Initialize(Context.ConnectionAborted);
+            // Fire-and-forget the initialization process, because we can't block the
+            // SignalR message loop (we'd get a deadlock if any of the initialization
+            // logic relied on receiving a subsequent message from SignalR), and it will
+            // take care of its own errors anyway.
+            _ = circuitHost.InitializeAsync(Context.ConnectionAborted);
 
             _circuitRegistry.Register(circuitHost);
 

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         }
 
         [Fact]
-        public async Task Initialize_InvokesHandlers()
+        public async Task InitializeAsync_InvokesHandlers()
         {
             // Arrange
             var cancellationToken = new CancellationToken();
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         }
 
         [Fact]
-        public async Task Initialize_ReportsOwnAsyncExceptions()
+        public async Task InitializeAsync_ReportsOwnAsyncExceptions()
         {
             // Arrange
             var handler = new Mock<CircuitHandler>(MockBehavior.Strict);


### PR DESCRIPTION
For more details, see https://github.com/aspnet/AspNetCore/issues/8274#issuecomment-477203983