### PR TITLE
Speed up PathStringHelper

### DIFF
--- a/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+++ b/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
@@ -53,7 +53,8 @@ namespace Microsoft.AspNetCore.Http.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPercentEncodedChar(string str, int index)
         {
-            if (str[index] == '%' && index < str.Length - 2)
+            var len = (uint)str.Length;
+            if (str[index] == '%' && index < len - 2)
             {
                 return AreFollowingTwoCharsHex(str, index);
             }

--- a/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+++ b/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
@@ -1,11 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.AspNetCore.Http.Internal
 {
     internal class PathStringHelper
     {
-        private static bool[] ValidPathChars = {
+        private static readonly bool[] ValidPathChars = {
             false, false, false, false, false, false, false, false,     // 0x00 - 0x07
             false, false, false, false, false, false, false, false,     // 0x08 - 0x0F
             false, false, false, false, false, false, false, false,     // 0x10 - 0x17
@@ -24,24 +27,57 @@ namespace Microsoft.AspNetCore.Http.Internal
             true,  true,  true,  false, false, false, true,  false,     // 0x78 - 0x7F
         };
 
+        // Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.
+        // From coreclr/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+        // byte[] rather than ReadOnlySpan<byte> to avoid double .Length check https://github.com/dotnet/coreclr/issues/24209
+        private static readonly byte[] CharToHexLookup = new byte[]
+        {
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 15
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 31
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 47
+            0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 63
+            0xFF, 0xA,  0xB,  0xC,  0xD,  0xE,  0xF,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 79
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 95
+            0xFF, 0xa,  0xb,  0xc,  0xd,  0xe,  0xf // 102
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsValidPathChar(char c)
         {
-            return c < ValidPathChars.Length && ValidPathChars[c];
+            // Use local array and uint .Length compare to elide the bounds check on array access
+            var validChars = ValidPathChars;
+            var i = (int)c;
+            return (uint)i < (uint)validChars.Length && validChars[i];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPercentEncodedChar(string str, int index)
         {
-            return index < str.Length - 2
-                && str[index] == '%'
-                && IsHexadecimalChar(str[index + 1])
-                && IsHexadecimalChar(str[index + 2]);
+            if (str[index] == '%' && index < str.Length - 2)
+            {
+                return AreFollowingTwoCharsHex(str, index);
+            }
+
+            return false;
         }
 
-        public static bool IsHexadecimalChar(char c)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool AreFollowingTwoCharsHex(string str, int index)
         {
-            return ('0' <= c && c <= '9')
-                || ('A' <= c && c <= 'F')
-                || ('a' <= c && c <= 'f');
+            Debug.Assert(index < str.Length - 2);
+
+            var charToHex = CharToHexLookup;
+            var i1 = (int)str[index + 1];
+            var i2 = (int)str[index + 2];
+            if ((uint)i1 < (uint)charToHex.Length &&
+                charToHex[i1] != 0xff &&
+               (uint)i2 < (uint)charToHex.Length &&
+                charToHex[i2] != 0xff)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+++ b/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Http.Internal
 {
-    internal class PathStringHelper
+    internal static class PathStringHelper
     {
         private static readonly bool[] ValidPathChars = {
             false, false, false, false, false, false, false, false,     // 0x00 - 0x07
@@ -70,12 +70,11 @@ namespace Microsoft.AspNetCore.Http.Internal
             var charToHex = CharToHexLookup;
             var i1 = (int)str[index + 1];
             var i2 = (int)str[index + 2];
-            if ((uint)i1 < (uint)charToHex.Length &&
-                charToHex[i1] != 0xff &&
-               (uint)i2 < (uint)charToHex.Length &&
-                charToHex[i2] != 0xff)
+            if ((uint)i1 < (uint)charToHex.Length
+                && (uint)i2 < (uint)charToHex.Length)
             {
-                return true;
+                var tmp = charToHex[i1] | charToHex[i2];
+                return tmp != 0xFF;
             }
 
             return false;

--- a/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+++ b/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Http.Internal
 
             // Check offset in bounds and check if significant bit set
             return (uint)offset < (uint)validChars.Length &&
-                ((validChars[offset] & significantBit) == significantBit);
+                ((validChars[offset] & significantBit) != 0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+++ b/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             var i = (int)c;
 
             // Array is in chunks of 32 bits, so get offset by dividing by 32
-            var offset = i / 32;
+            var offset = i >> 5;		// i / 32;
             // Significant bit position is the remainder of the above calc; i % 32 => i & 31
             var significantBit = 1u << (i & 31);
 
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Http.Internal
         private static bool IsHexadecimalChar(char c)
         {
             // Between 0 - 9 or uppercased between A - F
-            return (c - '0') <= 9 || ((c & ~0x20) - 'A') <= ('F' - 'A');
+            return (uint)(c - '0') <= 9 || (uint)((c & ~0x20) - 'A') <= ('F' - 'A');
         }
     }
 }

--- a/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+++ b/src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
@@ -8,6 +8,9 @@ namespace Microsoft.AspNetCore.Http.Internal
 {
     internal static class PathStringHelper
     {
+        // uint[] bits uses 1 cache line (Array info + 16 bytes)
+        // bool[] would use 3 cache lines (Array info + 128 bytes)
+        // So we use 128 bits rather than 128 bytes/bools
         private static readonly uint[] ValidPathChars = {
             0b_0000_0000__0000_0000__0000_0000__0000_0000, // 0x00 - 0x1F
             0b_0010_1111__1111_1111__1111_1111__1101_0010, // 0x20 - 0x3F

--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -74,12 +74,18 @@ namespace Microsoft.AspNetCore.Http
             }
 
             var value = _value;
-            for (var i = 0; i < value.Length; i++)
+            var i = 0;
+            for (; i < value.Length; i++)
             {
                 if (!PathStringHelper.IsValidPathChar(value[i]) || PathStringHelper.IsPercentEncodedChar(value, i))
                 {
-                    return ToEscapedUriComponent(value, i);
+                    break;
                 }
+            }
+
+            if (i < value.Length)
+            {
+                return ToEscapedUriComponent(value, i);
             }
 
             return value;


### PR DESCRIPTION
Called by `PathString.ToString()` in `HostingLogScope` as top contributor

![image](https://user-images.githubusercontent.com/1142958/56633495-50c7c200-6656-11e9-82b9-6b17f1517a73.png)

As they are per `char` methods they multiply up significantly

![image](https://user-images.githubusercontent.com/1142958/56633416-f464a280-6655-11e9-9c76-0d981e44b090.png)

With change moves to lowest contributor

![image](https://user-images.githubusercontent.com/1142958/57005675-c4774b00-6bd1-11e9-8128-edd4131d13e4.png)


Contributes to https://github.com/aspnet/AspNetCore/issues/9594

/cc @davidfowl 