### PR TITLE
Fix #8974 by supporting strings in configureLogging for SignalR JS client

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -13,18 +13,17 @@ import { JsonHubProtocol } from "./JsonHubProtocol";
 import { NullLogger } from "./Loggers";
 import { Arg, ConsoleLogger } from "./Utils";
 
-// This is exported from this module but NOT from index, so it's "internal" for testing purposes
-export const LogLevelNameMapping = {
-    // TS Lint prefers alphabetical sorting...
-    critical: LogLevel.Critical,
+// tslint:disable:object-literal-sort-keys
+const LogLevelNameMapping = {
+    trace: LogLevel.Trace,
     debug: LogLevel.Debug,
-    error: LogLevel.Error,
     info: LogLevel.Information,
     information: LogLevel.Information,
-    none: LogLevel.None,
-    trace: LogLevel.Trace,
     warn: LogLevel.Warning,
     warning: LogLevel.Warning,
+    error: LogLevel.Error,
+    critical: LogLevel.Critical,
+    none: LogLevel.None,
 };
 
 function parseLogLevel(name: keyof typeof LogLevelNameMapping): LogLevel {

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -13,6 +13,32 @@ import { JsonHubProtocol } from "./JsonHubProtocol";
 import { NullLogger } from "./Loggers";
 import { Arg, ConsoleLogger } from "./Utils";
 
+// This is exported from this module but NOT from index, so it's "internal" for testing purposes
+export const LogLevelNameMapping = {
+    // TS Lint prefers alphabetical sorting...
+    critical: LogLevel.Critical,
+    debug: LogLevel.Debug,
+    error: LogLevel.Error,
+    info: LogLevel.Information,
+    information: LogLevel.Information,
+    none: LogLevel.None,
+    trace: LogLevel.Trace,
+    warn: LogLevel.Warning,
+    warning: LogLevel.Warning,
+};
+
+function parseLogLevel(name: keyof typeof LogLevelNameMapping): LogLevel {
+    // Case-insensitive matching via lower-casing
+    // Yes, I know case-folding is a complicated problem in Unicode, but we only support
+    // the ASCII strings defined in LogLevelNameMapping anyway, so it's fine -anurse.
+    const mapping = LogLevelNameMapping[name.toLowerCase()];
+    if (typeof mapping !== "undefined") {
+        return mapping;
+    } else {
+        throw new Error(`Unknown log level: ${name}`);
+    }
+}
+
 /** A builder for configuring {@link @aspnet/signalr.HubConnection} instances. */
 export class HubConnectionBuilder {
     /** @internal */
@@ -47,12 +73,15 @@ export class HubConnectionBuilder {
      * @param {LogLevel | ILogger} logging An object implementing the {@link @aspnet/signalr.ILogger} interface or {@link @aspnet/signalr.LogLevel}.
      * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
      */
-    public configureLogging(logging: LogLevel | ILogger): HubConnectionBuilder;
-    public configureLogging(logging: LogLevel | ILogger): HubConnectionBuilder {
+    public configureLogging(logging: LogLevel | keyof typeof LogLevelNameMapping | ILogger): HubConnectionBuilder;
+    public configureLogging(logging: LogLevel | keyof typeof LogLevelNameMapping | ILogger): HubConnectionBuilder {
         Arg.isRequired(logging, "logging");
 
         if (isLogger(logging)) {
             this.logger = logging;
+        } else if (typeof logging === "string") {
+            const logLevel = parseLogLevel(logging);
+            this.logger = new ConsoleLogger(logLevel);
         } else {
             this.logger = new ConsoleLogger(logging);
         }
@@ -92,7 +121,7 @@ export class HubConnectionBuilder {
         // Flow-typing knows where it's at. Since HttpTransportType is a number and IHttpConnectionOptions is guaranteed
         // to be an object, we know (as does TypeScript) this comparison is all we need to figure out which overload was called.
         if (typeof transportTypeOrOptions === "object") {
-            this.httpConnectionOptions = {...this.httpConnectionOptions, ...transportTypeOrOptions};
+            this.httpConnectionOptions = { ...this.httpConnectionOptions, ...transportTypeOrOptions };
         } else {
             this.httpConnectionOptions = {
                 ...this.httpConnectionOptions,

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -69,11 +69,11 @@ export class HubConnectionBuilder {
 
     /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
      *
-     * @param {LogLevel | ILogger} logging An object implementing the {@link @aspnet/signalr.ILogger} interface or {@link @aspnet/signalr.LogLevel}.
+     * @param {LogLevel | string | ILogger} logging A {@link @aspnet/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @aspnet/signalr.ILogger} interface. See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
      * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public configureLogging(logging: LogLevel | keyof typeof LogLevelNameMapping | ILogger): HubConnectionBuilder;
-    public configureLogging(logging: LogLevel | keyof typeof LogLevelNameMapping | ILogger): HubConnectionBuilder {
+    public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder {
         Arg.isRequired(logging, "logging");
 
         if (isLogger(logging)) {

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -26,7 +26,7 @@ const LogLevelNameMapping = {
     none: LogLevel.None,
 };
 
-function parseLogLevel(name: keyof typeof LogLevelNameMapping): LogLevel {
+function parseLogLevel(name: string): LogLevel {
     // Case-insensitive matching via lower-casing
     // Yes, I know case-folding is a complicated problem in Unicode, but we only support
     // the ASCII strings defined in LogLevelNameMapping anyway, so it's fine -anurse.
@@ -69,7 +69,8 @@ export class HubConnectionBuilder {
 
     /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
      *
-     * @param {LogLevel | string | ILogger} logging A {@link @aspnet/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @aspnet/signalr.ILogger} interface. See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
+     * @param {LogLevel | string | ILogger} logging A {@link @aspnet/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @aspnet/signalr.ILogger} interface.
+     *    See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
      * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder {

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -69,10 +69,18 @@ export class HubConnectionBuilder {
 
     /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
      *
+     * @param {string} logLevel A string representing a LogLevel setting a minimum level of messages to log.
+     *    See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
+     */
+    public configureLogging(logLevel: string): HubConnectionBuilder;
+
+    /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
+     *
      * @param {LogLevel | string | ILogger} logging A {@link @aspnet/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @aspnet/signalr.ILogger} interface.
      *    See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
      * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
      */
+    public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder;
     public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder {
         Arg.isRequired(logging, "logging");
 

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -72,7 +72,6 @@ export class HubConnectionBuilder {
      * @param {LogLevel | string | ILogger} logging A {@link @aspnet/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @aspnet/signalr.ILogger} interface. See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
      * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
      */
-    public configureLogging(logging: LogLevel | keyof typeof LogLevelNameMapping | ILogger): HubConnectionBuilder;
     public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder {
         Arg.isRequired(logging, "logging");
 

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -146,6 +146,7 @@ export class SubjectSubscription<T> implements ISubscription<T> {
 /** @private */
 export class ConsoleLogger implements ILogger {
     private readonly minimumLogLevel: LogLevel;
+	// Public for testing purposes.
     public outputConsole: {
         error(message: any): void,
         warn(message: any): void,

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -146,9 +146,16 @@ export class SubjectSubscription<T> implements ISubscription<T> {
 /** @private */
 export class ConsoleLogger implements ILogger {
     private readonly minimumLogLevel: LogLevel;
+    public outputConsole: {
+        error(message: any): void,
+        warn(message: any): void,
+        info(message: any): void,
+        log(message: any): void,
+    };
 
     constructor(minimumLogLevel: LogLevel) {
         this.minimumLogLevel = minimumLogLevel;
+        this.outputConsole = console;
     }
 
     public log(logLevel: LogLevel, message: string): void {
@@ -156,17 +163,17 @@ export class ConsoleLogger implements ILogger {
             switch (logLevel) {
                 case LogLevel.Critical:
                 case LogLevel.Error:
-                    console.error(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
+                    this.outputConsole.error(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
                 case LogLevel.Warning:
-                    console.warn(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
+                    this.outputConsole.warn(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
                 case LogLevel.Information:
-                    console.info(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
+                    this.outputConsole.info(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
                 default:
                     // console.debug only goes to attached debuggers in Node, so we use console.log for Trace and Debug
-                    console.log(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
+                    this.outputConsole.log(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
             }
         }

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -146,7 +146,8 @@ export class SubjectSubscription<T> implements ISubscription<T> {
 /** @private */
 export class ConsoleLogger implements ILogger {
     private readonly minimumLogLevel: LogLevel;
-	// Public for testing purposes.
+
+    // Public for testing purposes.
     public outputConsole: {
         error(message: any): void,
         warn(message: any): void,

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -4,7 +4,7 @@
 import { DefaultReconnectPolicy } from "../src/DefaultReconnectPolicy";
 import { HttpRequest, HttpResponse } from "../src/HttpClient";
 import { HubConnection, HubConnectionState } from "../src/HubConnection";
-import { HubConnectionBuilder, LogLevelNameMapping } from "../src/HubConnectionBuilder";
+import { HubConnectionBuilder } from "../src/HubConnectionBuilder";
 import { IHttpConnectionOptions } from "../src/IHttpConnectionOptions";
 import { HubMessage, IHubProtocol } from "../src/IHubProtocol";
 import { ILogger, LogLevel } from "../src/ILogger";

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -27,6 +27,20 @@ const commonHttpOptions: IHttpConnectionOptions = {
     logMessageContent: true,
 };
 
+// We use a different mapping table here to help catch any unintentional breaking changes.
+// tslint:disable:object-literal-sort-keys
+const ExpectedLogLevelMappings = {
+    trace: LogLevel.Trace,
+    debug: LogLevel.Debug,
+    info: LogLevel.Information,
+    information: LogLevel.Information,
+    warn: LogLevel.Warning,
+    warning: LogLevel.Warning,
+    error: LogLevel.Error,
+    critical: LogLevel.Critical,
+    none: LogLevel.None,
+};
+
 class CapturingConsole {
     public messages: any[] = [];
 
@@ -180,9 +194,9 @@ describe("HubConnectionBuilder", () => {
             });
         });
 
-        const levelNames = Object.keys(LogLevelNameMapping) as Array<keyof typeof LogLevelNameMapping>;
+        const levelNames = Object.keys(ExpectedLogLevelMappings) as Array<keyof typeof ExpectedLogLevelMappings>;
         for (const str of levelNames) {
-            const mapped = LogLevelNameMapping[str];
+            const mapped = ExpectedLogLevelMappings[str];
             const mappedName = LogLevel[mapped];
             it(`accepts "${str}" as an alias for LogLevel.${mappedName}`, async () => {
                 const builder = new HubConnectionBuilder()

--- a/src/SignalR/samples/SignalRSamples/wwwroot/hubs.html
+++ b/src/SignalR/samples/SignalRSamples/wwwroot/hubs.html
@@ -151,7 +151,7 @@
         console.log('http://' + document.location.host + '/' + hubRoute);
 
         var connectionBuilder = new signalR.HubConnectionBuilder()
-            .configureLogging(signalR.LogLevel.Trace)
+            .configureLogging("trace")
             .withUrl(hubRoute, options)
             .withHubProtocol(protocol);
 


### PR DESCRIPTION
Fixes #8974 

This allows users to pass in a string for the log level when calling `configureLogging`. This makes it much easier to configure logging in environments where you don't have access to the enum definition (such as in Blazor when you're just doing this in a script block in your page).

Note: I also grouped all the `configureLogging` tests into their own `describe` because there were now quite a few :).

Test output for HubConnectionBuilder.test.ts:

```
 PASS  signalr/tests/HubConnectionBuilder.test.ts (6.62s)
  HubConnectionBuilder
    √ withUrl throws if url is null (3ms)
    √ withHubProtocol throws if protocol is null
    √ withUrl throws if url is undefined
    √ withHubProtocol throws if protocol is undefined (1ms)
    √ builds HubConnection with HttpConnection using provided URL (12ms)
    √ can configure transport type
    √ can configure hub protocol (2ms)
    √ reconnectPolicy undefined by default (1ms)
    √ withAutomaticReconnect throws if reconnectPolicy is already set
    √ withAutomaticReconnect uses default retryDelays when called with no arguments (1ms)
    √ withAutomaticReconnect uses custom retryDelays when provided
    √ withAutomaticReconnect uses a custom IReconnectPolicy when provided
    configureLogging
      √ throws if logger is null (1ms)
      √ throws if logger is undefined
      √ accepts LogLevel.None
      √ accepts LogLevel.Critical
      √ accepts LogLevel.Error
      √ accepts LogLevel.Warning (1ms)
      √ accepts LogLevel.Information
      √ accepts LogLevel.Debug
      √ accepts LogLevel.Trace (1ms)
      √ accepts "critical" as an alias for LogLevel.Critical
      √ accepts "debug" as an alias for LogLevel.Debug (1ms)
      √ accepts "error" as an alias for LogLevel.Error
      √ accepts "info" as an alias for LogLevel.Information
      √ accepts "information" as an alias for LogLevel.Information (1ms)
      √ accepts "none" as an alias for LogLevel.None
      √ accepts "trace" as an alias for LogLevel.Trace
      √ accepts "warn" as an alias for LogLevel.Warning
      √ accepts "warning" as an alias for LogLevel.Warning (1ms)
      √ allows logger to be replaced (1ms)
      √ configures logger for both HttpConnection and HubConnection (2ms)
      √ does not replace HttpConnectionOptions logger if provided (1ms)
```

cc @rynowak 