### PR TITLE
Make endpoint routing allocation free in common scenarios

### DIFF
--- a/src/Http/Routing.Abstractions/src/RoutingHttpContextExtensions.cs
+++ b/src/Http/Routing.Abstractions/src/RoutingHttpContextExtensions.cs
@@ -25,14 +25,7 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             var routingFeature = httpContext.Features.Get<IRoutingFeature>();
-
-            if (routingFeature == null)
-            {
-                // REVIEW: Handle data tokens somehow?
-                return new RouteData(httpContext.Request.RouteValues);
-            }
-
-            return routingFeature.RouteData;
+            return routingFeature?.RouteData ?? new RouteData(httpContext.Request.RouteValues);
         }
 
         /// <summary>
@@ -54,8 +47,7 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(key));
             }
 
-            return httpContext.Features.Get<IRoutingFeature>()?.RouteData.Values[key] ??
-                   httpContext.Features.Get<IRouteValuesFeature>()?.RouteValues[key];
+            return httpContext.Features.Get<IRouteValuesFeature>()?.RouteValues[key];
         }
     }
 }

--- a/src/Http/Routing.Abstractions/src/RoutingHttpContextExtensions.cs
+++ b/src/Http/Routing.Abstractions/src/RoutingHttpContextExtensions.cs
@@ -24,8 +24,15 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            var routingFeature = httpContext.Features[typeof(IRoutingFeature)] as IRoutingFeature;
-            return routingFeature?.RouteData;
+            var routingFeature = httpContext.Features.Get<IRoutingFeature>();
+
+            if (routingFeature == null)
+            {
+                // REVIEW: Handle data tokens somehow?
+                return new RouteData(httpContext.Request.RouteValues);
+            }
+
+            return routingFeature.RouteData;
         }
 
         /// <summary>

--- a/src/Http/Routing.Abstractions/src/RoutingHttpContextExtensions.cs
+++ b/src/Http/Routing.Abstractions/src/RoutingHttpContextExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Routing
 {
@@ -46,8 +47,8 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(key));
             }
 
-            var routingFeature = httpContext.Features[typeof(IRoutingFeature)] as IRoutingFeature;
-            return routingFeature?.RouteData.Values[key];
+            return httpContext.Features.Get<IRoutingFeature>()?.RouteData.Values[key] ??
+                   httpContext.Features.Get<IRouteValuesFeature>()?.RouteValues[key];
         }
     }
 }

--- a/src/Http/Routing/perf/EndpointRoutingBenchmarkBase.cs
+++ b/src/Http/Routing/perf/EndpointRoutingBenchmarkBase.cs
@@ -131,10 +131,9 @@ namespace Microsoft.AspNetCore.Routing
         protected (HttpContext httpContext, RouteValueDictionary ambientValues) CreateCurrentRequestContext(
             object ambientValues = null)
         {
-            var feature = new EndpointSelectorContext { RouteValues = new RouteValueDictionary(ambientValues) };
+            
             var context = new DefaultHttpContext();
-            context.Features.Set<IEndpointFeature>(feature);
-            context.Features.Set<IRouteValuesFeature>(feature);
+            var feature = new EndpointSelectorContext(context) { RouteValues = new RouteValueDictionary(ambientValues) };
 
             return (context, feature.RouteValues);
         }

--- a/src/Http/Routing/perf/EndpointRoutingBenchmarkBase.cs
+++ b/src/Http/Routing/perf/EndpointRoutingBenchmarkBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Routing
             return CreateServices().GetRequiredService<DfaMatcherBuilder>();
         }
 
