### PR TITLE
Call DiagnosticListener.OnActivityImport before starting Activity to support sampling better

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
             }
 
-            _diagnosticListener.OnActivityExport(activity, httpContext.Request);
+            _diagnosticListener.OnActivityImport(activity, httpContext);
 
             if (_diagnosticListener.IsEnabled(ActivityStartKey))
             {

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -273,6 +273,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
             }
 
+            _diagnosticListener.OnActivityExport(activity, httpContext.Request);
+
             if (_diagnosticListener.IsEnabled(ActivityStartKey))
             {
                 _diagnosticListener.StartActivity(activity, new { HttpContext = httpContext });

--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -308,24 +308,24 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var diagnosticSource = new DiagnosticListener("DummySource");
             var hostingApplication = CreateApplication(out var features, diagnosticSource: diagnosticSource);
 
-            bool onActivityExportCalled = false;
+            bool onActivityImportCalled = false;
             diagnosticSource.Subscribe(
                 observer: new CallbackDiagnosticListener(pair => { }),
                 isEnabled: (s, o, _) => true,
-                onActivityExport: (activity, request) =>
+                onActivityImport: (activity, context) =>
                 {
-                    onActivityExportCalled = true;
+                    onActivityImportCalled = true;
                     Assert.Null(Activity.Current);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", activity.OperationName);
-                    Assert.NotNull(request);
-                    Assert.IsAssignableFrom<HttpRequest>(request);
+                    Assert.NotNull(context);
+                    Assert.IsAssignableFrom<HttpContext>(context);
 
                     activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
                 });
 
             hostingApplication.CreateContext(features);
 
-            Assert.True(onActivityExportCalled);
+            Assert.True(onActivityImportCalled);
             Assert.NotNull(Activity.Current);
             Assert.True(Activity.Current.Recorded);
         }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Allows a tracing system to make sampling decision on Activity or modify it before Activity is started


See https://github.com/dotnet/corefx/issues/36349 for more info