### PR TITLE
Add missing using statement to Blazor hosted template.

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Serialization;
 using System.Linq;
 


### PR DESCRIPTION
Fixes compilation error in Startup.cs:

'IWebHostEnvironment' does not contain a definition for 'IsDevelopment' and the best extension method overload 'HostingEnvironmentExtensions.IsDevelopment(IHostingEnvironment)' requires a receiver of type 'IHostingEnvironment'

