### PR TITLE
Add a System.Text.Json based TempDataSerializer

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/BsonTempDataSerializer.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/BsonTempDataSerializer.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             }
             else
             {
-                return Array.Empty<byte>();;
+                return Array.Empty<byte>();
             }
         }
 

--- a/src/Mvc/Mvc.NewtonsoftJson/src/BsonTempDataSerializer.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/BsonTempDataSerializer.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             }
             else
             {
-                return new byte[0];
+                return Array.Empty<byte>();;
             }
         }
 
@@ -164,6 +164,8 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
                 throw new InvalidOperationException(errorMessage);
             }
         }
+
+        public override bool CanSerializeType(Type type) => CanSerializeType(type, out _);
 
         private static bool CanSerializeType(Type typeToSerialize, out string errorMessage)
         {
@@ -208,6 +210,8 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             }
 
             actualType = actualType ?? typeToSerialize;
+            actualType = Nullable.GetUnderlyingType(actualType) ?? actualType;
+
             if (!IsSimpleType(actualType))
             {
                 errorMessage = Resources.FormatTempData_CannotSerializeType(

--- a/src/Mvc/Mvc.NewtonsoftJson/test/BsonTempDataSerializerTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/BsonTempDataSerializerTest.cs
@@ -3,12 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
 {
-    public class BsonTempDataSerializerTest
+    public class BsonTempDataSerializerTest : TempDataSerializerTestBase
     {
+        protected override TempDataSerializer GetTempDataSerializer() => new BsonTempDataSerializer();
+
         public static TheoryData<object, Type> InvalidTypes
         {
             get
@@ -93,6 +96,112 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             }
         }
 
+        [Fact]
+        public void RoundTripTest_ArrayOfIntegers()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = new[] { 1, -2, 3 };
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<int[]>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_DateTime()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = new DateTime(2007, 1, 1);
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<DateTime>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_Guid()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = Guid.NewGuid();
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<Guid>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Theory]
+        [InlineData(2147483648)]
+        [InlineData(-2147483649)]
+        public void RoundTripTest_LongValue(long value)
+        {
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<long>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_Double()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = 10d;
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = (double)values[key];
+            Assert.Equal(value, roundTripValue);
+        }
+
         [Theory]
         [MemberData(nameof(ValidTypes))]
         public void EnsureObjectCanBeSerialized_DoesNotThrow_OnValidType(object value)
@@ -102,40 +211,6 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
 
             // Act & Assert (Does not throw)
             testProvider.EnsureObjectCanBeSerialized(value);
-        }
-
-        [Fact]
-        public void DeserializeTempData_ReturnsEmptyDictionary_DataIsEmpty()
-        {
-            // Arrange
-            var serializer = new BsonTempDataSerializer();
-
-            // Act
-            var tempDataDictionary = serializer.Deserialize(new byte[0]);
-
-            // Assert
-            Assert.NotNull(tempDataDictionary);
-            Assert.Empty(tempDataDictionary);
-        }
-
-        [Fact]
-        public void SerializeAndDeserialize_NullValue_RoundTripsSuccessfully()
-        {
-            // Arrange
-            var key = "NullKey";
-            var testProvider = new BsonTempDataSerializer();
-            var input = new Dictionary<string, object>
-             {
-                 { key, null }
-             };
-
-            // Act
-            var bytes = testProvider.Serialize(input);
-            var values = testProvider.Deserialize(bytes);
-
-            // Assert
-            Assert.True(values.ContainsKey(key));
-            Assert.Null(values[key]);
         }
 
         private class TestItem

--- a/src/Mvc/Mvc.NewtonsoftJson/test/BsonTempDataSerializerTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/BsonTempDataSerializerTest.cs
@@ -159,6 +159,27 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             Assert.Equal(value, roundTripValue);
         }
 
+        [Fact]
+        public void RoundTripTest_DateTimeValue()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = new DateTime(2009, 1, 1, 12, 37, 43);
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<DateTime>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
         [Theory]
         [InlineData(2147483648)]
         [InlineData(-2147483649)]

