### PR TITLE
Prevent synchronous writes when using Razor

### DIFF
--- a/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
@@ -370,12 +370,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var encoder = HtmlEncoder;
             if (value is IHtmlContent htmlContent)
             {
-                var bufferedWriter = writer as ViewBufferTextWriter;
-                if (bufferedWriter == null || !bufferedWriter.IsBuffering)
-                {
-                    htmlContent.WriteTo(writer, encoder);
-                }
-                else
+                if (writer is ViewBufferTextWriter bufferedWriter)
                 {
                     if (value is IHtmlContentContainer htmlContentContainer)
                     {
@@ -388,6 +383,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                         // for writing character by character.
                         bufferedWriter.Buffer.AppendHtml(htmlContent);
                     }
+                }
+                else
+                {
+                    htmlContent.WriteTo(writer, encoder);
                 }
 
                 return;

--- a/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.netcoreapp3.0.cs
@@ -1204,7 +1204,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
     }
     public partial class ViewComponentResultExecutor : Microsoft.AspNetCore.Mvc.Infrastructure.IActionResultExecutor<Microsoft.AspNetCore.Mvc.ViewComponentResult>
     {
+        [System.ObsoleteAttribute("This constructor is obsolete and will be removed in a future version.")]
         public ViewComponentResultExecutor(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.MvcViewOptions> mvcHelperOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider modelMetadataProvider, Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionaryFactory tempDataDictionaryFactory) { }
+        public ViewComponentResultExecutor(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.MvcViewOptions> mvcHelperOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider modelMetadataProvider, Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionaryFactory tempDataDictionaryFactory, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpResponseStreamWriterFactory writerFactory) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Mvc.ActionContext context, Microsoft.AspNetCore.Mvc.ViewComponentResult result) { throw null; }
     }

--- a/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBufferTextWriter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBufferTextWriter.cs
@@ -86,25 +86,20 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
         /// <inheritdoc />
         public override Encoding Encoding { get; }
 
-        /// <inheritdoc />
-        public bool IsBuffering { get; private set; } = true;
-
         /// <summary>
         /// Gets the <see cref="ViewBuffer"/>.
         /// </summary>
         public ViewBuffer Buffer { get; }
 
+        /// <summary>
+        /// Gets a value that indiciates if <see cref="Flush"/> or <see cref="FlushAsync" /> was invoked.
+        /// </summary>
+        public bool Flushed { get; private set; }
+
         /// <inheritdoc />
         public override void Write(char value)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value.ToString());
-            }
-            else
-            {
-                _inner.Write(value);
-            }
+            Buffer.AppendHtml(value.ToString());
         }
 
         /// <inheritdoc />
@@ -125,14 +120,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(new string(buffer, index, count));
-            }
-            else
-            {
-                _inner.Write(buffer, index, count);
-            }
+            Buffer.AppendHtml(new string(buffer, index, count));
         }
 
         /// <inheritdoc />
@@ -143,14 +131,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 return;
             }
 
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value);
-            }
-            else
-            {
-                _inner.Write(value);
-            }
+            Buffer.AppendHtml(value);
         }
 
         /// <inheritdoc />
@@ -186,14 +167,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 return;
             }
 
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value);
-            }
-            else
-            {
-                value.WriteTo(_inner, _htmlEncoder);
-            }
+            Buffer.AppendHtml(value);
         }
 
         /// <summary>
@@ -207,14 +181,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 return;
             }
 
-            if (IsBuffering)
-            {
-                value.MoveTo(Buffer);
-            }
-            else
-            {
-                value.WriteTo(_inner, _htmlEncoder);
-            }
+            value.MoveTo(Buffer);
         }
 
         /// <inheritdoc />
@@ -245,15 +212,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
         /// <inheritdoc />
         public override Task WriteAsync(char value)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value.ToString());
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteAsync(value);
-            }
+            Buffer.AppendHtml(value.ToString());
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />
@@ -273,121 +233,64 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(new string(buffer, index, count));
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteAsync(buffer, index, count);
-            }
+            Buffer.AppendHtml(new string(buffer, index, count));
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />
         public override Task WriteAsync(string value)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value);
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteAsync(value);
-            }
+            Buffer.AppendHtml(value);
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />
         public override void WriteLine()
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(NewLine);
-            }
-            else
-            {
-                _inner.WriteLine();
-            }
+            Buffer.AppendHtml(NewLine);
         }
 
         /// <inheritdoc />
         public override void WriteLine(string value)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value);
-                Buffer.AppendHtml(NewLine);
-            }
-            else
-            {
-                _inner.WriteLine(value);
-            }
+            Buffer.AppendHtml(value);
+            Buffer.AppendHtml(NewLine);
         }
 
         /// <inheritdoc />
         public override Task WriteLineAsync(char value)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value.ToString());
-                Buffer.AppendHtml(NewLine);
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteLineAsync(value);
-            }
+            Buffer.AppendHtml(value.ToString());
+            Buffer.AppendHtml(NewLine);
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />
         public override Task WriteLineAsync(char[] value, int start, int offset)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(new string(value, start, offset));
