### PR TITLE
Create an activity more often than before

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             Options = options.Value;
             Server = server;
-            Logger = loggerFactory.CreateLogger<GenericWebHostService>();
+            Logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Hosting.Diagnostics");
             LifetimeLogger = loggerFactory.CreateLogger("Microsoft.Hosting.Lifetime");
             DiagnosticListener = diagnosticListener;
             HttpContextFactory = httpContextFactory;
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public GenericWebHostServiceOptions Options { get; }
         public IServer Server { get; }
-        public ILogger<GenericWebHostService> Logger { get; }
+        public ILogger Logger { get; }
         // Only for high level lifetime events
         public ILogger LifetimeLogger { get; }
         public DiagnosticListener DiagnosticListener { get; }

--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             public HttpContext HttpContext { get; set; }
             public IDisposable Scope { get; set; }
             public long StartTimestamp { get; set; }
-            public bool EventSourceEnabled { get; set; }
+            public bool EventLogEnabled { get; set; }
             public Activity Activity { get; set; }
         }
     }

--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             public HttpContext HttpContext { get; set; }
             public IDisposable Scope { get; set; }
             public long StartTimestamp { get; set; }
-            public bool EventLogEnabled { get; set; }
+            public bool EventSourceEnabled { get; set; }
             public Activity Activity { get; set; }
         }
     }

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             if (HostingEventSource.Log.IsEnabled())
             {
-                context.EventSourceEnabled = true;
+                context.EventLogEnabled = true;
                 // To keep the hot path short we defer logging in this function to non-inlines
                 RecordRequestStartEventLog(httpContext);
             }
@@ -84,7 +84,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     LogRequestStarting(httpContext);
                 }
             }
-
             context.StartTimestamp = startTimestamp;
         }
 
@@ -141,7 +140,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 StopActivity(httpContext, activity);
             }
 
-            if (context.EventSourceEnabled && exception != null)
+            if (context.EventLogEnabled && exception != null)
             {
                 // Non-inline
                 HostingEventSource.Log.UnhandledException();
@@ -154,7 +153,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ContextDisposed(HostingApplication.Context context)
         {
-            if (context.EventSourceEnabled)
+            if (context.EventLogEnabled)
             {
                 // Non-inline
                 HostingEventSource.Log.RequestStop();

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -144,9 +144,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 {
                     _cachedToString = string.Format(
                         CultureInfo.InvariantCulture,
-                        "RequestId:{0} RequestPath:{1}",
+                        "RequestPath:{0} RequestId:{1}, ActivityId:{2}",
+                        _path,
                         _traceIdentifier,
-                        _path);
+                        _activityId);
                 }
 
                 return _cachedToString;

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -13,9 +13,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class HostingLoggerExtensions
     {
-        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string correlationId)
+        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string activityId)
         {
-            return logger.BeginScope(new HostingLogScope(httpContext, correlationId));
+            return logger.BeginScope(new HostingLogScope(httpContext, activityId));
         }
 
         public static void ApplicationError(this ILogger logger, Exception exception)
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             private readonly string _path;
             private readonly string _traceIdentifier;
-            private readonly string _correlationId;
+            private readonly string _activityId;
 
             private string _cachedToString;
 
@@ -122,20 +122,20 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
-                        return new KeyValuePair<string, object>("CorrelationId", _correlationId);
+                        return new KeyValuePair<string, object>("ActivityId", _activityId);
                     }
 
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
 
-            public HostingLogScope(HttpContext httpContext, string correlationId)
+            public HostingLogScope(HttpContext httpContext, string activityId)
             {
                 _traceIdentifier = httpContext.TraceIdentifier;
                 _path = (httpContext.Request.PathBase.HasValue 
                          ? httpContext.Request.PathBase + httpContext.Request.Path 
                          : httpContext.Request.Path).ToString();
-                _correlationId = correlationId;
+                _activityId = activityId;
             }
 
             public override string ToString()

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         private IServiceProvider _applicationServices;
         private ExceptionDispatchInfo _applicationServicesException;
