### PR TITLE
Use correct path to x86 installers to ANCM

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
@@ -162,12 +162,21 @@
         <Directory Id="INSTALLLOCATION" ShortName="ANCM" Name="$(var.ProductName)">
           <Directory Id="VersionDir" Name="$(var.ProductVersionString)">
             <Component Id="AspNetCoreModule" Guid="84ed6ce6-c8a3-4fa8-a872-c98a1d15dd4f" Win64="$(var.IsWin64)">
-              <File Id="AspNetCoreModuleDll"
-                    Name="aspnetcorev2.dll"
-                    Source="$(var.AspNetCoreV2.TargetPath)"
-                    DiskId="1"
-                    Vital="yes">
-              </File>
+                <?if $(var.Platform) = "x64" ?>
+                    <File Id="AspNetCoreModuleDll"
+                        Name="aspnetcorev2.dll"
+                        Source="$(var.AspNetCoreV2.TargetPath)"
+                        DiskId="1"
+                        Vital="yes">
+                    </File>
+                <?else ?>
+                    <File Id="AspNetCoreModuleDll"
+                        Name="aspnetcorev2.dll"
+                        Source="$(var.AspNetCoreV2WoW64.TargetPath)"
+                        DiskId="1"
+                        Vital="yes">
+                    </File>
+                <?endif?>
               <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
                 <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleDll]"/>
                 <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
@@ -175,12 +184,21 @@
             </Component>
             <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
               <Component Id="AspNetCoreModuleHandler" Guid="559EF726-B25C-480F-AFA4-32D0BA8B2376" Win64="$(var.IsWin64)">
-                <File Id="AspNetCoreModuleHandlerDll"
-                      Name="aspnetcorev2_outofprocess.dll"
-                      Source="$(var.AspNetCoreV2Handler.TargetPath)"
-                      DiskId="1"
-                      Vital="yes">
-                </File>
+                <?if $(var.Platform) = "x64" ?>
+                    <File Id="AspNetCoreModuleHandlerDll"
+                        Name="aspnetcorev2_outofprocess.dll"
+                        Source="$(var.AspNetCoreV2Handler.TargetPath)"
+                        DiskId="1"
+                        Vital="yes">
+                    </File>
+                <?else ?>
+                    <File Id="AspNetCoreModuleHandlerDll"
+                        Name="aspnetcorev2_outofprocess.dll"
+                        Source="$(var.AspNetCoreV2HandlerWoW64.TargetPath)"
+                        DiskId="1"
+                        Vital="yes">
+                    </File>
+                <?endif?>
               </Component>
             </Directory>
           </Directory>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
@@ -34,8 +34,12 @@
 <?if $(var.Platform) = "x64" ?>
     <?define SchemaGuid = "ab582af2-d6c0-43f7-8412-76a19c65d7f2" ?>
     <?define SchemaGuid32 = "e629b31a-3d56-4b5c-959c-586fc1c55599" ?>
+    <?define AspNetCoreV2ProgramFilesTargetPath = "$(var.AspNetCoreV2.TargetPath)" ?>
+    <?define AspNetCoreV2HandlerProgramFilesTargetPath = "$(var.AspNetCoreV2Handler.TargetPath)" ?>
 <?else ?>
     <?define SchemaGuid = "e629b31a-3d56-4b5c-959c-586fc1c55599" ?>
+    <?define AspNetCoreV2ProgramFilesTargetPath = "$(var.AspNetCoreV2WoW64.TargetPath)" ?>
+    <?define AspNetCoreV2HandlerProgramFilesTargetPath = "$(var.AspNetCoreV2HandlerWoW64.TargetPath)" ?>
 <?endif ?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
@@ -162,21 +166,12 @@
         <Directory Id="INSTALLLOCATION" ShortName="ANCM" Name="$(var.ProductName)">
           <Directory Id="VersionDir" Name="$(var.ProductVersionString)">
             <Component Id="AspNetCoreModule" Guid="84ed6ce6-c8a3-4fa8-a872-c98a1d15dd4f" Win64="$(var.IsWin64)">
