### PR TITLE
Fix folder version for global module to only have 3 numbers

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
@@ -173,7 +173,7 @@
                 <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
               </RegistryKey>
             </Component>
-            <Directory Id="HandlerVersionDir" Name="$(var.ANCMMsiVersion)" >
+            <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
               <Component Id="AspNetCoreModuleHandler" Guid="559EF726-B25C-480F-AFA4-32D0BA8B2376" Win64="$(var.IsWin64)">
                 <File Id="AspNetCoreModuleHandlerDll"
                       Name="aspnetcorev2_outofprocess.dll"
@@ -216,7 +216,7 @@
                     <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
                   </RegistryKey>
                 </Component>
-                <Directory Id="HandlerVersionDir32" Name="$(var.ANCMMsiVersion)" >
+                <Directory Id="HandlerVersionDir32" Name="$(var.ANCMFolderVersion)" >
                   <Component Id="AspNetCoreModuleHandler.wow" Guid="0A8EDB50-7D85-4825-8010-D27EFAF061B6" Win64="no">
                     <File Id="AspNetCoreModuleHandlerDll.wow"
                           Name="aspnetcorev2_outofprocess.dll"

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -149,7 +149,7 @@
                                    <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
                                </RegistryKey>
                            </Component>
-                           <Directory Id="HandlerVersionDir" Name="$(var.ANCMMsiVersion)" >
+                           <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
                                <Component Id="AspNetCoreModuleHandler" Guid="4b62060a-deb8-4de3-9557-9c0be21dc844" Win64="$(var.IsWin64)">
                                    <File Id="AspNetCoreModuleHandlerDll"
                                          Name="aspnetcorev2_outofprocess.dll"
@@ -192,7 +192,7 @@
                                     <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
                                 </RegistryKey>
                             </Component>
-                            <Directory Id="HandlerVersionDir32" Name="$(var.ANCMMsiVersion)" SourceName="WowOnly">
+                            <Directory Id="HandlerVersionDir32" Name="$(var.ANCMFolderVersion)" SourceName="WowOnly">
                                 <Component Id="AspNetCoreModuleHandler.wow" Guid="d927e5d3-c8b2-400c-b85c-ae5c2772d6c3" Win64="no">
                                     <File Id="AspNetCoreModuleHandlerDll.wow"
                                           Name="aspnetcorev2_outofprocess.dll"

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Directory.Build.props
@@ -15,7 +15,8 @@
     <BLDNUMMINOR>$(BUILD_MINOR)</BLDNUMMINOR>
 
     <!-- ANCM msi version is prepended with a 1 due to previous msi versions starting with 8.x.x.0 -->
-    <ANCMMsiVersion>1$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(BUILD_MAJOR).0</ANCMMsiVersion>
+    <ANCMFolderVersion>1$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(BUILD_MAJOR)</ANCMFolderVersion>
+    <ANCMMsiVersion>$(ANCMFolderVersion).0</ANCMMsiVersion>
 
     <!-- The handler version in the M.A.AspNetCoreV2 nuget package. Today, this is hard coded to 2.0.0
           The actual handler folder version is dependent on the ANCMMsiVersion -->
@@ -31,7 +32,7 @@
 
     <_ServerIISBasePath>$(RepositoryRoot)\src\Servers\IIS\</_ServerIISBasePath>
     <DefineConstants>BLDVERMAJOR=$(BLDVERMAJOR);BLDVERMINOR=$(BLDVERMINOR);BLDNUMMAJOR=$(BLDNUMMAJOR);BLDNUMMINOR=$(BLDNUMMINOR);$(DefineConstants)</DefineConstants>
-    <DefineConstants>ANCMMsiVersion=$(ANCMMsiVersion);ANCMOutOfProcessNugetPackageHandlerVersion=$(ANCMOutOfProcessNugetPackageHandlerVersion);$(DefineConstants)</DefineConstants>
+    <DefineConstants>ANCMMsiVersion=$(ANCMMsiVersion);ANCMFolderVersion=$(ANCMFolderVersion);ANCMOutOfProcessNugetPackageHandlerVersion=$(ANCMOutOfProcessNugetPackageHandlerVersion);$(DefineConstants)</DefineConstants>
     <DefineConstants>
       AspNetCoreSchemaPath=$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml;
       AspNetCoreMofPath=$(_ServerIISBasePath)AspNetCoreModuleV2\AspNetCore\ancm.mof;


### PR DESCRIPTION
### Description

Changes the default folder path for the AspNetCoreModule out of process request handler from a folder path of MAJOR.MINOR.PATCH.BUILD to MAJOR.MINOR.PATCH.

### Reason for change:

Without this change, ANCM+OutOfProcess will not work, giving a failure saying the out of process request handler cannot be loaded.

### What commit caused this failure

We recently took in a new dependency from core-setup to find the folder hostfxr is located in. Hostfxr recently was updated to support sem ver 2.0 (https://semver.org/), which we needed to react to if/when they start to support it (https://github.com/aspnet/AspNetCore/commit/7a1a53d76d62783ae33f116309c5d3745f00dd94 for the commit we made). We use this type (fx_ver) to also look for the request handler for ANCM out of process. However, the folder ANCM out of process is located in follows windows folder versions (MAJOR.MINOR.PATCH.BUILD) rather than sem var. Before updating our core-setup dependency, this folder version would still be parsed and valid. However, after this change, it says it cannot find the folder. 

### Why wasn't this caught earlier?

We added many automated tests checking for folder versions that contained MAJOR.MINOR.PATCH, but during installer cleanup, we decided to simplify the use of the MSI version and Folder version into the same value. We didn't add regression tests for this scenario at all. 

### Any concern of breaking changes?

No. The reason dlls are in folders are for rapid update scenarios, which have never been used yet. MSIs today remove the folder on uninstall, so there will never be more than one folder in the directory.