### PR TITLE
Enable custom restore

### DIFF
--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -18,12 +18,7 @@
 
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
-    <Yarn Command="install $(InstallArgs)" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
-    <Yarn Command="install $(InstallArgs)" Condition="'$(_YarnExitCode)' != '0'">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
+    <Yarn Command="install $(InstallArgs)" />
   </Target>
 
   <Target Name="PrepareForBuild">

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:3.0.0-build-20190408.1
-commithash:8b533cbfa5357e5785f4c4231231c1234cfc2c5f
+version:3.0.0-build-20190412.2
+commithash:0e543fb8761394491250585d3811bdbb62e350e8

--- a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
+++ b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
@@ -24,7 +24,7 @@
     <Yarn Command="install" />
   </Target>
 
-  <Target Name="_RequiresCustomRestore" Returns="@(CustomRestoreTargets)">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>YarnInstall</Targets>

--- a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
+++ b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
@@ -21,12 +21,15 @@
 
   <Target Name="YarnInstall">
     <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
-    <Yarn Command="install" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
-    <Yarn Command="install" Condition="'$(_YarnExitCode)' != '0'">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
+    <Yarn Command="install" />
+  </Target>
+
+  <Target Name="_RequiresCustomRestore" Returns="@(CustomRestoreTargets)">
+    <ItemGroup>
+      <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
+        <Targets>YarnInstall</Targets>
+      </CustomRestoreTargets>
+    </ItemGroup>
   </Target>
 
   <Target Name="PrepublishScript" DependsOnTargets="YarnInstall" BeforeTargets="PrepareForPublish" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">

--- a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
+++ b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
@@ -24,7 +24,7 @@
     <Yarn Command="install" />
   </Target>
 
-  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>YarnInstall</Targets>

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -28,7 +28,7 @@
     <Yarn Command="install" />
   </Target>
 
-  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>YarnInstall</Targets>

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -25,12 +25,15 @@
 
   <Target Name="YarnInstall">
     <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
-    <Yarn Command="install" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
-    <Yarn Command="install" Condition="'$(_YarnExitCode)' != '0'">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
+    <Yarn Command="install" />
+  </Target>
+
+  <Target Name="_RequiresCustomRestore" Returns="@(CustomRestoreTargets)">
+    <ItemGroup>
+      <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
+        <Targets>YarnInstall</Targets>
+      </CustomRestoreTargets>
+    </ItemGroup>
   </Target>
 
   <Target Name="PrepublishScript" DependsOnTargets="YarnInstall" BeforeTargets="PrepareForPublish" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -28,7 +28,7 @@
     <Yarn Command="install" />
   </Target>
 
-  <Target Name="_RequiresCustomRestore" Returns="@(CustomRestoreTargets)">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>YarnInstall</Targets>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -14,7 +14,7 @@
     <Yarn Command="install" />
   </Target>
 
-  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>EnsureNodeJSRestored</Targets>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -14,7 +14,7 @@
     <Yarn Command="install" />
   </Target>
 
-  <Target Name="_RequiresCustomRestore" Returns="@(CustomRestoreTargets)">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>EnsureNodeJSRestored</Targets>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -11,12 +11,15 @@
       Importance="High"
       Text="Prerequisites were not enforced at build time. Running Yarn or the E2E tests might fail as a result. Check /src/Shared/E2ETesting/Readme.md for instructions." />
 
-    <Yarn Command="install" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
-    <Yarn Command="install" Condition="'$(_YarnExitCode)' != '0'">
-      <Output TaskParameter="ExitCode" PropertyName="_YarnExitCode"/>
-    </Yarn>
+    <Yarn Command="install" />
+  </Target>
+
+  <Target Name="_RequiresCustomRestore" Returns="@(CustomRestoreTargets)">
+    <ItemGroup>
+      <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
+        <Targets>EnsureNodeJSRestored</Targets>
+      </CustomRestoreTargets>
+    </ItemGroup>
   </Target>
 
   <Target


### PR DESCRIPTION
This makes it so that yarn install runs at restore time on the "csproj" projects that require it.