-        private protected static  int[] SampleRequests(int endpointCount, int count)
+        private protected static int[] SampleRequests(int endpointCount, int count)
         {
             // This isn't very high tech, but it's at least regular distribution.
             // We sort the route templates by precedence, so this should result in
@@ -129,7 +129,6 @@ namespace Microsoft.AspNetCore.Routing
         protected (HttpContext httpContext, RouteValueDictionary ambientValues) CreateCurrentRequestContext(
             object ambientValues = null)
         {
-            
             var context = new DefaultHttpContext();
             context.Request.RouteValues = new RouteValueDictionary(ambientValues);
 

--- a/src/Http/Routing/perf/EndpointRoutingBenchmarkBase.cs
+++ b/src/Http/Routing/perf/EndpointRoutingBenchmarkBase.cs
@@ -7,14 +7,12 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.AspNetCore.Routing.Tree;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Routing
 {
@@ -133,9 +131,9 @@ namespace Microsoft.AspNetCore.Routing
         {
             
             var context = new DefaultHttpContext();
-            var feature = new EndpointSelectorContext(context) { RouteValues = new RouteValueDictionary(ambientValues) };
+            context.Request.RouteValues = new RouteValueDictionary(ambientValues);
 
-            return (context, feature.RouteValues);
+            return (context, context.Request.RouteValues);
         }
 
         protected void CreateOutboundRouteEntry(TreeRouteBuilder treeRouteBuilder, RouteEndpoint endpoint)

--- a/src/Http/Routing/perf/Matching/MatcherSingleEntryBenchmark.cs
+++ b/src/Http/Routing/perf/Matching/MatcherSingleEntryBenchmark.cs
@@ -18,8 +18,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
         private Matcher _route;
         private Matcher _tree;
 
-        private EndpointSelectorContext _feature;
-
         [GlobalSetup]
         public void Setup()
         {
@@ -35,8 +33,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
             _dfa = SetupMatcher(CreateDfaMatcherBuilder());
             _route = SetupMatcher(new RouteMatcherBuilder());
             _tree = SetupMatcher(new TreeRouterMatcherBuilder());
-
-            _feature = new EndpointSelectorContext();
         }
 
         private Matcher SetupMatcher(MatcherBuilder builder)
@@ -48,8 +44,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
         [Benchmark(Baseline = true)]
         public async Task Baseline()
         {
-            var feature = _feature;
             var httpContext = Requests[0];
+            var feature = new EndpointSelectorContext(httpContext);
 
             await _baseline.MatchAsync(httpContext, feature);
             Validate(httpContext, Endpoints[0], feature.Endpoint);
@@ -58,8 +54,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
         [Benchmark]
         public async Task Dfa()
         {
-            var feature = _feature;
             var httpContext = Requests[0];
+            var feature = new EndpointSelectorContext(httpContext);
 
             await _dfa.MatchAsync(httpContext, feature);
             Validate(httpContext, Endpoints[0], feature.Endpoint);
@@ -68,12 +64,11 @@ namespace Microsoft.AspNetCore.Routing.Matching
         [Benchmark]
         public async Task LegacyTreeRouter()
         {
-            var feature = _feature;
-
             var httpContext = Requests[0];
+            var feature = new EndpointSelectorContext(httpContext);
 
-            // This is required to make the legacy router implementation work with global routing.
-            httpContext.Features.Set<IEndpointFeature>(feature);
+            //// This is required to make the legacy router implementation work with global routing.
+            //httpContext.Features.Set<IEndpointFeature>(feature);
 
             await _tree.MatchAsync(httpContext, feature);
             Validate(httpContext, Endpoints[0], feature.Endpoint);
@@ -82,11 +77,11 @@ namespace Microsoft.AspNetCore.Routing.Matching
         [Benchmark]
         public async Task LegacyRouter()
         {
-            var feature = _feature;
             var httpContext = Requests[0];
+            var feature = new EndpointSelectorContext(httpContext);
 
             // This is required to make the legacy router implementation work with global routing.
-            httpContext.Features.Set<IEndpointFeature>(feature);
+            //httpContext.Features.Set<IEndpointFeature>(feature);
 
             await _route.MatchAsync(httpContext, feature);
             Validate(httpContext, Endpoints[0], feature.Endpoint);

--- a/src/Http/Routing/perf/Matching/MatcherSingleEntryBenchmark.cs
+++ b/src/Http/Routing/perf/Matching/MatcherSingleEntryBenchmark.cs
@@ -11,8 +11,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
     // Just like TechEmpower Plaintext
     public partial class MatcherSingleEntryBenchmark : EndpointRoutingBenchmarkBase
     {
-        private const int SampleCount = 100;
-
         private BarebonesMatcher _baseline;
         private Matcher _dfa;
         private Matcher _route;
@@ -67,9 +65,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var httpContext = Requests[0];
             var feature = new EndpointSelectorContext(httpContext);
 
-            //// This is required to make the legacy router implementation work with global routing.
-            //httpContext.Features.Set<IEndpointFeature>(feature);
-
             await _tree.MatchAsync(httpContext, feature);
             Validate(httpContext, Endpoints[0], feature.Endpoint);
         }
@@ -79,9 +74,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
         {
             var httpContext = Requests[0];
             var feature = new EndpointSelectorContext(httpContext);
-
-            // This is required to make the legacy router implementation work with global routing.
-            //httpContext.Features.Set<IEndpointFeature>(feature);
 
             await _route.MatchAsync(httpContext, feature);
             Validate(httpContext, Endpoints[0], feature.Endpoint);

--- a/src/Http/Routing/perf/Matching/TrivialMatcher.cs
+++ b/src/Http/Routing/perf/Matching/TrivialMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,11 +28,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
             if (httpContext == null)
             {
                 throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
             }
 
             var path = httpContext.Request.Path.Value;

--- a/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.netcoreapp3.0.cs
+++ b/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.netcoreapp3.0.cs
@@ -88,11 +88,12 @@ namespace Microsoft.AspNetCore.Routing
         public EndpointNameMetadata(string endpointName) { }
         public string EndpointName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    public sealed partial class EndpointSelectorContext : Microsoft.AspNetCore.Http.Features.IEndpointFeature, Microsoft.AspNetCore.Http.Features.IRouteValuesFeature, Microsoft.AspNetCore.Routing.IRoutingFeature
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct EndpointSelectorContext
     {
-        public EndpointSelectorContext() { }
-        public Microsoft.AspNetCore.Http.Endpoint Endpoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        Microsoft.AspNetCore.Routing.RouteData Microsoft.AspNetCore.Routing.IRoutingFeature.RouteData { get { throw null; } set { } }
+        private object _dummy;
+        public EndpointSelectorContext(Microsoft.AspNetCore.Http.HttpContext httpContext) { throw null; }
+        public Microsoft.AspNetCore.Http.Endpoint Endpoint { get { throw null; } set { } }
         public Microsoft.AspNetCore.Routing.RouteValueDictionary RouteValues { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=false)]

--- a/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.netcoreapp3.0.cs
+++ b/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.netcoreapp3.0.cs
@@ -89,9 +89,9 @@ namespace Microsoft.AspNetCore.Routing
         public string EndpointName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct EndpointSelectorContext
+    public readonly partial struct EndpointSelectorContext
     {
-        private object _dummy;
+        private readonly object _dummy;
         public EndpointSelectorContext(Microsoft.AspNetCore.Http.HttpContext httpContext) { throw null; }
         public Microsoft.AspNetCore.Http.Endpoint Endpoint { get { throw null; } set { } }
         public Microsoft.AspNetCore.Routing.RouteValueDictionary RouteValues { get { throw null; } set { } }

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Routing
 
         public Task Invoke(HttpContext httpContext)
         {
-            var feature = new EndpointSelectorContext();
+            var feature = new EndpointSelectorContext(httpContext);
 
             // There's an inherent race condition between waiting for init and accessing the matcher
             // this is OK because once `_matcher` is initialized, it will not be set to null again.
@@ -97,8 +97,6 @@ namespace Microsoft.AspNetCore.Routing
             {
                 // Set the endpoint feature only on success. This means we won't overwrite any
                 // existing state for related features unless we did something.
-                SetFeatures(httpContext, feature);
-
                 Log.MatchSuccess(_logger, feature);
             }
             else
@@ -107,15 +105,6 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             return _next(httpContext);
-        }
-
-        private static void SetFeatures(HttpContext httpContext, EndpointSelectorContext context)
-        {
-            // For back-compat EndpointSelectorContext implements IEndpointFeature,
-            // IRouteValuesFeature and IRoutingFeature
-            httpContext.Features.Set<IRoutingFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
-            httpContext.Features.Set<IEndpointFeature>(context);
         }
 
         // Initialization is async to avoid blocking threads while reflection and things

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -60,6 +60,7 @@ namespace Microsoft.AspNetCore.Routing
             // There's already an endpoint, skip maching completely
             if (feature.Endpoint != null)
             {
+                Log.MatchSkipped(_logger, feature.Endpoint);
                 return _next(httpContext);
             }
 
@@ -178,6 +179,11 @@ namespace Microsoft.AspNetCore.Routing
                 new EventId(2, "MatchFailure"),
                 "Request did not match any endpoints");
 
+            private static readonly Action<ILogger, string, Exception> _matchingSkipped = LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(3, "MatchingSkipped"),
+                "Endpoint '{EndpointName}' already set, skipping route matching.");
+
             public static void MatchSuccess(ILogger logger, EndpointSelectorContext context)
             {
                 _matchSuccess(logger, context.Endpoint.DisplayName, null);
@@ -186,6 +192,11 @@ namespace Microsoft.AspNetCore.Routing
             public static void MatchFailure(ILogger logger)
             {
                 _matchFailure(logger, null);
+            }
+
+            public static void MatchSkipped(ILogger logger, Endpoint endpoint)
+            {
+                _matchingSkipped(logger, endpoint.DisplayName, null);
             }
         }
     }

--- a/src/Http/Routing/src/EndpointSelectorContext.cs
+++ b/src/Http/Routing/src/EndpointSelectorContext.cs
@@ -7,9 +7,9 @@ using Microsoft.AspNetCore.Http.Endpoints;
 
 namespace Microsoft.AspNetCore.Routing
 {
-    public struct EndpointSelectorContext
+    public readonly struct EndpointSelectorContext
     {
-        private HttpContext _httpContext;
+        private readonly HttpContext _httpContext;
 
         public EndpointSelectorContext(HttpContext httpContext)
         {

--- a/src/Http/Routing/src/EndpointSelectorContext.cs
+++ b/src/Http/Routing/src/EndpointSelectorContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Routing
 
         public EndpointSelectorContext(HttpContext httpContext)
         {
-            _httpContext = httpContext;
+            _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
         }
 
         /// <summary>
@@ -28,10 +28,7 @@ namespace Microsoft.AspNetCore.Routing
             }
             set
             {
-                if (value != null)
-                {
-                    _httpContext.SetEndpoint(value);
-                }
+                _httpContext.SetEndpoint(value);
             }
         }
 

--- a/src/Http/Routing/src/Matching/DefaultEndpointSelector.cs
+++ b/src/Http/Routing/src/Matching/DefaultEndpointSelector.cs
@@ -21,11 +21,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             if (candidateSet == null)
             {
                 throw new ArgumentNullException(nameof(candidateSet));

--- a/src/Http/Routing/src/Matching/DfaMatcher.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcher.cs
@@ -34,11 +34,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             // All of the logging we do here is at level debug, so we can get away with doing a single check.
             var log = _logger.IsEnabled(LogLevel.Debug);
 

--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -77,11 +77,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             if (candidates == null)
             {
                 throw new ArgumentNullException(nameof(candidates));

--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -94,11 +94,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             if (candidates == null)
             {
                 throw new ArgumentNullException(nameof(candidates));

--- a/src/Http/Routing/src/RouterMiddleware.cs
+++ b/src/Http/Routing/src/RouterMiddleware.cs
@@ -45,9 +45,8 @@ namespace Microsoft.AspNetCore.Builder
                     RouteData = context.RouteData
                 };
 
-                // Set the RouteValues on the current request
+                // Set the RouteValues on the current request, this is to keep the IRouteValuesFeature inline with the IRoutingFeature
                 httpContext.Request.RouteValues = context.RouteData.Values;
-
                 httpContext.Features.Set<IRoutingFeature>(routingFeature);
 
                 await context.Handler(context.HttpContext);

--- a/src/Http/Routing/src/RouterMiddleware.cs
+++ b/src/Http/Routing/src/RouterMiddleware.cs
@@ -40,10 +40,15 @@ namespace Microsoft.AspNetCore.Builder
             }
             else
             {
-                httpContext.Features[typeof(IRoutingFeature)] = new RoutingFeature()
+                var routingFeature = new RoutingFeature()
                 {
-                    RouteData = context.RouteData,
+                    RouteData = context.RouteData
                 };
+
+                // Set the RouteValues on the current request
+                httpContext.Request.RouteValues = context.RouteData.Values;
+
+                httpContext.Features.Set<IRoutingFeature>(routingFeature);
 
                 await context.Handler(context.HttpContext);
             }

--- a/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorTest.cs
+++ b/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorTest.cs
@@ -635,12 +635,12 @@ namespace Microsoft.AspNetCore.Routing
 
             var linkGenerator = CreateLinkGenerator(endpointControllerAction, endpointController, endpointEmpty, endpointControllerActionParameter);
 
-            var context = new EndpointSelectorContext()
+            var httpContext = CreateHttpContext();
+            // This sets data on the feature directly in the HttpContext
+            var context = new EndpointSelectorContext(httpContext)
             {
                 RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index", })
             };
-            var httpContext = CreateHttpContext();
-            httpContext.Features.Set<IRouteValuesFeature>(context);
 
             var values = new RouteValueDictionary();
             for (int i = 0; i < routeNames.Length; i++)
@@ -678,12 +678,11 @@ namespace Microsoft.AspNetCore.Routing
 
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 
-            var context = new EndpointSelectorContext()
+            var httpContext = CreateHttpContext();
+            var context = new EndpointSelectorContext(httpContext)
             {
                 RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index", })
             };
-            var httpContext = CreateHttpContext();
-            httpContext.Features.Set<IRouteValuesFeature>(context);
 
             var values = new RouteValueDictionary();
             for (int i = 0; i < routeNames.Length; i++)
@@ -721,9 +720,7 @@ namespace Microsoft.AspNetCore.Routing
 
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 
-            var context = new EndpointSelectorContext();
             var httpContext = CreateHttpContext();
-            httpContext.Features.Set<IRouteValuesFeature>(context);
 
             var values = new RouteValueDictionary();
             for (int i = 0; i < routeNames.Length; i++)

--- a/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorTest.cs
+++ b/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorTest.cs
@@ -636,11 +636,7 @@ namespace Microsoft.AspNetCore.Routing
             var linkGenerator = CreateLinkGenerator(endpointControllerAction, endpointController, endpointEmpty, endpointControllerActionParameter);
 
             var httpContext = CreateHttpContext();
-            // This sets data on the feature directly in the HttpContext
-            var context = new EndpointSelectorContext(httpContext)
-            {
-                RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index", })
-            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index" });
 
             var values = new RouteValueDictionary();
             for (int i = 0; i < routeNames.Length; i++)
@@ -679,10 +675,7 @@ namespace Microsoft.AspNetCore.Routing
             var linkGenerator = CreateLinkGenerator(homeIndex, homeLogin);
 
             var httpContext = CreateHttpContext();
-            var context = new EndpointSelectorContext(httpContext)
-            {
-                RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index", })
-            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index", });
 
             var values = new RouteValueDictionary();
             for (int i = 0; i < routeNames.Length; i++)

--- a/src/Http/Routing/test/UnitTests/EndpointMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointMiddlewareTest.cs
@@ -45,10 +45,10 @@ namespace Microsoft.AspNetCore.Routing
             var httpContext = new DefaultHttpContext();
             httpContext.RequestServices = new ServiceProvider();
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = null,
-            });
+            };
 
             RequestDelegate next = (c) =>
             {
@@ -77,10 +77,10 @@ namespace Microsoft.AspNetCore.Routing
                 return Task.CompletedTask;
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(endpointFunc, EndpointMetadataCollection.Empty, "Test"),
-            });
+            };
 
             RequestDelegate next = (c) =>
             {
@@ -108,10 +108,10 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            });
+            };
 
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, RouteOptions);
 
@@ -131,10 +131,10 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            });
+            };
 
             httpContext.Items[EndpointMiddleware.AuthorizationMiddlewareInvokedKey] = true;
 
