### PR TITLE
Make IHubClients and IHubCallerClients Abstract Classes

### DIFF
--- a/src/SignalR/server/Core/src/DynamicHubClients.cs
+++ b/src/SignalR/server/Core/src/DynamicHubClients.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -11,13 +11,13 @@ namespace Microsoft.AspNetCore.SignalR
     /// </summary>
     public class DynamicHubClients
     {
-        private readonly IHubCallerClients _clients;
+        private readonly HubCallerClientsBase _clients;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicHubClients"/> class.
         /// </summary>
-        /// <param name="clients">A wrapped <see cref="IHubCallerClients"/> that is used to invoke methods.</param>
-        public DynamicHubClients(IHubCallerClients clients)
+        /// <param name="clients">A wrapped <see cref="HubCallerClientsBase"/> that is used to invoke methods.</param>
+        public DynamicHubClients(HubCallerClientsBase clients)
         {
             _clients = clients;
         }

--- a/src/SignalR/server/Core/src/Hub.cs
+++ b/src/SignalR/server/Core/src/Hub.cs
@@ -12,14 +12,14 @@ namespace Microsoft.AspNetCore.SignalR
     public abstract class Hub : IDisposable
     {
         private bool _disposed;
-        private IHubCallerClients _clients;
+        private HubCallerClientsBase _clients;
         private HubCallerContext _context;
         private IGroupManager _groups;
 
         /// <summary>
         /// Gets or sets an object that can be used to invoke methods on the clients connected to this hub.
         /// </summary>
-        public IHubCallerClients Clients
+        public HubCallerClientsBase Clients
         {
             get
             {

--- a/src/SignalR/server/Core/src/HubCallerClientsBase.cs
+++ b/src/SignalR/server/Core/src/HubCallerClientsBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.SignalR
 {
     public abstract class HubCallerClientsBase : HubCallerClientsBase<IClientProxy>

--- a/src/SignalR/server/Core/src/HubCallerClientsBase.cs
+++ b/src/SignalR/server/Core/src/HubCallerClientsBase.cs
@@ -1,9 +1,24 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.SignalR
 {
-    public abstract class HubCallerClientsBase : HubCallerClientsBase<IClientProxy>
+#pragma warning disable CS0618 // Type or member is obsolete
+    public abstract class HubCallerClientsBase : IHubCallerClients<IClientProxy>
     {
+        public abstract IClientProxy Caller { get; }
+        public abstract IClientProxy Others { get; }
+        public abstract IClientProxy All { get; }
+        public abstract IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds);
+        public abstract IClientProxy Client(string connectionId);
+        public abstract IClientProxy Clients(IReadOnlyList<string> connectionIds);
+        public abstract IClientProxy Group(string groupName);
+        public abstract IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds);
+        public abstract IClientProxy Groups(IReadOnlyList<string> groupNames);
+        public abstract IClientProxy OthersInGroup(string groupName);
+        public abstract IClientProxy User(string userId);
+        public abstract IClientProxy Users(IReadOnlyList<string> userIds);
     }
 }

--- a/src/SignalR/server/Core/src/HubCallerClientsBase.cs
+++ b/src/SignalR/server/Core/src/HubCallerClientsBase.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.AspNetCore.SignalR
+{
+    public abstract class HubCallerClientsBase : HubCallerClientsBase<IClientProxy>
+    {
+    }
+}

--- a/src/SignalR/server/Core/src/HubCallerClientsBase`T.cs
+++ b/src/SignalR/server/Core/src/HubCallerClientsBase`T.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.SignalR
 {

--- a/src/SignalR/server/Core/src/HubCallerClientsBase`T.cs
+++ b/src/SignalR/server/Core/src/HubCallerClientsBase`T.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public abstract class HubCallerClientsBase<T> : HubClientsBase<T>
+    {
+        /// <summary>
+        /// Gets a caller to the connection which triggered the current invocation.
+        /// </summary>
+        public abstract T Caller { get; }
+
+        /// <summary>
+        /// Gets a caller to all connections except the one which triggered the current invocation.
+        /// </summary>
+        public abstract T Others { get; }
+
+        /// <summary>
+        /// Gets a caller to all connections in the specified group, except the one which triggered the current invocation.
+        /// </summary>
+        /// <returns>A client caller.</returns>
+        public abstract T OthersInGroup(string groupName);
+    }
+}

--- a/src/SignalR/server/Core/src/HubCallerClientsBase`T.cs
+++ b/src/SignalR/server/Core/src/HubCallerClientsBase`T.cs
@@ -1,9 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.SignalR
 {
-    public abstract class HubCallerClientsBase<T> : HubClientsBase<T>
+#pragma warning disable CS0618 // Type or member is obsolete
+    public abstract class HubCallerClientsBase<T> : IHubCallerClients<T>
     {
         /// <summary>
         /// Gets a caller to the connection which triggered the current invocation.
@@ -15,10 +18,24 @@ namespace Microsoft.AspNetCore.SignalR
         /// </summary>
         public abstract T Others { get; }
 
-        /// <summary>
-        /// Gets a caller to all connections in the specified group, except the one which triggered the current invocation.
-        /// </summary>
-        /// <returns>A client caller.</returns>
+        public abstract T All { get; }
+
+        public abstract T AllExcept(IReadOnlyList<string> excludedConnectionIds);
+
+        public abstract T Client(string connectionId);
+
+        public abstract T Clients(IReadOnlyList<string> connectionIds);
+
+        public abstract T Group(string groupName);
+
+        public abstract T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds);
+
+        public abstract T Groups(IReadOnlyList<string> groupNames);
+
         public abstract T OthersInGroup(string groupName);
+
+        public abstract T User(string userId);
+
+        public abstract T Users(IReadOnlyList<string> userIds);
     }
 }

--- a/src/SignalR/server/Core/src/HubClientBase.cs
+++ b/src/SignalR/server/Core/src/HubClientBase.cs
@@ -1,51 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    public class HubClientBase : HubClientsBase<IClientProxy>
+    public abstract class HubClientsBase : HubClientsBase<IClientProxy>
     {
-        public override IClientProxy All => throw new NotImplementedException();
+        public override abstract IClientProxy All { get; }
+        public override abstract IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds);
 
-        public override IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy Client(string connectionId);
 
-        public override IClientProxy Client(string connectionId)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy Clients(IReadOnlyList<string> connectionIds);
 
-        public override IClientProxy Clients(IReadOnlyList<string> connectionIds)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy Group(string groupName);
 
-        public override IClientProxy Group(string groupName)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds);
 
-        public override IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy Groups(IReadOnlyList<string> groupNames);
 
-        public override IClientProxy Groups(IReadOnlyList<string> groupNames)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy User(string userId);
 
-        public override IClientProxy User(string userId)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override IClientProxy Users(IReadOnlyList<string> userIds)
-        {
-            throw new NotImplementedException();
-        }
+        public override abstract IClientProxy Users(IReadOnlyList<string> userIds);
     }
 }

