### PR TITLE
Cache some Headers lookups

### DIFF
--- a/src/Middleware/CORS/src/Infrastructure/CorsService.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsService.cs
@@ -79,8 +79,8 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 throw new ArgumentException(Resources.InsecureConfiguration, nameof(policy));
             }
 
-            var origin = context.Request.Headers[CorsConstants.Origin];
             var requestHeaders = context.Request.Headers;
+            var origin = requestHeaders[CorsConstants.Origin];
 
             var isOptionsRequest = string.Equals(context.Request.Method, CorsConstants.PreflightHttpMethod, StringComparison.OrdinalIgnoreCase);
             var isPreflightRequest = isOptionsRequest && requestHeaders.ContainsKey(CorsConstants.AccessControlRequestMethod);
@@ -110,6 +110,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
         private static void PopulateResult(HttpContext context, CorsPolicy policy, CorsResult result)
         {
+            var headers = context.Request.Headers;
             if (policy.AllowAnyOrigin)
             {
                 result.AllowedOrigin = CorsConstants.AnyOrigin;
@@ -117,7 +118,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             }
             else
             {
-                var origin = context.Request.Headers[CorsConstants.Origin];
+                var origin = headers[CorsConstants.Origin];
                 result.AllowedOrigin = origin;
                 result.VaryByOrigin = policy.Origins.Count > 1;
             }
@@ -129,12 +130,12 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             AddHeaderValues(result.AllowedExposedHeaders, policy.ExposedHeaders);
 
             var allowedMethods = policy.AllowAnyMethod ?
-                new[] { result.IsPreflightRequest ? (string)context.Request.Headers[CorsConstants.AccessControlRequestMethod] : context.Request.Method } :
+                new[] { result.IsPreflightRequest ? (string)headers[CorsConstants.AccessControlRequestMethod] : context.Request.Method } :
                 policy.Methods;
             AddHeaderValues(result.AllowedMethods, allowedMethods);
 
             var allowedHeaders = policy.AllowAnyHeader ?
-                context.Request.Headers.GetCommaSeparatedValues(CorsConstants.AccessControlRequestHeaders) :
+                headers.GetCommaSeparatedValues(CorsConstants.AccessControlRequestHeaders) :
                 policy.Headers;
             AddHeaderValues(result.AllowedHeaders, allowedHeaders);
         }
@@ -169,11 +170,12 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 return;
             }
 
-            response.Headers[CorsConstants.AccessControlAllowOrigin] = result.AllowedOrigin;
+            var headers = response.Headers;
+            headers[CorsConstants.AccessControlAllowOrigin] = result.AllowedOrigin;
 
             if (result.SupportsCredentials)
             {
-                response.Headers[CorsConstants.AccessControlAllowCredentials] = "true";
+                headers[CorsConstants.AccessControlAllowCredentials] = "true";
             }
 
             if (result.IsPreflightRequest)
@@ -184,17 +186,17 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 // `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Max-Age`
                 if (result.AllowedHeaders.Count > 0)
                 {
-                    response.Headers.SetCommaSeparatedValues(CorsConstants.AccessControlAllowHeaders, result.AllowedHeaders.ToArray());
+                    headers.SetCommaSeparatedValues(CorsConstants.AccessControlAllowHeaders, result.AllowedHeaders.ToArray());
                 }
 
                 if (result.AllowedMethods.Count > 0)
                 {
-                    response.Headers.SetCommaSeparatedValues(CorsConstants.AccessControlAllowMethods, result.AllowedMethods.ToArray());
+                    headers.SetCommaSeparatedValues(CorsConstants.AccessControlAllowMethods, result.AllowedMethods.ToArray());
                 }
 
                 if (result.PreflightMaxAge.HasValue)
                 {
-                    response.Headers[CorsConstants.AccessControlMaxAge] = result.PreflightMaxAge.Value.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+                    headers[CorsConstants.AccessControlMaxAge] = result.PreflightMaxAge.Value.TotalSeconds.ToString(CultureInfo.InvariantCulture);
                 }
             }
             else
@@ -203,13 +205,13 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 // `Access-Control-Expose-Headers`
                 if (result.AllowedExposedHeaders.Count > 0)
                 {
-                    response.Headers.SetCommaSeparatedValues(CorsConstants.AccessControlExposeHeaders, result.AllowedExposedHeaders.ToArray());
+                    headers.SetCommaSeparatedValues(CorsConstants.AccessControlExposeHeaders, result.AllowedExposedHeaders.ToArray());
                 }
             }
 
             if (result.VaryByOrigin)
             {
-                response.Headers.Append("Vary", "Origin");
+                headers.Append("Vary", "Origin");
             }
         }
 

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -104,11 +104,11 @@ namespace Microsoft.AspNetCore.Diagnostics
 
         private Task ClearCacheHeaders(object state)
         {
-            var response = (HttpResponse)state;
-            response.Headers[HeaderNames.CacheControl] = "no-cache";
-            response.Headers[HeaderNames.Pragma] = "no-cache";
-            response.Headers[HeaderNames.Expires] = "-1";
-            response.Headers.Remove(HeaderNames.ETag);
+            var headers = ((HttpResponse)state).Headers;
+            headers[HeaderNames.CacheControl] = "no-cache";
+            headers[HeaderNames.Pragma] = "no-cache";
+            headers[HeaderNames.Expires] = "-1";
+            headers.Remove(HeaderNames.ETag);
             return Task.CompletedTask;
         }
     }

