### PR TITLE
Support plain text exception formatting

### DIFF
--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.Internal;
@@ -135,7 +136,18 @@ namespace Microsoft.AspNetCore.Diagnostics
             if (acceptHeader != null && !acceptHeader.Contains("text/html", StringComparison.OrdinalIgnoreCase))
             {
                 httpContext.Response.ContentType = "text/plain";
-                return httpContext.Response.WriteAsync(errorContext.Exception.ToString());
+
+                var sb = new StringBuilder();
+                sb.AppendLine(errorContext.Exception.ToString());
+                sb.AppendLine();
+                sb.AppendLine("HEADERS");
+                sb.AppendLine("=======");
+                foreach (var pair in httpContext.Request.Headers)
+                {
+                    sb.AppendLine($"{pair.Key} = {pair.Value}");
+                }
+
+                return httpContext.Response.WriteAsync(sb.ToString());
             }
 
             if (errorContext.Exception is ICompilationException compilationException)

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -23,7 +23,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Diagnostics
 {
     /// <summary>
-    /// Captures synchronous and asynchronous exceptions from the pipeline and generates HTML error responses.
+    /// Captures synchronous and asynchronous exceptions from the pipeline and generates error responses.
     /// </summary>
     public class DeveloperExceptionPageMiddleware
     {

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                 sb.AppendLine("=======");
                 foreach (var pair in httpContext.Request.Headers)
                 {
-                    sb.AppendLine($"{pair.Key} = {pair.Value}");
+                    sb.AppendLine($"{pair.Key}: {pair.Value}");
                 }
 
                 return httpContext.Response.WriteAsync(sb.ToString());

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             var acceptHeader = headers.Accept;
 
             // If the client does not ask for HTML just format the exception as plain text
-            if (acceptHeader != null && !acceptHeader.Any(h => h.IsSubsetOf(_textPlainMediaType)))
+            if (acceptHeader == null || !acceptHeader.Any(h => h.IsSubsetOf(_textPlainMediaType)))
             {
                 httpContext.Response.ContentType = "text/plain";
 

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Diagnostics
         private readonly DiagnosticSource _diagnosticSource;
         private readonly ExceptionDetailsProvider _exceptionDetailsProvider;
         private readonly Func<ErrorContext, Task> _exceptionHandler;
+        private static readonly MediaTypeHeaderValue _textPlainMediaType = new MediaTypeHeaderValue("text/html");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeveloperExceptionPageMiddleware"/> class
@@ -134,7 +135,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             var acceptHeader = headers.Accept;
 
             // If the client does not ask for HTML just format the exception as plain text
-            if (acceptHeader != null && !acceptHeader.Any(h => h.IsSubsetOf(new MediaTypeHeaderValue("text/html"))))
+            if (acceptHeader != null && !acceptHeader.Any(h => h.IsSubsetOf(_textPlainMediaType)))
             {
                 httpContext.Response.ContentType = "text/plain";
 

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -130,10 +130,11 @@ namespace Microsoft.AspNetCore.Diagnostics
         private Task DisplayException(ErrorContext errorContext)
         {
             var httpContext = errorContext.HttpContext;
-            var acceptHeader = httpContext.Request.Headers[HeaderNames.Accept].ToString();
+            var headers = httpContext.Request.GetTypedHeaders();
+            var acceptHeader = headers.Accept;
 
             // If the client does not ask for HTML just format the exception as plain text
-            if (acceptHeader != null && !acceptHeader.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+            if (acceptHeader != null && !acceptHeader.Any(h => h.IsSubsetOf(new MediaTypeHeaderValue("text/html"))))
             {
                 httpContext.Response.ContentType = "text/plain";
 

--- a/src/Mvc/test/Mvc.FunctionalTests/ErrorPageTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ErrorPageTests.cs
@@ -39,6 +39,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Client = factory
                 .WithWebHostBuilder(builder => builder.ConfigureLogging(l => l.Services.AddSingleton<ILoggerFactory>(loggerProvider)))
                 .CreateDefaultClient();
+            // These tests want to verify runtime compilation and formatting in the HTML of the error page
+            Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
         }
 
         public HttpClient Client { get; }


### PR DESCRIPTION
- If there's no Accept: text/html then print the exception.ToString as plaintext

#8536

Here's an example of the same error page after the change, hitting it from postman and from the browser.

![image](https://user-images.githubusercontent.com/95136/56176428-e5278a00-5faf-11e9-85a4-6ff60ad4542b.png)



![image](https://user-images.githubusercontent.com/95136/56081564-8ef5f380-5dc3-11e9-9336-c56b7bc5c66e.png)
