### PR TITLE
Use LangVersion preview rather than 8.0

### DIFF
--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\AspNetCore.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
 


### PR DESCRIPTION
Reference updates are choking on nullable reference types (e.g. https://github.com/aspnet/AspNetCore/pull/8819, https://github.com/aspnet/AspNetCore/pull/8885); so switch from language "8.0" to "preview" to fix this (although they should be the same at this time, looks to be a roslyn update to put this under the new "preview" version)

/cc @NTaylorMullen,@dougbu 