### PR TITLE
Don't log action and page handler arguments above Trace level

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -28,6 +28,7 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.11' ">
     <PackagesInPatch>
+      Microsoft.AspNetCore.Mvc.Core;
     </PackagesInPatch>
   </PropertyGroup>
 

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -29,6 +29,7 @@ Later on, this will be checked using this condition:
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.11' ">
     <PackagesInPatch>
       Microsoft.AspNetCore.Mvc.Core;
+      Microsoft.AspNetCore.Mvc.RazorPages;
     </PackagesInPatch>
   </PropertyGroup>
 

--- a/src/Mvc/Mvc.Core/src/Internal/MvcCoreLoggerExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Internal/MvcCoreLoggerExtensions.cs
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 "Executing action method {ActionName} - Validation state: {ValidationState}");
 
             _actionMethodExecutingWithArguments = LoggerMessage.Define<string, string[]>(
-                LogLevel.Debug,
+                LogLevel.Trace,
                 3,
                 "Executing action method {ActionName} with arguments ({Arguments})");
 
@@ -816,7 +816,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 var validationState = context.ModelState.ValidationState;
                 _actionMethodExecuting(logger, actionName, validationState, null);
 
-                if (arguments != null && logger.IsEnabled(LogLevel.Debug))
+                if (arguments != null && logger.IsEnabled(LogLevel.Trace))
                 {
                     var convertedArguments = new string[arguments.Length];
                     for (var i = 0; i < arguments.Length; i++)

--- a/src/Mvc/Mvc.Core/src/Internal/MvcCoreLoggerExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Internal/MvcCoreLoggerExtensions.cs
@@ -39,6 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private static readonly Action<ILogger, string, Exception> _contentResultExecuting;
 
         private static readonly Action<ILogger, string, ModelValidationState, Exception> _actionMethodExecuting;
+        private static readonly Action<ILogger, string, string[], Exception> _actionMethodExecutingWithArguments;
         private static readonly Action<ILogger, string, string, double, Exception> _actionMethodExecuted;
 
         private static readonly Action<ILogger, string, string[], Exception> _logFilterExecutionPlan;
@@ -171,6 +172,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 LogLevel.Information,
                 1,
                 "Executing action method {ActionName} - Validation state: {ValidationState}");
+
+            _actionMethodExecutingWithArguments = LoggerMessage.Define<string, string[]>(
+                LogLevel.Debug,
+                3,
+                "Executing action method {ActionName} with arguments ({Arguments})");
 
             _actionMethodExecuted = LoggerMessage.Define<string, string, double>(
                 LogLevel.Information,
@@ -809,6 +815,17 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                 var validationState = context.ModelState.ValidationState;
                 _actionMethodExecuting(logger, actionName, validationState, null);
+
+                if (arguments != null && logger.IsEnabled(LogLevel.Debug))
+                {
+                    var convertedArguments = new string[arguments.Length];
+                    for (var i = 0; i < arguments.Length; i++)
+                    {
+                        convertedArguments[i] = Convert.ToString(arguments[i]);
+                    }
+
+                    _actionMethodExecutingWithArguments(logger, actionName, convertedArguments, null);
+                }
             }
         }
 

--- a/src/Mvc/Mvc.Core/src/Internal/MvcCoreLoggerExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Internal/MvcCoreLoggerExtensions.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private static readonly Action<ILogger, string, Exception> _contentResultExecuting;
 
         private static readonly Action<ILogger, string, ModelValidationState, Exception> _actionMethodExecuting;
-        private static readonly Action<ILogger, string, string[], ModelValidationState, Exception> _actionMethodExecutingWithArguments;
         private static readonly Action<ILogger, string, string, double, Exception> _actionMethodExecuted;
 
         private static readonly Action<ILogger, string, string[], Exception> _logFilterExecutionPlan;
@@ -172,11 +171,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 LogLevel.Information,
                 1,
                 "Executing action method {ActionName} - Validation state: {ValidationState}");
-
-            _actionMethodExecutingWithArguments = LoggerMessage.Define<string, string[], ModelValidationState>(
-                LogLevel.Information,
-                1,
-                "Executing action method {ActionName} with arguments ({Arguments}) - Validation state: {ValidationState}");
 
             _actionMethodExecuted = LoggerMessage.Define<string, string, double>(
                 LogLevel.Information,
@@ -814,22 +808,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 var actionName = context.ActionDescriptor.DisplayName;
 
                 var validationState = context.ModelState.ValidationState;
-
-                string[] convertedArguments;
-                if (arguments == null)
-                {
-                    _actionMethodExecuting(logger, actionName, validationState, null);
-                }
-                else
-                {
-                    convertedArguments = new string[arguments.Length];
-                    for (var i = 0; i < arguments.Length; i++)
-                    {
-                        convertedArguments[i] = Convert.ToString(arguments[i]);
-                    }
-
-                    _actionMethodExecutingWithArguments(logger, actionName, convertedArguments, validationState, null);
-                }
+                _actionMethodExecuting(logger, actionName, validationState, null);
             }
         }
 

