### PR TITLE
Avoid allocating the CandidateSet when there's a single match

### DIFF
--- a/src/Http/Routing/src/EndpointSelectorContext.cs
+++ b/src/Http/Routing/src/EndpointSelectorContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Routing
         /// </summary>
         public RouteValueDictionary RouteValues
         {
-            get => _routeValues;
+            get => _routeValues ?? (_routeValues = new RouteValueDictionary());
             set
             {
                 _routeValues = value;

--- a/src/Http/Routing/src/Matching/DfaMatcher.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcher.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         private readonly EndpointSelector _selector;
         private readonly DfaState[] _states;
         private readonly int _maxSegmentCount;
+        private readonly bool _isDefaultEndpointSelector;
 
         public DfaMatcher(ILogger<DfaMatcher> logger, EndpointSelector selector, DfaState[] states, int maxSegmentCount)
         {
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             _selector = selector;
             _states = states;
             _maxSegmentCount = maxSegmentCount;
+            _isDefaultEndpointSelector = selector is DefaultEndpointSelector;
         }
 
         public sealed override Task MatchAsync(HttpContext httpContext, EndpointSelectorContext context)
@@ -72,13 +74,12 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var policyCount = policies.Length;
 
             // This is a fast path for single candidate, 0 policies and default selector
-            if (policyCount == 0 && candidateCount == 1 && _selector is DefaultEndpointSelector)
+            if (candidateCount == 1 && policyCount == 0 && _isDefaultEndpointSelector)
             {
                 ref var candidate = ref candidates[0];
-                var flags = candidate.Flags;
 
                 // Just strict path matching
-                if (flags == Candidate.CandidateFlags.None)
+                if (candidate.Flags == Candidate.CandidateFlags.None)
                 {
                     context.Endpoint = candidate.Endpoint;
 

--- a/src/Http/Routing/src/Matching/DfaMatcher.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcher.cs
@@ -80,8 +80,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 // Just strict path matching
                 if (flags == Candidate.CandidateFlags.None)
                 {
-                    // TODO: Remove this allocation
-                    context.RouteValues = new RouteValueDictionary();
                     context.Endpoint = candidate.Endpoint;
 
                     // We're done


### PR DESCRIPTION
- Add fast path for 0 route values, and policies

Scenario, hello world plaintext (the /plaintext sample in the RoutingSandbox) hit with 10K requests.

Allocations before:

![image](https://user-images.githubusercontent.com/95136/56479854-5a8dd180-646c-11e9-8a9e-ffd72acd1657.png)

Allocations after:

![image](https://user-images.githubusercontent.com/95136/56479779-fb2fc180-646b-11e9-89b4-65ba4d02c488.png)

Microbenchmarks:

MatcherSingleEntryBenchmark

Before:

```
           Method |     Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
----------------- |---------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
         Baseline | 106.5 ns |  1.762 ns |  1.472 ns | 9,387,641.5 |   1.00 |     0.00 | 0.0074 |      40 B |
              Dfa | 185.6 ns |  3.724 ns |  8.556 ns | 5,388,922.3 |   1.74 |     0.08 | 0.0212 |     112 B |
 LegacyTreeRouter | 954.0 ns | 20.355 ns | 38.231 ns | 1,048,254.6 |   8.96 |     0.37 | 0.0458 |     408 B |
     LegacyRouter | 711.2 ns | 13.520 ns | 11.985 ns | 1,406,107.4 |   6.68 |     0.14 | 0.0525 |     280 B |
```

After:

```
           Method |      Mean |      Error |     StdDev |         Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
----------------- |----------:|-----------:|-----------:|-------------:|-------:|---------:|-------:|----------:|
         Baseline |  96.00 ns |  0.8115 ns |  0.7193 ns | 10,416,201.9 |   1.00 |     0.00 | 0.0076 |      40 B |
              Dfa |  97.07 ns |  1.0586 ns |  0.9902 ns | 10,301,416.6 |   1.01 |     0.01 |      - |       0 B |
 LegacyTreeRouter | 913.16 ns | 17.9336 ns | 17.6132 ns |  1,095,100.5 |   9.51 |     0.19 | 0.0772 |     408 B |
     LegacyRouter | 679.49 ns | 10.7855 ns | 10.0888 ns |  1,471,691.7 |   7.08 |     0.11 | 0.0534 |     280 B |
```