### PR TITLE
Rename Microsoft.AspNetCore.App.PlatformManifest.txt 

### DIFF
--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <!-- Shared between targeting pack and runtime build. -->
-    <PlatformManifestFileName>Microsoft.AspNetCore.App.PlatformManifest.txt</PlatformManifestFileName>
+    <PlatformManifestFileName>PlatformManifest.txt</PlatformManifestFileName>
     <PlatformManifestOutputPath>$(ArtifactsObjDir)$(PlatformManifestFileName)</PlatformManifestOutputPath>
   </PropertyGroup>
 

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void PlatformManifestListsAllFiles()
         {
-            var platformManifestPath = Path.Combine(_targetingPackRoot, "data", "Microsoft.AspNetCore.App.PlatformManifest.txt");
+            var platformManifestPath = Path.Combine(_targetingPackRoot, "data", "PlatformManifest.txt");
             var expectedAssemblies = TestData.GetSharedFxDependencies()
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
                 .ToHashSet();


### PR DESCRIPTION
Fix https://github.com/aspnet/AspNetCore/issues/8836

#### Description
The SDK is not reading version-conflict resolution data from our targeting pack because the manifest is in the wrong location. As a result, the SDK is copying assemblies into the build/publish output which should have come from the shared framework instead.
	
#### Customer Impact
When a project references EF Core 3.0 and ASP.NET Core 3.0,  published output is not optimized and duplicates assemblies which should have come from the shared framework.

#### Regression?
Yes, this is a regression from the shared framework behavior in 2.2.

#### Risk
Low.

