### PR TITLE
Updating ConfigureServices overload

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
@@ -16,7 +16,7 @@ namespace Company.Application1
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureServices(services =>
+                .ConfigureServices((hostContext, services) =>
                 {
                     services.AddHostedService<Worker>();
                 });


### PR DESCRIPTION
Using the overload where the HostBuilderContext is available to support common usage scenarios such as accessing the environment and configuration whilst registering services.

Summary of the changes (Less than 80 chars)
 - Changed overload of ConfigureServices

Addresses #9677 