### PR TITLE
Handle MicrosoftAccount email fallback

### DIFF
--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountOptions.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountOptions.cs
@@ -27,7 +27,15 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             ClaimActions.MapJsonKey(ClaimTypes.Name, "displayName");
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "givenName");
             ClaimActions.MapJsonKey(ClaimTypes.Surname, "surname");
-            ClaimActions.MapCustomJson(ClaimTypes.Email, user => user.GetString("mail") ?? user.GetString("userPrincipalName"));
+            ClaimActions.MapCustomJson(ClaimTypes.Email, user =>
+            {
+                var mail = user.GetString("mail");
+                if (string.IsNullOrEmpty(mail))
+                {
+                    mail = user.GetString("userPrincipalName");
+                }
+                return mail;
+            });
         }
     }
 }

--- a/src/Security/Authentication/test/MicrosoftAccountTests.cs
+++ b/src/Security/Authentication/test/MicrosoftAccountTests.cs
@@ -203,7 +203,8 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                                 displayName = "Test Name",
                                 givenName = "Test Given Name",
                                 surname = "Test Family Name",
-                                mail = "Test email"
+                                mail = "",
+                                userPrincipalName = "Test email"
                             });
                         }
 


### PR DESCRIPTION
 #9083 This was a regression when we switched JSON libraries. The new value was empty rather than null so the fallback didn't work as expected.

@nimal-work 