### PR TITLE
Don't override jasmine.DEFAULT_TIMEOUT_INTERVAL from Common.ts

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/ts/WebSocketTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/WebSocketTests.ts
@@ -4,9 +4,6 @@
 import { ECHOENDPOINT_URL } from "./Common";
 import "./LogBannerReporter";
 
-// On slower CI machines, these tests sometimes take longer than 5s
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 1000;
-
 describe("WebSockets", () => {
     it("can be used to connect to SignalR", (done) => {
         const message = "message";

--- a/src/SignalR/clients/ts/FunctionalTests/ts/WebWorkerTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/WebWorkerTests.ts
@@ -3,9 +3,6 @@
 
 import { ENDPOINT_BASE_URL } from "./Common";
 
-// On slower CI machines, these tests sometimes take longer than 5s
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 1000;
-
 describe("WebWorkers", () => {
     it("can use SignalR client", (done) => {
         if (typeof window !== "undefined" && (window as any).Worker) {


### PR DESCRIPTION
I noticed in https://github.com/aspnet/AspNetCore-Internal/issues/2334 that a functional test defined in HubConnectionTests.ts was timing out after only 10 seconds instead of the 20 seconds configured in Common.ts.

This happens despite the fact that HubConnectionTests.ts imports Common.ts. I think this is caused by one or both of WebSocketTests.ts and WebWorkerTests.ts reconfiguring jasmine.DEFAULT_TIMEOUT_INTERVAL back to 10 seconds by the time the tests defined in HubConnectionTests.ts are run.