-                Buffer.AppendHtml(NewLine);
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteLineAsync(value, start, offset);
-            }
+            Buffer.AppendHtml(new string(value, start, offset));
+            Buffer.AppendHtml(NewLine);
+            return Task.CompletedTask;
+
         }
 
         /// <inheritdoc />
         public override Task WriteLineAsync(string value)
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(value);
-                Buffer.AppendHtml(NewLine);
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteLineAsync(value);
-            }
+            Buffer.AppendHtml(value);
+            Buffer.AppendHtml(NewLine);
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />
         public override Task WriteLineAsync()
         {
-            if (IsBuffering)
-            {
-                Buffer.AppendHtml(NewLine);
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return _inner.WriteLineAsync();
-            }
+            Buffer.AppendHtml(NewLine);
+            return Task.CompletedTask;
         }
 
         /// <summary>
         /// Copies the buffered content to the unbuffered writer and invokes flush on it.
-        /// Additionally causes this instance to no longer buffer and direct all write operations
-        /// to the unbuffered writer.
         /// </summary>
         public override void Flush()
         {
@@ -396,20 +299,16 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 return;
             }
 
-            if (IsBuffering)
-            {
-                IsBuffering = false;
-                Buffer.WriteTo(_inner, _htmlEncoder);
-                Buffer.Clear();
-            }
+            Flushed = true;
+
+            Buffer.WriteTo(_inner, _htmlEncoder);
+            Buffer.Clear();
 
             _inner.Flush();
         }
 
         /// <summary>
         /// Copies the buffered content to the unbuffered writer and invokes flush on it.
-        /// Additionally causes this instance to no longer buffer and direct all write operations
-        /// to the unbuffered writer.
         /// </summary>
         /// <returns>A <see cref="Task"/> that represents the asynchronous copy and flush operations.</returns>
         public override async Task FlushAsync()
@@ -419,12 +318,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 return;
             }
 
-            if (IsBuffering)
-            {
-                IsBuffering = false;
-                await Buffer.WriteToAsync(_inner, _htmlEncoder);
-                Buffer.Clear();
-            }
+            Flushed = true;
+
+            await Buffer.WriteToAsync(_inner, _htmlEncoder);
+            Buffer.Clear();
 
             await _inner.FlushAsync();
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
@@ -9,8 +10,8 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Filters;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -24,13 +25,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         private readonly ILogger<ViewComponentResult> _logger;
         private readonly IModelMetadataProvider _modelMetadataProvider;
         private readonly ITempDataDictionaryFactory _tempDataDictionaryFactory;
+        private IHttpResponseStreamWriterFactory _writerFactory;
 
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public ViewComponentResultExecutor(
             IOptions<MvcViewOptions> mvcHelperOptions,
             ILoggerFactory loggerFactory,
             HtmlEncoder htmlEncoder,
             IModelMetadataProvider modelMetadataProvider,
             ITempDataDictionaryFactory tempDataDictionaryFactory)
+            : this(mvcHelperOptions, loggerFactory, htmlEncoder, modelMetadataProvider, tempDataDictionaryFactory, null)
+        {
+        }
+
+        public ViewComponentResultExecutor(
+            IOptions<MvcViewOptions> mvcHelperOptions,
+            ILoggerFactory loggerFactory,
+            HtmlEncoder htmlEncoder,
+            IModelMetadataProvider modelMetadataProvider,
+            ITempDataDictionaryFactory tempDataDictionaryFactory,
+            IHttpResponseStreamWriterFactory writerFactory)
         {
             if (mvcHelperOptions == null)
             {
@@ -62,6 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             _htmlEncoder = htmlEncoder;
             _modelMetadataProvider = modelMetadataProvider;
             _tempDataDictionaryFactory = tempDataDictionaryFactory;
+            _writerFactory = writerFactory;
         }
 
         /// <inheritdoc />
@@ -105,14 +120,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 response.StatusCode = result.StatusCode.Value;
             }
 
-            // Opt into sync IO support until we can work out an alternative https://github.com/aspnet/AspNetCore/issues/6397
-            var syncIOFeature = context.HttpContext.Features.Get<Http.Features.IHttpBodyControlFeature>();
-            if (syncIOFeature != null)
-            {
-                syncIOFeature.AllowSynchronousIO = true;
-            }
+            _writerFactory ??= context.HttpContext.RequestServices.GetRequiredService<IHttpResponseStreamWriterFactory>();
 
