### PR TITLE
SPA templates generate invalid package names in package.json

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Company.WebApplication1",
+  "name": "company.webapplication1",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Company.WebApplication1",
+  "name": "company.webapplication1",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Company.WebApplication1",
+  "name": "company.webapplication1",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Lowercased project name in NPM packages
 - Added unit test to check NPM package names matches regex validation

Addresses #9502