--- a/src/SignalR/server/Core/src/HubClientBase.cs
+++ b/src/SignalR/server/Core/src/HubClientBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
@@ -9,6 +8,7 @@ namespace Microsoft.AspNetCore.SignalR
     public abstract class HubClientsBase : HubClientsBase<IClientProxy>
     {
         public override abstract IClientProxy All { get; }
+
         public override abstract IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds);
 
         public override abstract IClientProxy Client(string connectionId);

--- a/src/SignalR/server/Core/src/HubClientBase.cs
+++ b/src/SignalR/server/Core/src/HubClientBase.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public class HubClientBase : HubClientsBase<IClientProxy>
+    {
+        public override IClientProxy All => throw new NotImplementedException();
+
+        public override IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy Client(string connectionId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy Clients(IReadOnlyList<string> connectionIds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy Group(string groupName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy Groups(IReadOnlyList<string> groupNames)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy User(string userId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IClientProxy Users(IReadOnlyList<string> userIds)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SignalR/server/Core/src/HubClientsBase`T.cs
+++ b/src/SignalR/server/Core/src/HubClientsBase`T.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
@@ -10,49 +9,48 @@ namespace Microsoft.AspNetCore.SignalR
     /// An abstraction that provides access to client connections.
     /// </summary>
     /// <typeparam name="T">The client invoker type.</typeparam>
-    [Obsolete("The IHubClients<T> interface is obsolete. Use the HubClientBase<T> abstract class instead.", false)]
-    public interface IHubClients<T>
+    public abstract class HubClientsBase<T>
     {
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all clients connected to the hub.
         /// </summary>
         /// <returns>A client caller.</returns>
-        T All { get; }
+        public abstract T All { get; }
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all clients connected to the hub excluding the specified client connections.
         /// </summary>
         /// <param name="excludedConnectionIds">A collection of connection IDs to exclude.</param>
         /// <returns>A client caller.</returns>
-        T AllExcept(IReadOnlyList<string> excludedConnectionIds);
+        public abstract T AllExcept(IReadOnlyList<string> excludedConnectionIds);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on the specified client connection.
         /// </summary>
         /// <param name="connectionId">The connection ID.</param>
         /// <returns>A client caller.</returns>
-        T Client(string connectionId);
+        public abstract T Client(string connectionId);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on the specified client connections.
         /// </summary>
         /// <param name="connectionIds">The connection IDs.</param>
         /// <returns>A client caller.</returns>
-        T Clients(IReadOnlyList<string> connectionIds);
+        public abstract T Clients(IReadOnlyList<string> connectionIds);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all connections in the specified group.
         /// </summary>
         /// <param name="groupName">The group name.</param>
         /// <returns>A client caller.</returns>
-        T Group(string groupName);
+        public abstract T Group(string groupName);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all connections in all of the specified groups.
         /// </summary>
         /// <param name="groupNames">The group names.</param>
         /// <returns>A client caller.</returns>
-        T Groups(IReadOnlyList<string> groupNames);
+        public abstract T Groups(IReadOnlyList<string> groupNames);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all connections in the specified group excluding the specified connections.
@@ -60,21 +58,20 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="groupName">The group name.</param>
         /// <param name="excludedConnectionIds">A collection of connection IDs to exclude.</param>
         /// <returns>A client caller.</returns>
-        T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds);
+        public abstract T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all connections associated with the specified user.
         /// </summary>
         /// <param name="userId">The user ID.</param>
         /// <returns>A client caller.</returns>
-        T User(string userId);
+        public abstract T User(string userId);
 
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all connections associated with all of the specified users.
         /// </summary>
         /// <param name="userIds">The user IDs.</param>
         /// <returns>A client caller.</returns>
-        T Users(IReadOnlyList<string> userIds);
+        public abstract T Users(IReadOnlyList<string> userIds);
     }
 }
-

--- a/src/SignalR/server/Core/src/HubClientsBase`T.cs
+++ b/src/SignalR/server/Core/src/HubClientsBase`T.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.SignalR
     /// An abstraction that provides access to client connections.
     /// </summary>
     /// <typeparam name="T">The client invoker type.</typeparam>
-    public abstract class HubClientsBase<T>
+    #pragma warning disable CS0618
+    public abstract class HubClientsBase<T> : IHubClients<T>
     {
         /// <summary>
         /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all clients connected to the hub.

--- a/src/SignalR/server/Core/src/HubClientsExtensions.cs
+++ b/src/SignalR/server/Core/src/HubClientsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Microsoft.AspNetCore.SignalR
 {
     /// <summary>
-    /// Extension methods for <see cref="IHubClients{T}"/>.
+    /// Extension methods for <see cref="HubClientsBase{T}"/>.
     /// </summary>
     public static class HubClientsExtensions
     {
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="hubClients">The abstraction that provides access to connections.</param>
         /// <param name="excludedConnectionId1">The first connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1 });
         }
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId1">The first connection to exclude.</param>
         /// <param name="excludedConnectionId2">The second connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2 });
         }
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId2">The second connection to exclude.</param>
         /// <param name="excludedConnectionId3">The third connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3 });
         }
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId3">The third connection to exclude.</param>
         /// <param name="excludedConnectionId4">The fourth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4 });
         }
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId4">The fourth connection to exclude.</param>
         /// <param name="excludedConnectionId5">The fifth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5 });
         }
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId5">The fifth connection to exclude.</param>
         /// <param name="excludedConnectionId6">The sixth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5, excludedConnectionId6 });
         }
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId6">The sixth connection to exclude.</param>
         /// <param name="excludedConnectionId7">The seventh connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5, excludedConnectionId6, excludedConnectionId7 });
         }
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId7">The seventh connection to exclude.</param>
         /// <param name="excludedConnectionId8">The eighth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T AllExcept<T>(this IHubClients<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7, string excludedConnectionId8)
