### PR TITLE
Added NegotiateMetadata to negotiate endpoints

### DIFF
--- a/src/SignalR/common/Http.Connections/ref/Microsoft.AspNetCore.Http.Connections.netcoreapp3.0.cs
+++ b/src/SignalR/common/Http.Connections/ref/Microsoft.AspNetCore.Http.Connections.netcoreapp3.0.cs
@@ -55,6 +55,10 @@ namespace Microsoft.AspNetCore.Http.Connections
         public LongPollingOptions() { }
         public System.TimeSpan PollTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
+    public partial class NegotiateMetadata
+    {
+        public NegotiateMetadata() { }
+    }
     public partial class WebSocketOptions
     {
         public WebSocketOptions() { }

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -105,6 +105,8 @@ namespace Microsoft.AspNetCore.Builder
 
             var negotiateBuilder = endpoints.Map(pattern + "/negotiate", negotiateHandler);
             conventionBuilders.Add(negotiateBuilder);
+            // Add the negotiate metadata so this endpoint can be identified
+            negotiateBuilder.WithMetadata(new NegotiateMetadata());
 
             // build the execute handler part of the protocol
             app = endpoints.CreateApplicationBuilder();

--- a/src/SignalR/common/Http.Connections/src/NegotiateMetadata.cs
+++ b/src/SignalR/common/Http.Connections/src/NegotiateMetadata.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Http.Connections
+{
+    /// <summary>
+    /// Metadata to identify the /negotiate endpoint for HTTP dispatcher based
+    /// </summary>
+    public class NegotiateMetadata
+    {
+    }
+}

--- a/src/SignalR/common/Http.Connections/src/NegotiateMetadata.cs
+++ b/src/SignalR/common/Http.Connections/src/NegotiateMetadata.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -5,7 +8,7 @@ using System.Text;
 namespace Microsoft.AspNetCore.Http.Connections
 {
     /// <summary>
-    /// Metadata to identify the /negotiate endpoint for HTTP dispatcher based
+    /// Metadata to identify the /negotiate endpoint for HTTP connections
     /// </summary>
     public class NegotiateMetadata
     {

--- a/src/SignalR/server/SignalR/test/MapSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/MapSignalRTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -204,6 +205,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.Equal(2, dataSource.Endpoints.Count);
                 Assert.Equal(typeof(AuthHub), dataSource.Endpoints[0].Metadata.GetMetadata<HubMetadata>()?.HubType);
                 Assert.Equal(typeof(AuthHub), dataSource.Endpoints[1].Metadata.GetMetadata<HubMetadata>()?.HubType);
+                Assert.NotNull(dataSource.Endpoints[0].Metadata.GetMetadata<NegotiateMetadata>());
+                Assert.Null(dataSource.Endpoints[1].Metadata.GetMetadata<NegotiateMetadata>());
             }
         }
 


### PR DESCRIPTION
- This makes it a bit cleaner to identify the negotiate when trying to apply policies (like replacing the endpoint)
- Added tests that cover MapConnectionHandler for endpoint routing

See https://github.com/davidfowl/AzureSignalRLightupPrototype/blob/166c69ddc54fc716cb46ab570dc0beb17f46c869/Microsoft.Azure.SignalR.Remix/NegotiateMatcherPolicy.cs#L28 for what it looks like today.

cc @rynowak 