### PR TITLE
Fix AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires 

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1164,6 +1164,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         internal async Task WaitForConnectionErrorAsync<TException>(bool ignoreNonGoAwayFrames, int expectedLastStreamId, Http2ErrorCode expectedErrorCode, params string[] expectedErrorMessage)
             where TException : Exception
         {
+            await WaitForConnectionErrorAsyncDoNotCloseTransport<TException>(ignoreNonGoAwayFrames, expectedLastStreamId, expectedErrorCode, expectedErrorMessage);
+            _pair.Application.Output.Complete();
+        }
+
+        internal async Task WaitForConnectionErrorAsyncDoNotCloseTransport<TException>(bool ignoreNonGoAwayFrames, int expectedLastStreamId, Http2ErrorCode expectedErrorCode, params string[] expectedErrorMessage)
+            where TException : Exception
+        {
             var frame = await ReceiveFrameAsync();
 
             if (ignoreNonGoAwayFrames)
@@ -1184,7 +1191,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             }
 
             await _connectionTask.DefaultTimeout();
-            _pair.Application.Output.Complete();
+            TestApplicationErrorLogger.LogInformation("Stopping Connection From ConnectionErrorAsync");
         }
 
         internal async Task WaitForStreamErrorAsync(int expectedStreamId, Http2ErrorCode expectedErrorCode, string expectedErrorMessage)


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1879.

The reason this test was flaky was due to a race between `WaitForConnectionErrorAsync` calling `Output.Complete()` and the cancellation token check before calling `await SendDataAsync(1, new byte[100], endStream: false);`. The output would be complete and we would try to send data, which would throw because the pipe is complete.

The fix I have is to delay calling Complete until we know the loop exited.