### PR TITLE
Install latest stable VS 2019 RTM from scripts

### DIFF
--- a/eng/scripts/vs.buildtools.json
+++ b/eng/scripts/vs.buildtools.json
@@ -1,6 +1,6 @@
 {
-    "channelUri": "https://aka.ms/vs/16/pre/channel",
-    "channelId": "VisualStudio.16.Preview",
+    "channelUri": "https://aka.ms/vs/16/release/channel",
+    "channelId": "VisualStudio.16.Release",
     "includeRecommended": false,
     "addProductLang": [
         "en-US"

--- a/eng/scripts/vs.json
+++ b/eng/scripts/vs.json
@@ -1,6 +1,6 @@
 {
-    "channelUri": "https://aka.ms/vs/16/pre/channel",
-    "channelId": "VisualStudio.16.Preview",
+    "channelUri": "https://aka.ms/vs/16/release/channel",
+    "channelId": "VisualStudio.16.Release",
     "includeRecommended": false,
     "addProductLang": [
         "en-US"


### PR DESCRIPTION
This restores the original behavior of the script (prior to https://github.com/aspnet/AspNetCore/commit/85ae18c723a27740a3e1056faca377fd999d613b) to install the latest stable version of Visual Studio.