### PR TITLE
Add IConnectionCompleteFeature.OnCompleted

### DIFF
--- a/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.netstandard2.0.cs
+++ b/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.netstandard2.0.cs
@@ -100,6 +100,10 @@ namespace Microsoft.AspNetCore.Connections
 }
 namespace Microsoft.AspNetCore.Connections.Features
 {
+    public partial interface IConnectionCompleteFeature
+    {
+        void OnCompleted(System.Func<object, System.Threading.Tasks.Task> callback, object state);
+    }
     public partial interface IConnectionHeartbeatFeature
     {
         void OnHeartbeat(System.Action<object> action, object state);

--- a/src/Servers/Connections.Abstractions/src/Features/IConnectionCompleteFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IConnectionCompleteFeature.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Connections.Features
+{
+    /// <summary>
+    /// Represents the completion action for a connection.
+    /// </summary>
+    public interface IConnectionCompleteFeature
+    {
+        /// <summary>
+        /// Registers a callback to be invoked after a connection has fully completed processing. This is
+        /// intended for resource cleanup.
+        /// </summary>
+        /// <param name="callback">The callback to invoke after the connection has completed processing.</param>
+        /// <param name="state">The state to pass into the callback.</param>
+        void OnCompleted(Func<object, Task> callback, object state);
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -82,6 +82,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             }
             finally
             {
+                await connectionContext.FireOnCompleted();
+
                 Log.ConnectionStop(connectionContext.ConnectionId);
                 KestrelEventSource.Log.ConnectionStop(connectionContext);
 

--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             }
             finally
             {
-                await connectionContext.FireOnCompleted();
+                await connectionContext.CompleteAsync();
 
                 Log.ConnectionStop(connectionContext.ConnectionId);
                 KestrelEventSource.Log.ConnectionStop(connectionContext);

--- a/src/Servers/Kestrel/Transport.Abstractions/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
+++ b/src/Servers/Kestrel/Transport.Abstractions/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
@@ -6,5 +6,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.netcoreapp3.0.cs" />
     <Reference Include="Microsoft.AspNetCore.Connections.Abstractions"  />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions"  />
   </ItemGroup>
 </Project>

--- a/src/Servers/Kestrel/Transport.Abstractions/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Transport.Abstractions/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.netcoreapp3.0.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         ThreadPool = 1,
         Inline = 2,
     }
-    public abstract partial class TransportConnection : Microsoft.AspNetCore.Connections.ConnectionContext, Microsoft.AspNetCore.Connections.Features.IConnectionHeartbeatFeature, Microsoft.AspNetCore.Connections.Features.IConnectionIdFeature, Microsoft.AspNetCore.Connections.Features.IConnectionItemsFeature, Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeFeature, Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeNotificationFeature, Microsoft.AspNetCore.Connections.Features.IConnectionTransportFeature, Microsoft.AspNetCore.Connections.Features.IMemoryPoolFeature, Microsoft.AspNetCore.Http.Features.IFeatureCollection, Microsoft.AspNetCore.Http.Features.IHttpConnectionFeature, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal.IApplicationTransportFeature, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal.ITransportSchedulerFeature, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, object>>, System.Collections.IEnumerable
+    public abstract partial class TransportConnection : Microsoft.AspNetCore.Connections.ConnectionContext, Microsoft.AspNetCore.Connections.Features.IConnectionCompleteFeature, Microsoft.AspNetCore.Connections.Features.IConnectionHeartbeatFeature, Microsoft.AspNetCore.Connections.Features.IConnectionIdFeature, Microsoft.AspNetCore.Connections.Features.IConnectionItemsFeature, Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeFeature, Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeNotificationFeature, Microsoft.AspNetCore.Connections.Features.IConnectionTransportFeature, Microsoft.AspNetCore.Connections.Features.IMemoryPoolFeature, Microsoft.AspNetCore.Http.Features.IFeatureCollection, Microsoft.AspNetCore.Http.Features.IHttpConnectionFeature, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal.IApplicationTransportFeature, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal.ITransportSchedulerFeature, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, object>>, System.Collections.IEnumerable
     {
         protected readonly System.Threading.CancellationTokenSource _connectionClosingCts;
         public TransportConnection() { }
@@ -73,6 +73,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         public override System.Collections.Generic.IDictionary<object, object> Items { get { throw null; } set { } }
         public System.Net.IPAddress LocalAddress { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int LocalPort { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        protected internal virtual Microsoft.Extensions.Logging.ILogger Logger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public virtual System.Buffers.MemoryPool<byte> MemoryPool { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         System.Collections.Generic.IDictionary<object, object> Microsoft.AspNetCore.Connections.Features.IConnectionItemsFeature.Items { get { throw null; } set { } }
         System.Threading.CancellationToken Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeFeature.ConnectionClosed { get { throw null; } set { } }
@@ -96,6 +97,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         public int RemotePort { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override System.IO.Pipelines.IDuplexPipe Transport { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override void Abort(Microsoft.AspNetCore.Connections.ConnectionAbortedException abortReason) { }
+        public System.Threading.Tasks.Task CompleteAsync() { throw null; }
+        void Microsoft.AspNetCore.Connections.Features.IConnectionCompleteFeature.OnCompleted(System.Func<object, System.Threading.Tasks.Task> callback, object state) { }
         void Microsoft.AspNetCore.Connections.Features.IConnectionHeartbeatFeature.OnHeartbeat(System.Action<object> action, object state) { }
         void Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeFeature.Abort() { }
         void Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeNotificationFeature.RequestClose() { }

--- a/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.FeatureCollection.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
@@ -106,7 +107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             OnHeartbeat(action, state);
         }
 
-        public void OnCompleted(Func<object, Task> callback, object state)
+        void IConnectionCompleteFeature.OnCompleted(Func<object, Task> callback, object state)
         {
             if (_onCompleted == null)
             {
@@ -139,8 +140,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                         return FireOnCompletedAwaited(task, onCompleted);
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Logger?.LogError(ex, "An error occured running an IConnectionCompleteFeature.OnCompleted callback.");
                 }
             }
 
@@ -153,8 +155,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             {
                 await currentTask;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Logger?.LogError(ex, "An error occured running an IConnectionCompleteFeature.OnCompleted callback.");
             }
 
             while (onCompleted.TryPop(out var entry))
@@ -163,8 +166,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 {
                     await entry.Key.Invoke(entry.Value);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Logger?.LogError(ex, "An error occured running an IConnectionCompleteFeature.OnCompleted callback.");
                 }
             }
         }

--- a/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.Generated.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         private static readonly Type IConnectionLifetimeFeatureType = typeof(IConnectionLifetimeFeature);
         private static readonly Type IConnectionHeartbeatFeatureType = typeof(IConnectionHeartbeatFeature);
         private static readonly Type IConnectionLifetimeNotificationFeatureType = typeof(IConnectionLifetimeNotificationFeature);
+        private static readonly Type IConnectionCompleteFeatureType = typeof(IConnectionCompleteFeature);
 
         private object _currentIHttpConnectionFeature;
         private object _currentIConnectionIdFeature;
@@ -33,6 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         private object _currentIConnectionLifetimeFeature;
         private object _currentIConnectionHeartbeatFeature;
         private object _currentIConnectionLifetimeNotificationFeature;
+        private object _currentIConnectionCompleteFeature;
 
         private int _featureRevision;
 
@@ -50,6 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             _currentIConnectionLifetimeFeature = this;
             _currentIConnectionHeartbeatFeature = this;
             _currentIConnectionLifetimeNotificationFeature = this;
+            _currentIConnectionCompleteFeature = this;
 
         }
 
@@ -145,6 +148,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 {
                     feature = _currentIConnectionLifetimeNotificationFeature;
                 }
+                else if (key == IConnectionCompleteFeatureType)
+                {
+                    feature = _currentIConnectionCompleteFeature;
+                }
                 else if (MaybeExtra != null)
                 {
                     feature = ExtraFeatureGet(key);
@@ -197,6 +204,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 {
                     _currentIConnectionLifetimeNotificationFeature = value;
                 }
+                else if (key == IConnectionCompleteFeatureType)
+                {
+                    _currentIConnectionCompleteFeature = value;
+                }
                 else
                 {
                     ExtraFeatureSet(key, value);
@@ -246,6 +257,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             else if (typeof(TFeature) == typeof(IConnectionLifetimeNotificationFeature))
             {
                 feature = (TFeature)_currentIConnectionLifetimeNotificationFeature;
+            }
+            else if (typeof(TFeature) == typeof(IConnectionCompleteFeature))
+            {
+                feature = (TFeature)_currentIConnectionCompleteFeature;
             }
             else if (MaybeExtra != null)
             {
@@ -298,6 +313,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             {
                 _currentIConnectionLifetimeNotificationFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(IConnectionCompleteFeature))
+            {
+                _currentIConnectionCompleteFeature = feature;
+            }
             else
             {
                 ExtraFeatureSet(typeof(TFeature), feature);
@@ -345,6 +364,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             if (_currentIConnectionLifetimeNotificationFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IConnectionLifetimeNotificationFeatureType, _currentIConnectionLifetimeNotificationFeature);
+            }
+            if (_currentIConnectionCompleteFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IConnectionCompleteFeatureType, _currentIConnectionCompleteFeature);
             }
 
             if (MaybeExtra != null)

--- a/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.cs
+++ b/src/Servers/Kestrel/Transport.Abstractions/src/Internal/TransportConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,7 @@ using System.Net;
 using System.Threading;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
@@ -34,6 +35,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         public override string ConnectionId { get; set; }
 
         public override IFeatureCollection Features => this;
+
+        protected internal virtual ILogger Logger { get; set; }
 
         public virtual MemoryPool<byte> MemoryPool { get; }
         public virtual PipeScheduler InputWriterScheduler { get; }

--- a/src/Servers/Kestrel/Transport.Abstractions/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
+++ b/src/Servers/Kestrel/Transport.Abstractions/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Connections.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             LocalPort = localEndPoint?.Port ?? 0;
 
             ConnectionClosed = _connectionClosedTokenSource.Token;
+            Logger = log;
             Log = log;
             Thread = thread;
         }

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             _socket = socket;
             MemoryPool = memoryPool;
             _scheduler = scheduler;
+            Logger = trace;
             _trace = trace;
 
             var localEndPoint = (IPEndPoint)_socket.LocalEndPoint;

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace CodeGenerator
@@ -20,7 +20,8 @@ namespace CodeGenerator
                 "ITransportSchedulerFeature",
                 "IConnectionLifetimeFeature",
                 "IConnectionHeartbeatFeature",
-                "IConnectionLifetimeNotificationFeature"
+                "IConnectionLifetimeNotificationFeature",
+                "IConnectionCompleteFeature"
             };
 
             var usings = $@"


### PR DESCRIPTION
#9213 This is a copy of the HttpResponse.OnCompleted feature down to the connection level. It's intended for resource cleanup at the end of the connection lifecycle and will be used by KerberosAuth to eagerly Dispose state (https://github.com/aspnet/AspNetCore/issues/8897).