### PR TITLE
Wait to dispose RequestAborted CTS

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -377,7 +377,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _manuallySetRequestAbortToken = null;
             _preventRequestAbortedCancellation = false;
 
-            // Lock to prevent CancelRequestAbortedToken from attempting to cancel an disposed CTS.
+            // Lock to prevent CancelRequestAbortedToken from attempting to cancel a disposed CTS.
             CancellationTokenSource localAbortCts = null;
             lock (_abortLock)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -378,6 +378,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             // Lock to prevent CancelRequestAbortedToken from attempting to cancel a disposed CTS.
             CancellationTokenSource localAbortCts = null;
+
             lock (_abortLock)
             {
                 _preventRequestAbortedCancellation = false;
@@ -446,20 +447,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             try
             {
                 CancellationTokenSource localAbortCts = null;
-                var shouldCancel = false;
+
                 lock (_abortLock)
                 {
                     if (_abortedCts != null && !_preventRequestAbortedCancellation)
                     {
                         localAbortCts = _abortedCts;
                         _abortedCts = null;
-                        shouldCancel = true;
                     }
                 }
 
                 // If we cancel the cts, we don't dispose as people may still be using
                 // the cts. It also isn't necessary to dispose a canceled cts.
-                if (shouldCancel)
+                if (localAbortCts != null)
                 {
                     localAbortCts.Cancel();
                 }
@@ -473,6 +473,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected void AbortRequest()
         {
             var shouldScheduleCancellation = false;
+
             lock (_abortLock)
             {
                 if (_connectionAborted)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -446,33 +446,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             try
             {
                 CancellationTokenSource localAbortCts = null;
-                var shouldDispose = false;
                 var shouldCancel = false;
                 lock (_abortLock)
                 {
-                    if (_abortedCts != null)
+                    if (_abortedCts != null && !_preventRequestAbortedCancellation)
                     {
                         localAbortCts = _abortedCts;
                         _abortedCts = null;
-
-                        if (_preventRequestAbortedCancellation)
-                        {
-                            shouldDispose = true;
-                        }
-                        else
-                        {
-                            shouldCancel = true;
-                        }
+                        shouldCancel = true;
                     }
                 }
 
                 // If we cancel the cts, we don't dispose as people may still be using
                 // the cts. It also isn't necessary to dispose a canceled cts.
-                if (shouldDispose)
-                {
-                    localAbortCts.Dispose();
-                }
-                else if (shouldCancel)
+                if (shouldCancel)
                 {
                     localAbortCts.Cancel();
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -378,17 +378,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _preventRequestAbortedCancellation = false;
 
             // Lock to prevent CancelRequestAbortedToken from attempting to cancel an disposed CTS.
-            CancellationTokenSource cts = null;
+            CancellationTokenSource localAbortCts = null;
             lock (_abortLock)
             {
                 if (_abortedCts != null)
                 {
-                    cts = _abortedCts;
+                    localAbortCts = _abortedCts;
                     _abortedCts = null;
                 }
             }
 
-            cts?.Dispose();
+            localAbortCts?.Dispose();
 
             if (_wrapperObjectsToDispose != null)
             {
@@ -445,14 +445,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             try
             {
-                CancellationTokenSource cts = null;
+                CancellationTokenSource localAbortCts = null;
                 lock (_abortLock)
                 {
                     if (_abortedCts != null)
                     {
                         if (!_preventRequestAbortedCancellation)
                         {
-                            cts = _abortedCts;
+                            localAbortCts = _abortedCts;
                         }
                         _abortedCts = null;
                     }
@@ -464,7 +464,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 // the _preventRequestAbortedCancellation is set to true.
                 // _preventRequestAbortedCancellation is mostly a heuristic rather than a guarantee
                 // we need to follow.
-                cts?.Cancel();
+                localAbortCts?.Cancel();
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -382,11 +382,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             lock (_abortLock)
             {
                 _preventRequestAbortedCancellation = false;
-                if (_abortedCts != null)
-                {
-                    localAbortCts = _abortedCts;
-                    _abortedCts = null;
-                }
+                localAbortCts = _abortedCts;
+                _abortedCts = null;
             }
 
             localAbortCts?.Dispose();
@@ -459,7 +456,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 // If we cancel the cts, we don't dispose as people may still be using
                 // the cts. It also isn't necessary to dispose a canceled cts.
-                localAbortedCts?.Cancel()
+                localAbortedCts?.Cancel();
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -456,7 +456,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 // If we cancel the cts, we don't dispose as people may still be using
                 // the cts. It also isn't necessary to dispose a canceled cts.
-                localAbortedCts?.Cancel();
+                localAbortCts?.Cancel();
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -459,10 +459,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 // If we cancel the cts, we don't dispose as people may still be using
                 // the cts. It also isn't necessary to dispose a canceled cts.
-                if (localAbortCts != null)
-                {
-                    localAbortCts.Cancel();
-                }
+                localAbortedCts?.Cancel()
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -730,6 +730,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public void RequestAbortedTokenIsFullyUsableAfterCancellation()
+        {
+            var originalToken = _http1Connection.RequestAborted;
+            var originalRegistration = originalToken.Register(() => { });
+
+            _http1Connection.Abort(new ConnectionAbortedException());
+
+            Assert.True(originalToken.WaitHandle.WaitOne(TestConstants.DefaultTimeout));
+            Assert.True(_http1Connection.RequestAborted.WaitHandle.WaitOne(TestConstants.DefaultTimeout));
+
+            Assert.Equal(originalToken, originalRegistration.Token);
+        }
+
+        [Fact]
         public void RequestAbortedTokenIsUsableAfterCancellation()
         {
             var originalToken = _http1Connection.RequestAborted;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -217,6 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        //[Repeat]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        //[Repeat]
+        [Repeat(20)]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
A redo of https://github.com/aspnet/AspNetCore/pull/4447. 

When we tried this PR before, it caused a pretty nasty deadlock between Reset and Cancel in HttpProcotol. This should avoid it by capturing the CTS in a local inside of the lock and then cancelling outside of the lock.

This change will eventually be applied to IIS (and then I'd probably add a helper because the pattern will be the same). However, I want to make sure this change stabilizes on CI and doesn't have flakiness.

If this change works well, we should consider porting it back to 2.2.x.

