### PR TITLE
Don't fire DiagnosticSource.StopActivity if there's no DiagnosticListener

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -62,6 +62,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             public long StartTimestamp { get; set; }
             public bool EventLogEnabled { get; set; }
             public Activity Activity { get; set; }
+            internal bool HasDiagnosticListener { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Don't fire the event if DiagnosticSource.StartActivity was never called. This avoids allocating the anonymous object and extra strings.

Contributes to #9594 