### PR TITLE
Make RouteOptions.EndpointDataSources internal

### DIFF
--- a/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.netcoreapp3.0.cs
+++ b/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.netcoreapp3.0.cs
@@ -319,7 +319,6 @@ namespace Microsoft.AspNetCore.Routing
         public RouteOptions() { }
         public bool AppendTrailingSlash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IDictionary<string, System.Type> ConstraintMap { get { throw null; } set { } }
-        public System.Collections.Generic.ICollection<Microsoft.AspNetCore.Routing.EndpointDataSource> EndpointDataSources { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public bool LowercaseQueryStrings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool LowercaseUrls { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SuppressCheckForUnhandledSecurityMetadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Http/Routing/src/RouteOptions.cs
+++ b/src/Http/Routing/src/RouteOptions.cs
@@ -3,13 +3,25 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Routing.Constraints;
 
 namespace Microsoft.AspNetCore.Routing
 {
     public class RouteOptions
     {
-        public ICollection<EndpointDataSource> EndpointDataSources { get; internal set; }
+        /// <summary>
+        /// Gets a collection of <see cref="EndpointDataSource"/> instances configured with routing.
+        /// </summary>
+        internal ICollection<EndpointDataSource> EndpointDataSources
+        {
+            get
+            {
+                Debug.Assert(_endpointDataSources != null, "Endpoint data sources should have been set in DI.");
+                return _endpointDataSources;
+            }
+            set => _endpointDataSources = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether all generated paths URLs are lower-case. 
@@ -49,6 +61,7 @@ namespace Microsoft.AspNetCore.Routing
         public bool SuppressCheckForUnhandledSecurityMetadata { get; set; }
 
         private IDictionary<string, Type> _constraintTypeMap = GetDefaultConstraintMap();
+        private ICollection<EndpointDataSource> _endpointDataSources;
 
         public IDictionary<string, Type> ConstraintMap
         {

--- a/src/Http/Routing/src/RouteOptions.cs
+++ b/src/Http/Routing/src/RouteOptions.cs
@@ -10,6 +10,9 @@ namespace Microsoft.AspNetCore.Routing
 {
     public class RouteOptions
     {
+        private IDictionary<string, Type> _constraintTypeMap = GetDefaultConstraintMap();
+        private ICollection<EndpointDataSource> _endpointDataSources;
+
         /// <summary>
         /// Gets a collection of <see cref="EndpointDataSource"/> instances configured with routing.
         /// </summary>
@@ -59,9 +62,6 @@ namespace Microsoft.AspNetCore.Routing
         /// this check if it does not match your application's requirements.
         /// </remarks>
         public bool SuppressCheckForUnhandledSecurityMetadata { get; set; }
-
-        private IDictionary<string, Type> _constraintTypeMap = GetDefaultConstraintMap();
-        private ICollection<EndpointDataSource> _endpointDataSources;
 
         public IDictionary<string, Type> ConstraintMap
         {

--- a/src/Mvc/Mvc.Core/test/Builder/MvcApplicationBuilderExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/Builder/MvcApplicationBuilderExtensionsTest.cs
@@ -55,10 +55,10 @@ namespace Microsoft.AspNetCore.Mvc.Core.Builder
                     template: "{controller=Home}/{action=Index}/{id?}");
             });
 
-            var routeOptions = appBuilder.ApplicationServices
-                .GetRequiredService<IOptions<RouteOptions>>();
+            var endpointDataSource = appBuilder.ApplicationServices
+                .GetRequiredService<EndpointDataSource>();
 
-            Assert.Empty(routeOptions.Value.EndpointDataSources);
+            Assert.Empty(endpointDataSource.Endpoints);
         }
 
         [Fact]


### PR DESCRIPTION
I noticed RouteOptions.EndpointDataSources was only set in DI and the setter is internal.

Return a collection if not set for use outside of DI, e.g. unit testing.