### PR TITLE
Stop running InstallVisualStudio.ps1 during CI builds

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -120,9 +120,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - powershell: ./eng/scripts/InstallVisualStudio.ps1 -Edition BuildTools -Quiet
-      displayName: Install Build Tools for Visual Studio 2019
   - ${{ if eq(parameters.installNodeJs, 'true') }}:
     - task: NodeTool@0
       displayName: Install Node 10.x

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -13,7 +13,7 @@ Building ASP.NET Core on Windows requires:
 
 * Windows 10
 * At least 10 GB of disk space and a good internet connection (our build scripts download a lot of tools and dependencies)
-* Visual Studio **2019 Preview**. <https://visualstudio.com>
+* Visual Studio 2019. <https://visualstudio.com>
     * To install the exact required components, run [eng/scripts/InstallVisualStudio.ps1](/eng/scripts/InstallVisualStudio.ps1).
         ```ps1
         PS> ./eng/scripts/InstallVisualStudio.ps1

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -33,6 +33,11 @@ param(
     [switch]$Quiet
 )
 
+if ($env:TF_BUILD) {
+    Write-Error 'This script is not intended for use on CI. It is only meant to be used to install a local developer environment. If you need to change Visual Studio requirements in CI agents, contact the @aspnet/build team.'
+    exit 1
+}
+
 if ($Passive -and $Quiet) {
     Write-Host -ForegroundColor Red "Error: The -Passive and -Quiet options cannot be used together."
     Write-Host -ForegroundColor Red "Run ``Get-Help $PSCommandPath`` for more details."

--- a/korebuild.json
+++ b/korebuild.json
@@ -12,7 +12,7 @@
         "Windows"
       ],
       "includePrerelease": true,
-      "versionRange": "[16.0.28608.199, 17.0)",
+      "versionRange": "[16.0, 17.0)",
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",


### PR DESCRIPTION
Resolves https://github.com/aspnet/AspNetCore-Internal/issues/2194

VS2019.BT queues should have VS 2019 RTM now, so this step _should_ be unnecessary.