### PR TITLE
[IdentityUI] Switch to Configure from PostConfigure

### DIFF
--- a/src/Identity/UI/src/IdentityDefaultUIConfigureOptions.cs
+++ b/src/Identity/UI/src/IdentityDefaultUIConfigureOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Identity.UI
     internal class IdentityDefaultUIConfigureOptions<TUser> :
         IPostConfigureOptions<RazorPagesOptions>,
         IPostConfigureOptions<StaticFileOptions>,
-        IPostConfigureOptions<CookieAuthenticationOptions> where TUser : class
+        IConfigureNamedOptions<CookieAuthenticationOptions> where TUser : class
     {
         private const string IdentityUIDefaultAreaName = "Identity";
 
@@ -72,7 +72,9 @@ namespace Microsoft.AspNetCore.Identity.UI
             options.FileProvider = new CompositeFileProvider(options.FileProvider, filesProvider);
         }
 
-        public void PostConfigure(string name, CookieAuthenticationOptions options)
+        public void Configure(CookieAuthenticationOptions options) { }
+
+        public void Configure(string name, CookieAuthenticationOptions options)
         {
             name = name ?? throw new ArgumentNullException(nameof(name));
             options = options ?? throw new ArgumentNullException(nameof(options));


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/5828

Makes it so configuring after AddDefaultIdentity behaves like normal as opposed to overriding normal configures when done as a PostConfigure