+        public static T AllExcept<T>(this HubClientsBase<T> hubClients, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7, string excludedConnectionId8)
         {
             return hubClients.AllExcept(new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5, excludedConnectionId6, excludedConnectionId7, excludedConnectionId8 });
         }
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="hubClients">The abstraction that provides access to connections.</param>
         /// <param name="connection1">The first connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1)
         {
             return hubClients.Clients(new [] { connection1 });
         }
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection1">The first connection to include.</param>
         /// <param name="connection2">The second connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2)
         {
             return hubClients.Clients(new [] { connection1, connection2 });
         }
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection2">The second connection to include.</param>
         /// <param name="connection3">The third connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2, string connection3)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2, string connection3)
         {
             return hubClients.Clients(new [] { connection1, connection2, connection3 });
         }
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection3">The third connection to include.</param>
         /// <param name="connection4">The fourth connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2, string connection3, string connection4)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2, string connection3, string connection4)
         {
             return hubClients.Clients(new [] { connection1, connection2, connection3, connection4 });
         }
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection4">The fourth connection to include.</param>
         /// <param name="connection5">The fifth connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5)
         {
             return hubClients.Clients(new [] { connection1, connection2, connection3, connection4, connection5 });
         }
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection5">The fifth connection to include.</param>
         /// <param name="connection6">The sixth connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5, string connection6)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5, string connection6)
         {
             return hubClients.Clients(new [] { connection1, connection2, connection3, connection4, connection5, connection6 });
         }
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection6">The sixth connection to include.</param>
         /// <param name="connection7">The seventh connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5, string connection6, string connection7)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5, string connection6, string connection7)
         {
             return hubClients.Clients(new [] { connection1, connection2, connection3, connection4, connection5, connection6, connection7 });
         }
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connection7">The seventh connection to include.</param>
         /// <param name="connection8">The eighth connection to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Clients<T>(this IHubClients<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5, string connection6, string connection7, string connection8)
