### PR TITLE
UriHelper use Ordinal string.IndexOf

### DIFF
--- a/src/Http/Http.Extensions/src/UriHelper.cs
+++ b/src/Http/Http.Extensions/src/UriHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
     public static class UriHelper
     {
         private const char ForwardSlash = '/';
-        private const char Pound = '#';
+        private const char Hash = '#';
         private const char QuestionMark = '?';
         private const string SchemeDelimiter = "://";
 
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
 
             int searchIndex;
             var limit = uri.Length;
-            if ((searchIndex = uri.IndexOf(Pound, startIndex)) >= 0 && searchIndex < limit)
+            if ((searchIndex = uri.IndexOf(Hash, startIndex)) >= 0 && searchIndex < limit)
             {
                 fragment = FragmentString.FromUriComponent(uri.Substring(searchIndex));
                 limit = searchIndex;

--- a/src/Http/Http.Extensions/src/UriHelper.cs
+++ b/src/Http/Http.Extensions/src/UriHelper.cs
@@ -11,9 +11,9 @@ namespace Microsoft.AspNetCore.Http.Extensions
     /// </summary>
     public static class UriHelper
     {
-        private const string ForwardSlash = "/";
-        private const string Pound = "#";
-        private const string QuestionMark = "?";
+        private const char ForwardSlash = '/';
+        private const char Pound = '#';
+        private const char QuestionMark = '?';
         private const string SchemeDelimiter = "://";
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
             path = new PathString();
             query = new QueryString();
             fragment = new FragmentString();
-            var startIndex = uri.IndexOf(SchemeDelimiter);
+            var startIndex = uri.IndexOf(SchemeDelimiter, StringComparison.Ordinal);
 
             if (startIndex < 0)
             {
@@ -115,9 +115,8 @@ namespace Microsoft.AspNetCore.Http.Extensions
             // PERF: Calculate the end of the scheme for next IndexOf
             startIndex += SchemeDelimiter.Length;
 
-            var searchIndex = -1;
+            int searchIndex;
             var limit = uri.Length;
-
             if ((searchIndex = uri.IndexOf(Pound, startIndex)) >= 0 && searchIndex < limit)
             {
                 fragment = FragmentString.FromUriComponent(uri.Substring(searchIndex));


### PR DESCRIPTION
Was wondering why the Proxy scenario was hitting Globablization https://github.com/aspnet/AspNetCore/issues/9404#issuecomment-484752406

`string.IndexOf(string)` is current culture by default; unlike most of the other string apis which are Ordinal; so switch to using Ordinal IndexOf to find things.

/cc @GrabYourPitchforks as I know you love the inconsistency of these apis 😉 