### PR TITLE
[Templating] Fixes an error in the react redux template when opened in VS

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/App.test.tsx
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/App.test.tsx
@@ -11,7 +11,7 @@ it('renders without crashing', () => {
         dispatch: () => {},
         getState: () => ({ ...state })
     });
-    const store = storeFake({});
+    const store = storeFake({}) as any;
 
     ReactDOM.render(
         <Provider store={store}>


### PR DESCRIPTION
* Works fine on the command line.
* We just make VS happy.
* We are marking the type as any to effectively disable type checking.
* It's ok because it's a test and its simply mocking something.
* The function it is complaining about doesn't get used, if it ever starts to get used, the test will fail.