@@ -155,10 +155,11 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            });
+            };
+
             var routeOptions = Options.Create(new RouteOptions { SuppressCheckForUnhandledSecurityMetadata = true });
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, routeOptions);
 
@@ -178,10 +179,10 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<ICorsMetadata>()), "Test"),
-            });
+            };
 
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, RouteOptions);
 
@@ -201,10 +202,10 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<ICorsMetadata>()), "Test"),
-            });
+            };
 
             httpContext.Items[EndpointMiddleware.CorsMiddlewareInvokedKey] = true;
 
@@ -225,10 +226,11 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
+            new EndpointSelectorContext(httpContext)
             {
                 Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            });
+            };
+
             var routeOptions = Options.Create(new RouteOptions { SuppressCheckForUnhandledSecurityMetadata = true });
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, routeOptions);
 

--- a/src/Http/Routing/test/UnitTests/EndpointMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointMiddlewareTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Endpoints;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -44,12 +45,8 @@ namespace Microsoft.AspNetCore.Routing
             // Arrange
             var httpContext = new DefaultHttpContext();
             httpContext.RequestServices = new ServiceProvider();
-
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = null,
-            };
-
+            httpContext.SetEndpoint(null);
+            
             RequestDelegate next = (c) =>
             {
                 return Task.CompletedTask;
@@ -77,11 +74,8 @@ namespace Microsoft.AspNetCore.Routing
                 return Task.CompletedTask;
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(endpointFunc, EndpointMetadataCollection.Empty, "Test"),
-            };
-
+            httpContext.SetEndpoint(new Endpoint(endpointFunc, EndpointMetadataCollection.Empty, "Test"));
+            
             RequestDelegate next = (c) =>
             {
                 return Task.CompletedTask;
@@ -108,10 +102,7 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            };
+            httpContext.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"));
 
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, RouteOptions);
 
@@ -131,10 +122,7 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            };
+            httpContext.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"));
 
             httpContext.Items[EndpointMiddleware.AuthorizationMiddlewareInvokedKey] = true;
 
@@ -155,10 +143,7 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            };
+            httpContext.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"));
 
             var routeOptions = Options.Create(new RouteOptions { SuppressCheckForUnhandledSecurityMetadata = true });
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, routeOptions);
@@ -179,10 +164,7 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<ICorsMetadata>()), "Test"),
-            };
+            httpContext.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<ICorsMetadata>()), "Test"));
 
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, RouteOptions);
 
@@ -202,10 +184,7 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<ICorsMetadata>()), "Test"),
-            };
+            httpContext.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<ICorsMetadata>()), "Test"));
 
             httpContext.Items[EndpointMiddleware.CorsMiddlewareInvokedKey] = true;
 
@@ -226,10 +205,7 @@ namespace Microsoft.AspNetCore.Routing
                 RequestServices = new ServiceProvider()
             };
 
