### PR TITLE
Remove redundant IEnumerable interface from ArrayRange<T>

### DIFF
--- a/src/Components/Blazor/Build/test/ComponentRenderingRazorIntegrationTest.cs
+++ b/src/Components/Blazor/Build/test/ComponentRenderingRazorIntegrationTest.cs
@@ -350,7 +350,7 @@ namespace Test
             // Assert: Captured ChildContent frames are correct
             var childFrames = GetFrames((RenderFragment)frames[2].AttributeValue);
             Assert.Collection(
-                childFrames,
+                childFrames.AsEnumerable(),
                 frame => AssertFrame.Text(frame, "Some text", 3),
                 frame => AssertFrame.Element(frame, "some-child", 4, 4),
                 frame => AssertFrame.Attribute(frame, "a", "1", 5),
@@ -393,7 +393,7 @@ namespace Test
             // correct relative to each other (i.e., incrementing) within the nesting level.
             // As an implementation detail, it happens that they do follow on from the parent
             // level, but we could change that part of the implementation if we wanted.
-            var innerFrames = GetFrames((RenderFragment)frames[1].AttributeValue).ToArray();
+            var innerFrames = GetFrames((RenderFragment)frames[1].AttributeValue).AsEnumerable().ToArray();
             Assert.Collection(
                 innerFrames,
                 frame => AssertFrame.Component(frame, "Test.MyComponent", 2, 2),
@@ -401,7 +401,7 @@ namespace Test
 
             // Assert: second level of ChildContent is correct
             Assert.Collection(
-                GetFrames((RenderFragment)innerFrames[1].AttributeValue),
+                GetFrames((RenderFragment)innerFrames[1].AttributeValue).AsEnumerable(),
                 frame => AssertFrame.Text(frame, "Some text", 4));
         }
 
@@ -547,7 +547,7 @@ namespace Test
             // Assert: Captured ChildContent frames are correct
             var childFrames = GetFrames((RenderFragment)frames[6].AttributeValue);
             Assert.Collection(
-                childFrames,
+                childFrames.AsEnumerable(),
                 frame => AssertFrame.MarkupWhitespace(frame, 7),
                 frame => AssertFrame.Markup(frame, "<div><span></span><span></span></div>\n      ", 8),
                 frame => AssertFrame.Element(frame, "div", 2, 9),

--- a/src/Components/Blazor/Build/test/RazorIntegrationTestBase.cs
+++ b/src/Components/Blazor/Build/test/RazorIntegrationTestBase.cs
@@ -457,7 +457,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
 
             protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
             {
-                LatestBatchReferenceFrames = renderBatch.ReferenceFrames.ToArray();
+                LatestBatchReferenceFrames = renderBatch.ReferenceFrames.AsEnumerable().ToArray();
                 return Task.CompletedTask;
             }
         }

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -726,14 +726,12 @@ namespace Microsoft.AspNetCore.Components.Rendering
 namespace Microsoft.AspNetCore.Components.RenderTree
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct ArrayRange<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+    public readonly partial struct ArrayRange<T>
     {
         public readonly T[] Array;
         public readonly int Count;
         public ArrayRange(T[] array, int count) { throw null; }
         public Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T> Clone() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
     public partial class RenderTreeBuilder
     {

--- a/src/Components/Components/src/RenderTree/ArrayRange.cs
+++ b/src/Components/Components/src/RenderTree/ArrayRange.cs
@@ -1,17 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Components.RenderTree
 {
     /// <summary>
     /// Represents a range of elements in an array that are in use.
     /// </summary>
     /// <typeparam name="T">The array item type.</typeparam>
-    public readonly struct ArrayRange<T> : IEnumerable, IEnumerable<T>
+    public readonly struct ArrayRange<T>
     {
         /// <summary>
         /// Gets the underlying array instance.
@@ -33,14 +29,6 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             Array = array;
             Count = count;
         }
-
-        /// <inheritdoc />
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-            => ((IEnumerable<T>)new ArraySegment<T>(Array, 0, Count)).GetEnumerator();
-
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator()
-            => ((IEnumerable)new ArraySegment<T>(Array, 0, Count)).GetEnumerator();
 
         /// <summary>
         /// Creates a shallow clone of the instance.

--- a/src/Components/Components/test/RenderTreeBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeBuilderTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Components.Test
             // Assert
             var frames = builder.GetFrames();
             Assert.NotNull(frames.Array);
-            Assert.Empty(frames);
+            Assert.Empty(frames.AsEnumerable());
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             var frames = builder.GetFrames();
-            Assert.Collection(frames,
+            Assert.Collection(frames.AsEnumerable(),
                 frame => AssertFrame.Text(frame, "First item"),
                 frame => AssertFrame.Text(frame, string.Empty),
                 frame => AssertFrame.Text(frame, "Second item"));
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             var frames = builder.GetFrames();
-            Assert.Collection(frames,
+            Assert.Collection(frames.AsEnumerable(),
                 frame => AssertFrame.Element(frame, "some elem", 3),
                 frame => AssertFrame.Markup(frame, "Blah"),
                 frame => AssertFrame.Markup(frame, string.Empty));
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             var frames = builder.GetFrames();
-            Assert.Collection(frames,
+            Assert.Collection(frames.AsEnumerable(),
                 frame => AssertFrame.Markup(frame, "Some markup"),
                 frame => AssertFrame.Markup(frame, string.Empty));
         }
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             var frames = builder.GetFrames();
-            Assert.Collection(frames,
+            Assert.Collection(frames.AsEnumerable(),
                 frame => AssertFrame.Markup(frame, string.Empty));
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             var frames = builder.GetFrames();
-            Assert.Collection(frames,
+            Assert.Collection(frames.AsEnumerable(),
                 frame => AssertFrame.Text(frame, "1234"),
                 frame => AssertFrame.Text(frame, string.Empty));
         }
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.OpenElement(0, "my element");
 
             // Assert
-            var frame = builder.GetFrames().Single();
+            var frame = builder.GetFrames().AsEnumerable().Single();
             AssertFrame.Element(frame, "my element", 0);
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.AddContent(0, "standalone text 2"); // 11:  standalone text 2
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Text(frame, "standalone text 1"),
                 frame => AssertFrame.Element(frame, "root", 10),
                 frame => AssertFrame.Text(frame, "root text 1"),
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();                                 //     </myelement>
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "myelement", 6),
                 frame => AssertFrame.Attribute(frame, "attribute1", "value 1"),
                 frame => AssertFrame.Attribute(frame, "attribute2", "123"),
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();                              //     </parent>
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "parent", 6),
                 frame => AssertFrame.Component<TestComponent>(frame),
                 frame => AssertFrame.Attribute(frame, "child1attribute1", "A"),
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();                              //     </parent>
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "parent", 6),
                 frame => AssertFrame.Component<TestComponent>(frame),
                 frame => AssertFrame.Attribute(frame, "child1attribute1", "A"),
@@ -419,7 +419,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();                                 //     </parent>
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "parent", 6, 10),
                 frame => AssertFrame.Region(frame, 5, 11),
                 frame => AssertFrame.Text(frame, "Hello", 3),
@@ -447,7 +447,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "parent", 5, 10),
                 frame => AssertFrame.Region(frame, 4, 11),
                 frame => AssertFrame.Text(frame, "Hello from the fragment", 0),
@@ -470,7 +470,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();                                 //     </myelement>
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "myelement", 4, 0),
                 frame => AssertFrame.Attribute(frame, "attribute2", "123", 1),
                 frame => AssertFrame.ElementReferenceCapture(frame, referenceCaptureAction, 2),
@@ -538,7 +538,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseElement();
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "myelement", 3),
                 frame => AssertFrame.ElementReferenceCapture(frame, referenceCaptureAction1),
                 frame => AssertFrame.ElementReferenceCapture(frame, referenceCaptureAction2));
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseComponent();                               //     </TestComponent>
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 4, 0),
                 frame => AssertFrame.Attribute(frame, "attribute2", 123, 1),
                 frame => AssertFrame.ComponentReferenceCapture(frame, myAction, 2),