--- a/src/Mvc/Mvc.NewtonsoftJson/test/BsonTempDataSerializerTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/BsonTempDataSerializerTest.cs
@@ -159,27 +159,6 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             Assert.Equal(value, roundTripValue);
         }
 
-        [Fact]
-        public void RoundTripTest_DateTimeValue()
-        {
-            // Arrange
-            var key = "test-key";
-            var value = new DateTime(2009, 1, 1, 12, 37, 43);
-            var testProvider = GetTempDataSerializer();
-            var input = new Dictionary<string, object>
-            {
-                { key, value },
-            };
-
-            // Act
-            var bytes = testProvider.Serialize(input);
-            var values = testProvider.Deserialize(bytes);
-
-            // Assert
-            var roundTripValue = Assert.IsType<DateTime>(values[key]);
-            Assert.Equal(value, roundTripValue);
-        }
-
         [Theory]
         [InlineData(2147483648)]
         [InlineData(-2147483649)]

--- a/src/Mvc/Mvc.NewtonsoftJson/test/Microsoft.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/Microsoft.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="..\..\Mvc.Core\test\Formatters\JsonInputFormatterTestBase.cs" />
     <Compile Include="..\..\Mvc.Core\test\Formatters\JsonOutputFormatterTestBase.cs" />
+    <Compile Include="..\..\Mvc.ViewFeatures\test\Infrastructure\TempDataSerializerTestBase.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/Mvc.RazorPages/test/ApplicationModels/TempDataFilterPageApplicationModelProviderTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/ApplicationModels/TempDataFilterPageApplicationModelProviderTest.cs
@@ -5,9 +5,9 @@ using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ApplicationModels
@@ -35,6 +35,23 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             // Arrange
             var type = typeof(TestPageModel_PrivateSet);
             var expected = $"The '{type.FullName}.Test' property with TempDataAttribute is invalid. A property using TempDataAttribute must have a public getter and setter.";
+
+            var provider = CreateProvider();
+            var context = CreateProviderContext(type);
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => provider.OnProvidersExecuting(context));
+            Assert.Equal(expected, ex.Message);
+        }
+
+        [Fact]
+        public void OnProvidersExecuting_ThrowsIfThePropertyTypeIsUnsupported()
+        {
+            // Arrange
+            var type = typeof(TestPageModel_InvalidProperties);
+            var expected = $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.ModelState' of type '{typeof(ModelStateDictionary)}'." +
+                Environment.NewLine +
+                $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.Guid' of type '{typeof(Guid)}'.";
 
             var provider = CreateProvider();
             var context = CreateProviderContext(type);
@@ -114,18 +131,9 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             return context;
         }
 
-        private static CompiledPageActionDescriptor CreateDescriptor(Type type)
-        {
-            return new CompiledPageActionDescriptor(new PageActionDescriptor())
-            {
-                PageTypeInfo = typeof(TestPage).GetTypeInfo(),
-                HandlerTypeInfo = type.GetTypeInfo(),
-            };
-        }
-
         private static TempDataFilterPageApplicationModelProvider CreateProvider()
         {
-            var tempDataSerializer = Mock.Of<TempDataSerializer>(s => s.CanSerializeType(It.IsAny<Type>()) == true);
+            var tempDataSerializer = new DefaultTempDataSerializer();
             return new TempDataFilterPageApplicationModelProvider(tempDataSerializer);
         }
 
@@ -159,6 +167,18 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
         {
             [TempData]
             public string Test { get; private set; }
+        }
+
+        public class TestPageModel_InvalidProperties
+        {
+            [TempData]
+            public ModelStateDictionary ModelState { get; set; }
+
+            [TempData]
+            public int SomeProperty { get; set; }
+
+            [TempData]
+            public Guid Guid { get; set; }
         }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/test/ApplicationModels/TempDataFilterPageApplicationModelProviderTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/ApplicationModels/TempDataFilterPageApplicationModelProviderTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             var type = typeof(TestPageModel_InvalidProperties);
             var expected = $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.ModelState' of type '{typeof(ModelStateDictionary)}'." +
                 Environment.NewLine +
