### PR TITLE
Don't fail shutdown-does-not-crash test if merely ungraceful

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
@@ -133,6 +133,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             var serviceContext = new TestServiceContext(LoggerFactory);
 
+            TestApplicationErrorLogger.ThrowOnUngracefulShutdown = false;
+
             var stopTask = Task.CompletedTask;
             using (var server = new TestServer(TestApp.EchoApp, serviceContext, listenOptions))
             {


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2101