### PR TITLE
Custom hub options don't change global hub options

### DIFF
--- a/src/SignalR/server/Core/src/Internal/HubOptionsSetup.cs
+++ b/src/SignalR/server/Core/src/Internal/HubOptionsSetup.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         internal static TimeSpan DefaultClientTimeoutInterval => TimeSpan.FromSeconds(30);
 
-        internal const int DefaultMaximumMessageSize = 32 * 1024 * 1024;
+        internal const int DefaultMaximumMessageSize = 32 * 1024;
 
         private readonly List<string> _defaultProtocols = new List<string>();
 

--- a/src/SignalR/server/Core/src/Internal/HubOptionsSetup`T.cs
+++ b/src/SignalR/server/Core/src/Internal/HubOptionsSetup`T.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
@@ -15,7 +16,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public void Configure(HubOptions<THub> options)
         {
-            options.SupportedProtocols = _hubOptions.SupportedProtocols;
+            options.SupportedProtocols = new List<string>(_hubOptions.SupportedProtocols.Count);
+            foreach (var protocol in _hubOptions.SupportedProtocols)
+            {
+                options.SupportedProtocols.Add(protocol);
+            }
             options.KeepAliveInterval = _hubOptions.KeepAliveInterval;
             options.HandshakeTimeout = _hubOptions.HandshakeTimeout;
         }

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -64,6 +64,21 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.IsType<CustomHubContext<CustomHub>>(serviceProvider.GetRequiredService<IHubContext<CustomHub>>());
             Assert.IsType<CustomHubContext<CustomTHub, string>>(serviceProvider.GetRequiredService<IHubContext<CustomTHub, string>>());
             Assert.IsType<CustomHubContext<CustomDynamicHub>>(serviceProvider.GetRequiredService<IHubContext<CustomDynamicHub>>());
+        }
+
+        [Fact]
+        public void HubSpecificOptionsDoNotAffectGlobalHubOptions()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSignalR().AddHubOptions<CustomHub>(options =>
+            {
+                options.SupportedProtocols.Clear();
+            });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.Equal(1, serviceProvider.GetRequiredService<IOptions<HubOptions>>().Value.SupportedProtocols.Count);
+            Assert.Equal(0, serviceProvider.GetRequiredService<IOptions<HubOptions<CustomHub>>>().Value.SupportedProtocols.Count);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/9627

The issue was we were shallow copying the list of protocols from the global options to the hub specific options, which for classes means they will point to the same object.

The change is to ~deep~ copy the list.