### PR TITLE
Spanify path -> string logic

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             var rawUrlInBytes = GetRawUrlInBytes();
 
             // Pre Windows 10 RS2 applicationInitialization request might not have pRawUrl set, fallback to cocked url
-            if (rawUrlInBytes == null)
+            if (rawUrlInBytes.Length == 0)
             {
                 return GetCookedUrl().GetAbsPath();
             }
@@ -193,9 +193,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             // check and skip it
             if (rawUrlInBytes.Length > 0 && rawUrlInBytes[rawUrlInBytes.Length - 1] == 0)
             {
-                var newRawUrlInBytes = new byte[rawUrlInBytes.Length - 1];
-                Array.Copy(rawUrlInBytes, newRawUrlInBytes, newRawUrlInBytes.Length);
-                rawUrlInBytes = newRawUrlInBytes;
+                rawUrlInBytes = rawUrlInBytes.Slice(0, rawUrlInBytes.Length - 1);
             }
 
             var originalPath = RequestUriBuilder.DecodeAndUnescapePath(rawUrlInBytes);

--- a/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
+++ b/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
@@ -138,17 +138,14 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             return null;
         }
 
-        internal byte[] GetRawUrlInBytes()
+        internal Span<byte> GetRawUrlInBytes()
         {
             if (NativeRequest->pRawUrl != null && NativeRequest->RawUrlLength > 0)
             {
-                var result = new byte[NativeRequest->RawUrlLength];
-                Marshal.Copy((IntPtr)NativeRequest->pRawUrl, result, 0, NativeRequest->RawUrlLength);
-
-                return result;
+                return new Span<byte>(NativeRequest->pRawUrl, NativeRequest->RawUrlLength);
             }
 
-            return null;
+            return default;
         }
 
         internal CookedUrl GetCookedUrl()

--- a/src/Shared/HttpSys/RequestProcessing/RequestUriBuilder.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestUriBuilder.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Text;
 
 namespace Microsoft.AspNetCore.HttpSys.Internal
@@ -17,23 +18,19 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             encoderShouldEmitUTF8Identifier: false,
             throwOnInvalidBytes: true);
 
-        public static string DecodeAndUnescapePath(byte[] rawUrlBytes)
+        public static string DecodeAndUnescapePath(Span<byte> rawUrlBytes)
         {
-            if (rawUrlBytes == null)
-            {
-                throw new ArgumentNullException(nameof(rawUrlBytes));
-            }
-
-            if (rawUrlBytes.Length == 0)
-            {
-                throw new ArgumentException("Length of the URL cannot be zero.", nameof(rawUrlBytes));
-            }
-
+            Debug.Assert(rawUrlBytes.Length == 0, "Length of the URL cannot be zero.");
             var rawPath = RawUrlHelper.GetPath(rawUrlBytes);
+
+            if (rawPath.Length == 0)
+            {
+                return "/";
+            }
 
             var unescapedPath = Unescape(rawPath);
 
-            return UTF8.GetString(unescapedPath.Array, unescapedPath.Offset, unescapedPath.Count);
+            return UTF8.GetString(unescapedPath);
         }
 
         /// <summary>
@@ -41,19 +38,16 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         /// </summary>
         /// <param name="rawPath">The raw path string to be unescaped</param>
         /// <returns>The unescaped path string</returns>
-        private static ArraySegment<byte> Unescape(ArraySegment<byte> rawPath)
+        private static ReadOnlySpan<byte> Unescape(Span<byte> rawPath)
         {
             // the slot to read the input
-            var reader = rawPath.Offset;
+            var reader = 0;
 
             // the slot to write the unescaped byte
-            var writer = rawPath.Offset;
+            var writer = 0;
 
             // the end of the path
-            var end = rawPath.Offset + rawPath.Count;
-
-            // the byte array
-            var buffer = rawPath.Array;
+            var end = rawPath.Length;
 
             while (true)
             {
@@ -62,7 +56,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     break;
                 }
 
-                if (rawPath.Array[reader] == '%')
+                if (rawPath[reader] == '%')
                 {
                     var decodeReader = reader;
 
@@ -73,20 +67,20 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     // The decodeReader iterator is always moved to the first byte not yet 
                     // be scanned after the process. A failed decoding means the chars
                     // between the reader and decodeReader can be copied to output untouched. 
-                    if (!DecodeCore(ref decodeReader, ref writer, end, buffer))
+                    if (!DecodeCore(ref decodeReader, ref writer, end, rawPath))
                     {
-                        Copy(reader, decodeReader, ref writer, buffer);
+                        Copy(reader, decodeReader, ref writer, rawPath);
                     }
 
                     reader = decodeReader;
                 }
                 else
                 {
-                    buffer[writer++] = buffer[reader++];
+                    rawPath[writer++] = rawPath[reader++];
                 }
             }
 
-            return new ArraySegment<byte>(buffer, rawPath.Offset, writer - rawPath.Offset);
+            return rawPath.Slice(0, writer);
         }
 
         /// <summary>
@@ -96,7 +90,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         /// <param name="writer">The place to write to</param>
         /// <param name="end">The end of the buffer</param>
         /// <param name="buffer">The byte array</param>
-        private static bool DecodeCore(ref int reader, ref int writer, int end, byte[] buffer)
+        private static bool DecodeCore(ref int reader, ref int writer, int end, Span<byte> buffer)
         {
             // preserves the original head. if the percent-encodings cannot be interpreted as sequence of UTF-8 octets,
             // bytes from this till the last scanned one will be copied to the memory pointed by writer.
@@ -232,7 +226,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             return true;
         }
 
-        private static void Copy(int begin, int end, ref int writer, byte[] buffer)
+        private static void Copy(int begin, int end, ref int writer, Span<byte> buffer)
         {
             while (begin != end)
             {
@@ -260,7 +254,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         /// <param name="end">The end of the buffer</param>
         /// <param name="buffer">The byte array</param>
         /// <returns>The unescaped byte if success. Otherwise return -1.</returns>
-        private static int? UnescapePercentEncoding(ref int scan, int end, byte[] buffer)
+        private static int? UnescapePercentEncoding(ref int scan, int end, ReadOnlySpan<byte> buffer)
         {
             if (buffer[scan++] != '%')
             {
@@ -300,7 +294,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         /// <param name="end">The end of the buffer</param>
         /// <param name="buffer">The byte array</param>
         /// <returns>The hexadecimal value if successes, otherwise -1.</returns>
-        private static int? ReadHex(ref int scan, int end, byte[] buffer)
+        private static int? ReadHex(ref int scan, int end, ReadOnlySpan<byte> buffer)
         {
             if (scan == end)
             {


### PR DESCRIPTION
- Use spans instead of byte[] and array segments when turning the URL into a string
