### PR TITLE
Lazy create EndpointRouting statemachines

### DIFF
--- a/src/Http/Routing/src/EndpointMiddleware.cs
+++ b/src/Http/Routing/src/EndpointMiddleware.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Routing
             _routeOptions = routeOptions?.Value ?? throw new ArgumentNullException(nameof(routeOptions));
         }
 
-        public async Task Invoke(HttpContext httpContext)
+        public Task Invoke(HttpContext httpContext)
         {
             var endpoint = httpContext.Features.Get<IEndpointFeature>()?.Endpoint;
             if (endpoint?.RequestDelegate != null)
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Routing
                 if (_routeOptions.SuppressCheckForUnhandledSecurityMetadata)
                 {
                     // User opted out of this check.
-                    return;
+                    return Task.CompletedTask;
                 }
 
                 if (endpoint.Metadata.GetMetadata<IAuthorizeData>() != null &&
@@ -58,17 +58,34 @@ namespace Microsoft.AspNetCore.Routing
 
                 try
                 {
-                    await endpoint.RequestDelegate(httpContext);
+                    var requestTask = endpoint.RequestDelegate(httpContext);
+                    if (!requestTask.IsCompletedSuccessfully)
+                    {
+                        return AwaitRequestTask(endpoint, requestTask, _logger);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Log.ExecutedEndpoint(_logger, endpoint);
+                    return Task.FromException(exception);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            return _next(httpContext);
+
+            static async Task AwaitRequestTask(Endpoint endpoint, Task requestTask, ILogger logger)
+            {
+                try
+                {
+                    await requestTask;
                 }
                 finally
                 {
-                    Log.ExecutedEndpoint(_logger, endpoint);
+                    Log.ExecutedEndpoint(logger, endpoint);
                 }
-
-                return;
             }
-
-            await _next(httpContext);
         }
 
         private static void ThrowMissingAuthMiddlewareException(Endpoint endpoint)

--- a/src/Http/Routing/src/EndpointMiddleware.cs
+++ b/src/Http/Routing/src/EndpointMiddleware.cs
@@ -70,6 +70,7 @@ namespace Microsoft.AspNetCore.Routing
                     return Task.FromException(exception);
                 }
 
+                Log.ExecutedEndpoint(_logger, endpoint);
                 return Task.CompletedTask;
             }
 

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -53,15 +53,24 @@ namespace Microsoft.AspNetCore.Routing
             _endpointDataSource = new CompositeEndpointDataSource(endpointRouteBuilder.DataSources);
         }
 
-        public async Task Invoke(HttpContext httpContext)
+        public Task Invoke(HttpContext httpContext)
         {
             var feature = new EndpointSelectorContext();
 
             // There's an inherent race condition between waiting for init and accessing the matcher
             // this is OK because once `_matcher` is initialized, it will not be set to null again.
-            var matcher = await InitializeAsync();
+            var matcherTask = InitializeAsync();
+            if (!matcherTask.IsCompletedSuccessfully)
+            {
+                return AwaitMatcher(this, httpContext, feature, matcherTask);
+            }
 
-            await matcher.MatchAsync(httpContext, feature);
+            var matchTask = matcherTask.Result.MatchAsync(httpContext, feature);
+            if (!matchTask.IsCompletedSuccessfully)
+            {
+                return AwaitMatch(this, httpContext, feature, matchTask);
+            }
+
             if (feature.Endpoint != null)
             {
                 // Set the endpoint feature only on success. This means we won't overwrite any
@@ -75,7 +84,39 @@ namespace Microsoft.AspNetCore.Routing
                 Log.MatchFailure(_logger);
             }
 
-            await _next(httpContext);
+            return _next(httpContext);
+
+            // Awaited fallbacks for when the Tasks do not synchronously complete
+            static async Task AwaitMatcher(EndpointRoutingMiddleware middleware, HttpContext httpContext, EndpointSelectorContext feature, Task<Matcher> matcherTask)
+            {
+                var matcher = await matcherTask;
+                await matcher.MatchAsync(httpContext, feature);
+                await CompleteAwaited(middleware, httpContext, feature);
+            }
+
+            static async Task AwaitMatch(EndpointRoutingMiddleware middleware, HttpContext httpContext, EndpointSelectorContext feature, Task matchTask)
+            {
+                await matchTask;
+                await CompleteAwaited(middleware, httpContext, feature);
+            }
+
+            static Task CompleteAwaited(EndpointRoutingMiddleware middleware, HttpContext httpContext, EndpointSelectorContext feature)
+            {
+                if (feature.Endpoint != null)
+                {
+                    // Set the endpoint feature only on success. This means we won't overwrite any
+                    // existing state for related features unless we did something.
+                    SetFeatures(httpContext, feature);
+
+                    Log.MatchSuccess(middleware._logger, feature);
+                }
+                else
+                {
+                    Log.MatchFailure(middleware._logger);
+                }
+
+                return middleware._next(httpContext);
+            }
         }
 
         private static void SetFeatures(HttpContext httpContext, EndpointSelectorContext context)


### PR DESCRIPTION
* Lazy create EndpointRouting statemachines
* Lazy create EndpointMiddleware statemachine

![image](https://user-images.githubusercontent.com/1142958/56375677-17c6c200-61fe-11e9-9b10-4c585c16d1e7.png)

Normally complete sync; so skip the async machines in the common path


/cc @rynowak @pranavkm