-            new EndpointSelectorContext(httpContext)
-            {
-                Endpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"),
-            };
+            httpContext.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"));
 
             var routeOptions = Options.Create(new RouteOptions { SuppressCheckForUnhandledSecurityMetadata = true });
             var middleware = new EndpointMiddleware(NullLogger<EndpointMiddleware>.Instance, _ => Task.CompletedTask, routeOptions);

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -132,12 +132,8 @@ namespace Microsoft.AspNetCore.Routing
 
         private HttpContext CreateHttpContext()
         {
-            var context = new EndpointSelectorContext();
-
             var httpContext = new DefaultHttpContext();
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
-
+            var context = new EndpointSelectorContext(httpContext);
             httpContext.RequestServices = new TestServiceProvider();
 
             return httpContext;

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -62,52 +62,6 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Fact]
-        public async Task Invoke_BackCompatGetRouteValue_ValueUsedFromEndpointFeature()
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-
-            var middleware = CreateMiddleware();
-
-            // Act
-            await middleware.Invoke(httpContext);
-            var routeData = httpContext.GetRouteData();
-            var routeValue = httpContext.GetRouteValue("controller");
-            var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
-
-            // Assert
-            Assert.NotNull(routeData);
-            Assert.Equal("Home", (string)routeValue);
-
-            // changing route data value is reflected in endpoint feature values
-            routeData.Values["testKey"] = "testValue";
-            Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
-        }
-
-        [Fact]
-        public async Task Invoke_BackCompatGetDataTokens_ValueUsedFromEndpointMetadata()
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-
-            var middleware = CreateMiddleware();
-
-            // Act
-            await middleware.Invoke(httpContext);
-            var routeData = httpContext.GetRouteData();
-            var routeValue = httpContext.GetRouteValue("controller");
-            var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
-
-            // Assert
-            Assert.NotNull(routeData);
-            Assert.Equal("Home", (string)routeValue);
-
-            // changing route data value is reflected in endpoint feature values
-            routeData.Values["testKey"] = "testValue";
-            Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
-        }
-
-        [Fact]
         public async Task Invoke_InitializationFailure_AllowsReinitialization()
         {
             // Arrange

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -62,6 +62,52 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Fact]
+        public async Task Invoke_BackCompatGetRouteValue_ValueUsedFromEndpointFeature()
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+
+            var middleware = CreateMiddleware();
+
+            // Act
+            await middleware.Invoke(httpContext);
+            var routeData = httpContext.GetRouteData();
+            var routeValue = httpContext.GetRouteValue("controller");
+            var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
+
+            // Assert
+            Assert.NotNull(routeData);
+            Assert.Equal("Home", (string)routeValue);
+
+            // changing route data value is reflected in endpoint feature values
+            routeData.Values["testKey"] = "testValue";
+            Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
+        }
+
+        [Fact]
+        public async Task Invoke_BackCompatGetDataTokens_ValueUsedFromEndpointMetadata()
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+
+            var middleware = CreateMiddleware();
+
+            // Act
+            await middleware.Invoke(httpContext);
+            var routeData = httpContext.GetRouteData();
+            var routeValue = httpContext.GetRouteValue("controller");
+            var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
+
+            // Assert
+            Assert.NotNull(routeData);
+            Assert.Equal("Home", (string)routeValue);
+
+            // changing route data value is reflected in endpoint feature values
+            routeData.Values["testKey"] = "testValue";
+            Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
+        }
+
+        [Fact]
         public async Task Invoke_InitializationFailure_AllowsReinitialization()
         {
             // Arrange

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -133,7 +133,6 @@ namespace Microsoft.AspNetCore.Routing
         private HttpContext CreateHttpContext()
         {
             var httpContext = new DefaultHttpContext();
-            var context = new EndpointSelectorContext(httpContext);
             httpContext.RequestServices = new TestServiceProvider();
 
             return httpContext;

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -2,17 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Endpoints;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -34,6 +33,24 @@ namespace Microsoft.AspNetCore.Routing
             // Assert
             var endpointFeature = httpContext.Features.Get<IEndpointFeature>();
             Assert.NotNull(endpointFeature);
+        }
+
+        [Fact]
+        public async Task Invoke_SkipsRouting_IfEndpointSet()
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            httpContext.SetEndpoint(new Endpoint(c => Task.CompletedTask, new EndpointMetadataCollection(), "myapp"));
+
+            var middleware = CreateMiddleware();
+
+            // Act
+            await middleware.Invoke(httpContext);
+
+            // Assert
+            var endpoint = httpContext.GetEndpoint();
+            Assert.NotNull(endpoint);
+            Assert.Equal("myapp", endpoint.DisplayName);
         }
 
         [Fact]
@@ -132,20 +149,22 @@ namespace Microsoft.AspNetCore.Routing
 
         private HttpContext CreateHttpContext()
         {
-            var httpContext = new DefaultHttpContext();
-            httpContext.RequestServices = new TestServiceProvider();
+            var httpContext = new DefaultHttpContext
+            {
+                RequestServices = new TestServiceProvider()
+            };
 
             return httpContext;
         }
 
         private EndpointRoutingMiddleware CreateMiddleware(
             Logger<EndpointRoutingMiddleware> logger = null,
-            MatcherFactory matcherFactory = null)
+            MatcherFactory matcherFactory = null,
+            RequestDelegate next = null)
         {
-            RequestDelegate next = (c) => Task.FromResult<object>(null);
-
-            logger = logger ?? new Logger<EndpointRoutingMiddleware>(NullLoggerFactory.Instance);
-            matcherFactory = matcherFactory ?? new TestMatcherFactory(true);
+            next ??= c => Task.CompletedTask;
+            logger ??= new Logger<EndpointRoutingMiddleware>(NullLoggerFactory.Instance);
+            matcherFactory ??= new TestMatcherFactory(true);
 
             var middleware = new EndpointRoutingMiddleware(
                 matcherFactory,

--- a/src/Http/Routing/test/UnitTests/EndpointSelectorContextTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointSelectorContextTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -9,51 +9,52 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Routing
 {
+    // The IRoutingFeature is TBD, we need a way to make it lazy.
     public class EndpointSelectorContextTest
     {
-        [Fact]
-        public void RouteData_CanIntializeDataTokens_WithMetadata()
-        {
-            // Arrange
-            var expected = new RouteValueDictionary(new { foo = 17, bar = "hello", });
+        //[Fact]
+        //public void RouteData_CanIntializeDataTokens_WithMetadata()
+        //{
+        //    // Arrange
+        //    var expected = new RouteValueDictionary(new { foo = 17, bar = "hello", });
 
-            var context = new EndpointSelectorContext()
-            {
-                Endpoint = new RouteEndpoint(
-                    TestConstants.EmptyRequestDelegate,
-                    RoutePatternFactory.Parse("/"),
-                    0,
-                    new EndpointMetadataCollection(new DataTokensMetadata(expected)),
-                    "test"),
-            };
+        //    var context = new EndpointSelectorContext()
+        //    {
+        //        Endpoint = new RouteEndpoint(
+        //            TestConstants.EmptyRequestDelegate,
+        //            RoutePatternFactory.Parse("/"),
+        //            0,
+        //            new EndpointMetadataCollection(new DataTokensMetadata(expected)),
+        //            "test"),
+        //    };
 
-            // Act
-            var routeData = ((IRoutingFeature)context).RouteData;
+        //    // Act
+        //    var routeData = ((IRoutingFeature)context).RouteData;
 
-            // Assert
-            Assert.NotSame(expected, routeData.DataTokens);
-            Assert.Equal(expected.OrderBy(kvp => kvp.Key), routeData.DataTokens.OrderBy(kvp => kvp.Key));
-        }
+        //    // Assert
+        //    Assert.NotSame(expected, routeData.DataTokens);
+        //    Assert.Equal(expected.OrderBy(kvp => kvp.Key), routeData.DataTokens.OrderBy(kvp => kvp.Key));
+        //}
 
-        [Fact]
-        public void RouteData_DataTokensIsEmpty_WithoutMetadata()
-        {
-            // Arrange
-            var context = new EndpointSelectorContext()
-            {
-                Endpoint = new RouteEndpoint(
-                    TestConstants.EmptyRequestDelegate,
-                    RoutePatternFactory.Parse("/"),
-                    0,
-                    new EndpointMetadataCollection(),
-                    "test"),
-            };
+        //[Fact]
+        //public void RouteData_DataTokensIsEmpty_WithoutMetadata()
+        //{
+        //    // Arrange
+        //    var context = new EndpointSelectorContext()
+        //    {
+        //        Endpoint = new RouteEndpoint(
+        //            TestConstants.EmptyRequestDelegate,
+        //            RoutePatternFactory.Parse("/"),
+        //            0,
+        //            new EndpointMetadataCollection(),
+        //            "test"),
+        //    };
 
-            // Act
-            var routeData = ((IRoutingFeature)context).RouteData;
+        //    // Act
+        //    var routeData = ((IRoutingFeature)context).RouteData;
 
-            // Assert
-            Assert.Empty(routeData.DataTokens);
-        }
+        //    // Assert
+        //    Assert.Empty(routeData.DataTokens);
+        //}
     }
 }

--- a/src/Http/Routing/test/UnitTests/EndpointSelectorContextTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointSelectorContextTest.cs
@@ -1,60 +1,53 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.AspNetCore.Http.Endpoints;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Routing
 {
-    // The IRoutingFeature is TBD, we need a way to make it lazy.
     public class EndpointSelectorContextTest
     {
-        //[Fact]
-        //public void RouteData_CanIntializeDataTokens_WithMetadata()
-        //{
-        //    // Arrange
-        //    var expected = new RouteValueDictionary(new { foo = 17, bar = "hello", });
+        [Fact]
+        public void SettingEndpointSetsEndpointOnHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            var ep = new RouteEndpoint(
+                    TestConstants.EmptyRequestDelegate,
+                    RoutePatternFactory.Parse("/"),
+                    0,
+                    new EndpointMetadataCollection(),
+                    "test");
 
-        //    var context = new EndpointSelectorContext()
-        //    {
-        //        Endpoint = new RouteEndpoint(
-        //            TestConstants.EmptyRequestDelegate,
-        //            RoutePatternFactory.Parse("/"),
-        //            0,
-        //            new EndpointMetadataCollection(new DataTokensMetadata(expected)),
-        //            "test"),
-        //    };
+            new EndpointSelectorContext(httpContext)
+            {
+                Endpoint = ep,
+            };
 
-        //    // Act
-        //    var routeData = ((IRoutingFeature)context).RouteData;
+            // Assert
+            var endpoint = httpContext.GetEndpoint();
+            Assert.NotNull(endpoint);
+            Assert.Same(ep, endpoint);
+        }
 
-        //    // Assert
-        //    Assert.NotSame(expected, routeData.DataTokens);
-        //    Assert.Equal(expected.OrderBy(kvp => kvp.Key), routeData.DataTokens.OrderBy(kvp => kvp.Key));
-        //}
+        [Fact]
+        public void SettingRouteValuesSetRouteValuesHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            var routeValues = new RouteValueDictionary(new { A = "1" });
 
-        //[Fact]
-        //public void RouteData_DataTokensIsEmpty_WithoutMetadata()
-        //{
-        //    // Arrange
-        //    var context = new EndpointSelectorContext()
-        //    {
-        //        Endpoint = new RouteEndpoint(
-        //            TestConstants.EmptyRequestDelegate,
-        //            RoutePatternFactory.Parse("/"),
-        //            0,
-        //            new EndpointMetadataCollection(),
-        //            "test"),
-        //    };
+            new EndpointSelectorContext(httpContext)
+            {
+                RouteValues = routeValues
+            };
 
-        //    // Act
-        //    var routeData = ((IRoutingFeature)context).RouteData;
-
-        //    // Assert
-        //    Assert.Empty(routeData.DataTokens);
-        //}
+            // Assert
+            Assert.NotNull(httpContext.Request.RouteValues);
+            Assert.Same(routeValues, httpContext.Request.RouteValues);
+            Assert.Single(httpContext.Request.RouteValues);
+            Assert.Equal("1", httpContext.Request.RouteValues["A"]);
+        }
     }
 }

