### PR TITLE
Crankier: Log connection exceptions

### DIFF
--- a/src/SignalR/perf/benchmarkapps/Crankier/Client.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Client.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
         private bool _sendInProgress;
         private volatile ConnectionState _connectionState = ConnectionState.Connecting;
 
+        public string ErrorMessage { get; private set;}
         public ConnectionState State => _connectionState;
         public async Task CreateAndStartConnectionAsync(string url, HttpTransportType transportType)
         {
@@ -33,7 +34,8 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                 }
                 else
                 {
-                    Trace.WriteLine($"Connection terminated with error: {ex.GetType()}: {ex.Message}");
+                    ErrorMessage = $"Connection terminated with error: {ex.GetType()}: {ex.Message}";
+                    Trace.WriteLine(ErrorMessage);
                     _connectionState = ConnectionState.Faulted;
                 }
 
@@ -57,7 +59,8 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                 }
                 catch (Exception ex)
                 {
-                    Trace.WriteLine($"Connection.Start Failed: {ex.GetType()}: {ex.Message}");
+                    ErrorMessage = $"Connection.Start Failed: {ex.GetType()}: {ex.Message}";
+                    Trace.WriteLine(ErrorMessage);
 
                     if (connectCount == 3)
                     {

--- a/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
@@ -140,9 +140,11 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                         case ConnectionState.Reconnecting:
                             reconnectingCount++;
                             break;
-                        case ConnectionState.Faulted:
+                        case ConnectionState.Faulted: {
+                            Log(client.ErrorMessage);
                             faultedCount++;
                             break;
+                        }
                     }
                 }
 

--- a/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
@@ -140,10 +140,9 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                         case ConnectionState.Reconnecting:
                             reconnectingCount++;
                             break;
-                        case ConnectionState.Faulted: {
+                        case ConnectionState.Faulted:
                             faultedCount++;
                             break;
-                        }
                     }
                 }
 

--- a/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
             _targetConnectionCount += numberOfConnections;
             for (var count = 0; count < numberOfConnections; count++)
             {
-                var client = new Client();
+                var client = new Client(_processId, _agent);
                 _clients.Add(client);
 
                 await client.CreateAndStartConnectionAsync(targetAddress, transportType);
@@ -141,7 +141,6 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                             reconnectingCount++;
                             break;
                         case ConnectionState.Faulted: {
-                            Log(client.ErrorMessage);
                             faultedCount++;
                             break;
                         }


### PR DESCRIPTION
Sends exception messages back to the worker for agent logging so you can see why faulted connections are failing.
