### PR TITLE
Make Blazor initialization configurable

### DIFF
--- a/src/Components/Browser.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Browser.JS/src/Boot.WebAssembly.ts
@@ -6,9 +6,17 @@ import { getAssemblyNameFromUrl } from './Platform/Url';
 import { renderBatch } from './Rendering/Renderer';
 import { SharedMemoryRenderBatch } from './Rendering/RenderBatch/SharedMemoryRenderBatch';
 import { Pointer } from './Platform/Platform';
-import { fetchBootConfigAsync, loadEmbeddedResourcesAsync } from './BootCommon';
+import { fetchBootConfigAsync, loadEmbeddedResourcesAsync, shouldAutoStart } from './BootCommon';
 
-async function boot() {
+let started = false;
+
+async function boot(options?: any) {
+
+  if (started) {
+    throw new Error('Blazor has already started.');
+  }
+  started = true;
+
   // Configure environment for execution under Mono WebAssembly with shared-memory rendering
   const platform = Environment.setPlatform(monoPlatform);
   window['Blazor'].platform = platform;
@@ -43,4 +51,7 @@ async function boot() {
   platform.callEntryPoint(mainAssemblyName, bootConfig.entryPoint, []);
 }
 
-boot();
+window['Blazor'].start = boot;
+if (shouldAutoStart()) {
+  boot();
+}

--- a/src/Components/Browser.JS/src/BootCommon.ts
+++ b/src/Components/Browser.JS/src/BootCommon.ts
@@ -37,3 +37,10 @@ interface BootJsonData {
   jsReferences: string[];
   linkerEnabled: boolean;
 }
+
+// Tells you if the script was added without <script src="..." autostart="false"></script>
+export function shouldAutoStart() {
+  return document &&
+    document.currentScript &&
+    document.currentScript.getAttribute('autostart') !== 'false';
+}

--- a/src/Components/Browser.JS/src/GlobalExports.ts
+++ b/src/Components/Browser.JS/src/GlobalExports.ts
@@ -1,8 +1,6 @@
-import { platform } from './Environment';
 import { navigateTo, internalFunctions as uriHelperInternalFunctions } from './Services/UriHelper';
 import { internalFunctions as httpInternalFunctions } from './Services/Http';
 import { attachRootComponentToElement } from './Rendering/Renderer';
-import { Pointer } from './Platform/Platform';
 
 // Make the following APIs available in global scope for invocation from JS
 window['Blazor'] = {

--- a/src/Components/Components.sln
+++ b/src/Components/Components.sln
@@ -210,6 +210,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\..\.editorconfig = ..\..\.editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Mvc.Components.Prerendering", "..\Mvc\Mvc.Components.Prerendering\src\Microsoft.AspNetCore.Mvc.Components.Prerendering.csproj", "{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1324,6 +1326,18 @@ Global
 		{9088E4E4-B855-457F-AE9E-D86709A5E1F4}.Release|x64.Build.0 = Debug|Any CPU
 		{9088E4E4-B855-457F-AE9E-D86709A5E1F4}.Release|x86.ActiveCfg = Debug|Any CPU
 		{9088E4E4-B855-457F-AE9E-D86709A5E1F4}.Release|x86.Build.0 = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Release|x64.Build.0 = Release|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1423,6 +1437,7 @@ Global
 		{04262990-929C-42BF-85A9-21C25FA95617} = {2FC10057-7A0A-4E34-8302-879925BC0102}
 		{DC47C40A-FC38-44E4-94A4-ADE794E76309} = {2FC10057-7A0A-4E34-8302-879925BC0102}
 		{9088E4E4-B855-457F-AE9E-D86709A5E1F4} = {7260DED9-22A9-4E9D-92F4-5E8A4404DEAF}
+		{3A4132B6-60DA-43A0-8E7B-4BF346F3247C} = {2FC10057-7A0A-4E34-8302-879925BC0102}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CC3C47E1-AD1A-4619-9CD3-E08A0148E5CE}

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>Basic test app</title>
-    <base href="/subdir/" />    
+    <base href="/subdir/" />
     <link href="style.css" rel="stylesheet" />
 </head>
 <body>

--- a/src/Components/test/testassets/ComponentsApp.Server/Pages/Index.cshtml
+++ b/src/Components/test/testassets/ComponentsApp.Server/Pages/Index.cshtml
@@ -15,7 +15,13 @@
 
     <app>@(await Html.RenderComponentAsync<App>(new { Name="Guest" }))</app>
 
-    <script src="_framework/components.server.js"></script>
-
+    <script src="_framework/components.server.js" autostart="false"></script>
+    <script>
+        Blazor.start({
+            configureSignalR: function (builder) {
+                builder.configureLogging(2); // LogLevel.Information
+            }
+        });
+    </script>
 </body>
 </html>

--- a/src/Components/test/testassets/TestServer/Pages/PrerenderedHost.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/PrerenderedHost.cshtml
@@ -15,15 +15,11 @@
         interactive states, we only load the .js file when told to.
     *@
     <hr />
-    <button id="load-boot-script" onclick="loadBootScript(event)">Load boot script</button>
-    <script>
-    function loadBootScript(event) {
-        event.srcElement.disabled = true;
-        var scriptElem = document.createElement('script');
-        scriptElem.src = '_framework/components.server.js';
-        document.body.appendChild(scriptElem);
-    }
 
+    <button id="load-boot-script" onclick="Blazor.start()">Load boot script</button>
+
+    <script src="_framework/components.server.js" autostart="false"></script>
+    <script>
     // Used by InteropOnInitializationComponent
     function setElementValue(element, newValue) {
       element.value = newValue;


### PR DESCRIPTION
Fixes: #6887 and #6887 and #5624

Sample:
```html
    <script src="_framework/components.server.js" autostart="false"></script>
    <script>
        Blazor.start({
            configureSignalR: function (builder) {
                builder.configureLogging(2); // LogLevel.Information
            }
        });
  </script>
```


Adds support for calling Blazor.start({...}) and passing in a
configuration object.

For now all you can configure is the SignalR HubConnectionBuilder. This
is a priority right now because we want to make configuring SignalR's
logging accessible.

