### PR TITLE
Use .IndexOf(char/byte) where possible

### DIFF
--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                     var port = ReadOnlySpan<char>.Empty;
 
                     // Split into host and port
-                    var pivot = host.IndexOf(":");
+                    var pivot = host.IndexOf(':');
                     if (pivot >= 0)
                     {
                         port = host.Slice(pivot + 1);

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                 // https://tools.ietf.org/html/rfc6750#section-3.1
                 // WWW-Authenticate: Bearer realm="example", error="invalid_token", error_description="The access token expired"
                 var builder = new StringBuilder(Options.Challenge);
-                if (Options.Challenge.IndexOf(" ", StringComparison.Ordinal) > 0)
+                if (Options.Challenge.IndexOf(' ') > 0)
                 {
                     // Only add a comma after the first param, if any
                     builder.Append(',');


### PR DESCRIPTION
As its faster. Also string.IndexOf(string) is by default CurrentCulture so its much faster than that.

Follow up to https://github.com/aspnet/AspNetCore/pull/9537

FormPipeReader goes a bit ugly using the ternaries

/cc @GrabYourPitchforks for more spice