+        public static T Clients<T>(this HubClientsBase<T> hubClients, string connection1, string connection2, string connection3, string connection4, string connection5, string connection6, string connection7, string connection8)
         {
             return hubClients.Clients(new [] { connection1, connection2, connection3, connection4, connection5, connection6, connection7, connection8 });
         }
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="hubClients">The abstraction that provides access to connections.</param>
         /// <param name="group1">The first group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1)
         {
             return hubClients.Groups(new [] { group1 });
         }
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group1">The first group to include.</param>
         /// <param name="group2">The second group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2)
         {
             return hubClients.Groups(new [] { group1, group2 });
         }
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group2">The second group to include.</param>
         /// <param name="group3">The third group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2, string group3)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2, string group3)
         {
             return hubClients.Groups(new [] { group1, group2, group3 });
         }
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group3">The third group to include.</param>
         /// <param name="group4">The fourth group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2, string group3, string group4)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2, string group3, string group4)
         {
             return hubClients.Groups(new [] { group1, group2, group3, group4 });
         }
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group4">The fourth group to include.</param>
         /// <param name="group5">The fifth group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2, string group3, string group4, string group5)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2, string group3, string group4, string group5)
         {
             return hubClients.Groups(new [] { group1, group2, group3, group4, group5 });
         }
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group5">The fifth group to include.</param>
         /// <param name="group6">The sixth group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2, string group3, string group4, string group5, string group6)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2, string group3, string group4, string group5, string group6)
         {
             return hubClients.Groups(new [] { group1, group2, group3, group4, group5, group6 });
         }
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group6">The sixth group to include.</param>
         /// <param name="group7">The seventh group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2, string group3, string group4, string group5, string group6, string group7)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2, string group3, string group4, string group5, string group6, string group7)
         {
             return hubClients.Groups(new [] { group1, group2, group3, group4, group5, group6, group7 });
         }
@@ -353,7 +353,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="group7">The seventh group to include.</param>
         /// <param name="group8">The eighth group to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Groups<T>(this IHubClients<T> hubClients, string group1, string group2, string group3, string group4, string group5, string group6, string group7, string group8)
+        public static T Groups<T>(this HubClientsBase<T> hubClients, string group1, string group2, string group3, string group4, string group5, string group6, string group7, string group8)
         {
             return hubClients.Groups(new [] { group1, group2, group3, group4, group5, group6, group7, group8 });
         }
@@ -365,7 +365,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="groupName">The group name.</param>
         /// <param name="excludedConnectionId1">The first connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1 });
         }
@@ -378,7 +378,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId1">The first connection to exclude.</param>
         /// <param name="excludedConnectionId2">The second connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2 });
         }
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId2">The second connection to exclude.</param>
         /// <param name="excludedConnectionId3">The third connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3 });
         }
@@ -407,7 +407,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId3">The third connection to exclude.</param>
         /// <param name="excludedConnectionId4">The fourth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4 });
         }
@@ -423,7 +423,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId4">The fourth connection to exclude.</param>
         /// <param name="excludedConnectionId5">The fifth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5 });
         }
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId5">The fifth connection to exclude.</param>
         /// <param name="excludedConnectionId6">The sixth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5, excludedConnectionId6 });
         }
@@ -458,7 +458,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId6">The sixth connection to exclude.</param>
         /// <param name="excludedConnectionId7">The seventh connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5, excludedConnectionId6, excludedConnectionId7 });
         }
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="excludedConnectionId7">The seventh connection to exclude.</param>
         /// <param name="excludedConnectionId8">The eighth connection to exclude.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T GroupExcept<T>(this IHubClients<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7, string excludedConnectionId8)
+        public static T GroupExcept<T>(this HubClientsBase<T> hubClients, string groupName, string excludedConnectionId1, string excludedConnectionId2, string excludedConnectionId3, string excludedConnectionId4, string excludedConnectionId5, string excludedConnectionId6, string excludedConnectionId7, string excludedConnectionId8)
         {
             return hubClients.GroupExcept(groupName, new [] { excludedConnectionId1, excludedConnectionId2, excludedConnectionId3, excludedConnectionId4, excludedConnectionId5, excludedConnectionId6, excludedConnectionId7, excludedConnectionId8 });
         }
@@ -488,7 +488,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="hubClients">The abstraction that provides access to connections.</param>
         /// <param name="user1">The first user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1)
         {
             return hubClients.Users(new [] { user1 });
         }
@@ -500,7 +500,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user1">The first user to include.</param>
         /// <param name="user2">The second user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2)
         {
             return hubClients.Users(new [] { user1, user2 });
         }
@@ -513,7 +513,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user2">The second user to include.</param>
         /// <param name="user3">The third user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2, string user3)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2, string user3)
         {
             return hubClients.Users(new [] { user1, user2, user3 });
         }
@@ -527,7 +527,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user3">The third user to include.</param>
         /// <param name="user4">The fourth user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2, string user3, string user4)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2, string user3, string user4)
         {
             return hubClients.Users(new [] { user1, user2, user3, user4 });
         }
@@ -542,7 +542,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user4">The fourth user to include.</param>
         /// <param name="user5">The fifth user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2, string user3, string user4, string user5)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2, string user3, string user4, string user5)
         {
             return hubClients.Users(new [] { user1, user2, user3, user4, user5 });
         }
