### PR TITLE
Client to Server Streaming with IAsyncEnumerable

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -513,8 +513,12 @@ namespace Microsoft.AspNetCore.SignalR.Client
             var moreReaders = PackageIAsyncEnumerableParams(ref args, out var secondStreamIds);
             if (streamIds != null)
             {
-                streamIds.AddRange(secondStreamIds);
-            } else
+                if (secondStreamIds != null)
+                {
+                    streamIds.AddRange(secondStreamIds);
+                }
+            }
+            else
             {
                 streamIds = secondStreamIds;
             }
@@ -652,7 +656,18 @@ namespace Microsoft.AspNetCore.SignalR.Client
             for (var i = 0; i < args.Length; i++)
             {
                 var type = args[i].GetType();
-                if (type.GetInterfaces().Any(t => t.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>)))
+                var isStreamType = type.GetInterfaces().Any(t =>
+                {
+                    if (t.IsGenericType)
+                    {
+                        return t.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                });
+                if (isStreamType)
                 {
                     if (readers == null)
                     {

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -534,7 +534,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 ReleaseConnectionLock();
             }
 
-            LaunchStreams(_readers, cancellationToken);
+            LaunchStreams(cancellationToken);
             return channel;
         }
 
@@ -575,14 +575,14 @@ namespace Microsoft.AspNetCore.SignalR.Client
             args = newArgs.ToArray();
         }
 
-        private void LaunchStreams(Dictionary<string, object> readers, CancellationToken cancellationToken)
+        private void LaunchStreams(CancellationToken cancellationToken)
         {
-            if (readers == null)
+            if (_readers == null)
             {
                 // if there were no streaming parameters then readers is never initialized
                 return;
             }
-            foreach (var kvp in readers)
+            foreach (var kvp in _readers)
             {
                 var reader = kvp.Value;
 
@@ -601,8 +601,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 _ = _sendStreamItemsMethod
                     .MakeGenericMethod(reader.GetType().GetGenericArguments())
                     .Invoke(this, new object[] { kvp.Key.ToString(), reader, cancellationToken });
-
-
             }
         }
 
@@ -684,7 +682,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 ReleaseConnectionLock();
             }
 
-            LaunchStreams(_readers, cancellationToken);
+            LaunchStreams(cancellationToken);
 
             // Wait for this outside the lock, because it won't complete until the server responds
             return await invocationTask;
@@ -766,7 +764,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             var invocationMessage = new InvocationMessage(null, methodName, args, streamIds?.ToArray());
             await SendWithLock(invocationMessage, callerName: nameof(SendCoreAsync));
 
