### PR TITLE
Try new Fedora queue for Helix

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -20,7 +20,7 @@
         <HelixAvailibleTargetQueue Include="Debian.8.Amd64.Open" Platform="Linux" />
         <HelixAvailibleTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
         <HelixAvailibleTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-        <HelixAvailibleTargetQueue Include="Fedora.28.Amd64.Open" Platform="Linux" />
+        <HelixAvailibleTargetQueue Include="\(Fedora.28.Amd64\)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190402012449" Platform="Linux" />
 
         <!--  TODO: re-enable Debian.9.Arm64.Open and Ubuntu.1804.Arm64.Open    -->
     </ItemGroup>


### PR DESCRIPTION
Right now helix is always failing on fedora agents: https://mc.dot.net/#/user/aspnetcore/pr~2Faspnet~2Faspnetcore/ci/20190408.19. Talked with @MattGal and it seems we can just use the following definition instead (original found here https://github.com/dotnet/corefx/blob/184089d748b705438a117002143ebb4429ce0d97/eng/pipelines/linux.yml#L104). 