### PR TITLE
Lazy create StaticFileMiddleware statemachine

### DIFF
--- a/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
+++ b/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
@@ -103,7 +103,6 @@ namespace Microsoft.AspNetCore.StaticFiles
     public partial class StaticFileMiddleware
     {
         public StaticFileMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnv, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.StaticFileOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
     }
     public partial class StaticFileResponseContext

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -130,7 +130,8 @@ namespace Microsoft.AspNetCore.StaticFiles
                     {
                         context.Response.Clear();
                     }
-                    break;
+                    await _next(context);
+                    return;
                 case StaticFileContext.PreconditionState.NotModified:
                     _logger.FileNotModified(fileContext.SubPath);
                     await fileContext.SendStatusAsync(Constants.Status304NotModified);

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             var fileContext = new StaticFileContext(context, _options, _matchUrl, _logger, _fileProvider, _contentTypeProvider);
 
@@ -95,52 +95,57 @@ namespace Microsoft.AspNetCore.StaticFiles
             else
             {
                 // If we get here, we can try to serve the file
-                fileContext.ComprehendRequestHeaders();
-                switch (fileContext.GetPreconditionState())
-                {
-                    case StaticFileContext.PreconditionState.Unspecified:
-                    case StaticFileContext.PreconditionState.ShouldProcess:
-                        if (fileContext.IsHeadMethod)
-                        {
-                            await fileContext.SendStatusAsync(Constants.Status200Ok);
-                            return;
-                        }
-
-                        try
-                        {
-                            if (fileContext.IsRangeRequest)
-                            {
-                                await fileContext.SendRangeAsync();
-                                return;
-                            }
-
-                            await fileContext.SendAsync();
-                            _logger.FileServed(fileContext.SubPath, fileContext.PhysicalPath);
-                            return;
-                        }
-                        catch (FileNotFoundException)
-                        {
-                            context.Response.Clear();
-                        }
-                        break;
-                    case StaticFileContext.PreconditionState.NotModified:
-                        _logger.FileNotModified(fileContext.SubPath);
-                        await fileContext.SendStatusAsync(Constants.Status304NotModified);
-                        return;
-
-                    case StaticFileContext.PreconditionState.PreconditionFailed:
-                        _logger.PreconditionFailed(fileContext.SubPath);
-                        await fileContext.SendStatusAsync(Constants.Status412PreconditionFailed);
-                        return;
-
-                    default:
-                        var exception = new NotImplementedException(fileContext.GetPreconditionState().ToString());
-                        Debug.Fail(exception.ToString());
-                        throw exception;
-                }
+                return ServeStaticFile(context, fileContext);
             }
 
-            await _next(context);
+            return _next(context);
+        }
+
+        private async Task ServeStaticFile(HttpContext context, StaticFileContext fileContext)
+        {
+            fileContext.ComprehendRequestHeaders();
+            switch (fileContext.GetPreconditionState())
+            {
+                case StaticFileContext.PreconditionState.Unspecified:
+                case StaticFileContext.PreconditionState.ShouldProcess:
+                    if (fileContext.IsHeadMethod)
+                    {
+                        await fileContext.SendStatusAsync(Constants.Status200Ok);
+                        return;
+                    }
+
+                    try
+                    {
+                        if (fileContext.IsRangeRequest)
+                        {
+                            await fileContext.SendRangeAsync();
+                            return;
+                        }
+
+                        await fileContext.SendAsync();
+                        _logger.FileServed(fileContext.SubPath, fileContext.PhysicalPath);
+                        return;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        context.Response.Clear();
+                    }
+                    break;
+                case StaticFileContext.PreconditionState.NotModified:
+                    _logger.FileNotModified(fileContext.SubPath);
+                    await fileContext.SendStatusAsync(Constants.Status304NotModified);
+                    return;
+
+                case StaticFileContext.PreconditionState.PreconditionFailed:
+                    _logger.PreconditionFailed(fileContext.SubPath);
+                    await fileContext.SendStatusAsync(Constants.Status412PreconditionFailed);
+                    return;
+
+                default:
+                    var exception = new NotImplementedException(fileContext.GetPreconditionState().ToString());
+                    Debug.Fail(exception.ToString());
+                    throw exception;
+            }
         }
     }
 }


### PR DESCRIPTION
* Lazy create StaticFileMiddleware statemachine

@rynowak @JamesNK @Tratcher question...

`dotnet new mvc` etc adds `app.UseStaticFiles();` prior to `app.UseRouting()` and `app.UseEndpoints()`  (also before auth) is this desirable?

https://github.com/aspnet/AspNetCore/blob/8b536b08ca76126e58f662b7f500bb191116f2bd/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs#L157-L174

e.g. it outputs
```csharp
app.UseStaticFiles();

app.UseCookiePolicy();

app.UseRouting();

app.UseAuthorization();

app.UseEndpoints(endpoints =>
{
    endpoints.MapControllerRoute(
        name: "default",
        pattern: "{controller=Home}/{action=Index}/{id?}");
    endpoints.MapRazorPages();
});
```
For the call chain

![image](https://user-images.githubusercontent.com/1142958/56378573-64fa6200-6205-11e9-86a4-9b015301da0b.png)
