### PR TITLE
Add retries to helix failures and re-enable helix as a required workload

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -13,12 +13,13 @@
     <HelixBuild>private-$(USERNAME)</HelixBuild>
     <HelixBuild Condition=" '$(USERNAME)' == '' ">private-$(USER)</HelixBuild>
     <HelixBuild Condition=" '$(CI)' == 'true' ">$(BUILD_BUILDNUMBER)</HelixBuild>
-    <WaitForWorkItemCompletion Condition=" '$(CI)' == 'true' ">false</WaitForWorkItemCompletion>
-    <FailOnMissionControlTestFailure>false</FailOnMissionControlTestFailure>
+    <WaitForWorkItemCompletion Condition=" '$(CI)' == 'true' ">true</WaitForWorkItemCompletion>
+    <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <IsExternal>true</IsExternal>
     <Creator>aspnetcore</Creator>
     <SkipInvalidConfigurations>true</SkipInvalidConfigurations>
+    <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
   </PropertyGroup>
 
   <Target Name="Gather" BeforeTargets="Build">

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -50,22 +50,6 @@ namespace Microsoft.AspNetCore.Http
         }
 
         [Fact]
-        public void AlwaysFails()
-        {
-            Assert.True(false);
-        }
-
-        [Fact]
-        public void SometimesFails()
-        {
-            var random = new Random();
-            if (random.Next(0, 2) == 0)
-            {
-                throw new Exception();
-            }
-        }
-
-        [Fact]
         public void HashCode_CheckNullAndEmptyHaveSameHashcodes()
         {
             Assert.Equal(PathString.Empty.GetHashCode(), default(PathString).GetHashCode());

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -47,6 +47,22 @@ namespace Microsoft.AspNetCore.Http
 
             // Act and Assert
             Assert.NotEqual(pathString, PathString.Empty);
+        }
+
+        [Fact]
+        public void AlwaysFails()
+        {
+            Assert.True(false);
+        }
+
+        [Fact]
+        public void SometimesFails()
+        {
+            var random = new Random();
+            if (random.Next(0, 2) == 0)
+            {
+                throw new Exception();
+            }
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -6,6 +6,8 @@
     <TestGroupName>Interop.FunctionalTests</TestGroupName>
     <!-- WebDriver is not strong named, so this test assembly cannot be strong-named either. -->
     <SignAssembly>false</SignAssembly>
+    <!-- See: https://github.com/aspnet/AspNetCore/issues/7299 -->
+    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Trying to see if max retries works correctly and if we can start making helix a required check. Still prototyping.