### PR TITLE
[master] Update certificate for SignalR Java client

### DIFF
--- a/build/CodeSign.targets
+++ b/build/CodeSign.targets
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <FilesToSign Include="$(ArtifactsShippingPackagesDir)*.jar" Certificate="MicrosoftJAR" />
+      <FilesToSign Include="$(ArtifactsShippingPackagesDir)*.jar" Certificate="MicrosoftJARSHA2" />
       <FilesToSign Include="$(ArtifactsShippingPackagesDir)*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)*.symbols.nupkg" Certificate="NuGet" />
       <FilesToSign Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" Exclude="$(ArtifactsNonShippingPackagesDir)*.symbols.nupkg" Certificate="NuGet" />
       <FilesToSign Include="$(VisualStudioSetupOutputPath)*.vsix" Certificate="VsixSHA2" />


### PR DESCRIPTION
There's a matching change coming for 2.2 (it's a different change so it's not a simple merge forward). 2.1 is not affected since SignalR didn't ship there.

Part of https://github.com/aspnet/AspNetCore-Internal/issues/2109