### PR TITLE
Specify AddRazorSupportForMvc in Blazor templates

### DIFF
--- a/src/Components/Blazor/Build/src/build/netstandard1.0/Microsoft.AspNetCore.Blazor.Build.props
+++ b/src/Components/Blazor/Build/src/build/netstandard1.0/Microsoft.AspNetCore.Blazor.Build.props
@@ -1,3 +1,8 @@
 ﻿<Project>
   <Import Project="$(MSBuildThisFileDirectory)..\..\targets\All.props" />
+
+  <PropertyGroup>
+    <!-- Removing this tracked via https://github.com/aspnet/AspNetCore/issues/9126 -->
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
 </Project>

--- a/src/Components/Blazor/Templates/src/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
@@ -9,6 +9,7 @@
     </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorClassLibrary-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorClassLibrary-CSharp.csproj.in
@@ -6,7 +6,7 @@
     <RazorLangVersion Condition="'$(SupportPagesAndViews)' != 'True'">3.0</RazorLangVersion>
     <AddRazorSupportForMvc Condition="'$(SupportPagesAndViews)' == 'True'">true</AddRazorSupportForMvc>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.RazorClassLibrary1</RootNamespace>
-    <AddRazorSupportForMvc Condition="'$(SupportPagesAndViews)' == 'True'">true</AddRazorSupportForMvc>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SupportPagesAndViews)' == 'True'">


### PR DESCRIPTION
VS 16.1 tooling does not support RazorConfigurations with no extensions
Working around this by treating Blazor templates as using MVC configuration
until we can resolve the issue in tooling

Workaround for https://github.com/aspnet/AspNetCore/issues/9119