@@ -558,7 +558,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user5">The fifth user to include.</param>
         /// <param name="user6">The sixth user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2, string user3, string user4, string user5, string user6)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2, string user3, string user4, string user5, string user6)
         {
             return hubClients.Users(new [] { user1, user2, user3, user4, user5, user6 });
         }
@@ -575,7 +575,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user6">The sixth user to include.</param>
         /// <param name="user7">The seventh user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2, string user3, string user4, string user5, string user6, string user7)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2, string user3, string user4, string user5, string user6, string user7)
         {
             return hubClients.Users(new [] { user1, user2, user3, user4, user5, user6, user7 });
         }
@@ -593,7 +593,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="user7">The seventh user to include.</param>
         /// <param name="user8">The eighth user to include.</param>
         /// <returns>A <typeparamref name="T" /> representing the methods that can be invoked on the clients.</returns>
-        public static T Users<T>(this IHubClients<T> hubClients, string user1, string user2, string user3, string user4, string user5, string user6, string user7, string user8)
+        public static T Users<T>(this HubClientsBase<T> hubClients, string user1, string user2, string user3, string user4, string user5, string user6, string user7, string user8)
         {
             return hubClients.Users(new [] { user1, user2, user3, user4, user5, user6, user7, user8 });
         }

--- a/src/SignalR/server/Core/src/Hub`T.cs
+++ b/src/SignalR/server/Core/src/Hub`T.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -11,12 +11,12 @@ namespace Microsoft.AspNetCore.SignalR
     /// <typeparam name="T">The type of client.</typeparam>
     public abstract class Hub<T> : Hub where T : class
     {
-        private IHubCallerClients<T> _clients;
+        private HubCallerClientsBase<T> _clients;
 
         /// <summary>
         /// Gets or sets a <typeparamref name="T"/> that can be used to invoke methods on the clients connected to this hub.
         /// </summary>
-        public new IHubCallerClients<T> Clients
+        public new HubCallerClientsBase<T> Clients
         {
             get
             {

--- a/src/SignalR/server/Core/src/IHubCallerClients.cs
+++ b/src/SignalR/server/Core/src/IHubCallerClients.cs
@@ -1,10 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.SignalR
 {
     /// <summary>
     /// A clients caller abstraction for a hub.
     /// </summary>
+    [Obsolete("The IHubClients<T> interface is obsolete. Use the HubClientBase<T> abstract class instead.", false)]
     public interface IHubCallerClients : IHubCallerClients<IClientProxy> { }
 }

--- a/src/SignalR/server/Core/src/IHubCallerClients`T.cs
+++ b/src/SignalR/server/Core/src/IHubCallerClients`T.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets a caller to the connection which triggered the current invocation.
         /// </summary>
-        
         T Caller { get; }
 
         /// <summary>

--- a/src/SignalR/server/Core/src/IHubCallerClients`T.cs
+++ b/src/SignalR/server/Core/src/IHubCallerClients`T.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.SignalR
 {
@@ -7,11 +9,14 @@ namespace Microsoft.AspNetCore.SignalR
     /// An abstraction that provides access to client connections, including the one that sent the current invocation.
     /// </summary>
     /// <typeparam name="T">The client caller type.</typeparam>
+    ///
+    [Obsolete("The IHubCallerClients<T> interface is obsolete. Use the HubCallerCliensBase<T> abstract class instead.", false)]
     public interface IHubCallerClients<T> : IHubClients<T>
     {
         /// <summary>
         /// Gets a caller to the connection which triggered the current invocation.
         /// </summary>
+        
         T Caller { get; }
 
         /// <summary>

--- a/src/SignalR/server/Core/src/IHubClients.cs
+++ b/src/SignalR/server/Core/src/IHubClients.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
 {

--- a/src/SignalR/server/Core/src/IHubClients.cs
+++ b/src/SignalR/server/Core/src/IHubClients.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
@@ -8,5 +9,6 @@ namespace Microsoft.AspNetCore.SignalR
     /// <summary>
     /// An abstraction that provides access to client connections.
     /// </summary>
+    [Obsolete("The IHubClients interface is obsolete. Use the HubClientBase abstract class instead.", false)]
     public interface IHubClients : IHubClients<IClientProxy> { }
 }

--- a/src/SignalR/server/Core/src/IHubContext.cs
+++ b/src/SignalR/server/Core/src/IHubContext.cs
@@ -9,9 +9,9 @@ namespace Microsoft.AspNetCore.SignalR
     public interface IHubContext<THub> where THub : Hub
     {
         /// <summary>
-        /// Gets a <see cref="IHubClients"/> that can be used to invoke methods on clients connected to the hub.
+        /// Gets a <see cref="HubClientsBase"/> that can be used to invoke methods on clients connected to the hub.
         /// </summary>
-        HubClientBase Clients { get; }
+        HubClientsBase Clients { get; }
 
         /// <summary>
         /// Gets a <see cref="IGroupManager"/> that can be used to add and remove connections to named groups.

--- a/src/SignalR/server/Core/src/IHubContext.cs
+++ b/src/SignalR/server/Core/src/IHubContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets a <see cref="IHubClients"/> that can be used to invoke methods on clients connected to the hub.
         /// </summary>
-        IHubClients Clients { get; }
+        HubClientBase Clients { get; }
 
         /// <summary>
         /// Gets a <see cref="IGroupManager"/> that can be used to add and remove connections to named groups.

--- a/src/SignalR/server/Core/src/IHubContext`T.cs
+++ b/src/SignalR/server/Core/src/IHubContext`T.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.SignalR
         where T : class
     {
         /// <summary>
-        /// Gets a <see cref="IHubClients{T}"/> that can be used to invoke methods on clients connected to the hub.
+        /// Gets a <see cref="HubClientsBase{T}"/> that can be used to invoke methods on clients connected to the hub.
         /// </summary>
         HubClientsBase<T> Clients { get; }
 

--- a/src/SignalR/server/Core/src/IHubContext`T.cs
+++ b/src/SignalR/server/Core/src/IHubContext`T.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets a <see cref="IHubClients{T}"/> that can be used to invoke methods on clients connected to the hub.
         /// </summary>
-        IHubClients<T> Clients { get; }
+        HubClientsBase<T> Clients { get; }
 
         /// <summary>
         /// Gets a <see cref="IGroupManager"/> that can be used to add and remove connections to named groups.

--- a/src/SignalR/server/Core/src/IUserIdProvider.cs
+++ b/src/SignalR/server/Core/src/IUserIdProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.SignalR
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     /// <summary>
     /// A provider abstraction for configuring the "User ID" for a connection.
     /// </summary>
-    /// <remarks><see cref="IUserIdProvider"/> is used by <see cref="IHubClients{T}.User(string)"/> to invoke connections associated with a user.</remarks>
+    /// <remarks><see cref="IUserIdProvider"/> is used by <see cref="HubClientsBase{T}.User(string)"/> to invoke connections associated with a user.</remarks>
     public interface IUserIdProvider
     {
         /// <summary>

--- a/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public override IClientProxy Others => _hubClients.AllExcept(_currentConnectionId);
 
-        public override IClientProxy All { get; }
+        public override IClientProxy All => _hubClients.All;
 
         public override IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {

--- a/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
@@ -1,70 +1,70 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    public class HubCallerClients : IHubCallerClients
+    public class HubCallerClients : HubCallerClientsBase
     {
         private readonly string _connectionId;
-        private readonly IHubClients _hubClients;
+        private readonly HubClientBase _hubClients;
         private readonly string[] _currentConnectionId;
 
-        public HubCallerClients(IHubClients hubClients, string connectionId)
+        public HubCallerClients(HubClientBase hubClients, string connectionId)
         {
             _connectionId = connectionId;
             _hubClients = hubClients;
             _currentConnectionId = new[] { _connectionId };
         }
 
-        public IClientProxy Caller => _hubClients.Client(_connectionId);
+        public override IClientProxy Caller => _hubClients.Client(_connectionId);
 
-        public IClientProxy Others => _hubClients.AllExcept(_currentConnectionId);
+        public override IClientProxy Others => _hubClients.AllExcept(_currentConnectionId);
 
-        public IClientProxy All => _hubClients.All;
+        public override IClientProxy All => _hubClients.All;
 
-        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
+        public override IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
             return _hubClients.AllExcept(excludedConnectionIds);
         }
 
-        public IClientProxy Client(string connectionId)
+        public override IClientProxy Client(string connectionId)
         {
             return _hubClients.Client(connectionId);
         }
 
-        public IClientProxy Group(string groupName)
+        public override IClientProxy Group(string groupName)
         {
             return _hubClients.Group(groupName);
         }
 
-        public IClientProxy Groups(IReadOnlyList<string> groupNames)
+        public override IClientProxy Groups(IReadOnlyList<string> groupNames)
         {
             return _hubClients.Groups(groupNames);
         }
 
-        public IClientProxy OthersInGroup(string groupName)
+        public override IClientProxy OthersInGroup(string groupName)
         {
             return _hubClients.GroupExcept(groupName, _currentConnectionId);
         }
 
-        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+        public override IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
             return _hubClients.GroupExcept(groupName, excludedConnectionIds);
         }
 
-        public IClientProxy User(string userId)
+        public override IClientProxy User(string userId)
         {
            return _hubClients.User(userId);
         }
 
-        public IClientProxy Clients(IReadOnlyList<string> connectionIds)
+        public override IClientProxy Clients(IReadOnlyList<string> connectionIds)
         {
             return _hubClients.Clients(connectionIds);
         }
 
-        public IClientProxy Users(IReadOnlyList<string> userIds)
+        public override IClientProxy Users(IReadOnlyList<string> userIds)
         {
             return _hubClients.Users(userIds);
         }

--- a/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
@@ -8,10 +8,10 @@ namespace Microsoft.AspNetCore.SignalR.Internal
     public class HubCallerClients : HubCallerClientsBase
     {
         private readonly string _connectionId;
-        private readonly HubClientBase _hubClients;
+        private readonly HubClientsBase _hubClients;
         private readonly string[] _currentConnectionId;
 
-        public HubCallerClients(HubClientBase hubClients, string connectionId)
+        public HubCallerClients(HubClientsBase hubClients, string connectionId)
         {
             _connectionId = connectionId;
             _hubClients = hubClients;
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public override IClientProxy Others => _hubClients.AllExcept(_currentConnectionId);
 
-        public override IClientProxy All => _hubClients.All;
+        public override IClientProxy All { get; }
 
         public override IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {

--- a/src/SignalR/server/Core/src/Internal/HubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    internal class HubClients<THub> : IHubClients where THub : Hub
+    internal class HubClients<THub> : HubClientBase where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
 
@@ -15,44 +15,44 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             All = new AllClientProxy<THub>(_lifetimeManager);
         }
 
-        public IClientProxy All { get; }
+        public override IClientProxy All { get; }
 
-        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
+        public override IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
             return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds);
         }
 
-        public IClientProxy Client(string connectionId)
+        public override IClientProxy Client(string connectionId)
         {
             return new SingleClientProxy<THub>(_lifetimeManager, connectionId);
         }
 
-        public IClientProxy Group(string groupName)
+        public override IClientProxy Group(string groupName)
         {
             return new GroupProxy<THub>(_lifetimeManager, groupName);
         }
 
-        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+        public override IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
             return new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludedConnectionIds);
         }
 
-        public IClientProxy Clients(IReadOnlyList<string> connectionIds)
+        public override IClientProxy Clients(IReadOnlyList<string> connectionIds)
         {
             return new MultipleClientProxy<THub>(_lifetimeManager, connectionIds);
         }
 
-        public IClientProxy Groups(IReadOnlyList<string> groupNames)
+        public override IClientProxy Groups(IReadOnlyList<string> groupNames)
         {
             return new MultipleGroupProxy<THub>(_lifetimeManager, groupNames);
         }
 
-        public IClientProxy User(string userId)
+        public override IClientProxy User(string userId)
         {
             return new UserProxy<THub>(_lifetimeManager, userId);
         }
 
-        public IClientProxy Users(IReadOnlyList<string> userIds)
+        public override IClientProxy Users(IReadOnlyList<string> userIds)
         {
             return new MultipleUserProxy<THub>(_lifetimeManager, userIds);
         }

--- a/src/SignalR/server/Core/src/Internal/HubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    internal class HubClients<THub> : HubClientBase where THub : Hub
+    internal class HubClients<THub> : HubClientsBase where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
 

--- a/src/SignalR/server/Core/src/Internal/HubClients`T.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients`T.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    internal class HubClients<THub, T> : IHubClients<T> where THub : Hub
+    internal class HubClients<THub, T> : HubClientsBase<T> where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
 
@@ -15,44 +15,44 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             All = TypedClientBuilder<T>.Build(new AllClientProxy<THub>(_lifetimeManager));
         }
 
-        public T All { get; }
+        public override T All { get; }
 
-        public T AllExcept(IReadOnlyList<string> excludedConnectionIds)
+        public override T AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
             return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds));
         }
 
-        public virtual T Client(string connectionId)
+        public override T Client(string connectionId)
         {
             return TypedClientBuilder<T>.Build(new SingleClientProxy<THub>(_lifetimeManager, connectionId));
         }
 
-        public T Clients(IReadOnlyList<string> connectionIds)
+        public override T Clients(IReadOnlyList<string> connectionIds)
         {
             return TypedClientBuilder<T>.Build(new MultipleClientProxy<THub>(_lifetimeManager, connectionIds));
         }
 
-        public virtual T Group(string groupName)
+        public override T Group(string groupName)
         {
             return TypedClientBuilder<T>.Build(new GroupProxy<THub>(_lifetimeManager, groupName));
         }
 
-        public T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+        public override T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
             return TypedClientBuilder<T>.Build(new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludedConnectionIds));
         }
 
