### PR TITLE
Move .Components.Services namespace to .Components

### DIFF
--- a/src/Components/Blazor/Blazor/ref/Microsoft.AspNetCore.Blazor.netstandard2.0.cs
+++ b/src/Components/Blazor/Blazor/ref/Microsoft.AspNetCore.Blazor.netstandard2.0.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
 }
 namespace Microsoft.AspNetCore.Blazor.Services
 {
-    public partial class WebAssemblyUriHelper : Microsoft.AspNetCore.Components.Services.UriHelperBase
+    public partial class WebAssemblyUriHelper : Microsoft.AspNetCore.Components.UriHelperBase
     {
         internal WebAssemblyUriHelper() { }
         public static readonly Microsoft.AspNetCore.Blazor.Services.WebAssemblyUriHelper Instance;

--- a/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHostBuilder.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.AspNetCore.Blazor.Services;
-using Microsoft.AspNetCore.Components.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 

--- a/src/Components/Blazor/Blazor/src/Services/WebAssemblyComponentContext.cs
+++ b/src/Components/Blazor/Blazor/src/Services/WebAssemblyComponentContext.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Components.Services;
+using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.AspNetCore.Blazor.Services
 {

--- a/src/Components/Blazor/Blazor/src/Services/WebAssemblyUriHelper.cs
+++ b/src/Components/Blazor/Blazor/src/Services/WebAssemblyUriHelper.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Components.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Interop = Microsoft.AspNetCore.Components.Browser.BrowserUriHelperInterop;
 

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -311,6 +311,10 @@ namespace Microsoft.AspNetCore.Components
         void Configure(Microsoft.AspNetCore.Components.RenderHandle renderHandle);
         System.Threading.Tasks.Task SetParametersAsync(Microsoft.AspNetCore.Components.ParameterCollection parameters);
     }
+    public partial interface IComponentContext
+    {
+        bool IsConnected { get; }
+    }
     public partial interface IHandleAfterRender
     {
         System.Threading.Tasks.Task OnAfterRenderAsync();
@@ -323,6 +327,16 @@ namespace Microsoft.AspNetCore.Components
     public partial class InjectAttribute : System.Attribute
     {
         public InjectAttribute() { }
+    }
+    public partial interface IUriHelper
+    {
+        event System.EventHandler<string> OnLocationChanged;
+        string GetAbsoluteUri();
+        string GetBaseUri();
+        void NavigateTo(string uri);
+        void NavigateTo(string uri, bool forceLoad);
+        System.Uri ToAbsoluteUri(string href);
+        string ToBaseRelativePath(string baseUri, string locationAbsolute);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MarkupString
@@ -544,6 +558,22 @@ namespace Microsoft.AspNetCore.Components
         public double DeltaX { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public double DeltaY { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public double DeltaZ { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public abstract partial class UriHelperBase : Microsoft.AspNetCore.Components.IUriHelper
+    {
+        protected UriHelperBase() { }
+        public event System.EventHandler<string> OnLocationChanged { add { } remove { } }
+        public string GetAbsoluteUri() { throw null; }
+        public virtual string GetBaseUri() { throw null; }
+        protected virtual void InitializeState() { }
+        public void NavigateTo(string uri) { }
+        public void NavigateTo(string uri, bool forceLoad) { }
+        protected abstract void NavigateToCore(string uri, bool forceLoad);
+        protected void SetAbsoluteBaseUri(string baseUri) { }
+        protected void SetAbsoluteUri(string uri) { }
+        public System.Uri ToAbsoluteUri(string href) { throw null; }
+        public string ToBaseRelativePath(string baseUri, string locationAbsolute) { throw null; }
+        protected void TriggerOnLocationChanged() { }
     }
 }
 namespace Microsoft.AspNetCore.Components.Forms
@@ -770,38 +800,5 @@ namespace Microsoft.AspNetCore.Components.Routing
     {
         All = 1,
         Prefix = 0,
-    }
-}
-namespace Microsoft.AspNetCore.Components.Services
-{
-    public partial interface IComponentContext
-    {
-        bool IsConnected { get; }
-    }
-    public partial interface IUriHelper
-    {
-        event System.EventHandler<string> OnLocationChanged;
-        string GetAbsoluteUri();
-        string GetBaseUri();
-        void NavigateTo(string uri);
-        void NavigateTo(string uri, bool forceLoad);
-        System.Uri ToAbsoluteUri(string href);
-        string ToBaseRelativePath(string baseUri, string locationAbsolute);
-    }
-    public abstract partial class UriHelperBase : Microsoft.AspNetCore.Components.Services.IUriHelper
-    {
-        protected UriHelperBase() { }
-        public event System.EventHandler<string> OnLocationChanged { add { } remove { } }
-        public string GetAbsoluteUri() { throw null; }
-        public virtual string GetBaseUri() { throw null; }
-        protected virtual void InitializeState() { }
-        public void NavigateTo(string uri) { }
-        public void NavigateTo(string uri, bool forceLoad) { }
-        protected abstract void NavigateToCore(string uri, bool forceLoad);
-        protected void SetAbsoluteBaseUri(string baseUri) { }
-        protected void SetAbsoluteUri(string uri) { }
-        public System.Uri ToAbsoluteUri(string href) { throw null; }
-        public string ToBaseRelativePath(string baseUri, string locationAbsolute) { throw null; }
-        protected void TriggerOnLocationChanged() { }
     }
 }

--- a/src/Components/Components/src/IComponentContext.cs
+++ b/src/Components/Components/src/IComponentContext.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNetCore.Components.Services
+namespace Microsoft.AspNetCore.Components
 {
     /// <summary>
     /// Provides information about the environment in which components are executing.

--- a/src/Components/Components/src/IUriHelper.cs
+++ b/src/Components/Components/src/IUriHelper.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.AspNetCore.Components.Services
+namespace Microsoft.AspNetCore.Components
 {
     /// <summary>
     /// Helpers for working with URIs and navigation state.

--- a/src/Components/Components/src/Routing/NavLink.cs
+++ b/src/Components/Components/src/Routing/NavLink.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.RenderTree;
-using Microsoft.AspNetCore.Components.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Layouts;
 using Microsoft.AspNetCore.Components.RenderTree;
-using Microsoft.AspNetCore.Components.Services;
 
 namespace Microsoft.AspNetCore.Components.Routing
 {

--- a/src/Components/Components/src/UriHelperBase.cs
+++ b/src/Components/Components/src/UriHelperBase.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.AspNetCore.Components.Services
+namespace Microsoft.AspNetCore.Components
 {
     /// <summary>
     /// A base class for <see cref="IUriHelper"/> implementations.

--- a/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
@@ -8,7 +8,6 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.Browser;
 using Microsoft.AspNetCore.Components.Browser.Rendering;
 using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Components/Server/src/Circuits/RemoteComponentContext.cs
+++ b/src/Components/Server/src/Circuits/RemoteComponentContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Components.Services;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits
 {

--- a/src/Components/Server/src/Circuits/RemoteUriHelper.cs
+++ b/src/Components/Server/src/Circuits/RemoteUriHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Interop = Microsoft.AspNetCore.Components.Browser.BrowserUriHelperInterop;

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.BlazorPack;
 using Microsoft.AspNetCore.Components.Server.Circuits;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;

--- a/src/Components/Server/test/Circuits/CircuitPrerendererTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitPrerendererTest.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Server.Circuits;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/src/Components/test/testassets/BasicTestApp/InteropOnInitializationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropOnInitializationComponent.razor
@@ -1,5 +1,5 @@
 @page "/prerendered-interop"
-@using Microsoft.AspNetCore.Components.Services
+@using Microsoft.AspNetCore.Components
 @using Microsoft.JSInterop
 @inject IComponentContext ComponentContext
 @inject IJSRuntime JSRuntime

--- a/src/Components/test/testassets/BasicTestApp/PrerenderedToInteractiveTransition.razor
+++ b/src/Components/test/testassets/BasicTestApp/PrerenderedToInteractiveTransition.razor
@@ -1,5 +1,5 @@
 @page "/prerendered-transition"
-@using Microsoft.AspNetCore.Components.Services
+@using Microsoft.AspNetCore.Components
 @inject IComponentContext ComponentContext
 
 <h1>Hello</h1>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
@@ -1,5 +1,5 @@
 @using Microsoft.AspNetCore.Components.Routing
-@inject Microsoft.AspNetCore.Components.Services.IUriHelper uriHelper
+@inject Microsoft.AspNetCore.Components.IUriHelper uriHelper
 <style type="text/css">a.active { background-color: yellow; font-weight: bold; }</style>
 <ul>
     <li><NavLink href="/subdir/" Match=NavLinkMatch.All>Default (matches all)</NavLink></li>

--- a/src/Mvc/Mvc.ViewFeatures/src/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Buffers;
 using System.Linq;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;

--- a/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/HttpUriHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/HttpUriHelper.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Components.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/MvcRazorComponentPrerenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/MvcRazorComponentPrerenderer.cs
@@ -4,9 +4,9 @@
 using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Server;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures.RazorComponents

--- a/src/Mvc/Mvc.ViewFeatures/test/HtmlHelperComponentExtensionsTests.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/HtmlHelperComponentExtensionsTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Server;
-using Microsoft.AspNetCore.Components.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.RazorComponents;


### PR DESCRIPTION
Remove namespace `Microsoft.AspNetCore.Components.Services` and move all classes under this namespace to `Microsoft.AspNetCore.Components`.

Addresses #8892
