### PR TITLE
Do not specify `name` of the default (hosted) pools

### DIFF
--- a/.azure/pipelines/e2e-tests.yml
+++ b/.azure/pipelines/e2e-tests.yml
@@ -1,9 +1,10 @@
 trigger: none
-phases:
-- phase: Host_Windows
-  queue:
-    name: Hosted VS2017
-    parallel: 8
+
+jobs:
+- job: Host_Windows
+  pool:
+    vmImage: vs2017-win2016
+  strategy:
     matrix:
       Portable_Node8:
         Test.RuntimeIdentifier: none
@@ -36,6 +37,7 @@ phases:
       versionSpec: $(Node.Version)
   - powershell: |
       test/Cli.FunctionalTests/run-tests.ps1 -ci -ProdConManifestUrl $env:PRODCONMANIFESTURL -TestRuntimeIdentifier $(Test.RuntimeIdentifier) -AdditionalRestoreSources $env:ADDITIONALRESTORESOURCES
+
     condition: ne(variables['PB_SkipTests'], 'true')
     displayName: Run E2E tests
   - task: PublishTestResults@2
@@ -44,10 +46,10 @@ phases:
     inputs:
       testRunner: vstest
       testResultsFiles: 'artifacts/logs/**/*.trx'
-- phase: Host_macOS
-  queue:
-    name: Hosted macOS
-    parallel: 4
+- job: Host_macOS
+  pool:
+    vmImage: macOS-10.13
+  strategy:
     # The ASP.NET Core 2.1.X templates are incompatible with Node10 on macOS
     # https://github.com/aspnet/Templating/issues/608
     matrix:
@@ -70,6 +72,7 @@ phases:
       versionSpec: $(Node.Version)
   - powershell: |
       test/Cli.FunctionalTests/run-tests.ps1 -ci -ProdConManifestUrl $env:PRODCONMANIFESTURL -TestRuntimeIdentifier $(Test.RuntimeIdentifier) -AdditionalRestoreSources $env:ADDITIONALRESTORESOURCES
+
     condition: ne(variables['PB_SkipTests'], 'true')
     displayName: Run E2E tests
   - task: PublishTestResults@2
@@ -78,10 +81,10 @@ phases:
     inputs:
       testRunner: vstest
       testResultsFiles: 'artifacts/logs/**/*.trx'
-- phase: Host_Linux
-  queue:
-    name: Hosted Linux Preview
-    parallel: 8
+- job: Host_Linux
+  pool:
+    vmImage: ubuntu-16.04
+  strategy:
     matrix:
       Portable_Node8:
         Test.RuntimeIdentifier: none
@@ -114,6 +117,7 @@ phases:
       versionSpec: $(Node.Version)
   - powershell: |
       test/Cli.FunctionalTests/run-tests.ps1 -ci -ProdConManifestUrl $env:PRODCONMANIFESTURL -TestRuntimeIdentifier $(Test.RuntimeIdentifier) -AdditionalRestoreSources $env:ADDITIONALRESTORESOURCES
+
     condition: ne(variables['PB_SkipTests'], 'true')
     displayName: Run E2E tests
   - task: PublishTestResults@2

--- a/.azure/pipelines/e2e-tests.yml
+++ b/.azure/pipelines/e2e-tests.yml
@@ -5,6 +5,7 @@ jobs:
   pool:
     vmImage: vs2017-win2016
   strategy:
+    maxParallel: 4
     matrix:
       Portable_Node8:
         Test.RuntimeIdentifier: none
@@ -50,6 +51,7 @@ jobs:
   pool:
     vmImage: macOS-10.13
   strategy:
+    maxParallel: 4
     # The ASP.NET Core 2.1.X templates are incompatible with Node10 on macOS
     # https://github.com/aspnet/Templating/issues/608
     matrix:
@@ -85,6 +87,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   strategy:
+    maxParallel: 4
     matrix:
       Portable_Node8:
         Test.RuntimeIdentifier: none

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -26,9 +26,9 @@
 #   variables: { string: string }
 #     A map of custom variables
 #   matrix: { string: { string: string } }
-#     A map of matrix configurations and variables. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#matrix
+#     A map of matrix configurations and variables. https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#job
 #   dependsOn: string | [ string ]
-#     For fan-out/fan-in. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#phase
+#     For fan-out/fan-in. https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#job
 #   codeSign: boolean
 #       This build definition is enabled for code signing. (Only applies to Windows)
 #   buildDirectory: string
@@ -75,7 +75,7 @@ jobs:
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
       vmImage: macOS-10.13
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
-      vmImage: Linux_Ubuntu_16.04
+      vmImage: ubuntu-16.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         name: NetCorePublic-Int-Pool

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -73,22 +73,16 @@ jobs:
     ${{ if ne(parameters.poolName, '') }}:
       name: ${{ parameters.poolName }}
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: Hosted Mac Internal
-      ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-        name: Hosted macOS
       vmImage: macOS-10.13
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: dnceng-linux-internal-temp
-      ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-        name: dnceng-linux-external-temp
       vmImage: Linux_Ubuntu_16.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: dotnet-internal-temp
-      ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-        name: dotnet-external-temp
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        name: NetCorePublic-Int-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2017.Open
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        name: NetCoreInternal-Int-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2017
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
- aspnet/AspNetCore#8862
- update e2e-test.yml to use modern AzDO job schema
  - https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/PhaseToJobSchemaChange.md
- use BYOC queues on Windows; part of aspnet/AspNetCore-Internal#2033
- pick up latest release/2.1 commit for aspnet/EntityFrameworkCore for related changes