--- a/src/Http/Routing/test/UnitTests/LinkGeneratorEndpointNameExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/LinkGeneratorEndpointNameExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -26,12 +26,11 @@ namespace Microsoft.AspNetCore.Routing
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
-            var context = new EndpointSelectorContext()
+            var httpContext = CreateHttpContext();
+            var context = new EndpointSelectorContext(httpContext)
             {
                 RouteValues = new RouteValueDictionary(new { p = "5", })
             };
-            var httpContext = CreateHttpContext();
-            httpContext.Features.Set<IRouteValuesFeature>(context);
             httpContext.Request.PathBase = new PathString("/Foo/Bar?encodeme?");
 
             var values = new { query = "some?query", };

--- a/src/Http/Routing/test/UnitTests/LinkGeneratorEndpointNameExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/LinkGeneratorEndpointNameExtensionsTest.cs
@@ -27,10 +27,7 @@ namespace Microsoft.AspNetCore.Routing
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
             var httpContext = CreateHttpContext();
-            var context = new EndpointSelectorContext(httpContext)
-            {
-                RouteValues = new RouteValueDictionary(new { p = "5", })
-            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(new { p = "5", });
             httpContext.Request.PathBase = new PathString("/Foo/Bar?encodeme?");
 
             var values = new { query = "some?query", };

--- a/src/Http/Routing/test/UnitTests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -32,12 +32,11 @@ namespace Microsoft.AspNetCore.Routing
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
-            var context = new EndpointSelectorContext()
+            var httpContext = CreateHttpContext();
+            var context = new EndpointSelectorContext(httpContext)
             {
                 RouteValues = new RouteValueDictionary(new { action = "Index", })
             };
-            var httpContext = CreateHttpContext();
-            httpContext.Features.Set<IRouteValuesFeature>(context);
             httpContext.Request.PathBase = new PathString("/Foo/Bar?encodeme?");
 
             // Act

--- a/src/Http/Routing/test/UnitTests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
@@ -33,10 +33,7 @@ namespace Microsoft.AspNetCore.Routing
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
             var httpContext = CreateHttpContext();
-            var context = new EndpointSelectorContext(httpContext)
-            {
-                RouteValues = new RouteValueDictionary(new { action = "Index", })
-            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(new { action = "Index", });
             httpContext.Request.PathBase = new PathString("/Foo/Bar?encodeme?");
 
             // Act

--- a/src/Http/Routing/test/UnitTests/LinkGeneratorTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/LinkGeneratorTestBase.cs
@@ -19,13 +19,11 @@ namespace Microsoft.AspNetCore.Routing
         {
             var httpContext = new DefaultHttpContext();
 
-            var context = new EndpointSelectorContext
+            var context = new EndpointSelectorContext(httpContext)
             {
                 RouteValues = new RouteValueDictionary(ambientValues)
             };
 
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
             return httpContext;
         }
 

--- a/src/Http/Routing/test/UnitTests/LinkGeneratorTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/LinkGeneratorTestBase.cs
@@ -18,12 +18,7 @@ namespace Microsoft.AspNetCore.Routing
         protected HttpContext CreateHttpContext(object ambientValues = null)
         {
             var httpContext = new DefaultHttpContext();
-
-            var context = new EndpointSelectorContext(httpContext)
-            {
-                RouteValues = new RouteValueDictionary(ambientValues)
-            };
-
+            httpContext.Request.RouteValues = new RouteValueDictionary(ambientValues);
             return httpContext;
         }
 

--- a/src/Http/Routing/test/UnitTests/Matching/BarebonesMatcher.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/BarebonesMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,11 +25,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
             if (httpContext == null)
             {
                 throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
             }
 
             var path = httpContext.Request.Path.Value;

--- a/src/Http/Routing/test/UnitTests/Matching/DefaultEndpointSelectorTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DefaultEndpointSelectorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -174,10 +174,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         private static (HttpContext httpContext, EndpointSelectorContext context) CreateContext()
         {
-            var context = new EndpointSelectorContext();
             var httpContext = new DefaultHttpContext();
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
+            var context = new EndpointSelectorContext(httpContext);
 
             return (httpContext, context);
         }

--- a/src/Http/Routing/test/UnitTests/Matching/DefaultEndpointSelectorTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DefaultEndpointSelectorTest.cs
@@ -175,9 +175,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         private static (HttpContext httpContext, EndpointSelectorContext context) CreateContext()
         {
             var httpContext = new DefaultHttpContext();
-            var context = new EndpointSelectorContext(httpContext);
-
-            return (httpContext, context);
+            return (httpContext, new EndpointSelectorContext(httpContext));
         }
 
         private static RouteEndpoint CreateEndpoint(string template)

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
@@ -822,9 +822,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
         private (HttpContext httpContext, EndpointSelectorContext context) CreateContext()
         {
             var httpContext = new DefaultHttpContext();
-            var context = new EndpointSelectorContext(httpContext);
 
-            return (httpContext, context);
+            return (httpContext, new EndpointSelectorContext(httpContext));
         }
     }
 }

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var endpointSelector = new Mock<EndpointSelector>();
             endpointSelector
                 .Setup(s => s.SelectAsync(It.IsAny<HttpContext>(), It.IsAny<EndpointSelectorContext>(), It.IsAny<CandidateSet>()))