-                $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.Guid' of type '{typeof(Guid)}'.";
+                $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.TimeZone' of type '{typeof(TimeZoneInfo)}'.";
 
             var provider = CreateProvider();
             var context = CreateProviderContext(type);
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             public int SomeProperty { get; set; }
 
             [TempData]
-            public Guid Guid { get; set; }
+            public TimeZoneInfo TimeZone { get; set; }
         }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/ArrayBufferWriter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/ArrayBufferWriter.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
+{
+    // Note: this is currently an internal class that will be replaced with a shared version.
+    internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>, IDisposable
+    {
+        private T[] _rentedBuffer;
+        private int _index;
+
+        private const int MinimumBufferSize = 256;
+
+        public ArrayBufferWriter()
+        {
+            _rentedBuffer = ArrayPool<T>.Shared.Rent(MinimumBufferSize);
+            _index = 0;
+        }
+
+        public ArrayBufferWriter(int initialCapacity)
+        {
+            if (initialCapacity <= 0)
+                throw new ArgumentException(nameof(initialCapacity));
+
+            _rentedBuffer = ArrayPool<T>.Shared.Rent(initialCapacity);
+            _index = 0;
+        }
+
+        public ReadOnlyMemory<T> WrittenMemory
+        {
+            get
+            {
+                CheckIfDisposed();
+
+                return _rentedBuffer.AsMemory(0, _index);
+            }
+        }
+
+        public int WrittenCount
+        {
+            get
+            {
+                CheckIfDisposed();
+
+                return _index;
+            }
+        }
+
+        public int Capacity
+        {
+            get
+            {
+                CheckIfDisposed();
+
+                return _rentedBuffer.Length;
+            }
+        }
+
+        public int FreeCapacity
+        {
+            get
+            {
+                CheckIfDisposed();
+
+                return _rentedBuffer.Length - _index;
+            }
+        }
+
+        public void Clear()
+        {
+            CheckIfDisposed();
+
+            ClearHelper();
+        }
+
+        private void ClearHelper()
+        {
+            Debug.Assert(_rentedBuffer != null);
+
+            _rentedBuffer.AsSpan(0, _index).Clear();
+            _index = 0;
+        }
+
+        // Returns the rented buffer back to the pool
+        public void Dispose()
+        {
+            if (_rentedBuffer == null)
+            {
+                return;
+            }
+
+            ClearHelper();
+            ArrayPool<T>.Shared.Return(_rentedBuffer);
+            _rentedBuffer = null;
+        }
+
+        private void CheckIfDisposed()
+        {
+            if (_rentedBuffer == null)
+            {
+                throw new ObjectDisposedException(nameof(ArrayBufferWriter<T>));
+            }
+        }
+
+        public void Advance(int count)
+        {
+            CheckIfDisposed();
+
+            if (count < 0)
+                throw new ArgumentException(nameof(count));
+
+            if (_index > _rentedBuffer.Length - count)
+                ThrowInvalidOperationException(_rentedBuffer.Length);
+
+            _index += count;
+        }
+
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            CheckIfDisposed();
+
+            CheckAndResizeBuffer(sizeHint);
+            return _rentedBuffer.AsMemory(_index);
+        }
+
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            CheckIfDisposed();
+
+            CheckAndResizeBuffer(sizeHint);
+            return _rentedBuffer.AsSpan(_index);
+        }
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            Debug.Assert(_rentedBuffer != null);
+
+            if (sizeHint < 0)
+                throw new ArgumentException(nameof(sizeHint));
+
+            if (sizeHint == 0)
+            {
+                sizeHint = MinimumBufferSize;
+            }
+
+            int availableSpace = _rentedBuffer.Length - _index;
+
+            if (sizeHint > availableSpace)
+            {
+                int growBy = Math.Max(sizeHint, _rentedBuffer.Length);
+
+                int newSize = checked(_rentedBuffer.Length + growBy);
+
+                T[] oldBuffer = _rentedBuffer;
+
+                _rentedBuffer = ArrayPool<T>.Shared.Rent(newSize);
+
+                Debug.Assert(oldBuffer.Length >= _index);
+                Debug.Assert(_rentedBuffer.Length >= _index);
+
+                Span<T> previousBuffer = oldBuffer.AsSpan(0, _index);
+                previousBuffer.CopyTo(_rentedBuffer);
+                previousBuffer.Clear();
+                ArrayPool<T>.Shared.Return(oldBuffer);
+            }
+
+            Debug.Assert(_rentedBuffer.Length - _index > 0);
+            Debug.Assert(_rentedBuffer.Length - _index >= sizeHint);
+        }
+
+        private static void ThrowInvalidOperationException(int capacity)
+        {
+            throw new InvalidOperationException($"Cannot advance past the end of the buffer, which has a size of {capacity}.");
+        }
+    }
+}