-        private ILogger<WebHost> _logger;
+        private ILogger _logger;
 
         private bool _stopped;
 
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public virtual async Task StartAsync(CancellationToken cancellationToken = default)
         {
             HostingEventSource.Log.HostStart();
-            _logger = _applicationServices.GetRequiredService<ILogger<WebHost>>();
+            _logger = _applicationServices.GetRequiredService<ILoggerFactory>().CreateLogger("Microsoft.AspNetCore.Hosting.Diagnostics");
             _logger.Starting();
 
             var application = BuildApplication();

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiBehaviorTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiBehaviorTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                     kvp =>
                     {
                         Assert.Equal("traceId", kvp.Key);
-                        Assert.Equal(Activity.Current.Id, kvp.Value);
+                        Assert.NotNull(kvp.Value);
                     });
             }
         }
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                     kvp =>
                     {
                         Assert.Equal("traceId", kvp.Key);
-                        Assert.Equal(Activity.Current.Id, kvp.Value);
+                        Assert.NotNull(kvp.Value);
                     });
             }
         }

--- a/src/Mvc/test/Mvc.FunctionalTests/XmlSerializerFormattersWrappingTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/XmlSerializerFormattersWrappingTest.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -210,7 +211,12 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 // Assert
                 await response.AssertStatusCodeAsync(HttpStatusCode.NotFound);
                 var content = await response.Content.ReadAsStringAsync();
-                XmlAssert.Equal(expected, content);
+                var root = XDocument.Parse(content).Root;
+                Assert.Equal("404", root.Element(root.Name.Namespace.GetName("status"))?.Value);
+                Assert.Equal("Not Found", root.Element(root.Name.Namespace.GetName("title"))?.Value);
+                Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.4", root.Element(root.Name.Namespace.GetName("type"))?.Value);
+                // Activity is not null
+                Assert.NotNull(root.Element(root.Name.Namespace.GetName("traceId"))?.Value);
             }
         }
 
@@ -241,22 +247,20 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Arrange
             using (new ActivityReplacer())
             {
-                var expected = "<problem xmlns=\"urn:ietf:rfc:7807\">" +
-               "<status>400</status>" +
-               "<title>One or more validation errors occurred.</title>" +
-               $"<traceId>{Activity.Current.Id}</traceId>" +
-               "<MVC-Errors>" +
-               "<State>The State field is required.</State>" +
-               "</MVC-Errors>" +
-               "</problem>";
-
                 // Act
                 var response = await Client.GetAsync("/api/XmlSerializerApi/ActionReturningValidationProblem");
 
                 // Assert
                 await response.AssertStatusCodeAsync(HttpStatusCode.BadRequest);
                 var content = await response.Content.ReadAsStringAsync();
-                XmlAssert.Equal(expected, content);
+                var root = XDocument.Parse(content).Root;
+                Assert.Equal("400", root.Element(root.Name.Namespace.GetName("status"))?.Value);
+                Assert.Equal("One or more validation errors occurred.", root.Element(root.Name.Namespace.GetName("title"))?.Value);
+                var mvcErrors = root.Element(root.Name.Namespace.GetName("MVC-Errors"));
+                Assert.NotNull(mvcErrors);
+                Assert.Equal("The State field is required.", mvcErrors.Element(root.Name.Namespace.GetName("State"))?.Value);
+                // Activity is not null
+                Assert.NotNull(root.Element(root.Name.Namespace.GetName("traceId"))?.Value);
             }
         }
 


### PR DESCRIPTION
- Create an Activity if there's a diagnostic listener attached with the activity name or if logging is enabled.
- Add the activity id to the logging scope (and call the field ActivityId)

cc @lmolkova @SergeyKanzhelev 

#5926 
#5918 