### PR TITLE
Skip string.Equals in FastPathTokenizer

### DIFF
--- a/src/Http/Routing/src/Matching/FastPathTokenizer.cs
+++ b/src/Http/Routing/src/Matching/FastPathTokenizer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         public static int Tokenize(string path, Span<PathSegment> segments)
         {
             // This can happen in test scenarios.
-            if (path == string.Empty)
+            if (string.IsNullOrEmpty(path))
             {
                 return 0;
             }


### PR DESCRIPTION
`string.Equals` is more heavyweight than `string.IsNullOrEmpty` 

![image](https://user-images.githubusercontent.com/1142958/56444124-61430a00-62ef-11e9-9183-2eaf52efc325.png)

/cc @rynowak 