### PR TITLE
Revert "Use new Fedora queue (#9178)"

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -20,7 +20,7 @@
         <HelixAvailibleTargetQueue Include="Debian.8.Amd64.Open" Platform="Linux" />
         <HelixAvailibleTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
         <HelixAvailibleTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-        <HelixAvailibleTargetQueue Include="\(Fedora.28.Amd64\)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190402012449" Platform="Linux" />
+        <HelixAvailibleTargetQueue Include="Fedora.28.Amd64.Open" Platform="Linux" />
 
         <!--  TODO: re-enable Debian.9.Arm64.Open and Ubuntu.1804.Arm64.Open    -->
     </ItemGroup>


### PR DESCRIPTION
This reverts commit 5fb1ac22e9dd0ed0efd97dfa72d3cfca4ec19aed.

Apparently the fedora 28 queue may be working again and the script we run doesn't work on docker images. Still investigating if we can update our script.
