### PR TITLE
Set CSharpLangVersion during runtime compilation

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/CSharpCompiler.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/CSharpCompiler.cs
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 
             if (string.IsNullOrEmpty(dependencyContextOptions.LanguageVersion))
             {
-                // During preview releases, the Roslyn assumes Preview language version for netcoreapp3.0 targeting projects.
+                // During preview releases, Roslyn assumes Preview language version for netcoreapp3.0 targeting projects.
                 // We will match the behavior if the project does not specify a value for C# language (e.g. if you're using Razor compilation in a F# project).
                 // Prior to 3.0 RTM, this value needs to be changed to "Latest". This is tracked via https://github.com/aspnet/AspNetCore/issues/9129
                 parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.Preview);

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/CSharpCompiler.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/CSharpCompiler.cs
@@ -209,16 +209,20 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 
             var parseOptions = new CSharpParseOptions(preprocessorSymbols: defines);
 
-            if (!string.IsNullOrEmpty(dependencyContextOptions.LanguageVersion))
+            if (string.IsNullOrEmpty(dependencyContextOptions.LanguageVersion))
             {
-                if (LanguageVersionFacts.TryParse(dependencyContextOptions.LanguageVersion, out var languageVersion))
-                {
-                    parseOptions = parseOptions.WithLanguageVersion(languageVersion);
-                }
-                else
-                {
-                    Debug.Fail($"LanguageVersion {languageVersion} specified in the deps file could not be parsed.");
-                }
+                // During preview releases, the Roslyn assumes Preview language version for netcoreapp3.0 targeting projects.
+                // We will match the behavior if the project does not specify a value for C# language (e.g. if you're using Razor compilation in a F# project).
+                // Prior to 3.0 RTM, this value needs to be changed to "Latest". This is tracked via https://github.com/aspnet/AspNetCore/issues/9129
+                parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.Preview);
+            }
+            else if (LanguageVersionFacts.TryParse(dependencyContextOptions.LanguageVersion, out var languageVersion))
+            {
+                parseOptions = parseOptions.WithLanguageVersion(languageVersion);
+            }
+            else
+            {
+                Debug.Fail($"LanguageVersion {languageVersion} specified in the deps file could not be parsed.");
             }
 
             return parseOptions;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton(s =>
             {
                 var fileSystem = s.GetRequiredService<RazorProjectFileSystem>();
+                var csharpCompiler = s.GetRequiredService<CSharpCompiler>();
                 var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, builder =>
                 {
                     RazorExtensions.Register(builder);
@@ -95,6 +96,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     // TagHelperDescriptorProviders (actually do tag helper discovery)
                     builder.Features.Add(new DefaultTagHelperDescriptorProvider());
                     builder.Features.Add(new ViewComponentTagHelperDescriptorProvider());
+                    builder.SetCSharpLanguageVersion(csharpCompiler.ParseOptions.LanguageVersion);
                 });
 
                 return projectEngine;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/build/netcoreapp3.0/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/build/netcoreapp3.0/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
@@ -2,5 +2,8 @@
   <PropertyGroup>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
+
+    <!-- Generate hosting attributes during build time compilation to support runtime compilation -->
+    <GenerateRazorHostingAssemblyInfo Condition="'$(GenerateRazorHostingAssemblyInfo)'==''">true</GenerateRazorHostingAssemblyInfo>
   </PropertyGroup>
 </Project>

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/test/CSharpCompilerTest.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/test/CSharpCompilerTest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 
             // Act & Assert
             var parseOptions = compiler.ParseOptions;
-            Assert.Equal(LanguageVersion.CSharp7_3, parseOptions.LanguageVersion);
+            Assert.Equal(LanguageVersion.CSharp8, parseOptions.LanguageVersion);
             Assert.Equal(new[] { "DEBUG" }, parseOptions.PreprocessorSymbolNames);
         }
 

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -26,7 +26,7 @@ namespace Templates.Test
 
         [Theory]
         [InlineData(null)]
-        [InlineData("F#", Skip = "https://github.com/aspnet/AspNetCore/issues/8996")]
+        [InlineData("F#")]
         public async Task MvcTemplate_NoAuthImplAsync(string languageOverride)
         {
             Project = await ProjectFactory.GetOrCreateProject("mvcnoauth" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);


### PR DESCRIPTION
* Pass CSharpLangVersion inferred by the CSharpCompiler to RazorEngine
* Set GenerateRazorHostingAssemblyInfo in Razor.RuntimeCompilation
targets
* Unskip failing test

Fixes https://github.com/aspnet/AspNetCore/issues/8996
