### PR TITLE
Efficiently pack network packets

### DIFF
--- a/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.netstandard2.0.cs
+++ b/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.netstandard2.0.cs
@@ -138,6 +138,11 @@ namespace Microsoft.AspNetCore.Connections.Features
     {
         System.Buffers.MemoryPool<byte> MemoryPool { get; }
     }
+    public partial interface ITcpCorkFeature
+    {
+        void Cork();
+        void UnCork();
+    }
     public partial interface ITlsHandshakeFeature
     {
         System.Security.Authentication.CipherAlgorithmType CipherAlgorithm { get; }

--- a/src/Servers/Connections.Abstractions/src/Features/ITcpCorkFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITcpCorkFeature.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Connections.Features
+{
+    public interface ITcpCorkFeature
+    {
+        void Cork();
+        void UnCork();
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             Input = _context.Transport.Input;
             Output = _http1Output;
             MemoryPool = _context.MemoryPool;
+            TcpCorkFeature?.Cork();
         }
 
         public PipeReader Input { get; }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -305,6 +305,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             ReasonPhrase = "Switching Protocols";
             ResponseHeaders[HeaderNames.Connection] = "Upgrade";
 
+            // Switch off TcpCork for Upgrade
+            TcpCorkFeature?.UnCork();
+
             await FlushAsync();
 
             return bodyControl.Upgrade();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -592,7 +592,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                         result = await awaitable;
                         TcpCorkFeature?.Cork();
-
                     }
                 } while (!TryParseRequest(result, out endConnection));
 

--- a/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.Generated.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         private static readonly Type IConnectionLifetimeFeatureType = typeof(IConnectionLifetimeFeature);
         private static readonly Type IConnectionHeartbeatFeatureType = typeof(IConnectionHeartbeatFeature);
         private static readonly Type IConnectionLifetimeNotificationFeatureType = typeof(IConnectionLifetimeNotificationFeature);
+        private static readonly Type ITcpCorkFeatureType = typeof(ITcpCorkFeature);
 
         private object _currentIHttpConnectionFeature;
         private object _currentIConnectionIdFeature;
@@ -33,6 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         private object _currentIConnectionLifetimeFeature;
         private object _currentIConnectionHeartbeatFeature;
         private object _currentIConnectionLifetimeNotificationFeature;
+        private object _currentITcpCorkFeature;
 
         private int _featureRevision;
 
@@ -51,6 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             _currentIConnectionHeartbeatFeature = this;
             _currentIConnectionLifetimeNotificationFeature = this;
 
+            _currentITcpCorkFeature = null;
         }
 
         // Internal for testing
@@ -145,6 +148,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 {
                     feature = _currentIConnectionLifetimeNotificationFeature;
                 }
