### PR TITLE
 Lazy create MVC ResourceInvoker statemachines

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                             filter);
 
                         var task = filter.OnAuthorizationAsync(authorizationContext);
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.AuthorizationAsyncEnd;
                             return task;
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                             filter);
 
                         var task = filter.OnResourceExecutionAsync(resourceExecutingContext, InvokeNextResourceFilterAwaitedAsync);
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResourceAsyncEnd;
                             return task;
@@ -418,7 +418,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                         }
 
                         var task = InvokeNextResourceFilter();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResourceSyncEnd;
                             return task;
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
                         _result = _resourceExecutingContext.Result;
                         var task = InvokeAlwaysRunResultFilters();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResourceEnd;
                             return task;
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                 case State.ExceptionAsyncBegin:
                     {
                         var task = InvokeNextExceptionFilterAsync();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ExceptionAsyncResume;
                             return task;
@@ -539,7 +539,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                                 filter);
 
                             var task = filter.OnExceptionAsync(exceptionContext);
-                            if (task.Status != TaskStatus.RanToCompletion)
+                            if (!task.IsCompletedSuccessfully)
                             {
                                 next = State.ExceptionAsyncEnd;
                                 return task;
@@ -579,7 +579,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                 case State.ExceptionSyncBegin:
                     {
                         var task = InvokeNextExceptionFilterAsync();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ExceptionSyncEnd;
                             return task;
@@ -650,7 +650,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                         _result = _exceptionContext.Result;
 
                         var task = InvokeAlwaysRunResultFilters();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResourceInsideEnd;
                             return task;
@@ -683,7 +683,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                         }
 
                         var task = InvokeResultFilters();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResourceInsideEnd;
                             return task;
@@ -694,7 +694,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                 case State.ActionBegin:
                     {
                         var task = InvokeInnerFilterAsync();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ActionEnd;
                             return task;
@@ -715,7 +715,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
                         Debug.Assert(scope == Scope.Invoker || scope == Scope.Resource);
                         var task = InvokeResultFilters();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResourceInsideEnd;
                             return task;
@@ -916,7 +916,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                             filter);
 
                         var task = filter.OnResultExecutionAsync(resultExecutingContext, InvokeNextResultFilterAwaitedAsync<TFilter, TFilterAsync>);
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResultAsyncEnd;
                             return task;
@@ -998,7 +998,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                         }
 
                         var task = InvokeNextResultFilterAsync<TFilter, TFilterAsync>();
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResultSyncEnd;
                             return task;
@@ -1048,7 +1048,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                         }
 
                         var task = InvokeResultAsync(_result);
-                        if (task.Status != TaskStatus.RanToCompletion)
+                        if (!task.IsCompletedSuccessfully)
                         {
                             next = State.ResultEnd;
                             return task;

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -1049,16 +1049,41 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             }
         }
 
-        private async Task InvokeResultFilters()
+        private Task InvokeResultFilters()
         {
-            var next = State.ResultBegin;
-            var scope = Scope.Invoker;
-            var state = (object)null;
-            var isCompleted = false;
-
-            while (!isCompleted)
+            try
             {
-                await ResultNext<IResultFilter, IAsyncResultFilter>(ref next, ref scope, ref state, ref isCompleted);
+                var next = State.ResultBegin;
+                var scope = Scope.Invoker;
+                var state = (object)null;
+                var isCompleted = false;
+
+                while (!isCompleted)
+                {
+                    var lastTask = ResultNext<IResultFilter, IAsyncResultFilter>(ref next, ref scope, ref state, ref isCompleted);
+                    if (!lastTask.IsCompletedSuccessfully)
+                    {
+                        return Awaited(this, lastTask, next, scope, state, isCompleted);
+                    }
+                }
+
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                // Wrap non task-wrapped exceptions in a Task, 
+                // as this isn't done automatically since the method is not async.
+                return Task.FromException(ex);
+            }
+
+            static async Task Awaited(ResourceInvoker invoker, Task lastTask, State next, Scope scope, object state, bool isCompleted)
+            {
+                await lastTask;
+
+                while (!isCompleted)
+                {
+                    await invoker.ResultNext<IResultFilter, IAsyncResultFilter>(ref next, ref scope, ref state, ref isCompleted);
+                }
             }
         }
 

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -67,20 +67,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             _actionContextAccessor.ActionContext = _actionContext;
             var scope = _logger.ActionScope(_actionContext.ActionDescriptor);
 
