### PR TITLE
Produce Corresponding symbols in installer output for ANCM

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj
@@ -11,6 +11,8 @@
     <SuppressIces>ICE03</SuppressIces>
     <DisableGuidGeneration>true</DisableGuidGeneration>
     <SchemaVersion>2.0</SchemaVersion>
+    <TempPlatform Condition="'$(Platform)' == 'x64'">x64</TempPlatform>
+    <TempPlatform Condition="'$(Platform)' == 'x86'">Win32</TempPlatform>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,6 +52,16 @@
       <DoNotHarvest>True</DoNotHarvest>
     </ProjectReference>
   </ItemGroup>
+
+  <Target Name="CopyBuildOutputToArtifactDirectory"
+          Condition=" '$(IsProductInstaller)' == 'true' "
+          AfterTargets="Build">
+    <ItemGroup>
+      <BuildContentForAncm Include="$(RepositoryRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\bin\$(Configuration)\$(TempPlatform)\*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(BuildContentForAncm)" DestinationFolder="$(InstallersOutputPath)\IISExpressSymbols\$(TempPlatform)" />
+  </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
   <Import Project="..\build\settings.props" />

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj
@@ -59,7 +59,6 @@
     <ItemGroup>
       <BuildContentForAncm Include="$(RepositoryRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\bin\$(Configuration)\$(TempPlatform)\*.*" />
     </ItemGroup>
-
     <Copy SourceFiles="@(BuildContentForAncm)" DestinationFolder="$(InstallersOutputPath)\IISExpressSymbols\$(TempPlatform)" />
   </Target>
 

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
@@ -11,8 +11,6 @@
     <GenerateRandomNamespaceGuid>true</GenerateRandomNamespaceGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <DisableGuidGeneration>true</DisableGuidGeneration>
-    <TempPlatform Condition="'$(Platform)' == 'x64'">x64</TempPlatform>
-    <TempPlatform Condition="'$(Platform)' == 'x86'">Win32</TempPlatform>
   </PropertyGroup>
 
   <ItemGroup>
@@ -56,14 +54,4 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
   <Import Project="..\build\settings.props" />
   <Import Project="..\build\versions.props" />
-  
-  <Target Name="CopyBuildOutputToArtifactDirectory"
-          Condition=" '$(IsProductInstaller)' == 'true' "
-          AfterTargets="Build">
-    <ItemGroup>
-      <BuildContentForAncm Include="$(RepositoryRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\bin\$(Configuration)\$(TempPlatform)\*.*" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(BuildContentForAncm)" DestinationFolder="$(InstallersOutputPath)\IISSymbols\$(TempPlatform)" />
-  </Target>
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
@@ -11,6 +11,8 @@
     <GenerateRandomNamespaceGuid>true</GenerateRandomNamespaceGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <DisableGuidGeneration>true</DisableGuidGeneration>
+    <TempPlatform Condition="'$(Platform)' == 'x64'">x64</TempPlatform>
+    <TempPlatform Condition="'$(Platform)' == 'x86'">Win32</TempPlatform>
   </PropertyGroup>
 
   <ItemGroup>
@@ -54,4 +56,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
   <Import Project="..\build\settings.props" />
   <Import Project="..\build\versions.props" />
+  
+  <Target Name="CopyBuildOutputToArtifactDirectory"
+          Condition=" '$(IsProductInstaller)' == 'true' "
+          AfterTargets="Build">
+    <ItemGroup>
+      <BuildContentForAncm Include="$(RepositoryRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\bin\$(Configuration)\$(TempPlatform)\*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(BuildContentForAncm)" DestinationFolder="$(InstallersOutputPath)\IISSymbols\$(TempPlatform)" />
+  </Target>
 </Project>


### PR DESCRIPTION
We don't export corresponding symbols for msis with ANCM. This is a simple approach for now. 