### PR TITLE
Fix stale references

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using BasicTestApp;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
@@ -12,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
 {
-    public class BasicTestAppTestBase : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
+    public abstract class BasicTestAppTestBase : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
     {
         public string ServerPathBase
             => "/subdir" + (_serverFixture.UsingAspNetHost ? "#server" : "");

--- a/src/Components/test/E2ETest/Infrastructure/ServerTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerTestBase.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
             _serverFixture = serverFixture;
         }
 
+        public override string BrowserIsolationContext => GetType().Name;
+
         public void Navigate(string relativeUrl, bool noReload = false)
         {
             var absoluteUrl = new Uri(_serverFixture.RootUri, relativeUrl);

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerSideAppTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerSideAppTest.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;

--- a/src/Components/test/E2ETest/Tests/HostedInAspNetTest.cs
+++ b/src/Components/test/E2ETest/Tests/HostedInAspNetTest.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using System;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/ProjectTemplates/test/RazorComponentsTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorComponentsTemplateTest.cs
@@ -23,6 +23,8 @@ namespace Templates.Test
 
         public Project Project { get; private set; }
 
+        public override string BrowserIsolationContext => GetType().Name;
+
         [Fact]
         public async Task RazorComponentsTemplateWorks()
         {

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -32,6 +32,8 @@ namespace Templates.Test.SpaTemplateTest
 
         public Project Project { get; set; }
 
+        public override string BrowserIsolationContext => GetType().Name;
+
         // Rather than using [Theory] to pass each of the different values for 'template',
         // it's important to distribute the SPA template tests over different test classes
         // so they can be run in parallel. Xunit doesn't parallelize within a test class.

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -16,8 +16,8 @@ namespace Microsoft.AspNetCore.E2ETesting
 {
     public class BrowserFixture : IDisposable
     {
-        private ConcurrentDictionary<string, Task<(IWebDriver browser, ILogs log)>> _browsers = new ConcurrentDictionary<string, Task<(IWebDriver, ILogs)>>();
-        private List<IWebDriver> _browsersToDispose = new List<IWebDriver>();
+        private readonly ConcurrentDictionary<string, Task<(IWebDriver browser, ILogs log)>> _browsers = new ConcurrentDictionary<string, Task<(IWebDriver, ILogs)>>();
+        private readonly List<IWebDriver> _browsersToDispose = new List<IWebDriver>();
 
         public BrowserFixture(IMessageSink diagnosticsMessageSink)
         {
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.E2ETesting
             }
         }
 
-        public Task<(IWebDriver, ILogs)> GetOrCreateBrowserAsync(ITestOutputHelper output, string isolationContext = "")
+        public Task<(IWebDriver, ILogs)> GetOrCreateBrowserAsync(ITestOutputHelper output, string isolationContext)
         {
             if (!IsHostAutomationSupported())
             {

--- a/src/Shared/E2ETesting/BrowserTestBase.cs
+++ b/src/Shared/E2ETesting/BrowserTestBase.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.E2ETesting
 {
     [CaptureSeleniumLogs]
-    public class BrowserTestBase : IClassFixture<BrowserFixture>, IAsyncLifetime
+    public abstract class BrowserTestBase : IClassFixture<BrowserFixture>, IAsyncLifetime
     {
         private static readonly AsyncLocal<IWebDriver> _asyncBrowser = new AsyncLocal<IWebDriver>();
         private static readonly AsyncLocal<ILogs> _logs = new AsyncLocal<ILogs>();
@@ -32,6 +32,8 @@ namespace Microsoft.AspNetCore.E2ETesting
 
         public BrowserFixture BrowserFixture { get; }
 
+        public abstract string BrowserIsolationContext { get; }
+
         public Task DisposeAsync()
         {
             return Task.CompletedTask;
@@ -39,7 +41,7 @@ namespace Microsoft.AspNetCore.E2ETesting
 
         public virtual async Task InitializeAsync()
         {
-            var (browser, logs) = await BrowserFixture.GetOrCreateBrowserAsync(Output);
+            var (browser, logs) = await BrowserFixture.GetOrCreateBrowserAsync(Output, BrowserIsolationContext);
             _asyncBrowser.Value = browser;
             _logs.Value = logs;
 


### PR DESCRIPTION
Attempted fix for https://github.com/aspnet/AspNetCore-Internal/issues/2136. I wasn't able to get this to re-produce, but seeing as the `FindElement` is on the same line as the `.Text` here it seems likely that the problem here is that Browsers are getting re-used.