--- a/src/Mvc/Mvc.RazorPages/src/Internal/PageLoggerExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Internal/PageLoggerExtensions.cs
@@ -35,10 +35,9 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 "Executing handler method {HandlerName} - ModelState is {ValidationState}");
 
             _handlerMethodExecutingWithArguments = LoggerMessage.Define<string, string[]>(
-                LogLevel.Debug,
+                LogLevel.Trace,
                 103,
                 "Executing handler method {HandlerName} with arguments ({Arguments})");
-            "Executing handler method {HandlerName} - ModelState is {ValidationState}");
 
             _handlerMethodExecuted = LoggerMessage.Define<string, string>(
                 LogLevel.Debug,
@@ -85,7 +84,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 var validationState = context.ModelState.ValidationState;
                 _handlerMethodExecuting(logger, handlerName, validationState, null);
 
-                if (arguments != null && logger.IsEnabled(LogLevel.Debug))
+                if (arguments != null && logger.IsEnabled(LogLevel.Trace))
                 {
                     var convertedArguments = new string[arguments.Length];
                     for (var i = 0; i < arguments.Length; i++)

--- a/src/Mvc/Mvc.RazorPages/src/Internal/PageLoggerExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Internal/PageLoggerExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         public const string PageFilter = "Page Filter";
 
         private static readonly Action<ILogger, string, ModelValidationState, Exception> _handlerMethodExecuting;
+        private static readonly Action<ILogger, string, string[], Exception> _handlerMethodExecutingWithArguments;
         private static readonly Action<ILogger, string, string, Exception> _handlerMethodExecuted;
         private static readonly Action<ILogger, object, Exception> _pageFilterShortCircuit;
         private static readonly Action<ILogger, string, string[], Exception> _malformedPageDirective;
@@ -32,6 +33,12 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 LogLevel.Information,
                 101,
                 "Executing handler method {HandlerName} - ModelState is {ValidationState}");
+
+            _handlerMethodExecutingWithArguments = LoggerMessage.Define<string, string[]>(
+                LogLevel.Debug,
+                103,
+                "Executing handler method {HandlerName} with arguments ({Arguments})");
+            "Executing handler method {HandlerName} - ModelState is {ValidationState}");
 
             _handlerMethodExecuted = LoggerMessage.Define<string, string>(
                 LogLevel.Debug,
@@ -77,6 +84,17 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
                 var validationState = context.ModelState.ValidationState;
                 _handlerMethodExecuting(logger, handlerName, validationState, null);
+
+                if (arguments != null && logger.IsEnabled(LogLevel.Debug))
+                {
+                    var convertedArguments = new string[arguments.Length];
+                    for (var i = 0; i < arguments.Length; i++)
+                    {
+                        convertedArguments[i] = Convert.ToString(arguments[i]);
+                    }
+
+                    _handlerMethodExecutingWithArguments(logger, handlerName, convertedArguments, null);
+                }
             }
         }
 

--- a/src/Mvc/Mvc.RazorPages/src/Internal/PageLoggerExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Internal/PageLoggerExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
     {
         public const string PageFilter = "Page Filter";
 
-        private static readonly Action<ILogger, string, string[], ModelValidationState, Exception> _handlerMethodExecuting;
+        private static readonly Action<ILogger, string, ModelValidationState, Exception> _handlerMethodExecuting;
         private static readonly Action<ILogger, string, string, Exception> _handlerMethodExecuted;
         private static readonly Action<ILogger, object, Exception> _pageFilterShortCircuit;
         private static readonly Action<ILogger, string, string[], Exception> _malformedPageDirective;
@@ -28,10 +28,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         {
             // These numbers start at 101 intentionally to avoid conflict with the IDs used by ResourceInvoker.
 
-            _handlerMethodExecuting = LoggerMessage.Define<string, string[], ModelValidationState>(
+            _handlerMethodExecuting = LoggerMessage.Define<string, ModelValidationState>(
                 LogLevel.Information,
                 101,
-                "Executing handler method {HandlerName} with arguments ({Arguments}) - ModelState is {ValidationState}");
+                "Executing handler method {HandlerName} - ModelState is {ValidationState}");
 
             _handlerMethodExecuted = LoggerMessage.Define<string, string>(
                 LogLevel.Debug,
@@ -75,23 +75,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             {
                 var handlerName = handler.MethodInfo.Name;
 
-                string[] convertedArguments;
-                if (arguments == null)
-                {
-                    convertedArguments = null;
-                }
-                else
-                {
-                    convertedArguments = new string[arguments.Length];
-                    for (var i = 0; i < arguments.Length; i++)
-                    {
-                        convertedArguments[i] = Convert.ToString(arguments[i]);
-                    }
-                }
-
                 var validationState = context.ModelState.ValidationState;
-
-                _handlerMethodExecuting(logger, handlerName, convertedArguments, validationState, null);
+                _handlerMethodExecuting(logger, handlerName, validationState, null);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/9121


### Impact
The contract for logging says any sensitive information would be logged at `LogLevel.Trace`. However, MVC logs some user inputs which could contain potentially sensitive information at `LogLevel.Info`

Workaround
Workaround is to disable Info logging for Mvc.

Risk
This should be fairly low risk. Logging MVC is disabled in production applications.
