### PR TITLE
Add retries to InstallVisualStudio.ps1 script

### DIFF
--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -133,7 +133,7 @@ foreach ($i in 0, 1, 2) {
         $bootstrapperLogs = Get-ChildItem $env:Temp\dd_bootstrapper_*.log |Sort-Object CreationTime
         if ($bootstrapperLogs.Count -ne 0) {
             $bootstrapperLog = $bootstrapperLogs[$bootstrapperLogs.Count - 1]
-            Write-Host "$bootstraperLog:"
+            Write-Host "${bootstraperLog}:"
             Get-Content "$bootstrapperLog"
             Write-Host ""
         }
@@ -141,7 +141,7 @@ foreach ($i in 0, 1, 2) {
         $clientLogs = Get-ChildItem $env:Temp\dd_client_*.log |Sort-Object CreationTime
         if ($clientLogs.Count -ne 0) {
             $clientLog = $clientLogs[$clientLogs.Count - 1]
-            Write-Host "$clientLog:"
+            Write-Host "${clientLog}:"
             Get-Content "$clientLog"
             Write-Host ""
         }
@@ -149,7 +149,7 @@ foreach ($i in 0, 1, 2) {
         $setupLogs = Get-ChildItem $env:Temp\dd_setup_*.log |Sort-Object CreationTime
         if ($setupLogs.Count -ne 0) {
             $setupLog = $setupLogs[$bootstrapperLogs.Count - 1]
-            Write-Host "$setupLog:"
+            Write-Host "${setupLog}:"
             Get-Content "$setupLog"
             Write-Host ""
         }

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -149,8 +149,8 @@ foreach ($i in 0, 1, 2) {
         $setupLogs = Get-ChildItem $env:Temp\dd_setup_*.log |Sort-Object CreationTime
         if ($setupLogs.Count -ne 0) {
             $setupLog = $setupLogs[$bootstrapperLogs.Count - 1]
-            Write-Host "$setupLogs:"
-            Get-Content "$setupLogs"
+            Write-Host "$setupLog:"
+            Get-Content "$setupLog"
             Write-Host ""
         }
 

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -135,19 +135,19 @@ foreach ($i in 0, 1, 2) {
         Write-Host
 
         Get-ChildItem $env:Temp\dd_bootstrapper_*.log |Sort-Object CreationTime -Descending |Select-Object -First 1 |% {
-            Write-Host "$_:"
+            Write-Host "${_}:"
             Get-Content "$_"
             Write-Host
         }
 
         $clientLogs = Get-ChildItem $env:Temp\dd_client_*.log |Sort-Object CreationTime -Descending |Select-Object -First 1 |% {
-            Write-Host "$_:"
+            Write-Host "${_}:"
             Get-Content "$_"
             Write-Host
         }
 
         $setupLogs = Get-ChildItem $env:Temp\dd_setup_*.log |Sort-Object CreationTime -Descending |Select-Object -First 1 |% {
-            Write-Host "$_:"
+            Write-Host "${_}:"
             Get-Content "$_"
             Write-Host
         }

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -102,8 +102,13 @@ Write-Host "Installing Visual Studio 2019 $Edition" -f Magenta
 Write-Host ""
 Write-Host "Running '$bootstrapper $arguments'"
 
+$ErrorActionPreference = 'Continue'
 foreach ($i in 0, 1, 2) {
-    $process = Start-Process -FilePath "$bootstrapper" -ArgumentList $arguments -ErrorAction Continue -PassThru `
+    if ($i -ne 0) {
+        Write-Host "Retrying..."
+    }
+
+    $process = Start-Process -FilePath "$bootstrapper" -ArgumentList $arguments -PassThru `
         -RedirectStandardError "$intermedateDir\errors.txt" -Verbose -Wait
     Write-Host "Exit code = $($process.ExitCode)."
     if ($process.ExitCode -eq 0) {
@@ -126,7 +131,7 @@ foreach ($i in 0, 1, 2) {
         }
 
         Write-Host ""
-        WriteHost "Errors:"
+        Write-Host "Errors:"
         Get-Content "$intermedateDir\errors.txt" | Write-Error
         Write-Host ""
 
@@ -153,8 +158,6 @@ foreach ($i in 0, 1, 2) {
             Get-Content "$setupLog"
             Write-Host ""
         }
-
-        Write-Host "Retrying..."
     }
 }
 


### PR DESCRIPTION
- short-term attempt to reduce CI problems in this area; see dotnet/core-eng#5760
- add `-ErrorAction Continue` to the `Start-Process` command line to enable retries

nits & debugging:
- display and interpret any exit code from the VS installer
- display VS installation logs
- remove unnecessary `[CmdletBinding]` attribute