### PR TITLE
Fixed the demo video link in the Blazor readme

### DIFF
--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -31,7 +31,7 @@ Blazor uses only the latest web standards. No plugins or transpilation needed. I
 
 > Note: client-side Blazor is an *experimental* project. It's not yet a committed product . This is to allow time to fully investigate the technical issues associated with running .NET in the browser and to ensure we can build something that developers love and can be productive with. During this experimental phase, we expect to engage deeply with early Blazor adopters like you to hear your feedback and suggestions.
 
-To see Blazor in action, check out [Steve Sanderson's demo at NDC London](https://www.youtube.com/watch?v=Qe8UW5543-s). You can also try out a [simple live Blazor app](https://blazor-demo.github.io/).
+To see Blazor in action, check out [Steve Sanderson's demo at NDC London](https://youtu.be/0RfUPr0KrSM). You can also try out a [simple live Blazor app](https://blazor-demo.github.io/).
 
 ## Getting Started
 


### PR DESCRIPTION
Fixed the demo video link in the Blazor readme.

[9147#issue-430080241](https://github.com/aspnet/AspNetCore/issues/9147#issue-430080241)