--- a/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/ArrayBufferWriter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/ArrayBufferWriter.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Buffers;

--- a/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/DefaultTempDataSerializer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/DefaultTempDataSerializer.cs
@@ -46,15 +46,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
                         break;
 
                     case JsonValueType.String:
-                        var stringValue = item.Value.GetString();
-                        if (DateTime.TryParseExact(stringValue, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateTime))
-                        {
-                            deserializedValue = dateTime;
-                        }
-                        else
-                        {
-                            deserializedValue = stringValue;
-                        }
+                        deserializedValue = item.Value.GetString();
                         break;
 
                     case JsonValueType.Null:
@@ -116,10 +108,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
                         case bool boolValue:
                             writer.WriteBoolean(key, boolValue);
                             break;
-
-                        case DateTime dateTimeValue:
-                            writer.WriteString(key, dateTimeValue.ToString("o", CultureInfo.InvariantCulture));
-                            break;
                     }
                 }
                 writer.WriteEndObject();
@@ -137,8 +125,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
                 type.IsEnum ||
                 type == typeof(int) ||
                 type == typeof(string) ||
-                type == typeof(bool) ||
-                type == typeof(DateTime);
+                type == typeof(bool);
         }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/Properties/Resources.Designer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Properties/Resources.Designer.cs
@@ -808,6 +808,34 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         internal static string FormatSerializingTempData()
             => GetString("SerializingTempData");
 
+        /// <summary>
+        /// The '{0}' cannot serialize an object of type '{1}'.
+        /// </summary>
+        internal static string TempData_CannotSerializeType
+        {
+            get => GetString("TempData_CannotSerializeType");
+        }
+
+        /// <summary>
+        /// The '{0}' cannot serialize an object of type '{1}'.
+        /// </summary>
+        internal static string FormatTempData_CannotSerializeType(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("TempData_CannotSerializeType"), p0, p1);
+
+        /// <summary>
+        /// Unsupported data type '{0}'.
+        /// </summary>
+        internal static string TempData_CannotDeserializeType
+        {
+            get => GetString("TempData_CannotDeserializeType");
+        }
+
+        /// <summary>
+        /// Unsupported data type '{0}'.
+        /// </summary>
+        internal static string FormatTempData_CannotDeserializeType(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("TempData_CannotDeserializeType"), p0);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Mvc/Mvc.ViewFeatures/src/Resources.resx
+++ b/src/Mvc/Mvc.ViewFeatures/src/Resources.resx
@@ -289,4 +289,10 @@
   <data name="SerializingTempData" xml:space="preserve">
     <value>Serializing TempDataDictionary</value>
   </data>
+  <data name="TempData_CannotSerializeType" xml:space="preserve">
+    <value>The '{0}' cannot serialize an object of type '{1}'.</value>
+  </data>
+  <data name="TempData_CannotDeserializeType" xml:space="preserve">
+    <value>Unsupported data type '{0}'.</value>
+  </data>
 </root>

