### PR TITLE
Fix race in dotnet-watch test

### DIFF
--- a/src/Tools/dotnet-watch/src/DotNetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatcher.cs
@@ -93,8 +93,6 @@ namespace Microsoft.DotNet.Watcher
 
                     if (finishedTask == processTask)
                     {
-                        _reporter.Warn("Waiting for a file to change before restarting dotnet...");
-
                         // Now wait for a file to change before restarting process
                         await fileSetWatcher.GetChangedFileAsync(cancellationToken);
                     }

--- a/src/Tools/dotnet-watch/src/DotNetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatcher.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Watcher
                     if (finishedTask == processTask)
                     {
                         // Now wait for a file to change before restarting process
-                        await fileSetWatcher.GetChangedFileAsync(cancellationToken);
+                        await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _reporter.Warn("Waiting for a file to change before restarting dotnet..."));
                     }
 
                     if (!string.IsNullOrEmpty(fileSetTask.Result))

--- a/src/Tools/dotnet-watch/src/Internal/FileSetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/Internal/FileSetWatcher.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.Watcher.Internal
     {
         private readonly FileWatcher _fileWatcher;
         private readonly IFileSet _fileSet;
+        private readonly IReporter _reporter;
 
         public FileSetWatcher(IFileSet fileSet, IReporter reporter)
         {
@@ -20,6 +21,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 
             _fileSet = fileSet;
             _fileWatcher = new FileWatcher(reporter);
+            _reporter = reporter;
         }
 
         public async Task<string> GetChangedFileAsync(CancellationToken cancellationToken)
@@ -41,6 +43,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             };
 
             _fileWatcher.OnFileChange += callback;
+            _reporter.Warn("Waiting for a file to change before restarting dotnet...");
             var changedFile = await tcs.Task;
             _fileWatcher.OnFileChange -= callback;
 


### PR DESCRIPTION
Possibly makes the `RunsWithIterationEnvVariable` test not flaky anymore.

The race is that we wait for the "Waiting for a file to change" log and then set the file time, but if we set the time before the `fileSetWatcher.OnFileChange` handler is registered then we could miss the file changed event.