### PR TITLE
Make DataProtection certificate tests assertions stricter about which  cert is used in the test

### DIFF
--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -115,7 +115,6 @@ namespace Microsoft.AspNetCore.DataProtection
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2177", FlakyOn.AzP.Windows)]
         [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
         [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
         public void System_UsesProvidedDirectoryAndCertificate()
@@ -132,7 +131,8 @@ namespace Microsoft.AspNetCore.DataProtection
             {
                 var certificateStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
                 certificateStore.Open(OpenFlags.ReadWrite);
-                var certificate = certificateStore.Certificates.Find(X509FindType.FindBySubjectName, "TestCert", false)[0];
+                var certificatesInStore = certificateStore.Certificates.Find(X509FindType.FindByThumbprint, "EF068A16FE536A50907E7634E86F0E2805F0D232", false);
+                var certificate = Assert.IsType<X509Certificate2>(Assert.Single(certificatesInStore));
 
                 try
                 {
@@ -184,7 +184,8 @@ namespace Microsoft.AspNetCore.DataProtection
                 using (var certificateStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
                 {
                     certificateStore.Open(OpenFlags.ReadWrite);
-                    var certInStore = certificateStore.Certificates.Find(X509FindType.FindBySubjectName, "TestCert", false)[0];
+                    var certificatesInStore = certificateStore.Certificates.Find(X509FindType.FindByThumbprint, "6A46E3E5FA9D3F4D81C1E8333D4F3E63769EECCF", false);
+                    var certInStore = Assert.IsType<X509Certificate2>(Assert.Single(certificatesInStore));
                     Assert.NotNull(certInStore);
                     Assert.False(certInStore.HasPrivateKey);
 


### PR DESCRIPTION
Addresses aspnet/AspNetCore-Internal#2177

This test only fails on some CI agents. As these tests rely on a certificate store shared by other builds, it's probably that the failures are the result of some other dotnet team adding a cert called 'TestCert' into the X509Store.

This changes the tests to pull from the X509Store the _exact_ cert we want the test to use.
