### PR TITLE
Update PatchConfig.props

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -51,8 +51,9 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.5' ">
     <PackagesInPatch>
-        Microsoft.AspNetCore.AspNetCoreModule;
-        Microsoft.AspNetCore.AspNetCoreModuleV2;
+      Microsoft.AspNetCore.AspNetCoreModule;
+      Microsoft.AspNetCore.AspNetCoreModuleV2;
+      java:signalr;
     </PackagesInPatch>
   </PropertyGroup>
 


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore/pull/8726 didn't add `java:signalr` to the PatchConfig.props file, so it's not in the build output.