+                else if (key == ITcpCorkFeatureType)
+                {
+                    feature = _currentITcpCorkFeature;
+                }
                 else if (MaybeExtra != null)
                 {
                     feature = ExtraFeatureGet(key);
@@ -197,6 +204,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 {
                     _currentIConnectionLifetimeNotificationFeature = value;
                 }
+                else if (key == ITcpCorkFeatureType)
+                {
+                    _currentITcpCorkFeature = value;
+                }
                 else
                 {
                     ExtraFeatureSet(key, value);
@@ -246,6 +257,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             else if (typeof(TFeature) == typeof(IConnectionLifetimeNotificationFeature))
             {
                 feature = (TFeature)_currentIConnectionLifetimeNotificationFeature;
+            }
+            else if (typeof(TFeature) == typeof(ITcpCorkFeature))
+            {
+                feature = (TFeature)_currentITcpCorkFeature;
             }
             else if (MaybeExtra != null)
             {
@@ -298,6 +313,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             {
                 _currentIConnectionLifetimeNotificationFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(ITcpCorkFeature))
+            {
+                _currentITcpCorkFeature = feature;
+            }
             else
             {
                 ExtraFeatureSet(typeof(TFeature), feature);
@@ -345,6 +364,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             if (_currentIConnectionLifetimeNotificationFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IConnectionLifetimeNotificationFeatureType, _currentIConnectionLifetimeNotificationFeature);
+            }
+            if (_currentITcpCorkFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(ITcpCorkFeatureType, _currentITcpCorkFeature);
             }
 
             if (MaybeExtra != null)

--- a/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
     {
         public SocketTransportOptions() { }
         public int IOQueueCount { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool TcpCork { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -371,12 +371,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         public unsafe static void SetCorkOption(this Socket socket, bool isCorked)
         {
             int optval = isCorked ? 1 : 0;
-            setsockopt(socket.Handle, SOL_TCP, TCP_CORK, &optval, sizeof(int));
+            setsockopt((int)socket.Handle, SOL_TCP, TCP_CORK, &optval, sizeof(int));
         }
 
         // Option is rejected by corefx PAL layer
         // Shim until api supported e.g. SetRawSocketOption https://github.com/dotnet/corefx/issues/37122
         [DllImport("libc")]
-        static unsafe extern int setsockopt(IntPtr sockfd, int level, int optname, void* optval, int optlen);
+        static unsafe extern int setsockopt(int sockfd, int level, int optname, void* optval, int optlen);
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -374,6 +374,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             setsockopt(socket.Handle, SOL_TCP, TCP_CORK, &optval, sizeof(int));
         }
 
+        // Option is rejected by corefx PAL layer
+        // Shim until api supported e.g. SetRawSocketOption https://github.com/dotnet/corefx/issues/37122
         [DllImport("libc")]
         static unsafe extern int setsockopt(IntPtr sockfd, int level, int optname, void* optval, int optlen);
     }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 throw new ArgumentNullException(nameof(dispatcher));
             }
 
-            return new SocketTransport(endPointInformation, dispatcher, _appLifetime, _options.IOQueueCount, _trace, _options.MemoryPoolFactory());
+            return new SocketTransport(endPointInformation, dispatcher, _appLifetime, _options, _trace);
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -17,6 +17,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// </remarks>
         public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
+        /// <summary>
+        /// Set to false to disable use of TCP_CORK for all connections.
+        /// </summary>
+        /// <remarks>
+        /// Only supported on Linux. Defaults to true.
+        /// </remarks>
+        public bool TcpCork { get; set; } = true;
+
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => KestrelMemoryPool.Create();
     }
 }

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+
 namespace CodeGenerator
 {
     public class TransportConnectionFeatureCollection
@@ -9,7 +11,7 @@ namespace CodeGenerator
         {
             // NOTE: This list MUST always match the set of feature interfaces implemented by TransportConnection.
             // See also: src/Kestrel.Transport.Abstractions/Internal/TransportConnection.FeatureCollection.cs
-            var features = new[]
+            var implementedFeatures = new[]
             {
                 "IHttpConnectionFeature",
                 "IConnectionIdFeature",
@@ -23,6 +25,11 @@ namespace CodeGenerator
                 "IConnectionLifetimeNotificationFeature"
             };
 
+            var extraFeatures = new[]
+            {
+                "ITcpCorkFeature"
+            };
+
             var usings = $@"
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;";
@@ -30,8 +37,8 @@ using Microsoft.AspNetCore.Http.Features;";
             return FeatureCollectionGenerator.GenerateFile(
                 namespaceName: "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal",
                 className: "TransportConnection",
-                allFeatures: features,
-                implementedFeatures: features,
+                allFeatures: implementedFeatures.Concat(extraFeatures).ToArray(),
+                implementedFeatures: implementedFeatures,
                 extraUsings: usings,
                 fallbackFeatures: null);
         }


### PR DESCRIPTION
On Linux we can use the socket option TCP_CORK to get the kernel to only send TCP/IP packets at the full MTU. 

* When there is no more input data and no more output processing we remove the cork to send the remaining partial packet.
* The cork also needs to be removed for real-time sends, so Upgrades (WebSockets) and Server Sent Events.

This should improve transmission efficiency where the application writes do not exactly match the ideal network size.

e.g. an example

Given a MTU of 1400, IP+TCP header of 20+20 = 40, ideal write sizes would be in multiples of 1360

If application writes were occurring in 4096 byte chunks; this would be 3 complete packets + 1 packet of 16 bytes (or 1.2% full).

This change instructs the kernel to hold back that final packet and wait for further writes to send when full; making the network transmission more efficient.

This should improve the throughput of any transmission over the network MTU (e.g. 1400 bytes on IPv4); or any sequence of writes where individually they are under the MTU; which should improve MVC, StaticFiles etc and let the kernel worry about the ideal packet size rather than leaking it into application code.

Similar functionality would be needed to use Windows RIO at maximal efficiency

Also don't have an Linux environment to test; have provided info for @sebastienros to provide assistance as to the effects.