-        public T Groups(IReadOnlyList<string> groupNames)
+        public override T Groups(IReadOnlyList<string> groupNames)
         {
             return TypedClientBuilder<T>.Build(new MultipleGroupProxy<THub>(_lifetimeManager, groupNames));
         }
 
-        public virtual T User(string userId)
+        public override T User(string userId)
         {
             return TypedClientBuilder<T>.Build(new UserProxy<THub>(_lifetimeManager, userId));
         }
 
-        public virtual T Users(IReadOnlyList<string> userIds)
+        public override T Users(IReadOnlyList<string> userIds)
         {
             return TypedClientBuilder<T>.Build(new MultipleUserProxy<THub>(_lifetimeManager, userIds));
         }

--- a/src/SignalR/server/Core/src/Internal/HubContext.cs
+++ b/src/SignalR/server/Core/src/Internal/HubContext.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
     internal class HubContext<THub> : IHubContext<THub> where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
-        private readonly IHubClients _clients;
+        private readonly HubClientBase _clients;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             Groups = new GroupManager<THub>(lifetimeManager);
         }
 
-        public IHubClients Clients => _clients;
+        public HubClientBase Clients => _clients;
 
         public virtual IGroupManager Groups { get; }
     }

--- a/src/SignalR/server/Core/src/Internal/HubContext.cs
+++ b/src/SignalR/server/Core/src/Internal/HubContext.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
     internal class HubContext<THub> : IHubContext<THub> where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