--- a/src/Middleware/ResponseCaching/src/Internal/ResponseCachingKeyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/Internal/ResponseCachingKeyProvider.cs
@@ -110,19 +110,21 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                 builder.Append(varyByRules.VaryByKeyPrefix);
 
                 // Vary by headers
-                if (varyByRules?.Headers.Count > 0)
+                var headersCount = varyByRules?.Headers.Count ?? 0;
+                if (headersCount > 0)
                 {
                     // Append a group separator for the header segment of the cache key
                     builder.Append(KeyDelimiter)
                         .Append('H');
 
-                    for (var i = 0; i < varyByRules.Headers.Count; i++)
+                    var requestHeaders = context.HttpContext.Request.Headers;
+                    for (var i = 0; i < headersCount; i++)
                     {
                         var header = varyByRules.Headers[i];
-                        var headerValues = context.HttpContext.Request.Headers[header];
+                        var headerValues = requestHeaders[header];
                         builder.Append(KeyDelimiter)
                             .Append(header)
-                            .Append("=");
+                            .Append('=');
 
                         var headerValuesArray = headerValues.ToArray();
                         Array.Sort(headerValuesArray, StringComparer.Ordinal);
@@ -152,7 +154,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                         {
                             builder.Append(KeyDelimiter)
                                 .AppendUpperInvariant(queryArray[i].Key)
-                                .Append("=");
+                                .Append('=');
 
                             var queryValueArray = queryArray[i].Value.ToArray();
                             Array.Sort(queryValueArray, StringComparer.Ordinal);
@@ -176,7 +178,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                             var queryKeyValues = context.HttpContext.Request.Query[queryKey];
                             builder.Append(KeyDelimiter)
                                 .Append(queryKey)
-                                .Append("=");
+                                .Append('=');
 
                             var queryValueArray = queryKeyValues.ToArray();
                             Array.Sort(queryValueArray, StringComparer.Ordinal);

--- a/src/Middleware/ResponseCaching/src/Internal/ResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/Internal/ResponseCachingPolicyProvider.cs
@@ -33,12 +33,12 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
 
         public virtual bool AllowCacheLookup(ResponseCachingContext context)
         {
-            var request = context.HttpContext.Request;
+            var requestHeaders = context.HttpContext.Request.Headers;
 
             // Verify request cache-control parameters
-            if (!StringValues.IsNullOrEmpty(request.Headers[HeaderNames.CacheControl]))
+            if (!StringValues.IsNullOrEmpty(requestHeaders[HeaderNames.CacheControl]))
             {
-                if (HeaderUtilities.ContainsCacheDirective(request.Headers[HeaderNames.CacheControl], CacheControlHeaderValue.NoCacheString))
+                if (HeaderUtilities.ContainsCacheDirective(requestHeaders[HeaderNames.CacheControl], CacheControlHeaderValue.NoCacheString))
                 {
                     context.Logger.RequestWithNoCacheNotCacheable();
                     return false;
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
             else
             {
                 // Support for legacy HTTP 1.0 cache directive
-                if (HeaderUtilities.ContainsCacheDirective(request.Headers[HeaderNames.Pragma], CacheControlHeaderValue.NoCacheString))
+                if (HeaderUtilities.ContainsCacheDirective(requestHeaders[HeaderNames.Pragma], CacheControlHeaderValue.NoCacheString))
                 {
                     context.Logger.RequestWithPragmaNoCacheNotCacheable();
                     return false;

--- a/src/Middleware/Session/src/SessionMiddleware.cs
+++ b/src/Middleware/Session/src/SessionMiddleware.cs
@@ -158,11 +158,13 @@ namespace Microsoft.AspNetCore.Session
             {
                 var cookieOptions = _options.Cookie.Build(_context);
 
-                _context.Response.Cookies.Append(_options.Cookie.Name, _cookieValue, cookieOptions);
+                var response = _context.Response;
+                response.Cookies.Append(_options.Cookie.Name, _cookieValue, cookieOptions);
 
-                _context.Response.Headers[HeaderNames.CacheControl] = "no-cache";
-                _context.Response.Headers[HeaderNames.Pragma] = "no-cache";
-                _context.Response.Headers[HeaderNames.Expires] = "-1";
+                var responseHeaders = response.Headers;
+                responseHeaders[HeaderNames.CacheControl] = "no-cache";
+                responseHeaders[HeaderNames.Pragma] = "no-cache";
+                responseHeaders[HeaderNames.Expires] = "-1";
             }
 
             // Returns true if the session has already been established, or if it still can be because the response has not been sent.


### PR DESCRIPTION
`context.Request.Headers` goes via feature reference lookups; so once its been resolved, use that for further use rather than resolving again.