### PR TITLE
Ensure PlatformBenchmark is compiled for .NET Core 3.0

### DIFF
--- a/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/Servers/Kestrel/perf/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -125,11 +125,9 @@ namespace PlatformBenchmarks
         {
         }
 
-#if NETCOREAPP3_0
         public void OnHeadersComplete()
         {
         }
-#endif
 
         public async ValueTask OnReadCompletedAsync()
         {
@@ -182,9 +180,10 @@ namespace PlatformBenchmarks
             public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
                 => RequestHandler.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
 
-#if NETCOREAPP3_0
             public void OnHeadersComplete()
                 => RequestHandler.OnHeadersComplete();
+#if !NETCOREAPP3_0
+#error This is a .NET Core 3.0 application and needs to be compiled for <TargetFramework>netcoreapp3.0</TargetFramework>
 #endif
         }
     }


### PR DESCRIPTION
/cc @sebastienros not sure you use it on earlier frameworks?