### PR TITLE
[SignalR] Test definition isn't async

### DIFF
--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -148,7 +148,7 @@ describe("HubConnectionBuilder", () => {
         });
     });
 
-    describe("configureLogging", async () => {
+    describe("configureLogging", () => {
         function testLogLevels(logger: ILogger, minLevel: LogLevel) {
             const capturingConsole = new CapturingConsole();
             (logger as ConsoleLogger).outputConsole = capturingConsole;


### PR DESCRIPTION
Jest is warning us that this will be deprecated in the future. There's no reason for the `describe` callback to be `async` since all it's doing is registering tests through nested `it` calls.