### PR TITLE
Native build fails if repo is in a path containing spaces (e.g. C:\Users\Bob

### DIFF
--- a/src/Servers/IIS/build/native.targets
+++ b/src/Servers/IIS/build/native.targets
@@ -7,7 +7,7 @@
   <ItemGroup Condition="@(MessageFile->Count()) != 0">
     <CustomBuild Include="@(MessageFile)">
       <FileType>Document</FileType>
-      <Command>mc %(FullPath) -h $(IntDir) -r $(IntDir)</Command>
+      <Command>mc "%(FullPath)" -h $(IntDir) -r $(IntDir)</Command>
       <Message>Compiling Event Messages ...</Message>
       <Outputs>$(IntDir)\%(Filename).rc;$(IntDir)\%(Filename).h;$(IntDir)\MSG0409.bin</Outputs>
     </CustomBuild>


### PR DESCRIPTION
I checked out the source code to `C:\Users\Justin Dearing\source\repos\aspnet\AspNetCore` on my laptop and ran `build.cmd` and I got errors on the vcxproj builds. I traced it down to this. 
