### PR TITLE
Fix documentation typo

### DIFF
--- a/src/Http/Http.Abstractions/src/Routing/Endpoint.cs
+++ b/src/Http/Http.Abstractions/src/Routing/Endpoint.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Http
 {
     /// <summary>
-    /// Respresents a logical endpoint in an application.
+    /// Represents a logical endpoint in an application.
     /// </summary>
     public class Endpoint
     {


### PR DESCRIPTION
Looking at the Endpoint class [documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.endpoint?view=aspnetcore-2.2), there is `Respresents` instead of `Represents`.

This PR fixes this documentation typo.