### PR TITLE
Update DataProtection.AzureStorage to use latest Azure SDK dependency (Microsoft.Azure.Storage.Blob)

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -41,6 +41,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
     <LatestPackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Bcl.Json.Sources" Version="$(MicrosoftBclJsonSourcesPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
@@ -159,7 +160,6 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsPackageVersion)" />
     <LatestPackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsPackageVersion)" />
     <LatestPackageReference Include="Utf8Json" Version="$(Utf8JsonPackageVersion)" />
-    <LatestPackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStoragePackageVersion)" />
     <LatestPackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsPackageVersion)" />
     <LatestPackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" />
     <LatestPackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -146,6 +146,7 @@
     <MicrosoftAspNetWebApiClientPackageVersion>5.2.6</MicrosoftAspNetWebApiClientPackageVersion>
     <!-- Partner teams -->
     <MicrosoftAzureKeyVaultPackageVersion>2.3.2</MicrosoftAzureKeyVaultPackageVersion>
+    <MicrosoftAzureStorageBlobPackageVersion>10.0.1</MicrosoftAzureStorageBlobPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>15.8.166</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.8.166</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftCodeAnalysisCommonPackageVersion>2.8.0</MicrosoftCodeAnalysisCommonPackageVersion>
@@ -162,7 +163,6 @@
     <MicrosoftWebAdministrationPackageVersion>11.1.0</MicrosoftWebAdministrationPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <SystemIdentityModelTokensJwtPackageVersion>5.3.0</SystemIdentityModelTokensJwtPackageVersion>
-    <WindowsAzureStoragePackageVersion>8.1.4</WindowsAzureStoragePackageVersion>
     <!-- Dependencies for Blazor. -->
     <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.10.0-preview-20190325.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from 2.1/2.2 branches used for site extension build -->

--- a/src/DataProtection/AzureStorage/ref/Microsoft.AspNetCore.DataProtection.AzureStorage.csproj
+++ b/src/DataProtection/AzureStorage/ref/Microsoft.AspNetCore.DataProtection.AzureStorage.csproj
@@ -6,6 +6,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Microsoft.AspNetCore.DataProtection.AzureStorage.netcoreapp3.0.cs" />
     <Reference Include="Microsoft.AspNetCore.DataProtection"  />
-    <Reference Include="WindowsAzure.Storage"  />
+    <Reference Include="Microsoft.Azure.Storage.Blob"  />
   </ItemGroup>
 </Project>

--- a/src/DataProtection/AzureStorage/ref/Microsoft.AspNetCore.DataProtection.AzureStorage.netcoreapp3.0.cs
+++ b/src/DataProtection/AzureStorage/ref/Microsoft.AspNetCore.DataProtection.AzureStorage.netcoreapp3.0.cs
@@ -5,9 +5,9 @@ namespace Microsoft.AspNetCore.DataProtection
 {
     public static partial class AzureDataProtectionBuilderExtensions
     {
-        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer container, string blobName) { throw null; }
-        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.WindowsAzure.Storage.Blob.CloudBlockBlob blobReference) { throw null; }
-        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.WindowsAzure.Storage.CloudStorageAccount storageAccount, string relativePath) { throw null; }
+        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.Azure.Storage.Blob.CloudBlobContainer container, string blobName) { throw null; }
+        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.Azure.Storage.Blob.CloudBlockBlob blobReference) { throw null; }
+        public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, Microsoft.Azure.Storage.CloudStorageAccount storageAccount, string relativePath) { throw null; }
         public static Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder PersistKeysToAzureBlobStorage(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder builder, System.Uri blobUri) { throw null; }
     }
 }
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.DataProtection.AzureStorage
 {
     public sealed partial class AzureBlobXmlRepository : Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository
     {
-        public AzureBlobXmlRepository(System.Func<Microsoft.WindowsAzure.Storage.Blob.ICloudBlob> blobRefFactory) { }
+        public AzureBlobXmlRepository(System.Func<Microsoft.Azure.Storage.Blob.ICloudBlob> blobRefFactory) { }
         public System.Collections.Generic.IReadOnlyCollection<System.Xml.Linq.XElement> GetAllElements() { throw null; }
         public void StoreElement(System.Xml.Linq.XElement element, string friendlyName) { }
     }

--- a/src/DataProtection/AzureStorage/src/AzureBlobXmlRepository.cs
+++ b/src/DataProtection/AzureStorage/src/AzureBlobXmlRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.DataProtection.Repositories;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
 
 namespace Microsoft.AspNetCore.DataProtection.AzureStorage
 {
@@ -42,12 +42,7 @@ namespace Microsoft.AspNetCore.DataProtection.AzureStorage
         /// concurrent threads, and each invocation must return a new object.</param>
         public AzureBlobXmlRepository(Func<ICloudBlob> blobRefFactory)
         {
-            if (blobRefFactory == null)
-            {
-                throw new ArgumentNullException(nameof(blobRefFactory));
-            }
-
-            _blobRefFactory = blobRefFactory;
+            _blobRefFactory = blobRefFactory ?? throw new ArgumentNullException(nameof(blobRefFactory));
             _random = new Random();
         }
 

--- a/src/DataProtection/AzureStorage/src/AzureDataProtectionBuilderExtensions.cs
+++ b/src/DataProtection/AzureStorage/src/AzureDataProtectionBuilderExtensions.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.DataProtection.AzureStorage;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Auth;
+using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.AspNetCore.DataProtection
 {

--- a/src/DataProtection/AzureStorage/src/Microsoft.AspNetCore.DataProtection.AzureStorage.csproj
+++ b/src/DataProtection/AzureStorage/src/Microsoft.AspNetCore.DataProtection.AzureStorage.csproj
@@ -11,7 +11,12 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.DataProtection" />
-    <Reference Include="WindowsAzure.Storage" />
+    <Reference Include="Microsoft.Azure.Storage.Blob" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(AspNetCoreMajorMinorVersion)' == '3.0'">
+    <!-- This dependency was replaced by Microsoft.Azure.Storage.Blob between 3.0 and 2.2. This suppression can be removed after 3.0 is complete. -->
+    <SuppressBaselineReference Include="WindowsAzure.Storage" />
   </ItemGroup>
 
 </Project>

--- a/src/DataProtection/AzureStorage/test/AzureBlobXmlRepositoryTests.cs
+++ b/src/DataProtection/AzureStorage/test/AzureBlobXmlRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
 using Moq;
 using Xunit;
 

--- a/src/DataProtection/AzureStorage/test/AzureDataProtectionBuilderExtensionsTest.cs
+++ b/src/DataProtection/AzureStorage/test/AzureDataProtectionBuilderExtensionsTest.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
 using Xunit;
 
 namespace Microsoft.AspNetCore.DataProtection.AzureStorage

--- a/src/DataProtection/samples/AzureBlob/Program.cs
+++ b/src/DataProtection/samples/AzureBlob/Program.cs
@@ -1,11 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace AzureBlob


### PR DESCRIPTION
Fix https://github.com/aspnet/AspNetCore/issues/8472. The Azure Storage SDK has gone through some major updates since our last update. Notably, the entire API has been moved into a namespace and the packages have new IDs. This updates the DataProtection.AzureStorage extension to use the new APIs. It is a breaking change because of the new namespaces and APIs.