--- a/src/Mvc/Mvc.ViewFeatures/test/Filters/TempDataApplicationModelProviderTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Filters/TempDataApplicationModelProviderTest.cs
@@ -64,23 +64,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Filters
         }
 
         [Fact]
-        public void AddsTempDataPropertyFilter_ForTempDataAttributeProperties()
-        {
-            // Arrange
-            var type = typeof(TestController_NullableNonPrimitiveTempDataProperty);
-            var provider = CreateProvider();
-
-            var context = GetContext(type);
-
-            // Act
-            provider.OnProvidersExecuting(context);
-
-            // Assert
-            var controller = Assert.Single(context.Result.Controllers);
-            Assert.IsType<ControllerSaveTempDataPropertyFilterFactory>(Assert.Single(controller.Filters));
-        }
-
-        [Fact]
         public void InitializeFilterFactory_WithExpectedPropertyHelpers_ForTempDataAttributeProperties()
         {
             // Arrange
@@ -142,12 +125,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Filters
 
         public class TestController_NoTempDataProperties
         {
-            public DateTime? DateTime { get; set; }
-        }
-
-        public class TestController_NullableNonPrimitiveTempDataProperty
-        {
-            [TempData]
             public DateTime? DateTime { get; set; }
         }
 

--- a/src/Mvc/Mvc.ViewFeatures/test/Filters/TempDataApplicationModelProviderTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Filters/TempDataApplicationModelProviderTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Filters
             var type = typeof(TestController_InvalidProperties);
             var expected = $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.ModelState' of type '{typeof(ModelStateDictionary)}'." +
                 Environment.NewLine +
-                $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.Guid' of type '{typeof(Guid)}'.";
+                $"TempData serializer '{typeof(DefaultTempDataSerializer)}' cannot serialize property '{type}.TimeZone' of type '{typeof(TimeZoneInfo)}'.";
             var provider = CreateProvider();
 
             var context = GetContext(type);
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Filters
             public int SomeProperty { get; set; }
 
             [TempData]
-            public Guid Guid { get; set; }
+            public TimeZoneInfo TimeZone { get; set; }
         }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/DefaultTempDataSerializerTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/DefaultTempDataSerializerTest.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
+{
+    public class DefaultTempDataSerializerTest : TempDataSerializerTestBase
+    {
+        protected override TempDataSerializer GetTempDataSerializer() => new DefaultTempDataSerializer();
+    }
+}

