### PR TITLE
Http1OutputProducer Reset sequentially

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -481,6 +481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             Debug.Assert(_currentSegmentOwner == null);
             Debug.Assert(_completedSegments == null || _completedSegments.Count == 0);
+            // Cleared in sequential address ascending order 
             _currentMemoryPrefixBytes = 0;
             _autoChunk = false;
             _currentChunkMemoryUpdated = false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -481,10 +481,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             Debug.Assert(_currentSegmentOwner == null);
             Debug.Assert(_completedSegments == null || _completedSegments.Count == 0);
-            _autoChunk = false;
-            _startCalled = false;
-            _currentChunkMemoryUpdated = false;
             _currentMemoryPrefixBytes = 0;
+            _autoChunk = false;
+            _currentChunkMemoryUpdated = false;
+            _startCalled = false;
         }
 
         private ValueTask<FlushResult> WriteAsync(


### PR DESCRIPTION
Currently jumps about in addresses; better for cache if it processes in ascending order

Previous
```asm
G_M57007_IG02:
       mov      byte  ptr [rcx+119], 0
       mov      byte  ptr [rcx+121], 0
       mov      byte  ptr [rcx+120], 0
       xor      eax, eax
       mov      dword ptr [rcx+104], eax
```
New
```asm
G_M57007_IG02:
       xor      eax, eax
       mov      dword ptr [rcx+104], eax
       mov      byte  ptr [rcx+119], 0
       mov      byte  ptr [rcx+120], 0
       mov      byte  ptr [rcx+121], 0
```