### PR TITLE
HostingLogScope now logs RequestPath as Request.BasePath+Request.Path

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -132,7 +132,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             public HostingLogScope(HttpContext httpContext, string correlationId)
             {
                 _traceIdentifier = httpContext.TraceIdentifier;
-                _path = (httpContext.Request.PathBase+httpContext.Request.Path).ToString();
+                _path = (httpContext.Request.PathBase.HasValue 
+                         ? httpContext.Request.PathBase + httpContext.Request.Path 
+                         : httpContext.Request.Path).ToString();
                 _correlationId = correlationId;
             }
 

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             public HostingLogScope(HttpContext httpContext, string correlationId)
             {
                 _traceIdentifier = httpContext.TraceIdentifier;
-                _path = (httpContext.Request.BasePath+httpContext.Request.Path).ToString();
+                _path = (httpContext.Request.PathBase+httpContext.Request.Path).ToString();
                 _correlationId = correlationId;
             }
 

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             public HostingLogScope(HttpContext httpContext, string correlationId)
             {
                 _traceIdentifier = httpContext.TraceIdentifier;
-                _path = httpContext.Request.Path.ToString();
+                _path = (httpContext.Request.BasePath+httpContext.Request.Path).ToString();
                 _correlationId = correlationId;
             }
 


### PR DESCRIPTION
fixes #8942
