### PR TITLE
Support internal pull requests

### DIFF
--- a/.azure/pipelines/e2e-tests.yml
+++ b/.azure/pipelines/e2e-tests.yml
@@ -5,7 +5,7 @@ jobs:
   pool:
     vmImage: vs2017-win2016
   strategy:
-    maxParallel: 4
+    maxParallel: 8
     matrix:
       Portable_Node8:
         Test.RuntimeIdentifier: none
@@ -87,7 +87,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   strategy:
-    maxParallel: 4
+    maxParallel: 8
     matrix:
       Portable_Node8:
         Test.RuntimeIdentifier: none

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -93,9 +93,9 @@ jobs:
     BuildDirectory: ${{ parameters.buildDirectory }}
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-    ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal')) }}:
+    ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'PullRequest'))) }}:
       _SignType:
-    ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
+    ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest'))) }}:
       TeamName: AspNetCore
       _SignType: real
     ${{ insert }}: ${{ parameters.variables }}

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -6,7 +6,7 @@
 #   jobDisplayName: string
 #       The friendly job name to display in the UI. Defaults to the name of the OS.
 #   poolName: string
-#       The name of the VSTS agent queue to use.
+#       The name of the Azure DevOps agent pool to use.
 #   agentOs: string
 #       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, macOS }
 #   buildArgs: string
@@ -77,10 +77,10 @@ jobs:
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
       vmImage: ubuntu-16.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
-      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCorePublic-Int-Pool
         queue: BuildPool.Windows.10.Amd64.VS2017.Open
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCoreInternal-Int-Pool
         queue: BuildPool.Windows.10.Amd64.VS2017
   variables:

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -93,9 +93,9 @@ jobs:
     BuildDirectory: ${{ parameters.buildDirectory }}
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-    ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'PullRequest'))) }}:
+    ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'PullRequest')) }}:
       _SignType:
-    ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest'))) }}:
+    ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       TeamName: AspNetCore
       _SignType: real
     ${{ insert }}: ${{ parameters.variables }}


### PR DESCRIPTION
- aspnet/AspNetCore-Internal#2231
- use internal pools for all internal builds
- do not sign in builds for internal pull requests

nits:
- bit of VSTS -> Azure DevOps
- restore higher `maxParallel` values for E2E tests on Linux and Windows