### PR TITLE
Avoid async in AuthorizationMiddleware when no metadata

### DIFF
--- a/src/Security/Authorization/Policy/ref/Microsoft.AspNetCore.Authorization.Policy.netcoreapp3.0.cs
+++ b/src/Security/Authorization/Policy/ref/Microsoft.AspNetCore.Authorization.Policy.netcoreapp3.0.cs
@@ -6,7 +6,6 @@ namespace Microsoft.AspNetCore.Authorization
     public partial class AuthorizationMiddleware
     {
         public AuthorizationMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider policyProvider) { }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
     }
 }

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -50,7 +50,6 @@ namespace Microsoft.AspNetCore.Authorization
             // Flag to indicate to other systems, e.g. MVC, that authorization middleware was run for this request
             context.Items[AuthorizationMiddlewareInvokedKey] = AuthorizationMiddlewareInvokedValue;
 
-            // IMPORTANT: Changes to authorization logic should be mirrored in MVC's AuthorizeFilter
             var authorizeData = endpoint?.Metadata.GetOrderedMetadata<IAuthorizeData>();
             if (authorizeData == null || authorizeData.Count() == 0)
             {
@@ -62,6 +61,7 @@ namespace Microsoft.AspNetCore.Authorization
 
         private async Task EvaluatePolicy(HttpContext context, Endpoint endpoint, IEnumerable<IAuthorizeData> authorizeData)
         {
+            // IMPORTANT: Changes to authorization logic should be mirrored in MVC's AuthorizeFilter
             var policy = await AuthorizationPolicy.CombineAsync(_policyProvider, authorizeData);
             if (policy == null)
             {

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -51,8 +51,8 @@ namespace Microsoft.AspNetCore.Authorization
             context.Items[AuthorizationMiddlewareInvokedKey] = AuthorizationMiddlewareInvokedValue;
 
             // IMPORTANT: Changes to authorization logic should be mirrored in MVC's AuthorizeFilter
-            var authorizeData = endpoint?.Metadata.GetOrderedMetadata<IAuthorizeData>() ?? Array.Empty<IAuthorizeData>();
-            if (authorizeData.Count() == 0)
+            var authorizeData = endpoint?.Metadata.GetOrderedMetadata<IAuthorizeData>();
+            if (authorizeData == null || authorizeData.Count() == 0)
             {
                 return _next(context);
             }


### PR DESCRIPTION
Minor performance optimization. Avoid the overhead of an async state machine when it is not needed.