### PR TITLE
Revert "Skip IIS Express on Windows 7 (#8330)"

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/TestMatrix.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/TestMatrix.cs
@@ -289,15 +289,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     }
                 }
 
-                // https://github.com/aspnet/AspNetCore/issues/8329
-                if (hostingModel == HostingModel.OutOfProcess &&
-                    server == ServerType.IISExpress &&
-                    Environment.OSVersion.Version.Major == 6 &&
-                    Environment.OSVersion.Version.Minor == 1)
-                {
-                    continue;
-                }
-
                 variants.Add(new TestVariant()
                 {
                     Server = server,

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                from s in new string[] { (_minPort - 1).ToString(), (_maxPort + 1).ToString(), "noninteger" }
                select new object[] { v, s };
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/8329")]
+        [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
         public async Task EnvVarInWebConfig_Valid(TestVariant variant)
         {
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             Assert.Equal(port, new Uri(responseText).Port);
         }
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/8329")]
+        [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
         public async Task EnvVarInWebConfig_Empty(TestVariant variant)
         {
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             Assert.InRange(new Uri(responseText).Port, _minPort, _maxPort);
         }
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/8329")]
+        [ConditionalTheory]
         [MemberData(nameof(InvalidTestVariants))]
         public async Task EnvVarInWebConfig_Invalid(TestVariant variant, string port)
         {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/HelloWorldTest.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/HelloWorldTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                 .WithTfms(Tfm.NetCoreApp30)
                 .WithAllApplicationTypes();
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/8329")]
+        [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
         public async Task HelloWorld(TestVariant variant)
         {

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             => TestMatrix.ForServers(DeployerSelector.ServerType)
                 .WithTfms(Tfm.NetCoreApp30);
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/8329")]
+        [ConditionalTheory]
         [RequiresIIS(IISCapability.WindowsAuthentication)]
         [MemberData(nameof(TestVariants))]
         public async Task NtlmAuthentication(TestVariant variant)

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/RequiresIISAttribute.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/RequiresIISAttribute.cs
@@ -10,22 +10,13 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
     public sealed class RequiresIISAttribute : Attribute, ITestCondition
     {
-        public bool IsMet { get ; } = IISExpressAncmSchema.SupportsInProcessHosting;
+        public bool IsMet => IISExpressAncmSchema.SupportsInProcessHosting;
 
-        public string SkipReason { get; } = IISExpressAncmSchema.SkipReason;
+        public string SkipReason => IISExpressAncmSchema.SkipReason;
 
-        public RequiresIISAttribute()
-        {
-            // https://github.com/aspnet/AspNetCore/issues/8329
-            if (Environment.OSVersion.Version.Major == 6 &&
-                Environment.OSVersion.Version.Minor == 1)
-            {
-                IsMet = false;
-                SkipReason = "Skipped on Windows 7";
-            }
-        }
+        public RequiresIISAttribute() { }
 
-        public RequiresIISAttribute(IISCapability capabilities) : this()
+        public RequiresIISAttribute(IISCapability capabilities)
         {
             // IISCapabilities aren't pertinent to IISExpress
         }


### PR DESCRIPTION
This reverts commit b2a58ab8ded6bc2ab55edb835b00d8b601921c4f.

We disabled a large number of OutOfProc tests due to a change in coreclr. This reverts it as it has been fixed.