--- a/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/DefaultTempDataSerializerTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/DefaultTempDataSerializerTest.cs
@@ -1,10 +1,86 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using Xunit;
+
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
 {
     public class DefaultTempDataSerializerTest : TempDataSerializerTestBase
     {
         protected override TempDataSerializer GetTempDataSerializer() => new DefaultTempDataSerializer();
+
+        [Fact]
+        public void RoundTripTest_StringThatLooksLikeCompliantDateTime()
+        {
+            // This is an unintentional side-effect of trying to support a compat with JSON.NET.
+            // Any string that looks like a compliant DateTime object will be parsed as a DateTime.
+            // This test documents this behavior.
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var value = new DateTime(2009, 1, 1, 12, 37, 43);
+            var input = new Dictionary<string, object>
+            {
+                { key, value.ToString("r") }
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<DateTime>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_StringThatIsNotCompliantDateTime()
+        {
+            // This is an unintentional side-effect of trying to support a compat with JSON.NET.
+            // Any string that looks like a compliant DateTime object will be parsed as a DateTime.
+            // This test documents this behavior.
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var value = new DateTime(2009, 1, 1, 12, 37, 43);
+            var input = new Dictionary<string, object>
+            {
+                { key, value.ToString() }
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<string>(values[key]);
+            Assert.Equal(value.ToString(), roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_StringThatIsNotCompliantGuid()
+        {
+            // This is an unintentional side-effect of trying to support a compat with JSON.NET.
+            // Any string that looks like a compliant DateTime object will be parsed as a DateTime.
+            // This test documents this behavior.
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var value = Guid.NewGuid();
+            var input = new Dictionary<string, object>
+            {
+                { key, value.ToString() }
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<string>(values[key]);
+            Assert.Equal(value.ToString(), roundTripValue);
+        }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/TempDataSerializerTestBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/TempDataSerializerTestBase.cs
@@ -111,27 +111,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
         }
 
         [Fact]
-        public void RoundTripTest_DateTimeValue()
-        {
-            // Arrange
-            var key = "test-key";
-            var value = new DateTime(2009, 1, 1, 12, 37, 43);
-            var testProvider = GetTempDataSerializer();
-            var input = new Dictionary<string, object>
-            {
-                { key, value },
-            };
-
-            // Act
-            var bytes = testProvider.Serialize(input);
-            var values = testProvider.Deserialize(bytes);
-
-            // Assert
-            var roundTripValue = Assert.IsType<DateTime>(values[key]);
-            Assert.Equal(value, roundTripValue);
-        }
-
-        [Fact]
         public void RoundTripTest_Enum()
         {
             // Arrange

--- a/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/TempDataSerializerTestBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/TempDataSerializerTestBase.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
+{
+    public abstract class TempDataSerializerTestBase
+    {
+        [Fact]
+        public void DeserializeTempData_ReturnsEmptyDictionary_DataIsEmpty()
+        {
+            // Arrange
+            var serializer = GetTempDataSerializer();
+
+            // Act
+            var tempDataDictionary = serializer.Deserialize(new byte[0]);
+
+            // Assert
+            Assert.NotNull(tempDataDictionary);
+            Assert.Empty(tempDataDictionary);
+        }
+
+        [Fact]
+        public void RoundTripTest_NullValue()
+        {
+            // Arrange
+            var key = "NullKey";
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, null }
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            Assert.True(values.ContainsKey(key));
+            Assert.Null(values[key]);
+        }
+
+        [Theory]
+        [InlineData(-10)]
+        [InlineData(3340)]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        public void RoundTripTest_IntValue(int value)
+        {
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<int>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(10)]
+        public void RoundTripTest_NullableInt(int? value)
+        {
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = (int?)values[key];
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_StringValue()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = "test-value";
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<string>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_DateTimeValue()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = new DateTime(2009, 1, 1, 12, 37, 43);
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<DateTime>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_Enum()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = DayOfWeek.Friday;
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = (DayOfWeek)values[key];
+            Assert.Equal(value, roundTripValue);
+        }
+
+        protected abstract TempDataSerializer GetTempDataSerializer();
+    }
+}

--- a/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/TempDataSerializerTestBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Infrastructure/TempDataSerializerTestBase.cs
@@ -131,6 +131,49 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
             Assert.Equal(value, roundTripValue);
         }
 
+        [Fact]
+        public void RoundTripTest_DateTimeValue()
+        {
+            // Arrange
+            var key = "test-key";
+            var value = new DateTime(2009, 1, 1, 12, 37, 43);
+            var testProvider = GetTempDataSerializer();
+            var input = new Dictionary<string, object>
+            {
+                { key, value },
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<DateTime>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
+        [Fact]
+        public void RoundTripTest_GuidValue()
+        {
+            // Arrange
+            var key = "test-key";
+            var testProvider = GetTempDataSerializer();
+            var value = Guid.NewGuid();
+            var input = new Dictionary<string, object>
+            {
+                { key, value }
+            };
+
+            // Act
+            var bytes = testProvider.Serialize(input);
+            var values = testProvider.Deserialize(bytes);
+
+            // Assert
+            var roundTripValue = Assert.IsType<Guid>(values[key]);
+            Assert.Equal(value, roundTripValue);
+        }
+
         protected abstract TempDataSerializer GetTempDataSerializer();
     }
 }
+

--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -507,7 +507,7 @@ Products: Book1, Book2 (1)";
 
             // Act - 3
             // Trigger an expiration of the nested content.
-            var content = @"[{ productName: ""Music Systems"" },{ productName: ""Televisions"" }]";
+            var content = @"[{ ""ProductName"": ""Music Systems"" },{ ""ProductName"": ""Televisions"" }]";
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, "/categories/Electronics");
             requestMessage.Content = new StringContent(content, Encoding.UTF8, "application/json");
             (await Client.SendAsync(requestMessage)).EnsureSuccessStatusCode();

--- a/src/Mvc/test/Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorPagesTest.cs
@@ -784,7 +784,7 @@ Hello from /Pages/WithViewStart/Index.cshtml!";
             Assert.Equal(expected, content);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/corefx/issues/36024")]
         public async Task PolymorphicPropertiesOnPageModelsAreValidated()
         {
             // Arrange

--- a/src/Mvc/test/WebSites/CorsWebSite/CorsWebSite.csproj
+++ b/src/Mvc/test/WebSites/CorsWebSite/CorsWebSite.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -8,7 +8,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
 
     <Reference Include="Microsoft.AspNetCore.Cors" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />

--- a/src/Mvc/test/WebSites/CorsWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/CorsWebSite/Startup.cs
@@ -13,7 +13,6 @@ namespace CorsWebSite
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers(ConfigureMvcOptions)
-                .AddNewtonsoftJson()
                 .SetCompatibilityVersion(CompatibilityVersion.Latest);
             services.Configure<CorsOptions>(options =>
             {

--- a/src/Mvc/test/WebSites/GenericHostWebSite/GenericHostWebSite.csproj
+++ b/src/Mvc/test/WebSites/GenericHostWebSite/GenericHostWebSite.csproj
@@ -11,8 +11,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
 
     <Reference Include="Microsoft.AspNetCore.Localization.Routing" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />

--- a/src/Mvc/test/WebSites/GenericHostWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/GenericHostWebSite/Startup.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,9 +21,7 @@ namespace GenericHostWebSite
                     // Remove when all URL generation tests are passing - https://github.com/aspnet/Routing/issues/590
                     options.EnableEndpointRouting = false;
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Latest)
-                .AddNewtonsoftJson()
-                .AddXmlDataContractSerializerFormatters();
+                .SetCompatibilityVersion(CompatibilityVersion.Latest);
 
             services.AddLogging();
             services.AddHttpContextAccessor();

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/HtmlGenerationWebSite.csproj
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/HtmlGenerationWebSite.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Startup.cs
@@ -19,7 +19,6 @@ namespace HtmlGenerationWebSite
             // null which is interpreted as true unless element includes an action attribute.
             services.AddMvc(ConfigureMvcOptions)
                 .InitializeTagHelper<FormTagHelper>((helper, _) => helper.Antiforgery = false)
-                .AddNewtonsoftJson()
                 .SetCompatibilityVersion(CompatibilityVersion.Latest);
 
             services.AddSingleton(typeof(ISignalTokenProviderService<>), typeof(SignalTokenProviderService<>));

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/StartupWithoutEndpointRouting.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/StartupWithoutEndpointRouting.cs
@@ -17,7 +17,6 @@ namespace RazorPagesWebSite
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie(options => options.LoginPath = "/Login");
             services.AddMvc(options => options.EnableEndpointRouting = false)
                 .AddMvcLocalization()
-                .AddNewtonsoftJson()
                 .AddRazorPagesOptions(options =>
                 {
                     options.Conventions.AuthorizePage("/HelloWorldWithAuth");


### PR DESCRIPTION
* Update DefaultTempDataSerializer
* Add common tests for DefaultTempDataSerializer & BsonTempDataSerializer
* Remove uses of NewtonsoftJson in tests solely required for temp-data support

Fixes https://github.com/aspnet/AspNetCore/issues/7255