-            LaunchStreams(_readers, cancellationToken);
+            LaunchStreams(cancellationToken);
         }
 
         private async Task SendWithLock(HubMessage message, CancellationToken cancellationToken = default, [CallerMemberName] string callerName = "")

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -607,12 +607,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
         // this is called via reflection using the `_sendStreamItems` field
         private Task SendStreamItems<T>(string streamId, ChannelReader<T> reader, CancellationToken token)
         {
-
             async Task ReadChannelStream(CancellationTokenSource tokenSource)
             {
-                while (await reader.WaitToReadAsync(token))
+                while (await reader.WaitToReadAsync(tokenSource.Token))
                 {
-                    while (!token.IsCancellationRequested && reader.TryRead(out var item))
+                    while (!tokenSource.Token.IsCancellationRequested && reader.TryRead(out var item))
                     {
                         await SendWithLock(new StreamItemMessage(streamId, item));
                         Log.SendingStreamItem(_logger, streamId);

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -540,8 +540,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private void PackageStreamingParams(ref object[] args, out List<string> streamIds)
         {
-            // lazy initialized, to avoid allocating unecessary dictionaries
-            //Dictionary<string, object> readers = null;
             streamIds = null;
             var newArgs = new List<object>(args.Length);
 

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -629,9 +629,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
         {
             async Task ReadAsyncEnumerableStream(CancellationTokenSource tokenSource)
             {
-                var s = AsyncEnumerableAdapters.MakeCancelableTypedAsyncEnumerable(stream, tokenSource);
+                var streamValues = AsyncEnumerableAdapters.MakeCancelableTypedAsyncEnumerable(stream, tokenSource);
 
-                await foreach (var streamValue in s)
+                await foreach (var streamValue in streamValues)
                 {
                     await SendWithLock(new StreamItemMessage(streamId, streamValue));
                     Log.SendingStreamItem(_logger, streamId);

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -723,8 +723,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     {
                         for (var i = 0; i < 1000; i++)
                         {
-                            await Task.Delay(10);
                             yield return i;
+                            await Task.Delay(10);
                         }
                     }
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -43,6 +43,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         public ChannelReader<string> StreamEcho(ChannelReader<string> source) => TestHubMethodsImpl.StreamEcho(source);
 
+        public ChannelReader<int> StreamEchoInt(ChannelReader<int> source) => TestHubMethodsImpl.StreamEchoInt(source);
+
+
         public string GetUserIdentifier()
         {
             return Context.UserIdentifier;
@@ -121,6 +124,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         }
 
         public ChannelReader<string> StreamEcho(ChannelReader<string> source) => TestHubMethodsImpl.StreamEcho(source);
+
+        public ChannelReader<int> StreamEchoInt(ChannelReader<int> source) => TestHubMethodsImpl.StreamEchoInt(source);
     }
 
     public class TestHubT : Hub<ITestHub>
@@ -151,6 +156,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         }
 
         public ChannelReader<string> StreamEcho(ChannelReader<string> source) => TestHubMethodsImpl.StreamEcho(source);
+
+        public ChannelReader<int> StreamEchoInt(ChannelReader<int> source) => TestHubMethodsImpl.StreamEchoInt(source);
     }
 
     internal static class TestHubMethodsImpl
@@ -193,6 +200,29 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         public static ChannelReader<string> StreamEcho(ChannelReader<string> source)
         {
             var output = Channel.CreateUnbounded<string>();
+            _ = Task.Run(async () => {
+                try
+                {
+                    while (await source.WaitToReadAsync())
+                    {
+                        while (source.TryRead(out var item))
+                        {
+                            await output.Writer.WriteAsync(item);
+                        }
+                    }
+                }
+                finally
+                {
+                    output.Writer.TryComplete();
+                }
+            });
+
+            return output.Reader;
+        }
+
+        public static ChannelReader<int> StreamEchoInt(ChannelReader<int> source)
+        {
+            var output = Channel.CreateUnbounded<int>();
             _ = Task.Run(async () => {
                 try
                 {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -222,7 +222,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         public static ChannelReader<int> StreamEchoInt(ChannelReader<int> source)
         {
             var output = Channel.CreateUnbounded<int>();
-            _ = Task.Run(async () => {
+            _ = Task.Run(async () =>
+            {
                 try
                 {
                     while (await source.WaitToReadAsync())

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -45,7 +45,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         public ChannelReader<int> StreamEchoInt(ChannelReader<int> source) => TestHubMethodsImpl.StreamEchoInt(source);
 
-
         public string GetUserIdentifier()
         {
             return Context.UserIdentifier;

--- a/src/SignalR/common/Shared/ReflectionHelper.cs
+++ b/src/SignalR/common/Shared/ReflectionHelper.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Channels;
 
 namespace Microsoft.AspNetCore.SignalR
@@ -13,6 +15,13 @@ namespace Microsoft.AspNetCore.SignalR
         public static bool IsStreamingType(Type type, bool mustBeDirectType = false)
         {
             // TODO #2594 - add Streams here, to make sending files easy
+
+#if NETCOREAPP3_0
+            if (IsIAsyncEnumerable(type))
+            {
+                return true;
+            }
+#endif
             do
             {
                 if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ChannelReader<>))
@@ -25,5 +34,22 @@ namespace Microsoft.AspNetCore.SignalR
 
             return false;
         }
+
+#if NETCOREAPP3_0
+        public static bool IsIAsyncEnumerable(Type type)
+        {
+            return type.GetInterfaces().Any(t =>
+            {
+                if (t.IsGenericType)
+                {
+                    return t.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
+                }
+                else
+                {
+                    return false;
+                }
+            });
+        }
+#endif
     }
 }

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTestBase.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTestBase.cs
@@ -277,8 +277,10 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             // StreamItemMessage
             new InvalidMessageData("StreamItemMissingId", new byte[] { 0x92, 2, 0x80 }, "Reading 'invocationId' as String failed."),
             new InvalidMessageData("StreamItemInvocationIdBoolean", new byte[] { 0x93, 2, 0x80, 0xc2 }, "Reading 'invocationId' as String failed."),
-            new InvalidMessageData("StreamItemMissing", new byte[] { 0x93, 2, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z' }, "Deserializing object of the `String` type for 'item' failed."),
-            new InvalidMessageData("StreamItemTypeMismatch", new byte[] { 0x94, 2, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 42 }, "Deserializing object of the `String` type for 'item' failed."),
+
+            // These now trigger StreamBindingInvocationFailureMessages
+            //new InvalidMessageData("StreamItemMissing", new byte[] { 0x93, 2, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z' }, "Deserializing object of the `String` type for 'item' failed."),
+            //new InvalidMessageData("StreamItemTypeMismatch", new byte[] { 0x94, 2, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 42 }, "Deserializing object of the `String` type for 'item' failed."),
 
             // CompletionMessage
             new InvalidMessageData("CompletionMissingId", new byte[] { 0x92, 3, 0x80 }, "Reading 'invocationId' as String failed."),


### PR DESCRIPTION
~Not ready for review. Just hacking something that works together.~ Time for some eyes on this. Got rid of a lot of similar code.
We're essentially adding checks for an `IAsyncEnumerable` type in the invocation params, associated themwith a stream id similarly to how we do with channels, then consume items from the stream and send them as `StreamItem`  messages.