@@ -627,7 +627,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.CloseComponent();
 
             // Assert
-            Assert.Collection(builder.GetFrames(),
+            Assert.Collection(builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 3),
                 frame => AssertFrame.ComponentReferenceCapture(frame, referenceCaptureAction1),
                 frame => AssertFrame.ComponentReferenceCapture(frame, referenceCaptureAction2));
@@ -647,7 +647,7 @@ namespace Microsoft.AspNetCore.Components.Test
             builder.Clear();
 
             // Assert
-            Assert.Empty(builder.GetFrames());
+            Assert.Empty(builder.GetFrames().AsEnumerable());
         }
 
         [Fact]
@@ -663,7 +663,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", true, 1));
         }
@@ -681,7 +681,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 1, 0));
         }
 
@@ -700,7 +700,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -718,7 +718,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", "hi", 1));
         }
@@ -736,7 +736,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 1, 0));
         }
 
@@ -755,7 +755,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -775,7 +775,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -793,7 +793,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 1, 0));
         }
 
@@ -812,7 +812,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -830,7 +830,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 1, 0));
         }
 
@@ -854,7 +854,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -872,7 +872,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", true, 1));
         }
@@ -890,7 +890,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 1, 0));
         }
 
@@ -909,7 +909,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -927,7 +927,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", "hi", 1));
         }
@@ -945,7 +945,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", "hi", 1));
         }
@@ -965,7 +965,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -985,7 +985,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -1005,7 +1005,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -1025,7 +1025,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Component<TestComponent>(frame, 2, 0),
                 frame => AssertFrame.Attribute(frame, "attr", value, 1));
         }