-            Exception invokeException = null;
             Task task = null;
             try
             {
                 task = InvokeFilterPipelineAsync();
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                invokeException = ex;
-            }
-
-            if (invokeException != null)
-            {
-                return Awaited(this, Task.FromException(invokeException), scope);
+                return Awaited(this, Task.FromException(exception), scope);
             }
 
             Debug.Assert(task != null);
@@ -94,9 +88,9 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             {
                 ReleaseResources();
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                releaseException = ex;
+                releaseException = exception;
             }
 
             Exception scopeException = null;
@@ -104,9 +98,9 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             {
                 scope.Dispose();
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                scopeException = ex;
+                scopeException = exception;
             }
 
             if (releaseException == null && scopeException == null)


### PR DESCRIPTION
Creates quite a few for a simple sync controller method ([plaintext](https://github.com/aspnet/Benchmarks/blob/master/src/Benchmarks/Controllers/HomeController.cs#L15-L19))

+3% gain on mvc plaintext 

* ResourceInvoker faster task completion check

* Lazy create ResourceInvoker.InvokeAsync statemachine

* Lazy create ResourceInvoker.InvokeFilterPipelineAsync statemachine

* Lazy create ResourceInvoker.InvokeResultAsync statemachine

* Lazy create ResourceInvoker.InvokeNextResourceFilter statemachine

* Lazy create ResourceInvoker.InvokeNextExceptionFilterAsync statemachine

* Lazy create ResourceInvoker.InvokeAlwaysRunResultFilters statemachine

* Lazy create ResourceInvoker.InvokeResultFilters statemachine

* Lazy create ResourceInvoker.InvokeNextResultFilterAsync statemachine

* Lazy create ResourceInvoker.InvokeNextResultFilterAwaitedAsync statemachine

* Lazy create ResourceInvoker.InvokeNextResourceFilterAwaitedAsync statemachine

Before
```
 wrk -c 128 -t 4 -d 35 -H "Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7" -H "Connection: keep-alive" http://127.0.0.1:5000/mvc/plaintext -s ./wrk/scripts/pipeline.lua -- 16
Pipeline depth: 16

Running 35s test @ http://127.0.0.1:5000/mvc/plaintext
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.79ms    4.34ms  79.39ms   71.56%
    Req/Sec    39.97k     5.09k   61.52k    70.19%
  5571990 requests in 35.07s, 701.43MB read
Requests/sec: 158875.01
Transfer/sec:     20.00MB
```
After
```
wrk -c 128 -t 4 -d 35 -H "Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7" -H "Connection: keep-alive" http://127.0.0.1:5000/mvc/plaintext -s ./wrk/scripts/pipeline.lua -- 16
Pipeline depth: 16

Running 35s test @ http://127.0.0.1:5000/mvc/plaintext
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.54ms    4.27ms  59.78ms   72.49%
    Req/Sec    41.23k     5.89k   63.74k    69.81%
  5747056 requests in 35.09s, 723.47MB read
Requests/sec: 163757.40
Transfer/sec:     20.61MB
```

Before calls this elides (highlighted)

![image](https://user-images.githubusercontent.com/1142958/56033194-e3459880-5d1b-11e9-9eb0-99756e4a34a8.png)

After calls

![image](https://user-images.githubusercontent.com/1142958/56033206-eb053d00-5d1b-11e9-9839-6db69d3bd84b.png)


That section of stack trace is also improved

Before

![image](https://user-images.githubusercontent.com/1142958/56041530-ded7aa80-5d30-11e9-877a-4b066d2be62d.png)

After

![image](https://user-images.githubusercontent.com/1142958/56041595-0169c380-5d31-11e9-87ea-aab20e425f96.png)


/cc @rynowak @pranavkm