### PR TITLE
Improve performance of ByteArraysEqual

### DIFF
--- a/src/Identity/Extensions.Core/src/PasswordHasher.cs
+++ b/src/Identity/Extensions.Core/src/PasswordHasher.cs
@@ -77,12 +77,12 @@ namespace Microsoft.AspNetCore.Identity
             {
                 return false;
             }
-            var areSame = true;
+            int diff = 0;
             for (var i = 0; i < a.Length; i++)
             {
-                areSame &= (a[i] == b[i]);
+                diff |= (a[i] ^ b[i]);
             }
-            return areSame;
+            return diff == 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Very small performance improvements

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i5-6600 CPU 3.30GHz (Skylake), 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=3.0.100-preview3-010431
  [Host] : .NET Core 3.0.0-preview3-27503-5 (CoreCLR 4.6.27422.72, CoreFX 4.7.19.12807), 64bit RyuJIT
  Core   : .NET Core 3.0.0-preview3-27503-5 (CoreCLR 4.6.27422.72, CoreFX 4.7.19.12807), 64bit RyuJIT

Job=Core  Runtime=Core  

```
| Method |     Size of the array |         Mean |       Error |      StdDev |
|------- |------ |-------------:|------------:|------------:|
|    **Xor** |    **32** |     **84.81 ns** |   **1.1060 ns** |   **1.0346 ns** |
| Equals |    32 |     85.73 ns |   0.7217 ns |   0.6751 ns |
|    **Xor** |    **61** |    **158.93 ns** |   **1.4582 ns** |   **1.3640 ns** |
| Equals |    61 |    160.44 ns |   1.0615 ns |   0.9410 ns |
|    **Xor** |   **100** |    **267.39 ns** |   **2.9445 ns** |   **2.7543 ns** |
| Equals |   100 |    274.84 ns |   2.0553 ns |   1.9225 ns |
|    **Xor** |  **1000** |  **2,535.46 ns** |  **14.1535 ns** |  **13.2391 ns** |
| Equals |  1000 |  2,604.82 ns |  16.1195 ns |  14.2895 ns |
|    **Xor** | **10000** | **25,486.97 ns** | **188.7544 ns** | **176.5610 ns** |
| Equals | 10000 | 26,149.50 ns | 254.7591 ns | 238.3018 ns |

