### PR TITLE
Lock during finalizer to not race with dispose in MemoryPoolBlock

### DIFF
--- a/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
+++ b/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         private const int _ulongMaxValueLength = 20;
 
         private readonly Pipe _pipe;
-        private readonly MemoryPool<byte> _memoryPool = new DiagnosticMemoryPool(new SlabMemoryPool());
+        private readonly MemoryPool<byte> _memoryPool = KestrelMemoryPool.Create();
 
         public PipelineExtensionTests()
         {

--- a/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
+++ b/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         private const int _ulongMaxValueLength = 20;
 
         private readonly Pipe _pipe;
-        private readonly MemoryPool<byte> _memoryPool = KestrelMemoryPool.Create();
+        private readonly MemoryPool<byte> _memoryPool = new DiagnosticMemoryPool(new SlabMemoryPool());
 
         public PipelineExtensionTests()
         {

--- a/src/Servers/Kestrel/Core/test/SlabMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/SlabMemoryPoolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;

--- a/src/Servers/Kestrel/Core/test/SlabMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/SlabMemoryPoolTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolBlock.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolBlock.cs
@@ -42,11 +42,7 @@ namespace System.Buffers
 
         ~MemoryPoolBlock()
         {
-            if (Slab != null && Slab.IsActive)
-            {
-                // Need to make a new object because this one is being finalized
-                Pool.Return(new MemoryPoolBlock(Pool, Slab, _offset, _length));
-            }
+            Pool.RefreshBlock(Slab, _offset, _length);
         }
 
         public void Dispose()

--- a/src/Shared/Buffers.MemoryPool/SlabMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/SlabMemoryPool.cs
@@ -160,6 +160,18 @@ namespace System.Buffers
             }
         }
 
+        internal void RefreshBlock(MemoryPoolSlab slab, int offset, int length)
+        {
+            lock (_disposeSync)
+            {
+                if (!_isDisposed && slab != null && slab.IsActive)
+                {
+                    // Need to make a new object because this one is being finalized
+                    Return(new MemoryPoolBlock(this, slab, offset, length));
+                }
+            }
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (_isDisposed)

--- a/src/Shared/Buffers.MemoryPool/SlabMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/SlabMemoryPool.cs
@@ -160,6 +160,7 @@ namespace System.Buffers
             }
         }
 
+        // This method can ONLY be called from the finalizer of MemoryPoolBlock
         internal void RefreshBlock(MemoryPoolSlab slab, int offset, int length)
         {
             lock (_disposeSync)
@@ -167,6 +168,8 @@ namespace System.Buffers
                 if (!_isDisposed && slab != null && slab.IsActive)
                 {
                     // Need to make a new object because this one is being finalized
+                    // Note, this must be called within the _disposeSync lock because the block
+                    // could be disposed at the same time as the finalizer.
                     Return(new MemoryPoolBlock(this, slab, offset, length));
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2324

From what I can tell, the reason these tests were failing were due to a race between Dispose and the Finalizer of the MemoryPoolBlock. The test causing it was https://github.com/aspnet/AspNetCore/blob/77d66682ab29240f3e1b030e24b38baa7b6788cd/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs#L87, which has a Dispose method on the test itself.

My only thought was the _memoryPool that is created (DiagnosticMemoryPool) isn't calling dispose on the underlying MemoryPool (SlabMemoryPool).