### PR TITLE
Placeholder RenderTreeBuilder.SetKey() to enable aspnetcore-tooling work

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -763,6 +763,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         public void OpenComponent(int sequence, System.Type componentType) { }
         public void OpenComponent<TComponent>(int sequence) where TComponent : Microsoft.AspNetCore.Components.IComponent { }
         public void OpenElement(int sequence, string elementName) { }
+        public void SetKey(object value) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct RenderTreeDiff

--- a/src/Components/Components/src/RenderTree/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeBuilder.cs
@@ -448,6 +448,21 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             OpenComponentUnchecked(sequence, componentType);
         }
 
+        /// <summary>
+        /// Assigns the specified key value to the current element or component.
+        /// </summary>
+        /// <param name="value">The value for the key.</param>
+        public void SetKey(object value)
+        {
+            // This is just a placeholder to enable work in parallel in the
+            // aspnetcore-tooling repo.
+            //
+            // The real implementation will involve multiple overloads, likely:
+            //   SetKey(int value) -- underlying logic
+            //   SetKey<T>(T value) where T: struct -- avoids boxing 'value' before calling .GetHashCode()
+            //   SetKey(object value) -- performs null check before calling .GetHashCode()
+        }
+
         private void OpenComponentUnchecked(int sequence, Type componentType)
         {
             _openElementIndices.Push(_entries.Count);


### PR DESCRIPTION
I've done most of the compiler work for `key` in aspnetcore-tooling, but the tests can't pass yet because the output now tries to call `builder.SetKey(...)`, but it doesn't yet exist.

This small placeholder will make it possible to complete the PR in aspnetcore-tooling, after which I'll be able to add the real runtime logic in this repo.