### PR TITLE
Mild Mvc perf

### DIFF
--- a/src/Http/Http/src/Internal/ItemsDictionary.cs
+++ b/src/Http/Http/src/Internal/ItemsDictionary.cs
@@ -8,111 +8,160 @@ namespace Microsoft.AspNetCore.Http.Internal
 {
     public class ItemsDictionary : IDictionary<object, object>
     {
+        private IDictionary<object, object> _items;
+
         public ItemsDictionary()
-            : this(new Dictionary<object, object>())
-        {
-        }
+        {}
 
         public ItemsDictionary(IDictionary<object, object> items)
         {
-            Items = items;
+            _items = items;
         }
 
-        public IDictionary<object, object> Items { get; }
+        public IDictionary<object, object> Items => this;
 
         // Replace the indexer with one that returns null for missing values
         object IDictionary<object, object>.this[object key]
         {
             get
             {
-                object value;
-                if (Items.TryGetValue(key, out value))
+                if (_items != null && _items.TryGetValue(key, out var value))
                 {
                     return value;
                 }
                 return null;
             }
-            set { Items[key] = value; }
+            set
+            {
+                if (_items == null)
+                {
+                    CreateDictionary();
+                }
+
+                _items[key] = value;
+            }
         }
 
         void IDictionary<object, object>.Add(object key, object value)
         {
-            Items.Add(key, value);
+            if (_items == null)
+            {
+                CreateDictionary();
+            }
+
+            _items.Add(key, value);
         }
 
         bool IDictionary<object, object>.ContainsKey(object key)
-        {
-            return Items.ContainsKey(key);
-        }
+            => _items != null && _items.ContainsKey(key);
 
         ICollection<object> IDictionary<object, object>.Keys
         {
-            get { return Items.Keys; }
+            get
+            {
+                if (_items == null)
+                {
+                    CreateDictionary();
+                }
+
+                return _items.Keys;
+            }
         }
 
         bool IDictionary<object, object>.Remove(object key)
-        {
-            return Items.Remove(key);
-        }
+            => _items != null && _items.Remove(key);
 
         bool IDictionary<object, object>.TryGetValue(object key, out object value)
         {
-            return Items.TryGetValue(key, out value);
+            value = null;
+            return _items != null && _items.TryGetValue(key, out value);
         }
 
         ICollection<object> IDictionary<object, object>.Values
         {
-            get { return Items.Values; }
+            get
+            {
+                if (_items == null)
+                {
+                    CreateDictionary();
+                }
+
+                return _items.Values;
+            }
         }
 
         void ICollection<KeyValuePair<object, object>>.Add(KeyValuePair<object, object> item)
         {
-            Items.Add(item);
+            if (_items == null)
+            {
+                CreateDictionary();
+            }
+
+            _items.Add(item);
         }
 
-        void ICollection<KeyValuePair<object, object>>.Clear()
-        {
-            Items.Clear();
-        }
+        void ICollection<KeyValuePair<object, object>>.Clear() => _items?.Clear();
 
         bool ICollection<KeyValuePair<object, object>>.Contains(KeyValuePair<object, object> item)
-        {
-            return Items.Contains(item);
-        }
+            => _items != null && _items.Contains(item);
 
         void ICollection<KeyValuePair<object, object>>.CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
         {
-            Items.CopyTo(array, arrayIndex);
+            if (_items == null)
+            {
+                EmptyDictionary.Collection.CopyTo(array, arrayIndex);
+            }
+
+            _items.CopyTo(array, arrayIndex);
         }
 
-        int ICollection<KeyValuePair<object, object>>.Count
-        {
-            get { return Items.Count; }
-        }
+        int ICollection<KeyValuePair<object, object>>.Count => _items?.Count ?? 0;
 
-        bool ICollection<KeyValuePair<object, object>>.IsReadOnly
-        {
-            get { return Items.IsReadOnly; }
-        }
+        bool ICollection<KeyValuePair<object, object>>.IsReadOnly => _items?.IsReadOnly ?? false;
 
         bool ICollection<KeyValuePair<object, object>>.Remove(KeyValuePair<object, object> item)
         {
-            object value;
-            if (Items.TryGetValue(item.Key, out value) && Equals(item.Value, value))
+            if (_items == null)
             {
-                return Items.Remove(item.Key);
+                return false;
+            }
+
+            if (_items.TryGetValue(item.Key, out var value) && Equals(item.Value, value))
+            {
+                return _items.Remove(item.Key);
             }
             return false;
         }
 
+        private void CreateDictionary() => _items = new Dictionary<object, object>();
+
         IEnumerator<KeyValuePair<object, object>> IEnumerable<KeyValuePair<object, object>>.GetEnumerator()
+            => _items?.GetEnumerator() ?? EmptyEnumerator.Instance;
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator() ?? EmptyEnumerator.Instance;
+
+        private class EmptyEnumerator : IEnumerator<KeyValuePair<object, object>>
         {
-            return Items.GetEnumerator();
+            // In own class so only initalized if GetEnumerator is called on an empty ItemsDictionary
+            public readonly static IEnumerator<KeyValuePair<object, object>> Instance = new EmptyEnumerator();
+            public KeyValuePair<object, object> Current => default;
+
+            object IEnumerator.Current => null;
+
+            public void Dispose()
+            { }
+
+            public bool MoveNext() => false;
+
+            public void Reset()
+            { }
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
+        private static class EmptyDictionary
         {
-            return Items.GetEnumerator();
+            // In own class so only initalized if CopyTo is called on an empty ItemsDictionary
+            public readonly static IDictionary<object, object> Dictionary = new Dictionary<object, object>();
+            public static ICollection<KeyValuePair<object, object>> Collection => Dictionary;
         }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
@@ -146,21 +146,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 return;
             }
 
-            // Because it is not possible to delete while enumerating, a copy of the keys must be taken.
-            // Use the size of the dictionary as an upper bound to avoid creating more than one copy of the keys.
-            var removeCount = 0;
-            var keys = new string[_data.Count];
+            // In .NET Core 3.0 a Dictionary can have items removed during enumeration 
+            // https://github.com/dotnet/coreclr/pull/18854
             foreach (var entry in _data)
             {
                 if (!_initialKeys.Contains(entry.Key) && !_retainedKeys.Contains(entry.Key))
                 {
-                    keys[removeCount] = entry.Key;
-                    removeCount++;
+                    _data.Remove(entry.Key);
                 }
-            }
-            for (var i = 0; i < removeCount; i++)
-            {
-                _data.Remove(keys[i]);
             }
 
             _provider.SaveTempData(_context, _data);


### PR DESCRIPTION
Lazy allocate dictionary in ItemsDictionary (doesn't need to allocate a dict to find out an item is not there)

Static cache the OnStarting callback delegate 

Skip keys array allocation when removing items from the TempDataDictionary 