@@ -1043,7 +1043,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Assert
             Assert.Collection(
-                builder.GetFrames(),
+                builder.GetFrames().AsEnumerable(),
                 frame => AssertFrame.Element(frame, "elem", 1, 0));
         }
 

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -486,7 +486,7 @@ namespace Microsoft.AspNetCore.Components.Test
             Assert.NotEqual(0, removedEventHandlerFrame.AttributeEventHandlerId);
             Assert.Equal(
                 new[] { removedEventHandlerFrame.AttributeEventHandlerId },
-                batch.DisposedEventHandlerIDs);
+                batch.DisposedEventHandlerIDs.AsEnumerable());
         }
 
         [Fact]
@@ -1114,7 +1114,7 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderBatch = GetRenderedBatch();
 
             // Assert
-            var diff = renderBatch.UpdatedComponents.Single();
+            var diff = renderBatch.UpdatedComponents.AsEnumerable().Single();
             Assert.Collection(diff.Edits,
                 entry => AssertEdit(entry, RenderTreeEditType.StepIn, 1),
                 entry =>
@@ -1145,7 +1145,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             var renderBatch = GetRenderedBatch();
-            var componentInstance = newTree.GetFrames().First().Component as FakeComponent;
+            var componentInstance = newTree.GetFrames().AsEnumerable().First().Component as FakeComponent;
 
             // Assert
             Assert.Equal(1, renderBatch.UpdatedComponents.Count);
@@ -1216,7 +1216,7 @@ namespace Microsoft.AspNetCore.Components.Test
             AssertFrame.Attribute(newAttributeFrame, "ontest", retainedHandler);
             Assert.NotEqual(0, oldAttributeFrame.AttributeEventHandlerId);
             Assert.Equal(oldAttributeFrame.AttributeEventHandlerId, newAttributeFrame.AttributeEventHandlerId);
-            Assert.Empty(batch.DisposedEventHandlerIDs);
+            Assert.Empty(batch.DisposedEventHandlerIDs.AsEnumerable());
         }
 
         [Fact]
@@ -1243,7 +1243,7 @@ namespace Microsoft.AspNetCore.Components.Test
             AssertFrame.Attribute(newAttributeFrame, "ontest", retainedHandler);
             Assert.NotEqual(0, oldAttributeFrame.AttributeEventHandlerId);
             Assert.Equal(oldAttributeFrame.AttributeEventHandlerId, newAttributeFrame.AttributeEventHandlerId);
-            Assert.Empty(batch.DisposedEventHandlerIDs);
+            Assert.Empty(batch.DisposedEventHandlerIDs.AsEnumerable());
         }
 
         [Fact]
@@ -1503,7 +1503,7 @@ namespace Microsoft.AspNetCore.Components.Test
             var batch = GetRenderedBatch(initializeFromFrames);
             var diffsInBatch = batch.UpdatedComponents;
             Assert.Equal(1, diffsInBatch.Count);
-            return (diffsInBatch.Array[0], batch.ReferenceFrames.ToArray(), batch);
+            return (diffsInBatch.Array[0], batch.ReferenceFrames.AsEnumerable().ToArray(), batch);
         }
 
         private RenderBatch GetRenderedBatch(bool initializeFromFrames = false)

--- a/src/Components/Shared/test/ArrayRangeExtensions.cs
+++ b/src/Components/Shared/test/ArrayRangeExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components.RenderTree;
+
+namespace Microsoft.AspNetCore.Components
+{
+    internal static class ArrayRangeExtensions
+    {
+        public static IEnumerable<T> AsEnumerable<T>(this ArrayRange<T> source)
+        {
+            // This is very allocatey, hence it only existing in test code.
+            // If we need a way to enumerate ArrayRange in product code, we should
+            // consider adding an AsSpan() method or a struct enumerator.
+            return new ArraySegment<T>(source.Array, 0, source.Count);
+        }
+    }
+}

--- a/src/Components/Shared/test/TestRenderer.cs
+++ b/src/Components/Shared/test/TestRenderer.cs
@@ -97,8 +97,8 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
             }
 
             // Clone other data, as underlying storage will get reused by later batches
-            capturedBatch.ReferenceFrames = renderBatch.ReferenceFrames.ToArray();
-            capturedBatch.DisposedComponentIDs = renderBatch.DisposedComponentIDs.ToList();
+            capturedBatch.ReferenceFrames = renderBatch.ReferenceFrames.AsEnumerable().ToArray();
+            capturedBatch.DisposedComponentIDs = renderBatch.DisposedComponentIDs.AsEnumerable().ToList();
 
             // This renderer updates the UI synchronously, like the WebAssembly one.
             // To test async UI updates, subclass TestRenderer and override UpdateDisplayAsync.


### PR DESCRIPTION
No urgency on this since it won't affect shipping code.

`ArrayRange<T>` declared itself as `IEnumerable`/`IEnumerable<T>`, but this was only used by test code. It's a good job it wasn't used in product code, since as @davidfowl noticed, it allocated twice on every call.

To ensure we don't accidentally start using the allocatey methods in production code, this PR removes those interfaces. There quite a lot of noise making the tests continue to work, but it's all simple mechanical changes.

**Reviewers**: The easiest way to read this PR is each commit separately.