### PR TITLE
Fix flaky routing test

### DIFF
--- a/src/Http/Routing/test/UnitTests/Matching/CandidateSetTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/CandidateSetTest.cs
@@ -325,10 +325,11 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var ex = Assert.Throws<InvalidOperationException>(() => candidateSet.ExpandEndpoint(0, Array.Empty<Endpoint>(), comparer));
 
             // Assert
-            Assert.Equal(@"
-Using ExpandEndpoint requires that the replaced endpoint have a unique priority. The following endpoints were found with the same priority:
-test: /0
-test: /1"
+            Assert.Equal(@"Using ExpandEndpoint requires that the replaced endpoint have a unique priority. The following endpoints were found with the same priority:" +
+                Environment.NewLine +
+                "test: /0" +
+                Environment.NewLine +
+                "test: /1"
                 .TrimStart(), ex.Message);
         }
 


### PR DESCRIPTION
Bunch of helix tests failing due to newlines not matching https://mc.dot.net/#/user/aspnetcore/pr~2Faspnet~2Faspnetcore/ci/20190417.64/workItem/Microsoft.AspNetCore.Routing.Tests-netcoreapp3.0/wilogs.

I think this is because on helix, we build the dlls on windows and then test on linux, so \r\n gets compiled in. 