### PR TITLE
Fix log message in RemoteRenderer

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteRenderer.cs
+++ b/src/Components/Server/src/Circuits/RemoteRenderer.cs
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Components.Browser.Rendering
             else
             {
                 var message = $"Completing batch {entry.BatchId} " +
-                    errorMessageOrNull == null ? "without error." : "with error.";
+                    (errorMessageOrNull == null ? "without error." : "with error.");
 
                 _logger.LogDebug(message);
                 CompleteRender(entry.CompletionSource, errorMessageOrNull);


### PR DESCRIPTION
Previously it would always log the string `with error`, because without the parens, the expression was evaluated as:

```cs
var message = ($"Completing batch {entry.BatchId} " + errorMessageOrNull) == null
    ? "without error." : "with error.";
```