-        private readonly HubClientBase _clients;
+        private readonly HubClientsBase _clients;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             Groups = new GroupManager<THub>(lifetimeManager);
         }
 
-        public HubClientBase Clients => _clients;
+        public HubClientsBase Clients => _clients;
 
         public virtual IGroupManager Groups { get; }
     }

--- a/src/SignalR/server/Core/src/Internal/HubContext`T.cs
+++ b/src/SignalR/server/Core/src/Internal/HubContext`T.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         where T : class
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
-        private readonly IHubClients<T> _clients;
+        private readonly HubClientsBase<T> _clients;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             Groups = new GroupManager<THub>(lifetimeManager);
         }
 
-        public IHubClients<T> Clients => _clients;
+        public HubClientsBase<T> Clients => _clients;
 
         public virtual IGroupManager Groups { get; }
     }

--- a/src/SignalR/server/Core/src/Internal/TypedHubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/TypedHubClients.cs
@@ -1,63 +1,63 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    internal class TypedHubClients<T> : IHubCallerClients<T>
+    internal class TypedHubClients<T> : HubCallerClientsBase<T>
     {
-        private readonly IHubCallerClients _hubClients;
+        private readonly HubCallerClientsBase _hubClients;
 
-        public TypedHubClients(IHubCallerClients dynamicContext)
+        public TypedHubClients(HubCallerClientsBase dynamicContext)
         {
             _hubClients = dynamicContext;
         }
 
-        public T All => TypedClientBuilder<T>.Build(_hubClients.All);
+        public override T All => TypedClientBuilder<T>.Build(_hubClients.All);
 
-        public T Caller => TypedClientBuilder<T>.Build(_hubClients.Caller);
+        public override T Caller => TypedClientBuilder<T>.Build(_hubClients.Caller);
 
-        public T Others => TypedClientBuilder<T>.Build(_hubClients.Others);
+        public override T Others => TypedClientBuilder<T>.Build(_hubClients.Others);
 
-        public T AllExcept(IReadOnlyList<string> excludedConnectionIds) => TypedClientBuilder<T>.Build(_hubClients.AllExcept(excludedConnectionIds));
+        public override T AllExcept(IReadOnlyList<string> excludedConnectionIds) => TypedClientBuilder<T>.Build(_hubClients.AllExcept(excludedConnectionIds));
 
-        public T Client(string connectionId)
+        public override T Client(string connectionId)
         {
             return TypedClientBuilder<T>.Build(_hubClients.Client(connectionId));
         }
 
-        public T Group(string groupName)
+        public override T Group(string groupName)
         {
             return TypedClientBuilder<T>.Build(_hubClients.Group(groupName));
         }
 
-        public T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+        public override T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
             return TypedClientBuilder<T>.Build(_hubClients.GroupExcept(groupName, excludedConnectionIds));
         }
 
