### PR TITLE
Use WORKITEM_ROOT instead of CORRELATIONPAYLOAD for helix workloads

### DIFF
--- a/eng/helix/vstest/runtests.sh
+++ b/eng/helix/vstest/runtests.sh
@@ -16,11 +16,11 @@ fi
 # Call "sync" between "chmod" and execution to prevent "text file busy" error in Docker (aufs)
 chmod +x "dotnet-install.sh"; sync
 
-./dotnet-install.sh --version $2 --install-dir $HELIX_CORRELATION_PAYLOAD/sdk
+./dotnet-install.sh --version $2 --install-dir $HELIX_WORKITEM_ROOT/sdk
 if [ $? -ne 0 ]; then
     sdk_retries=3
     while [ $sdk_retries -gt 0 ]; do
-        ./dotnet-install.sh --version $2 --install-dir $HELIX_CORRELATION_PAYLOAD/sdk
+        ./dotnet-install.sh --version $2 --install-dir $HELIX_WORKITEM_ROOT/sdk
         if [ $? -ne 0 ]; then
             let sdk_retries=sdk_retries-1
             echo -e "${YELLOW}Failed to install .NET Core SDK $version. Retries left: $sdk_retries.${RESET}"
@@ -30,11 +30,11 @@ if [ $? -ne 0 ]; then
     done
 fi
 
-./dotnet-install.sh --runtime dotnet --version $3 --install-dir $HELIX_CORRELATION_PAYLOAD/sdk
+./dotnet-install.sh --runtime dotnet --version $3 --install-dir $HELIX_WORKITEM_ROOT/sdk
 if [ $? -ne 0 ]; then
     runtime_retries=3
     while [ $runtime_retries -gt 0 ]; do
-        ./dotnet-install.sh --runtime dotnet --version $3 --install-dir $HELIX_CORRELATION_PAYLOAD/sdk
+        ./dotnet-install.sh --runtime dotnet --version $3 --install-dir $HELIX_WORKITEM_ROOT/sdk
         if [ $? -ne 0 ]; then
             let runtime_retries=runtime_retries-1
             echo -e "${YELLOW}Failed to install .NET Core runtime $version. Retries left: $runtime_retries.${RESET}"
@@ -47,7 +47,7 @@ fi
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 # Ensures every invocation of dotnet apps uses the same dotnet.exe
-export DOTNET_ROOT="$HELIX_CORRELATION_PAYLOAD/sdk"
+export DOTNET_ROOT="$HELIX_WORKITEM_ROOT/sdk"
 
 # Ensure dotnet comes first on PATH
 export PATH="$DOTNET_ROOT:$PATH"

--- a/eng/helix/vstest/runtests.sh
+++ b/eng/helix/vstest/runtests.sh
@@ -56,7 +56,7 @@ export PATH="$DOTNET_ROOT:$PATH"
 export DOTNET_MULTILEVEL_LOOKUP=0
 
 # Avoid contaminating userprofiles
-export DOTNET_CLI_HOME="$HELIX_CORRELATION_PAYLOAD/home"
+export DOTNET_CLI_HOME="$HELIX_WORKITEM_ROOT/home"
 
 export helix="$4"
 

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -20,7 +20,7 @@
         <HelixAvailibleTargetQueue Include="Debian.8.Amd64.Open" Platform="Linux" />
         <HelixAvailibleTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
         <HelixAvailibleTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-        <HelixAvailibleTargetQueue Include="Fedora.28.Amd64.Open" Platform="Linux" />
+        <HelixAvailibleTargetQueue Include="\(Fedora.28.Amd64\)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190402012449" Platform="Linux" />
 
         <!--  TODO: re-enable Debian.9.Arm64.Open and Ubuntu.1804.Arm64.Open    -->
     </ItemGroup>


### PR DESCRIPTION
Better way of fixing https://github.com/aspnet/AspNetCore/pull/9186, but not certain it will work yet. CORRELATION_PAYLOAD is readonly on these new helix payloads.