-            using (var writer = new HttpResponseStreamWriter(response.Body, resolvedContentTypeEncoding))
+            using (var writer = _writerFactory.CreateWriter(response.Body, resolvedContentTypeEncoding))
             {
                 var viewContext = new ViewContext(
                     context,
@@ -127,9 +137,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 // IViewComponentHelper is stateful, we want to make sure to retrieve it every time we need it.
                 var viewComponentHelper = context.HttpContext.RequestServices.GetRequiredService<IViewComponentHelper>();
                 (viewComponentHelper as IViewContextAware)?.Contextualize(viewContext);
-
                 var viewComponentResult = await GetViewComponentResult(viewComponentHelper, _logger, result);
-                viewComponentResult.WriteTo(writer, _htmlEncoder);
+
+                if (viewComponentResult is ViewBuffer viewBuffer)
+                {
+                    // In the ordinary case, DefaultViewComponentHelper will return an instance of ViewBuffer. We can simply
+                    // invoke WriteToAsync on it.
+                    await viewBuffer.WriteToAsync(writer, _htmlEncoder);
+                    await writer.FlushAsync();
+                }
+                else
+                {
+                    using var memoryStream = new MemoryStream();
+                    using (var intermediateWriter = _writerFactory.CreateWriter(response.Body, resolvedContentTypeEncoding))
+                    {
+                        viewComponentResult.WriteTo(intermediateWriter, _htmlEncoder);
+                    }
+
+                    memoryStream.Position = 0;
+                    await memoryStream.CopyToAsync(response.Body);
+                }
             }
         }
 

--- a/src/Mvc/test/Mvc.FunctionalTests/FlushPointTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/FlushPointTest.cs
@@ -36,6 +36,33 @@ RenderBody content
         }
 
         [Fact]
+        public async Task FlushFollowedByLargeContent()
+        {
+            // Arrange
+            var expected = new string('a', 1024 * 1024);
+
+            // Act
+            var document = await Client.GetHtmlDocumentAsync("http://localhost/FlushPoint/FlushFollowedByLargeContent");
+
+            // Assert
+            var largeContent = document.RequiredQuerySelector("#large-content");
+            Assert.StartsWith(expected, largeContent.TextContent);
+        }
+
+        [Fact]
+        public async Task FlushInvokedInComponent()
+        {
+            var expected = new string('a', 1024 * 1024);
+
+            // Act
+            var document = await Client.GetHtmlDocumentAsync("http://localhost/FlushPoint/FlushInvokedInComponent");
+
+            // Assert
+            var largeContent = document.RequiredQuerySelector("#large-content");
+            Assert.StartsWith(expected, largeContent.TextContent);
+        }
+
+        [Fact]
         public async Task FlushPointsAreExecutedForPagesWithoutLayouts()
         {
             var expected = @"Initial content

--- a/src/Mvc/test/WebSites/RazorWebSite/Components/ComponentWithFlush.cs
+++ b/src/Mvc/test/WebSites/RazorWebSite/Components/ComponentWithFlush.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace MvcSample.Web.Components
+{
+    [ViewComponent(Name = "ComponentWithFlush")]
+    public class ComponentWithFlush : ViewComponent
+    {
+        public IViewComponentResult Invoke()
+        {
+            return View();
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RazorWebSite/Controllers/FlushPoint.cs
+++ b/src/Mvc/test/WebSites/RazorWebSite/Controllers/FlushPoint.cs
@@ -12,6 +12,10 @@ namespace RazorWebSite
             return View();
         }
 
+        public IActionResult FlushFollowedByLargeContent() => View();
+
+        public IActionResult FlushInvokedInComponent() => View();
+
         public IActionResult PageWithoutLayout()
         {
             return View();

--- a/src/Mvc/test/WebSites/RazorWebSite/Views/FlushPoint/FlushFollowedByLargeContent.cshtml
+++ b/src/Mvc/test/WebSites/RazorWebSite/Views/FlushPoint/FlushFollowedByLargeContent.cshtml
@@ -1,0 +1,7 @@
+﻿Header content
+@{
+    await FlushAsync();
+    var largeContent = new string('a', 1024 * 1024);
+}
+
+<span id="large-content">@largeContent</span>

--- a/src/Mvc/test/WebSites/RazorWebSite/Views/FlushPoint/FlushInvokedInComponent.cshtml
+++ b/src/Mvc/test/WebSites/RazorWebSite/Views/FlushPoint/FlushInvokedInComponent.cshtml
@@ -1,0 +1,1 @@
+﻿@await Component.InvokeAsync("ComponentWithFlush")

--- a/src/Mvc/test/WebSites/RazorWebSite/Views/Shared/Components/ComponentWithFlush/Default.cshtml
+++ b/src/Mvc/test/WebSites/RazorWebSite/Views/Shared/Components/ComponentWithFlush/Default.cshtml
@@ -1,0 +1,8 @@
+﻿Hello from component
+@{
+    await FlushAsync();
+    var largeContent = new string('a', 1024 * 1024);
+}
+
+<span id="large-content">@largeContent</span>
+


### PR DESCRIPTION
* Do not perform synchronous writes to the Response TextWriter after a Razor FlushAsync
* Use ViewBuffer to perform async writes to the response when using ViewComponentResult

Related to #6397 

Fixes https://github.com/aspnet/AspNetCore/issues/4885