-                <?if $(var.Platform) = "x64" ?>
-                    <File Id="AspNetCoreModuleDll"
-                        Name="aspnetcorev2.dll"
-                        Source="$(var.AspNetCoreV2.TargetPath)"
-                        DiskId="1"
-                        Vital="yes">
-                    </File>
-                <?else ?>
-                    <File Id="AspNetCoreModuleDll"
-                        Name="aspnetcorev2.dll"
-                        Source="$(var.AspNetCoreV2WoW64.TargetPath)"
-                        DiskId="1"
-                        Vital="yes">
-                    </File>
-                <?endif?>
+                <File Id="AspNetCoreModuleDll"
+                    Name="aspnetcorev2.dll"
+                    Source="$(var.AspNetCoreV2ProgramFilesTargetPath)"
+                    DiskId="1"
+                    Vital="yes">
+                </File>
               <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
                 <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleDll]"/>
                 <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
@@ -184,21 +179,12 @@
             </Component>
             <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
               <Component Id="AspNetCoreModuleHandler" Guid="559EF726-B25C-480F-AFA4-32D0BA8B2376" Win64="$(var.IsWin64)">
-                <?if $(var.Platform) = "x64" ?>
                     <File Id="AspNetCoreModuleHandlerDll"
                         Name="aspnetcorev2_outofprocess.dll"
-                        Source="$(var.AspNetCoreV2Handler.TargetPath)"
+                        Source="$(var.AspNetCoreV2HandlerProgramFilesTargetPath)"
                         DiskId="1"
                         Vital="yes">
                     </File>
-                <?else ?>
-                    <File Id="AspNetCoreModuleHandlerDll"
-                        Name="aspnetcorev2_outofprocess.dll"
-                        Source="$(var.AspNetCoreV2HandlerWoW64.TargetPath)"
-                        DiskId="1"
-                        Vital="yes">
-                    </File>
-                <?endif?>
               </Component>
             </Directory>
           </Directory>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -24,6 +24,14 @@
 <?define PlatformValue = "x86" ?>
 <?endif?>
 
+<?if $(var.Platform) = "x64" ?>
+    <?define AspNetCoreV2ProgramFilesTargetPath = "$(var.AspNetCoreV2.TargetPath)" ?>
+    <?define AspNetCoreV2HandlerProgramFilesTargetPath = "$(var.AspNetCoreV2Handler.TargetPath)" ?>
+<?else ?>
+    <?define AspNetCoreV2ProgramFilesTargetPath = "$(var.AspNetCoreV2WoW64.TargetPath)" ?>
+    <?define AspNetCoreV2HandlerProgramFilesTargetPath = "$(var.AspNetCoreV2HandlerWoW64.TargetPath)" ?>
+<?endif ?>
+
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
     <Product Id="$(var.ProductCode)"
           Name="!(loc.AspNetCoreModuleProductNameV2)"
@@ -137,21 +145,12 @@
                    <Directory Id="INSTALLLOCATION" ShortName="ANCM" Name="Asp.Net Core Module">
                        <Directory Id="VersionDir" Name="$(var.ProductVersionString)">
                            <Component Id="AspNetCoreModuleV2" Guid="3a692941-59be-43cf-98a8-6ed01b12a519" Win64="$(var.IsWin64)">
-                                <?if $(var.Platform) = "x64" ?>
-                                    <File Id="AspNetCoreModuleV2Dll"
-                                        Name="aspnetcorev2.dll"
-                                        Source="$(var.AspNetCoreV2.TargetPath)"
-                                        DiskId="1"
-                                        Vital="yes">
-                                    </File>
-                                <?else ?>
-                                    <File Id="AspNetCoreModuleV2Dll"
-                                        Name="aspnetcorev2.dll"
-                                        Source="$(var.AspNetCoreV2WoW64.TargetPath)"
-                                        DiskId="1"
-                                        Vital="yes">
-                                    </File>
-                                <?endif?>
+                                <File Id="AspNetCoreModuleV2Dll"
+                                    Name="aspnetcorev2.dll"
+                                    Source="$(var.AspNetCoreV2ProgramFilesTargetPath)"
+                                    DiskId="1"
+                                    Vital="yes">
+                                </File>
                                <RemoveFile Id="AspNetCoreModuleV2Dll_Remove" Name="aspnetcorev2.dll" On="install" />
                                <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
                                    <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleV2Dll]"/>
