### PR TITLE
Fix resolving custom services from startup

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     throw new NotSupportedException($"ConfigureServices returning an {typeof(IServiceProvider)} isn't supported.");
                 }
 
-                instance = ActivatorUtilities.CreateInstance(new HostServiceProvider(webHostBuilderContext), startupType);
+                instance = ActivatorUtilities.CreateInstance(new HostServiceProvider(webHostBuilderContext, services.BuildServiceProvider()), startupType);
                 context.Properties[_startupKey] = instance;
 
                 // Startup.ConfigureServices
@@ -354,10 +354,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private class HostServiceProvider : IServiceProvider
         {
             private readonly WebHostBuilderContext _context;
+            private readonly IServiceProvider _serviceProvider;
 
-            public HostServiceProvider(WebHostBuilderContext context)
+            public HostServiceProvider(WebHostBuilderContext context, IServiceProvider serviceProvider)
             {
                 _context = context;
+                _serviceProvider = serviceProvider;
             }
 
             public object GetService(Type serviceType)
@@ -379,7 +381,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     return _context.Configuration;
                 }
 
-                return null;
+                return _serviceProvider.GetService(serviceType);
             }
         }
     }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
Issue here https://github.com/aspnet/AspNetCore/issues/9294
 - Pass to `HostServiceProvider` built `IServiceProvider` from already registered services
- `HostServiceProvider.GetService` tries to resolve that services

Should i write some tests for that?

Addresses #bugnumber (in this specific format)