-        public T Clients(IReadOnlyList<string> connectionIds)
+        public override T Clients(IReadOnlyList<string> connectionIds)
         {
             return TypedClientBuilder<T>.Build(_hubClients.Clients(connectionIds));
         }
 
-        public T Groups(IReadOnlyList<string> groupNames)
+        public override T Groups(IReadOnlyList<string> groupNames)
         {
             return TypedClientBuilder<T>.Build(_hubClients.Groups(groupNames));
         }
 
-        public T OthersInGroup(string groupName)
+        public override T OthersInGroup(string groupName)
         {
             return TypedClientBuilder<T>.Build(_hubClients.OthersInGroup(groupName));
         }
 
-        public T User(string userId)
+        public override T User(string userId)
         {
             return TypedClientBuilder<T>.Build(_hubClients.User(userId));
         }
 
-        public T Users(IReadOnlyList<string> userIds)
+        public override T Users(IReadOnlyList<string> userIds)
         {
             return TypedClientBuilder<T>.Build(_hubClients.Users(userIds));
         }

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
     public class CustomHubContext<THub> : IHubContext<THub> where THub : Hub
     {
-        public IHubClients Clients => throw new System.NotImplementedException();
+        public HubClientBase Clients => throw new System.NotImplementedException();
 
         public IGroupManager Groups => throw new System.NotImplementedException();
     }
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         where THub : Hub<T>
         where T : class
     {
-        public IHubClients<T> Clients => throw new System.NotImplementedException();
+        public HubClientsBase<T> Clients => throw new System.NotImplementedException();
 
         public IGroupManager Groups => throw new System.NotImplementedException();
     }

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
     public class CustomHubContext<THub> : IHubContext<THub> where THub : Hub
     {
-        public HubClientBase Clients => throw new System.NotImplementedException();
+        public HubClientsBase Clients => throw new System.NotImplementedException();
 
         public IGroupManager Groups => throw new System.NotImplementedException();
     }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/5382

I obsoleted the `IHubClients` and `IHubCallerClients` interfaces and created abstract base classes to replace them.