@@ -160,21 +159,12 @@
                            </Component>
                            <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
                                <Component Id="AspNetCoreModuleHandler" Guid="4b62060a-deb8-4de3-9557-9c0be21dc844" Win64="$(var.IsWin64)">
-                                    <?if $(var.Platform) = "x64" ?>
-                                        <File Id="AspNetCoreModuleHandlerDll"
-                                            Name="aspnetcorev2_outofprocess.dll"
-                                            Source="$(var.AspNetCoreV2Handler.TargetPath)"
-                                            DiskId="1"
-                                            Vital="yes">
-                                        </File>
-                                    <?else ?>
-                                        <File Id="AspNetCoreModuleHandlerDll"
-                                            Name="aspnetcorev2_outofprocess.dll"
-                                            Source="$(var.AspNetCoreV2HandlerWoW64.TargetPath)"
-                                            DiskId="1"
-                                            Vital="yes">
-                                        </File>
-                                    <?endif?>
+                                    <File Id="AspNetCoreModuleHandlerDll"
+                                        Name="aspnetcorev2_outofprocess.dll"
+                                        Source="$(var.AspNetCoreV2HandlerProgramFilesTargetPath)"
+                                        DiskId="1"
+                                        Vital="yes">
+                                    </File>
                                </Component>
                            </Directory>
                        </Directory>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -137,12 +137,21 @@
                    <Directory Id="INSTALLLOCATION" ShortName="ANCM" Name="Asp.Net Core Module">
                        <Directory Id="VersionDir" Name="$(var.ProductVersionString)">
                            <Component Id="AspNetCoreModuleV2" Guid="3a692941-59be-43cf-98a8-6ed01b12a519" Win64="$(var.IsWin64)">
-                               <File Id="AspNetCoreModuleV2Dll"
-                                     Name="aspnetcorev2.dll"
-                                     Source="$(var.AspNetCoreV2.TargetPath)"
-                                     DiskId="1"
-                                     Vital="yes">
-                               </File>
+                                <?if $(var.Platform) = "x64" ?>
+                                    <File Id="AspNetCoreModuleV2Dll"
+                                        Name="aspnetcorev2.dll"
+                                        Source="$(var.AspNetCoreV2.TargetPath)"
+                                        DiskId="1"
+                                        Vital="yes">
+                                    </File>
+                                <?else ?>
+                                    <File Id="AspNetCoreModuleV2Dll"
+                                        Name="aspnetcorev2.dll"
+                                        Source="$(var.AspNetCoreV2WoW64.TargetPath)"
+                                        DiskId="1"
+                                        Vital="yes">
+                                    </File>
+                                <?endif?>
                                <RemoveFile Id="AspNetCoreModuleV2Dll_Remove" Name="aspnetcorev2.dll" On="install" />
                                <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
                                    <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleV2Dll]"/>
@@ -151,12 +160,21 @@
                            </Component>
                            <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
                                <Component Id="AspNetCoreModuleHandler" Guid="4b62060a-deb8-4de3-9557-9c0be21dc844" Win64="$(var.IsWin64)">
-                                   <File Id="AspNetCoreModuleHandlerDll"
-                                         Name="aspnetcorev2_outofprocess.dll"
-                                         Source="$(var.AspNetCoreV2Handler.TargetPath)"
-                                         DiskId="1"
-                                         Vital="yes">
-                                   </File>
+                                    <?if $(var.Platform) = "x64" ?>
+                                        <File Id="AspNetCoreModuleHandlerDll"
+                                            Name="aspnetcorev2_outofprocess.dll"
+                                            Source="$(var.AspNetCoreV2Handler.TargetPath)"
+                                            DiskId="1"
+                                            Vital="yes">
+                                        </File>
+                                    <?else ?>
+                                        <File Id="AspNetCoreModuleHandlerDll"
+                                            Name="aspnetcorev2_outofprocess.dll"
+                                            Source="$(var.AspNetCoreV2HandlerWoW64.TargetPath)"
+                                            DiskId="1"
+                                            Vital="yes">
+                                        </File>
+                                    <?endif?>
                                </Component>
                            </Directory>
                        </Directory>


### PR DESCRIPTION
Right now, the x86 msis for ANCM contain the wrong bitness for dlls. This addresses it.