### PR TITLE
Fix Platform benchmark

### DIFF
--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -181,6 +181,11 @@ namespace PlatformBenchmarks
 
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
                 => RequestHandler.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
+
+#if NETCOREAPP3_0
+            public void OnHeadersComplete()
+                => RequestHandler.OnHeadersComplete();
+#endif
         }
     }
 


### PR DESCRIPTION
Implement `OnHeadersComplete` method on the adaptor