### PR TITLE
[2.1] Update dependency version of Extensions.Binder to avoid downgrading sharedfx versions from 2.1.10

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,10 +4,7 @@
     <!-- MicrosoftNETCoreApp21PackageVersion is assigned at the bottom so it can automatically pick up MicrosoftNETCoreAppPackageVersion in an orchestrated build. -->
     <MicrosoftNETCoreAppPackageVersion>2.1.10</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>2.1.10</MicrosoftNETCoreDotNetAppHostPackageVersion>
-
     <SystemNetHttpWinHttpHandlerPackageVersion>4.5.2</SystemNetHttpWinHttpHandlerPackageVersion>
-
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.1</MicrosoftExtensionsConfigurationBinderPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
@@ -35,6 +32,7 @@
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.1</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.10</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.1</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.1</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
     <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.1</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>

--- a/test/SharedFx.UnitTests/SharedFxTests.cs
+++ b/test/SharedFx.UnitTests/SharedFxTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore
                         var localAssemblyVersion = AssemblyName.GetAssemblyName(file).Version;
                         var dllName = Path.GetFileName(file);
                         Assert.Contains(dllName, nugetAssemblyVersions.Keys);
-                        Assert.InRange(localAssemblyVersion.CompareTo(nugetAssemblyVersions[dllName]), 0, int.MaxValue);
+                        Assert.True(localAssemblyVersion >= nugetAssemblyVersions[dllName], $"Expected {dllName} ({localAssemblyVersion}) to have assembly version >= {nugetAssemblyVersions[dllName]}");
                     }
                     catch (BadImageFormatException) { }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2212

Test error caught what would have been another version-downgrade from 2.1.10 to 2.1.11. This updates the dependency version of Extensions.Binder