### PR TITLE
[release/2.2] update SignalR Java client signing cert

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,7 @@
     <PowerShellSigningCertName>Microsoft400</PowerShellSigningCertName>
     <PackageSigningCertName>NuGet</PackageSigningCertName>
     <VsixSigningCertName>VsixSHA2</VsixSigningCertName>
-    <JarSigningCertName>MicrosoftJAR</JarSigningCertName>
+    <JarSigningCertName>MicrosoftJARSHA2</JarSigningCertName>
   </PropertyGroup>
 
   <Import Project="build\external-dependencies.props" />


### PR DESCRIPTION
Update the Java signing cert in 2.2. See https://github.com/aspnet/AspNetCore/pull/9048

Part of https://github.com/aspnet/AspNetCore-Internal/issues/2109