### PR TITLE
Dispose configuration in WebHost

### DIFF
--- a/src/Hosting/Hosting/src/WebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilder.cs
@@ -175,6 +175,10 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 host.Initialize();
 
+                // resolve configuration explicitly once to mark it as resolved within the
+                // service provider, ensuring it will be properly disposed with the provider
+                _ = host.Services.GetService<IConfiguration>();
+
                 var logger = host.Services.GetRequiredService<ILogger<WebHost>>();
 
                 // Warn about duplicate HostingStartupAssemblies
@@ -264,12 +268,13 @@ namespace Microsoft.AspNetCore.Hosting
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(_hostingEnvironment.ContentRootPath)
-                .AddConfiguration(_config);
+                .AddConfiguration(_config, shouldDisposeConfiguration: true);
 
             _configureAppConfigurationBuilder?.Invoke(_context, builder);
 
             var configuration = builder.Build();
-            services.AddSingleton<IConfiguration>(configuration);
+            // register configuration as factory to make it dispose with the service provider
+            services.AddSingleton<IConfiguration>(_ => configuration);
             _context.Configuration = configuration;
 
             var listener = new DiagnosticListener("Microsoft.AspNetCore");


### PR DESCRIPTION
This is a companion-PR to aspnet/Extensions#1361 which addresses aspnet/Extensions#938: When disposing the WebHost, the underlying configurations will also be disposed by the service provider.

~Since the `IConfiguration` that is passed to the `WebHost` constructor is the *host* configuration, and does not access the configuration directly (the `Startup` may though), the `WebHost` has to resolve the app configuration from the service provider. This is done early within `Initialize` as soon as the service provider is available to avoid having to retrieve it later only for disposal.~

The host configuration is also disposed ~by the `WebHost`~ transitively. While the host configuration only ever contains a single environment variables configuration provider (which is not disposable itself), disposing the configuration will also make sure to dispose the change registration.

The drawback for this is that using the `WebHostBuilder.GetSetting()` *after* the web host is disposed means that the operation is made on an already disposed configuration root. The way the configuration root is currently implemented, this should not actually prevent this from working though.