-                .Callback<HttpContext, IEndpointFeature, CandidateSet>((c, f, cs) =>
+                .Callback<HttpContext, EndpointSelectorContext, CandidateSet>((c, f, cs) =>
                 {
                     Assert.Equal(2, cs.Count);
 
@@ -449,7 +449,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var endpointSelector = new Mock<EndpointSelector>();
             endpointSelector
                 .Setup(s => s.SelectAsync(It.IsAny<HttpContext>(), It.IsAny<EndpointSelectorContext>(), It.IsAny<CandidateSet>()))
-                .Callback<HttpContext, IEndpointFeature, CandidateSet>((c, f, cs) =>
+                .Callback<HttpContext, EndpointSelectorContext, CandidateSet>((c, f, cs) =>
                 {
                     Assert.Equal(2, cs.Count);
 
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var endpointSelector = new Mock<EndpointSelector>();
             endpointSelector
                 .Setup(s => s.SelectAsync(It.IsAny<HttpContext>(), It.IsAny<EndpointSelectorContext>(), It.IsAny<CandidateSet>()))
-                .Callback<HttpContext, IEndpointFeature, CandidateSet>((c, f, cs) =>
+                .Callback<HttpContext, EndpointSelectorContext, CandidateSet>((c, f, cs) =>
                 {
                     Assert.Equal(2, cs.Count);
 

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
@@ -727,7 +727,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             var (httpContext, context) = CreateContext();
             httpContext.Request.Path = "/test/17";
-            
+
             // Act
             await matcher.MatchAsync(httpContext, context);
 
@@ -821,11 +821,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         private (HttpContext httpContext, EndpointSelectorContext context) CreateContext()
         {
-            var context = new EndpointSelectorContext();
-
             var httpContext = new DefaultHttpContext();
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
+            var context = new EndpointSelectorContext(httpContext);
 
             return (httpContext, context);
         }

--- a/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyIntegrationTestBase.cs
@@ -303,9 +303,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             httpContext.Request.Path = path;
             httpContext.Request.Scheme = scheme;
 
-            var context = new EndpointSelectorContext();
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
+            var context = new EndpointSelectorContext(httpContext);
 
             return (httpContext, context);
         }

--- a/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyIntegrationTestBase.cs
@@ -303,9 +303,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             httpContext.Request.Path = path;
             httpContext.Request.Scheme = scheme;
 
-            var context = new EndpointSelectorContext(httpContext);
-
-            return (httpContext, context);
+            return (httpContext, new EndpointSelectorContext(httpContext));
         }
 
         internal RouteEndpoint CreateEndpoint(

--- a/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyIntegrationTestBase.cs
@@ -352,9 +352,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 httpContext.Request.Headers[AccessControlRequestMethod] = httpMethod;
             }
 
-            var context = new EndpointSelectorContext();
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
+            var context = new EndpointSelectorContext(httpContext);
 
             return (httpContext, context);
         }

--- a/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyIntegrationTestBase.cs
@@ -352,9 +352,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 httpContext.Request.Headers[AccessControlRequestMethod] = httpMethod;
             }
 
-            var context = new EndpointSelectorContext(httpContext);
-
-            return (httpContext, context);
+            return (httpContext, new EndpointSelectorContext(httpContext));
         }
 
         internal RouteEndpoint CreateEndpoint(

--- a/src/Http/Routing/test/UnitTests/Matching/MatcherAssert.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/MatcherAssert.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 throw new XunitException($"Was expected to match '{expected.DisplayName}' but did not match.");
             }
 
-            var actualValues = httpContext.Features.Get<IRouteValuesFeature>().RouteValues;
+            var actualValues = httpContext.Request.RouteValues;
 
             if (actualValues == null)
             {

--- a/src/Http/Routing/test/UnitTests/Matching/MatcherConformanceTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/MatcherConformanceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,13 +21,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
             httpContext.Request.Path = path;
             httpContext.RequestServices = CreateServices();
 
-            var context = new EndpointSelectorContext()
+            var context = new EndpointSelectorContext(httpContext)
             {
                 RouteValues = new RouteValueDictionary()
             };
-            httpContext.Features.Set<IEndpointFeature>(context);
-            httpContext.Features.Set<IRouteValuesFeature>(context);
-
             return (httpContext, context);
         }
 

--- a/src/Http/Routing/test/UnitTests/Matching/MatcherConformanceTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/MatcherConformanceTest.cs
@@ -20,12 +20,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             httpContext.Request.Method = "TEST";
             httpContext.Request.Path = path;
             httpContext.RequestServices = CreateServices();
-
-            var context = new EndpointSelectorContext(httpContext)
-            {
-                RouteValues = new RouteValueDictionary()
-            };
-            return (httpContext, context);
+            return (httpContext, new EndpointSelectorContext(httpContext));
         }
 
         // The older routing implementations retrieve services when they first execute.

--- a/src/Http/Routing/test/UnitTests/Matching/RouteMatcher.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/RouteMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -22,11 +22,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
             if (httpContext == null)
             {
                 throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
             }
 
             var routeContext = new RouteContext(httpContext);

--- a/src/Http/Routing/test/UnitTests/Matching/RouteMatcherBuilder.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/RouteMatcherBuilder.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.TestObjects;
@@ -95,12 +96,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             public async Task RouteAsync(RouteContext routeContext)
             {
-                var context = (EndpointSelectorContext)routeContext.HttpContext.Features.Get<IEndpointFeature>();
-                
-                // This is needed due to a quirk of our tests - they reuse the endpoint feature
-                // across requests.
-                context.Endpoint = null;
-
+                var context = new EndpointSelectorContext(routeContext.HttpContext);
                 await _selector.SelectAsync(routeContext.HttpContext, context, new CandidateSet(_candidates, _values, _scores));
                 if (context.Endpoint != null)
                 {

--- a/src/Http/Routing/test/UnitTests/Matching/RouteMatcherBuilder.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/RouteMatcherBuilder.cs
@@ -97,6 +97,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
             public async Task RouteAsync(RouteContext routeContext)
             {
                 var context = new EndpointSelectorContext(routeContext.HttpContext);
+
+                // This is needed due to a quirk of our tests - they reuse the endpoint feature.
+                context.Endpoint = null;
+
                 await _selector.SelectAsync(routeContext.HttpContext, context, new CandidateSet(_candidates, _values, _scores));
                 if (context.Endpoint != null)
                 {

--- a/src/Http/Routing/test/UnitTests/Matching/TreeRouterMatcher.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/TreeRouterMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -24,11 +24,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
             if (httpContext == null)
             {
                 throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
             }
 
             var routeContext = new RouteContext(httpContext);

--- a/src/Http/Routing/test/UnitTests/Matching/TreeRouterMatcherBuilder.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/TreeRouterMatcherBuilder.cs
@@ -99,11 +99,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             public async Task RouteAsync(RouteContext routeContext)
             {
-                var context = (EndpointSelectorContext)routeContext.HttpContext.Features.Get<IEndpointFeature>();
-
-                // This is needed due to a quirk of our tests - they reuse the endpoint feature.
-                context.Endpoint = null;
-                
+                var context = new EndpointSelectorContext(routeContext.HttpContext);
                 await _selector.SelectAsync(routeContext.HttpContext, context, new CandidateSet(_candidates, _values, _scores));
                 if (context.Endpoint != null)
                 {

--- a/src/Http/Routing/test/UnitTests/Matching/TreeRouterMatcherBuilder.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/TreeRouterMatcherBuilder.cs
@@ -100,6 +100,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
             public async Task RouteAsync(RouteContext routeContext)
             {
                 var context = new EndpointSelectorContext(routeContext.HttpContext);
+
+                // This is needed due to a quirk of our tests - they reuse the endpoint feature.
+                context.Endpoint = null;
+
                 await _selector.SelectAsync(routeContext.HttpContext, context, new CandidateSet(_candidates, _values, _scores));
                 if (context.Endpoint != null)
                 {

--- a/src/Http/Routing/test/UnitTests/RouterMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/RouterMiddlewareTest.cs
@@ -5,13 +5,65 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Routing
 {
     public class RouterMiddlewareTest
     {
+        [Fact]
+        public async Task RoutingFeatureSetInIRouter()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddLogging();
+            var httpContext = new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider()
+            };
+
+            httpContext.Request.Path = "/foo/10";
+
+            var routeHandlerExecuted = false;
+
+            var handler = new RouteHandler(context =>
+            {
+                routeHandlerExecuted = true;
+
+                var routingFeature = context.Features.Get<IRoutingFeature>();
+
+                Assert.NotNull(routingFeature);
+                Assert.NotNull(context.Features.Get<IRouteValuesFeature>());
+
+                Assert.Single(routingFeature.RouteData.Values);
+                Assert.Single(context.Request.RouteValues);
+                Assert.True(routingFeature.RouteData.Values.ContainsKey("id"));
+                Assert.True(context.Request.RouteValues.ContainsKey("id"));
+                Assert.Equal("10", routingFeature.RouteData.Values["id"]);
+                Assert.Equal("10", context.Request.RouteValues["id"]);
+                Assert.Equal("10", context.GetRouteValue("id"));
+                Assert.Same(routingFeature.RouteData, context.GetRouteData());
+
+                return Task.CompletedTask;
+            });
+
+            var route = new Route(handler, "/foo/{id}", Mock.Of<IInlineConstraintResolver>());
+
+            var middleware = new RouterMiddleware(context => Task.CompletedTask, NullLoggerFactory.Instance, route);
+
+            // Act
+            await middleware.Invoke(httpContext);
+
+            // Assert
+            Assert.True(routeHandlerExecuted);
+            
+        }
+
         [Fact]
         public async Task Invoke_LogsCorrectValues_WhenNotHandled()
         {

--- a/src/Http/Routing/test/testassets/RoutingSandbox/Program.cs
+++ b/src/Http/Routing/test/testassets/RoutingSandbox/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Http/Routing/test/testassets/RoutingWebSite/UseEndpointRoutingStartup.cs
+++ b/src/Http/Routing/test/testassets/RoutingWebSite/UseEndpointRoutingStartup.cs
@@ -173,7 +173,7 @@ namespace RoutingWebSite
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapGet("api/get/{id}", (context) => context.Response.WriteAsync($"{name} - API Get {context.GetRouteData().Values["id"]}"));
+                endpoints.MapGet("api/get/{id}", (context) => context.Response.WriteAsync($"{name} - API Get {context.Request.RouteValues["id"]}"));
             });
         }
     }

--- a/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
@@ -286,7 +286,9 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             RequestDelegate requestDelegate = (context) =>
             {
-                var routeData = context.GetRouteData();
+                var routeData = new RouteData();
+                routeData.PushState(router: null, context.Request.RouteValues, dataTokens);
+
                 var actionContext = new ActionContext(context, routeData, action);
 
                 if (invokerFactory == null)

--- a/src/Mvc/Mvc.Core/src/Routing/ConsumesMatcherPolicy.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ConsumesMatcherPolicy.cs
@@ -60,11 +60,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             if (candidates == null)
             {
                 throw new ArgumentNullException(nameof(candidates));

--- a/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointMatcherPolicy.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointMatcherPolicy.cs
@@ -66,12 +66,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             {
                 throw new ArgumentNullException(nameof(httpContext));
             }
-
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
+            
             if (candidates == null)
             {
                 throw new ArgumentNullException(nameof(candidates));

--- a/src/Mvc/Mvc.Core/test/Routing/ConsumesMatcherPolicyTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/ConsumesMatcherPolicyTest.cs
@@ -532,7 +532,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             };
 
             var candidates = CreateCandidateSet(endpoints);
-            var context = new EndpointSelectorContext();
             var httpContext = new DefaultHttpContext()
             {
                 Request =
@@ -540,6 +539,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                     ContentType = "application/json",
                 },
             };
+            var context = new EndpointSelectorContext(httpContext);
 
             var policy = CreatePolicy();
 
@@ -562,7 +562,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             };
 
             var candidates = CreateCandidateSet(endpoints);
-            var context = new EndpointSelectorContext();
             var httpContext = new DefaultHttpContext()
             {
                 Request =
@@ -570,6 +569,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                     ContentType = "application/json",
                 },
             };
+            var context = new EndpointSelectorContext(httpContext);
 
             var policy = CreatePolicy();
 
@@ -592,7 +592,6 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             };
 
             var candidates = CreateCandidateSet(endpoints);
-            var context = new EndpointSelectorContext();
             var httpContext = new DefaultHttpContext()
             {
                 Request =
@@ -600,6 +599,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                     ContentType = "application/json",
                 },
             };
+            var context = new EndpointSelectorContext(httpContext);
 
             var policy = CreatePolicy();
 

--- a/src/Mvc/Mvc.Core/test/Routing/ControllerLinkGeneratorExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/ControllerLinkGeneratorExtensionsTest.cs
@@ -209,14 +209,7 @@ namespace Microsoft.AspNetCore.Routing
         private HttpContext CreateHttpContext(object ambientValues = null)
         {
             var httpContext = new DefaultHttpContext();
-
-            var feature = new EndpointSelectorContext
-            {
-                RouteValues = new RouteValueDictionary(ambientValues)
-            };
-
-            httpContext.Features.Set<IEndpointFeature>(feature);
-            httpContext.Features.Set<IRouteValuesFeature>(feature);
+            httpContext.Request.RouteValues = new RouteValueDictionary(ambientValues);
             return httpContext;
         }
     }

--- a/src/Mvc/Mvc.Core/test/Routing/EndpointRoutingUrlHelperTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/EndpointRoutingUrlHelperTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Endpoints;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
@@ -59,12 +60,8 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 routeName: "OrdersApi");
             var urlHelper = CreateUrlHelper(new[] { endpoint1, endpoint2 });
 
-            // Set the endpoint feature and current context just as a normal request to MVC app would be
-            var endpointFeature = new EndpointSelectorContext();
-            urlHelper.ActionContext.HttpContext.Features.Set<IEndpointFeature>(endpointFeature);
-            urlHelper.ActionContext.HttpContext.Features.Set<IRouteValuesFeature>(endpointFeature);
-            endpointFeature.Endpoint = endpoint1;
-            endpointFeature.RouteValues = new RouteValueDictionary
+            urlHelper.ActionContext.HttpContext.SetEndpoint(endpoint1);
+            urlHelper.ActionContext.HttpContext.Request.RouteValues = new RouteValueDictionary
             {
                 ["controller"] = "Orders",
                 ["action"] = "GetById",
@@ -149,13 +146,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         protected override IUrlHelper CreateUrlHelper(ActionContext actionContext)
         {
             var httpContext = actionContext.HttpContext;
-            httpContext.Features.Set<IEndpointFeature>(new EndpointSelectorContext()
-            {
-                Endpoint = new Endpoint(
-                    context => Task.CompletedTask,
-                    EndpointMetadataCollection.Empty,
-                    null)
-            });
+           httpContext.SetEndpoint(new Endpoint(context => Task.CompletedTask, EndpointMetadataCollection.Empty, null)); 
 
             var urlHelperFactory = httpContext.RequestServices.GetRequiredService<IUrlHelperFactory>();
             var urlHelper = urlHelperFactory.GetUrlHelper(actionContext);

--- a/src/Mvc/Mvc.Core/test/Routing/PageLinkGeneratorExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/PageLinkGeneratorExtensionsTest.cs
@@ -207,14 +207,7 @@ namespace Microsoft.AspNetCore.Routing
         private HttpContext CreateHttpContext(object ambientValues = null)
         {
             var httpContext = new DefaultHttpContext();
-
-            var feature = new EndpointSelectorContext
-            {
-                RouteValues = new RouteValueDictionary(ambientValues)
-            };
-
-            httpContext.Features.Set<IEndpointFeature>(feature);
-            httpContext.Features.Set<IRouteValuesFeature>(feature);
+            httpContext.Request.RouteValues = new RouteValueDictionary(ambientValues);
             return httpContext;
         }
     }

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointMatcherPolicy.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointMatcherPolicy.cs
@@ -68,11 +68,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             if (candidates == null)
             {
                 throw new ArgumentNullException(nameof(candidates));

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageLoaderMatcherPolicy.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageLoaderMatcherPolicy.cs
@@ -58,11 +58,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
             if (candidates == null)
             {
                 throw new ArgumentNullException(nameof(candidates));

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
@@ -18,16 +19,18 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal partial class HttpProtocol : IHttpRequestFeature,
-                                        IHttpResponseFeature,
-                                        IResponseBodyPipeFeature,
-                                        IRequestBodyPipeFeature,
-                                        IHttpUpgradeFeature,
-                                        IHttpConnectionFeature,
-                                        IHttpRequestLifetimeFeature,
-                                        IHttpRequestIdentifierFeature,
-                                        IHttpBodyControlFeature,
-                                        IHttpMaxRequestBodySizeFeature,
-                                        IHttpResponseStartFeature
+                                          IHttpResponseFeature,
+                                          IResponseBodyPipeFeature,
+                                          IRequestBodyPipeFeature,
+                                          IHttpUpgradeFeature,
+                                          IHttpConnectionFeature,
+                                          IHttpRequestLifetimeFeature,
+                                          IHttpRequestIdentifierFeature,
+                                          IHttpBodyControlFeature,
+                                          IHttpMaxRequestBodySizeFeature,
+                                          IHttpResponseStartFeature,
+                                          IEndpointFeature,
+                                          IRouteValuesFeature
     {
         // NOTE: When feature interfaces are added to or removed from this HttpProtocol class implementation,
         // then the list of `implementedFeatures` in the generated code project MUST also be updated.
@@ -255,6 +258,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     _wrapperObjectsToDispose = new List<IDisposable>();
                 }
                 _wrapperObjectsToDispose.Add(responsePipeWriter);
+            }
+        }
+
+        Endpoint IEndpointFeature.Endpoint
+        {
+            get;
+            set;
+        }
+
+        RouteValueDictionary IRouteValuesFeature.RouteValues
+        {
+            get
+            {
+                return _routeValues ??= new RouteValueDictionary();
+            }
+            set
+            {
+                _routeValues = value;
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -263,20 +263,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         Endpoint IEndpointFeature.Endpoint
         {
-            get;
-            set;
+            get => _endpoint;
+            set => _endpoint = value;
         }
 
         RouteValueDictionary IRouteValuesFeature.RouteValues
         {
-            get
-            {
-                return _routeValues ??= new RouteValueDictionary();
-            }
-            set
-            {
-                _routeValues = value;
-            }
+            get => _routeValues ??= new RouteValueDictionary();
+            set => _routeValues = value;
         }
 
         protected void ResetHttp1Features()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private static readonly Type IServiceProvidersFeatureType = typeof(IServiceProvidersFeature);
         private static readonly Type IHttpRequestLifetimeFeatureType = typeof(IHttpRequestLifetimeFeature);
         private static readonly Type IHttpConnectionFeatureType = typeof(IHttpConnectionFeature);
+        private static readonly Type IRouteValuesFeatureType = typeof(IRouteValuesFeature);
+        private static readonly Type IEndpointFeatureType = typeof(IEndpointFeature);
         private static readonly Type IHttpAuthenticationFeatureType = typeof(IHttpAuthenticationFeature);
         private static readonly Type IQueryFeatureType = typeof(IQueryFeature);
         private static readonly Type IFormFeatureType = typeof(IFormFeature);
@@ -47,6 +49,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private object _currentIServiceProvidersFeature;
         private object _currentIHttpRequestLifetimeFeature;
         private object _currentIHttpConnectionFeature;
+        private object _currentIRouteValuesFeature;
+        private object _currentIEndpointFeature;
         private object _currentIHttpAuthenticationFeature;
         private object _currentIQueryFeature;
         private object _currentIFormFeature;
@@ -82,6 +86,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIHttpMaxRequestBodySizeFeature = this;
             _currentIHttpBodyControlFeature = this;
             _currentIHttpResponseStartFeature = this;
+            _currentIRouteValuesFeature = this;
+            _currentIEndpointFeature = this;
 
             _currentIServiceProvidersFeature = null;
             _currentIHttpAuthenticationFeature = null;
@@ -182,6 +188,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == IHttpConnectionFeatureType)
                 {
                     feature = _currentIHttpConnectionFeature;
+                }
+                else if (key == IRouteValuesFeatureType)
+                {
+                    feature = _currentIRouteValuesFeature;
+                }
+                else if (key == IEndpointFeatureType)
+                {
+                    feature = _currentIEndpointFeature;
                 }
                 else if (key == IHttpAuthenticationFeatureType)
                 {
@@ -295,6 +309,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIHttpConnectionFeature = value;
                 }
+                else if (key == IRouteValuesFeatureType)
+                {
+                    _currentIRouteValuesFeature = value;
+                }
+                else if (key == IEndpointFeatureType)
+                {
+                    _currentIEndpointFeature = value;
+                }
                 else if (key == IHttpAuthenticationFeatureType)
                 {
                     _currentIHttpAuthenticationFeature = value;
@@ -404,6 +426,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
             {
                 feature = (TFeature)_currentIHttpConnectionFeature;
+            }
+            else if (typeof(TFeature) == typeof(IRouteValuesFeature))
+            {
+                feature = (TFeature)_currentIRouteValuesFeature;
+            }
+            else if (typeof(TFeature) == typeof(IEndpointFeature))
+            {
+                feature = (TFeature)_currentIEndpointFeature;
             }
             else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
@@ -521,6 +551,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttpConnectionFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(IRouteValuesFeature))
+            {
+                _currentIRouteValuesFeature = feature;
+            }
+            else if (typeof(TFeature) == typeof(IEndpointFeature))
+            {
+                _currentIEndpointFeature = feature;
+            }
             else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
                 _currentIHttpAuthenticationFeature = feature;
@@ -628,6 +666,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttpConnectionFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IHttpConnectionFeatureType, _currentIHttpConnectionFeature);
+            }
+            if (_currentIRouteValuesFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IRouteValuesFeatureType, _currentIRouteValuesFeature);
+            }
+            if (_currentIEndpointFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IEndpointFeatureType, _currentIEndpointFeature);
             }
             if (_currentIHttpAuthenticationFeature != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -64,6 +65,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private readonly HttpConnectionContext _context;
         private DefaultHttpContext _httpContext;
+        private RouteValueDictionary _routeValues;
 
         protected string _methodText = null;
         private string _scheme = null;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -66,6 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private readonly HttpConnectionContext _context;
         private DefaultHttpContext _httpContext;
         private RouteValueDictionary _routeValues;
+        private Endpoint _endpoint;
 
         protected string _methodText = null;
         private string _scheme = null;
@@ -328,6 +329,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             _onStarting?.Clear();
             _onCompleted?.Clear();
+            _routeValues?.Clear();
 
             _requestProcessingStatus = RequestProcessingStatus.RequestPending;
             _autoChunk = false;
@@ -342,6 +344,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             TraceIdentifier = null;
             Method = HttpMethod.None;
             _methodText = null;
+            _endpoint = null;
             PathBase = null;
             Path = null;
             RawTarget = null;

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -127,6 +127,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _collection[typeof(IHttpMinResponseDataRateFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpBodyControlFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpResponseStartFeature)] = CreateHttp1Connection();
+            _collection[typeof(IRouteValuesFeature)] = CreateHttp1Connection();
+            _collection[typeof(IEndpointFeature)] = CreateHttp1Connection();
 
             CompareGenericGetterToIndexer();
 
@@ -148,6 +150,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _collection.Set<IHttpMinResponseDataRateFeature>(CreateHttp1Connection());
             _collection.Set<IHttpBodyControlFeature>(CreateHttp1Connection());
             _collection.Set<IHttpResponseStartFeature>(CreateHttp1Connection());
+            _collection.Set<IRouteValuesFeature>(CreateHttp1Connection());
+            _collection.Set<IEndpointFeature>(CreateHttp1Connection());
 
             CompareGenericGetterToIndexer();
 

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -19,6 +19,8 @@ namespace CodeGenerator
                 "IServiceProvidersFeature",
                 "IHttpRequestLifetimeFeature",
                 "IHttpConnectionFeature",
+                "IRouteValuesFeature",
+                "IEndpointFeature"
             };
 
             var commonFeatures = new[]
@@ -70,7 +72,9 @@ namespace CodeGenerator
                 "IHttpConnectionFeature",
                 "IHttpMaxRequestBodySizeFeature",
                 "IHttpBodyControlFeature",
-                "IHttpResponseStartFeature"
+                "IHttpResponseStartFeature",
+                "IRouteValuesFeature",
+                "IEndpointFeature"
             };
             
             var usings = $@"


### PR DESCRIPTION
- This change tries to remove the EndpointSelectorContext allocation by making it a wrapper struct over the HttpContext. Unlike before, the HttpContext gets mutated once any component in the routnig pipeline sets a non null endpoint. This used to happen after the processing was complete.
- This change also implements the IRouteValuesFeature and IEndpointFeature in HttpProtocol to avoid the feature allocation and feature collection version churn.

Open issues:
- The log that checks if the endpoit is non null is wrong. If code sets an end point manually before routing runs it'll say match success. We'd need to compare the end point before and after routing to see if it changed to be accurate.
- Currently I removed the IRoutingFeature (partially why this is a draft). We need to push it into the HttpRequest feature in order to make it lazy. We should only be allocating this thing if it's requested. I know @rynowak wants it to go away but maybe it can't right now?
- I didn't do thourough testing yet, it's late and I'll just wait for the CI to explode.

Plaintext without logging now indistinguishable from middleware from an allocation profile:

![image](https://user-images.githubusercontent.com/95136/56845708-1dfe1380-687a-11e9-9f5c-edc87371153f.png)

Fixes https://github.com/aspnet/AspNetCore/issues/6596