### PR TITLE
Stabilize StreamAsyncCanBeCanceledThroughGetAsyncEnumerator test

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -449,7 +449,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
                     var cts = new CancellationTokenSource();
 
-                    var stream = connection.StreamAsync<int>("Stream", 5, cts.Token);
+                    var stream = connection.StreamAsync<int>("Stream", 1000, cts.Token);
                     var results = new List<int>();
 
                     var enumerator = stream.GetAsyncEnumerator();
@@ -462,8 +462,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                         }
                     });
 
-                    Assert.Single(results);
-                    Assert.Equal(0, results[0]);
+                    Assert.True(results.Count > 0 && results.Count < 1000);
                 }
                 catch (Exception ex)
                 {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -665,7 +665,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         [LogLevel(LogLevel.Trace)]
-        public async Task StreamAsyncCanBeCanceledThroughGetEnumerator(string protocolName, HttpTransportType transportType, string path)
+        public async Task StreamAsyncCanBeCanceledThroughGetAsyncEnumerator(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartServer<Startup>(out var server))
@@ -674,7 +674,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 try
                 {
                     await connection.StartAsync().OrTimeout();
-                    var stream = connection.StreamAsync<int>("Stream", 5 );
+                    var stream = connection.StreamAsync<int>("Stream", 1000 );
                     var results = new List<int>();
 
                     var cts = new CancellationTokenSource();
@@ -689,8 +689,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                         }
                     });
 
-                    Assert.Single(results);
-                    Assert.Equal(0, results[0]);
+                    Assert.True(results.Count > 0 && results.Count < 1000);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore-Internal/issues/2196
We were seeing some flakiness on some of the PR builds for this test. 

I updated this test to use a strategy that we have in a similar test for our channel streaming API
https://github.com/aspnet/AspNetCore/blob/8bfbc4a2ac8f32e61a9d6eee8c55901771478428/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs#L728-L742

Instead of only expected 1 item to have been written to the stream just enforce that we at least gotten one item and that less than the total amount, in this case 1000 items, were written because of the token getting triggered.