### PR TITLE
Reduce boxing in RedirectRule.cs

### DIFF
--- a/src/Middleware/Rewrite/src/Internal/RedirectRule.cs
+++ b/src/Middleware/Rewrite/src/Internal/RedirectRule.cs
@@ -74,11 +74,11 @@ namespace Microsoft.AspNetCore.Rewrite.Internal
                         QueryString.FromUriComponent(
                             newPath.Substring(split)));
                     // not using the HttpContext.Response.redirect here because status codes may be 301, 302, 307, 308
-                    response.Headers[HeaderNames.Location] = pathBase + newPath.Substring(0, split) + query;
+                    response.Headers[HeaderNames.Location] = pathBase + newPath.Substring(0, split) + query.ToUriComponent();
                 }
                 else
                 {
-                    response.Headers[HeaderNames.Location] = pathBase + newPath + context.HttpContext.Request.QueryString;
+                    response.Headers[HeaderNames.Location] = pathBase + newPath + context.HttpContext.Request.QueryString.ToUriComponent();
                 }
 
                 context.Logger?.RedirectedRequest(newPath);


### PR DESCRIPTION
`QueryString` is a struct and when concatenating it with a `string` it will be boxed. The `ToString()` method of `QueryString` just calls `ToUriComponent()` so call it directly to prevent boxing.