### PR TITLE
React to "Shrink StringValues"

### DIFF
--- a/src/Servers/Kestrel/Core/src/BadHttpRequestException.cs
+++ b/src/Servers/Kestrel/Core/src/BadHttpRequestException.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         [StackTraceHidden]
-        internal static void Throw(RequestRejectionReason reason, in StringValues detail)
+        internal static void Throw(RequestRejectionReason reason, StringValues detail)
         {
             throw GetException(reason, detail.ToString());
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 // status code and then close the connection.
                 if (transferCoding != TransferCoding.Chunked)
                 {
-                    BadHttpRequestException.Throw(RequestRejectionReason.FinalTransferCodingNotChunked, in transferEncoding);
+                    BadHttpRequestException.Throw(RequestRejectionReason.FinalTransferCodingNotChunked, transferEncoding);
                 }
 
                 // TODO may push more into the wrapper rather than just calling into the message body

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -1258,7 +1258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return MaybeUnknown?.TryGetValue(key, out value) ?? false;
         }
 
-        protected override void SetValueFast(string key, in StringValues value)
+        protected override void SetValueFast(string key, StringValues value)
         {
             switch (key.Length)
             {
@@ -1606,7 +1606,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             SetValueUnknown(key, value);
         }
 
-        protected override bool AddValueFast(string key, in StringValues value)
+        protected override bool AddValueFast(string key, StringValues value)
         {
             switch (key.Length)
             {
@@ -5337,25 +5337,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public void SetRawConnection(in StringValues value, byte[] raw)
+        public void SetRawConnection(StringValues value, byte[] raw)
         {
             _bits |= 0x2L;
             _headers._Connection = value;
             _headers._rawConnection = raw;
         }
-        public void SetRawDate(in StringValues value, byte[] raw)
+        public void SetRawDate(StringValues value, byte[] raw)
         {
             _bits |= 0x4L;
             _headers._Date = value;
             _headers._rawDate = raw;
         }
-        public void SetRawTransferEncoding(in StringValues value, byte[] raw)
+        public void SetRawTransferEncoding(StringValues value, byte[] raw)
         {
             _bits |= 0x40L;
             _headers._TransferEncoding = value;
             _headers._rawTransferEncoding = raw;
         }
-        public void SetRawServer(in StringValues value, byte[] raw)
+        public void SetRawServer(StringValues value, byte[] raw)
         {
             _bits |= 0x2000000L;
             _headers._Server = value;
@@ -5776,7 +5776,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return MaybeUnknown?.TryGetValue(key, out value) ?? false;
         }
 
-        protected override void SetValueFast(string key, in StringValues value)
+        protected override void SetValueFast(string key, StringValues value)
         {
             ValidateHeaderValueCharacters(value);
             switch (key.Length)
@@ -6081,7 +6081,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             SetValueUnknown(key, value);
         }
 
-        protected override bool AddValueFast(string key, in StringValues value)
+        protected override bool AddValueFast(string key, StringValues value)
         {
             ValidateHeaderValueCharacters(value);
             switch (key.Length)
@@ -8589,7 +8589,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return MaybeUnknown?.TryGetValue(key, out value) ?? false;
         }
 
-        protected override void SetValueFast(string key, in StringValues value)
+        protected override void SetValueFast(string key, StringValues value)
         {
             ValidateHeaderValueCharacters(value);
             switch (key.Length)
@@ -8609,7 +8609,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             SetValueUnknown(key, value);
         }
 
-        protected override bool AddValueFast(string key, in StringValues value)
+        protected override bool AddValueFast(string key, StringValues value)
         {
             ValidateHeaderValueCharacters(value);
             switch (key.Length)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        protected static StringValues AppendValue(in StringValues existing, string append)
+        protected static StringValues AppendValue(StringValues existing, string append)
         {
             return StringValues.Concat(existing, append);
         }
@@ -157,10 +157,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected virtual bool TryGetValueFast(string key, out StringValues value)
         { throw new NotImplementedException(); }
 
-        protected virtual void SetValueFast(string key, in StringValues value)
+        protected virtual void SetValueFast(string key, StringValues value)
         { throw new NotImplementedException(); }
 
-        protected virtual bool AddValueFast(string key, in StringValues value)
+        protected virtual bool AddValueFast(string key, StringValues value)
         { throw new NotImplementedException(); }
 
         protected virtual bool RemoveFast(string key)
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return TryGetValueFast(key, out value);
         }
 
-        public static void ValidateHeaderValueCharacters(in StringValues headerValues)
+        public static void ValidateHeaderValueCharacters(StringValues headerValues)
         {
             var count = headerValues.Count;
             for (var i = 0; i < count; i++)
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public static unsafe ConnectionOptions ParseConnection(in StringValues connection)
+        public static unsafe ConnectionOptions ParseConnection(StringValues connection)
         {
             var connectionOptions = ConnectionOptions.None;
 
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return connectionOptions;
         }
 
-        public static unsafe TransferCoding GetFinalTransferCoding(in StringValues transferEncoding)
+        public static unsafe TransferCoding GetFinalTransferCoding(StringValues transferEncoding)
         {
             var transferEncodingOptions = TransferCoding.None;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SetValueUnknown(string key, in StringValues value)
+        private void SetValueUnknown(string key, StringValues value)
         {
             Unknown[key] = value;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SetValueUnknown(string key, in StringValues value)
+        private void SetValueUnknown(string key, StringValues value)
         {
             ValidateHeaderNameCharacters(key);
             Unknown[key] = value;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseTrailers.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseTrailers.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SetValueUnknown(string key, in StringValues value)
+        private void SetValueUnknown(string key, StringValues value)
         {
             ValidateHeaderNameCharacters(key);
             Unknown[key] = value;

--- a/src/Servers/Kestrel/tools/CodeGenerator/KnownHeaders.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/KnownHeaders.cs
@@ -385,7 +385,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }}")}
         }}")}
 {Each(loop.Headers.Where(header => header.EnhancedSetter), header => $@"
-        public void SetRaw{header.Identifier}(in StringValues value, byte[] raw)
+        public void SetRaw{header.Identifier}(StringValues value, byte[] raw)
         {{
             {header.SetBit()};
             _headers._{header.Identifier} = value;
@@ -425,7 +425,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return MaybeUnknown?.TryGetValue(key, out value) ?? false;
         }}
 
-        protected override void SetValueFast(string key, in StringValues value)
+        protected override void SetValueFast(string key, StringValues value)
         {{{(loop.ClassName != "HttpRequestHeaders" ? @"
             ValidateHeaderValueCharacters(value);" : "")}
             switch (key.Length)
@@ -447,7 +447,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             SetValueUnknown(key, value);
         }}
 
-        protected override bool AddValueFast(string key, in StringValues value)
+        protected override bool AddValueFast(string key, StringValues value)
         {{{(loop.ClassName != "HttpRequestHeaders" ? @"
             ValidateHeaderValueCharacters(value);" : "")}
             switch (key.Length)


### PR DESCRIPTION
`StringValues` has been shrunk to single pointer size; so `in` offers no advantages.

React to https://github.com/aspnet/Extensions/pull/1283

/cc @Tratcher @davidfowl 