### PR TITLE
Avoid buffering during input formatting for longer than necessary

### DIFF
--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp3.0.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp3.0.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.WebUtilities
     }
     public partial class FileBufferingReadStream : System.IO.Stream
     {
+        public FileBufferingReadStream(System.IO.Stream inner, int memoryThreshold) { }
         public FileBufferingReadStream(System.IO.Stream inner, int memoryThreshold, long? bufferLimit, System.Func<string> tempFileDirectoryAccessor) { }
         public FileBufferingReadStream(System.IO.Stream inner, int memoryThreshold, long? bufferLimit, System.Func<string> tempFileDirectoryAccessor, System.Buffers.ArrayPool<byte> bytePool) { }
         public FileBufferingReadStream(System.IO.Stream inner, int memoryThreshold, long? bufferLimit, string tempFileDirectory) { }

--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Internal;
 
 namespace Microsoft.AspNetCore.WebUtilities
 {
@@ -32,6 +33,16 @@ namespace Microsoft.AspNetCore.WebUtilities
         private bool _completelyBuffered;
 
         private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="FileBufferingReadStream" />.
+        /// </summary>
+        /// <param name="inner">The wrapping <see cref="Stream" />.</param>
+        /// <param name="memoryThreshold">The maximum size to buffer in memory.</param>
+        public FileBufferingReadStream(Stream inner, int memoryThreshold)
+            : this(inner, memoryThreshold, bufferLimit: null, tempFileDirectoryAccessor: AspNetCoreTempDirectory.TempDirectoryFactory)
+        {
+        }
 
         public FileBufferingReadStream(
             Stream inner,
@@ -223,13 +234,19 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     oldBuffer.Position = 0;
                     var rentedBuffer = _bytePool.Rent(Math.Min((int)oldBuffer.Length, _maxRentedBufferSize));
-                    var copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
-                    while (copyRead > 0)
+                    try
                     {
-                        _buffer.Write(rentedBuffer, 0, copyRead);
-                        copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
+                        var copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
+                        while (copyRead > 0)
+                        {
+                            _buffer.Write(rentedBuffer, 0, copyRead);
+                            copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
+                        }
                     }
-                    _bytePool.Return(rentedBuffer);
+                    finally
+                    {
+                        _bytePool.Return(rentedBuffer);
+                    }
                 }
                 else
                 {
@@ -277,14 +294,19 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     oldBuffer.Position = 0;
                     var rentedBuffer = _bytePool.Rent(Math.Min((int)oldBuffer.Length, _maxRentedBufferSize));
-                    // oldBuffer is a MemoryStream, no need to do async reads.
-                    var copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
-                    while (copyRead > 0)
+                    try
                     {
-                        await _buffer.WriteAsync(rentedBuffer, 0, copyRead, cancellationToken);
-                        copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
+                        // oldBuffer is a MemoryStream, no need to do async reads.
+                        var copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
+                        while (copyRead > 0)
+                        {
+                            await _buffer.WriteAsync(rentedBuffer, 0, copyRead, cancellationToken);
+                            copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
+                        }
+                    }finally
+                    {
+                        _bytePool.Return(rentedBuffer);
                     }
-                    _bytePool.Return(rentedBuffer);
                 }
                 else
                 {

--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -303,7 +303,8 @@ namespace Microsoft.AspNetCore.WebUtilities
                             await _buffer.WriteAsync(rentedBuffer, 0, copyRead, cancellationToken);
                             copyRead = oldBuffer.Read(rentedBuffer, 0, rentedBuffer.Length);
                         }
-                    }finally
+                    }
+                    finally
                     {
                         _bytePool.Return(rentedBuffer);
                     }

--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -103,7 +103,8 @@ namespace Microsoft.AspNetCore.Mvc
         public FormatterCollection<IInputFormatter> InputFormatters { get; }
 
         /// <summary>
-        /// Gets or sets the flag to buffer the request body in input formatters. Default is <c>false</c>.
+        /// Gets or sets the flag that determines if buffering is disabled for input formatters that
+        /// synchronously read from the HTTP request body.
         /// </summary>
         public bool SuppressInputFormatterBuffering { get; set; }
 

--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc
         public FormatterCollection<IInputFormatter> InputFormatters { get; }
 
         /// <summary>
-        /// Gets or sets the flag that determines if buffering is disabled for input formatters that
+        /// Gets or sets a value that determines if buffering is disabled for input formatters that
         /// synchronously read from the HTTP request body.
         /// </summary>
         public bool SuppressInputFormatterBuffering { get; set; }

--- a/src/Mvc/Mvc.Formatters.Xml/src/XmlDataContractSerializerInputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/XmlDataContractSerializerInputFormatter.cs
@@ -4,14 +4,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.WebUtilities;
@@ -24,6 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     /// </summary>
     public class XmlDataContractSerializerInputFormatter : TextInputFormatter, IInputFormatterExceptionPolicy
     {
+        private const int DefaultMemoryThreshold = 1024 * 30;
         private readonly ConcurrentDictionary<Type, object> _serializerCache = new ConcurrentDictionary<Type, object>();
         private readonly XmlDictionaryReaderQuotas _readerQuotas = FormattingUtilities.GetDefaultXmlReaderQuotas();
         private readonly MvcOptions _options;
@@ -118,42 +117,54 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
 
             var request = context.HttpContext.Request;
+            Stream readStream = new NonDisposableStream(request.Body);
 
             if (!request.Body.CanSeek && !_options.SuppressInputFormatterBuffering)
             {
                 // XmlDataContractSerializer does synchronous reads. In order to avoid blocking on the stream, we asynchronously
                 // read everything into a buffer, and then seek back to the beginning.
-                request.EnableBuffering();
-                Debug.Assert(request.Body.CanSeek);
+                var memoryThreshold = DefaultMemoryThreshold;
+                if (request.ContentLength.HasValue && request.ContentLength.Value > 0 && request.ContentLength.Value < memoryThreshold)
+                {
+                    // If the Content-Length is known and is smaller than the default buffer size, use it.
+                    memoryThreshold = (int)request.ContentLength.Value;
+                }
 
-                await request.Body.DrainAsync(CancellationToken.None);
-                request.Body.Seek(0L, SeekOrigin.Begin);
+                readStream = new FileBufferingReadStream(request.Body, memoryThreshold);
+
+                await readStream.DrainAsync(CancellationToken.None);
+                readStream.Seek(0L, SeekOrigin.Begin);
             }
 
             try
             {
-                using (var xmlReader = CreateXmlReader(new NonDisposableStream(request.Body), encoding))
+                using var xmlReader = CreateXmlReader(readStream, encoding);
+                var type = GetSerializableType(context.ModelType);
+                var serializer = GetCachedSerializer(type);
+
+                var deserializedObject = serializer.ReadObject(xmlReader);
+
+                // Unwrap only if the original type was wrapped.
+                if (type != context.ModelType)
                 {
-                    var type = GetSerializableType(context.ModelType);
-                    var serializer = GetCachedSerializer(type);
-
-                    var deserializedObject = serializer.ReadObject(xmlReader);
-
-                    // Unwrap only if the original type was wrapped.
-                    if (type != context.ModelType)
+                    if (deserializedObject is IUnwrappable unwrappable)
                     {
-                        if (deserializedObject is IUnwrappable unwrappable)
-                        {
-                            deserializedObject = unwrappable.Unwrap(declaredType: context.ModelType);
-                        }
+                        deserializedObject = unwrappable.Unwrap(declaredType: context.ModelType);
                     }
-
-                    return InputFormatterResult.Success(deserializedObject);
                 }
+
+                return InputFormatterResult.Success(deserializedObject);
             }
             catch (SerializationException exception)
             {
                 throw new InputFormatterException(Resources.ErrorDeserializingInputData, exception);
+            }
+            finally
+            {
+                if (readStream is FileBufferingReadStream fileBufferingReadStream)
+                {
+                    fileBufferingReadStream.Dispose();
+                }
             }
         }
 

--- a/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerInputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerInputFormatter.cs
@@ -4,14 +4,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.WebUtilities;
@@ -24,6 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     /// </summary>
     public class XmlSerializerInputFormatter : TextInputFormatter, IInputFormatterExceptionPolicy
     {
+        private const int DefaultMemoryThreshold = 1024 * 30;
         private readonly ConcurrentDictionary<Type, object> _serializerCache = new ConcurrentDictionary<Type, object>();
         private readonly XmlDictionaryReaderQuotas _readerQuotas = FormattingUtilities.GetDefaultXmlReaderQuotas();
         private readonly MvcOptions _options;
@@ -99,39 +98,43 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
 
             var request = context.HttpContext.Request;
-
+            Stream readStream = new NonDisposableStream(request.Body);
             if (!request.Body.CanSeek && !_options.SuppressInputFormatterBuffering)
             {
                 // XmlSerializer does synchronous reads. In order to avoid blocking on the stream, we asynchronously
                 // read everything into a buffer, and then seek back to the beginning.
-                request.EnableBuffering();
-                Debug.Assert(request.Body.CanSeek);
+                var memoryThreshold = DefaultMemoryThreshold;
+                if (request.ContentLength.HasValue && request.ContentLength.Value > 0 && request.ContentLength.Value < memoryThreshold)
+                {
+                    // If the Content-Length is known and is smaller than the default buffer size, use it.
+                    memoryThreshold = (int)request.ContentLength.Value;
+                }
 
-                await request.Body.DrainAsync(CancellationToken.None);
-                request.Body.Seek(0L, SeekOrigin.Begin);
+                readStream = new FileBufferingReadStream(request.Body, memoryThreshold);
+
+                await readStream.DrainAsync(CancellationToken.None);
+                readStream.Seek(0L, SeekOrigin.Begin);
             }
 
             try
             {
-                using (var xmlReader = CreateXmlReader(new NonDisposableStream(request.Body), encoding))
+                using var xmlReader = CreateXmlReader(readStream, encoding);
+                var type = GetSerializableType(context.ModelType);
+
+                var serializer = GetCachedSerializer(type);
+
+                var deserializedObject = serializer.Deserialize(xmlReader);
+
+                // Unwrap only if the original type was wrapped.
+                if (type != context.ModelType)
                 {
-                    var type = GetSerializableType(context.ModelType);
-
-                    var serializer = GetCachedSerializer(type);
-
-                    var deserializedObject = serializer.Deserialize(xmlReader);
-
-                    // Unwrap only if the original type was wrapped.
-                    if (type != context.ModelType)
+                    if (deserializedObject is IUnwrappable unwrappable)
                     {
-                        if (deserializedObject is IUnwrappable unwrappable)
-                        {
-                            deserializedObject = unwrappable.Unwrap(declaredType: context.ModelType);
-                        }
+                        deserializedObject = unwrappable.Unwrap(declaredType: context.ModelType);
                     }
-
-                    return InputFormatterResult.Success(deserializedObject);
                 }
+
+                return InputFormatterResult.Success(deserializedObject);
             }
             // XmlSerializer wraps actual exceptions (like FormatException or XmlException) into an InvalidOperationException
             // https://github.com/dotnet/corefx/blob/master/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs#L652
@@ -148,6 +151,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 exception.InnerException is XmlException)
             {
                 throw new InputFormatterException(Resources.ErrorDeserializingInputData, exception.InnerException);
+            }
+            finally
+            {
+                if (readStream is FileBufferingReadStream fileBufferingReadStream)
+                {
+                    fileBufferingReadStream.Dispose();
+                }
             }
         }
 

--- a/src/Mvc/Mvc.Formatters.Xml/test/XmlSerializerInputFormatterTest.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/test/XmlSerializerInputFormatterTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
-            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes, allowSyncReads: true);
             httpContext.Request.ContentType = "application/json";
             var context = GetInputFormatterContext(httpContext, typeof(TestLevelOne));
 
@@ -68,22 +68,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.NotNull(result);
             Assert.False(result.HasError);
             var model = Assert.IsType<TestLevelOne>(result.Model);
-
-            Assert.Equal(expectedInt, model.SampleInt);
-            Assert.Equal(expectedString, model.sampleString);
-            Assert.Equal(
-                XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
-                model.SampleDate);
-
-            Assert.True(httpContext.Request.Body.CanSeek);
-            httpContext.Request.Body.Seek(0L, SeekOrigin.Begin);
-
-            result = await formatter.ReadAsync(context);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.False(result.HasError);
-            model = Assert.IsType<TestLevelOne>(result.Model);
 
             Assert.Equal(expectedInt, model.SampleInt);
             Assert.Equal(expectedString, model.sampleString);
@@ -127,9 +111,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.Equal(
                 XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
                 model.SampleDate);
-
-            // Reading again should fail as buffering request body is disabled
-            await Assert.ThrowsAsync<XmlException>(() => formatter.ReadAsync(context));
         }
 
         [Fact]
@@ -149,7 +130,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
-            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes, allowSyncReads: false);
             httpContext.Request.ContentType = "application/json";
             var context = GetInputFormatterContext(httpContext, typeof(TestLevelOne));
 
@@ -160,22 +141,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.NotNull(result);
             Assert.False(result.HasError);
             var model = Assert.IsType<TestLevelOne>(result.Model);
-
-            Assert.Equal(expectedInt, model.SampleInt);
-            Assert.Equal(expectedString, model.sampleString);
-            Assert.Equal(
-                XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
-                model.SampleDate);
-
-            Assert.True(httpContext.Request.Body.CanSeek);
-            httpContext.Request.Body.Seek(0L, SeekOrigin.Begin);
-
-            result = await formatter.ReadAsync(context);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.False(result.HasError);
-            model = Assert.IsType<TestLevelOne>(result.Model);
 
             Assert.Equal(expectedInt, model.SampleInt);
             Assert.Equal(expectedString, model.sampleString);

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 using Microsoft.AspNetCore.WebUtilities;
@@ -24,6 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     /// </summary>
     public class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFormatterExceptionPolicy
     {
+        private const int DefaultMemoryThreshold = 1024 * 30;
         private readonly IArrayPool<char> _charPool;
         private readonly ILogger _logger;
         private readonly ObjectPoolProvider _objectPoolProvider;
@@ -129,117 +128,128 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             var suppressInputFormatterBuffering = _options.SuppressInputFormatterBuffering;
 
+            var readStream = request.Body;
             if (!request.Body.CanSeek && !suppressInputFormatterBuffering)
             {
                 // JSON.Net does synchronous reads. In order to avoid blocking on the stream, we asynchronously
                 // read everything into a buffer, and then seek back to the beginning.
-                request.EnableBuffering();
-                Debug.Assert(request.Body.CanSeek);
+                var memoryThreshold = DefaultMemoryThreshold;
+                if (request.ContentLength.HasValue && request.ContentLength.Value > 0 && request.ContentLength.Value < memoryThreshold)
+                {
+                    // If the Content-Length is known and is smaller than the default buffer size, use it.
+                    memoryThreshold = (int)request.ContentLength.Value;
+                }
 
-                await request.Body.DrainAsync(CancellationToken.None);
-                request.Body.Seek(0L, SeekOrigin.Begin);
+                readStream = new FileBufferingReadStream(request.Body, memoryThreshold);
+
+                await readStream.DrainAsync(CancellationToken.None);
+                readStream.Seek(0L, SeekOrigin.Begin);
             }
 
-            using (var streamReader = context.ReaderFactory(request.Body, encoding))
+            var successful = true;
+            Exception exception = null;
+            object model;
+
+            using (var streamReader = context.ReaderFactory(readStream, encoding))
             {
-                using (var jsonReader = new JsonTextReader(streamReader))
+                using var jsonReader = new JsonTextReader(streamReader);
+                jsonReader.ArrayPool = _charPool;
+                jsonReader.CloseInput = false;
+
+                var type = context.ModelType;
+                var jsonSerializer = CreateJsonSerializer(context);
+                jsonSerializer.Error += ErrorHandler;
+                try
                 {
-                    jsonReader.ArrayPool = _charPool;
-                    jsonReader.CloseInput = false;
+                    model = jsonSerializer.Deserialize(jsonReader, type);
+                }
+                finally
+                {
+                    // Clean up the error handler since CreateJsonSerializer() pools instances.
+                    jsonSerializer.Error -= ErrorHandler;
+                    ReleaseJsonSerializer(jsonSerializer);
 
-                    var successful = true;
-                    Exception exception = null;
-                    void ErrorHandler(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs eventArgs)
+                    if (readStream is FileBufferingReadStream fileBufferingReadStream)
                     {
-                        successful = false;
-
-                        // When ErrorContext.Path does not include ErrorContext.Member, add Member to form full path.
-                        var path = eventArgs.ErrorContext.Path;
-                        var member = eventArgs.ErrorContext.Member?.ToString();
-                        var addMember = !string.IsNullOrEmpty(member);
-                        if (addMember)
-                        {
-                            // Path.Member case (path.Length < member.Length) needs no further checks.
-                            if (path.Length == member.Length)
-                            {
-                                // Add Member in Path.Memb case but not for Path.Path.
-                                addMember = !string.Equals(path, member, StringComparison.Ordinal);
-                            }
-                            else if (path.Length > member.Length)
-                            {
-                                // Finally, check whether Path already ends with Member.
-                                if (member[0] == '[')
-                                {
-                                    addMember = !path.EndsWith(member, StringComparison.Ordinal);
-                                }
-                                else
-                                {
-                                    addMember = !path.EndsWith("." + member, StringComparison.Ordinal);
-                                }
-                            }
-                        }
-
-                        if (addMember)
-                        {
-                            path = ModelNames.CreatePropertyModelName(path, member);
-                        }
-
-                        // Handle path combinations such as ""+"Property", "Parent"+"Property", or "Parent"+"[12]".
-                        var key = ModelNames.CreatePropertyModelName(context.ModelName, path);
-
-                        exception = eventArgs.ErrorContext.Error;
-
-                        var metadata = GetPathMetadata(context.Metadata, path);
-                        var modelStateException = WrapExceptionForModelState(exception);
-                        context.ModelState.TryAddModelError(key, modelStateException, metadata);
-
-                        _logger.JsonInputException(exception);
-
-                        // Error must always be marked as handled
-                        // Failure to do so can cause the exception to be rethrown at every recursive level and
-                        // overflow the stack for x64 CLR processes
-                        eventArgs.ErrorContext.Handled = true;
+                        fileBufferingReadStream.Dispose();
                     }
+                }
+            }
 
-                    var type = context.ModelType;
-                    var jsonSerializer = CreateJsonSerializer(context);
-                    jsonSerializer.Error += ErrorHandler;
-                    object model;
-                    try
-                    {
-                        model = jsonSerializer.Deserialize(jsonReader, type);
-                    }
-                    finally
-                    {
-                        // Clean up the error handler since CreateJsonSerializer() pools instances.
-                        jsonSerializer.Error -= ErrorHandler;
-                        ReleaseJsonSerializer(jsonSerializer);
-                    }
+            if (successful)
+            {
+                if (model == null && !context.TreatEmptyInputAsDefaultValue)
+                {
+                    // Some nonempty inputs might deserialize as null, for example whitespace,
+                    // or the JSON-encoded value "null". The upstream BodyModelBinder needs to
+                    // be notified that we don't regard this as a real input so it can register
+                    // a model binding error.
+                    return InputFormatterResult.NoValue();
+                }
+                else
+                {
+                    return InputFormatterResult.Success(model);
+                }
+            }
 
-                    if (successful)
+            if (!(exception is JsonException || exception is OverflowException))
+            {
+                var exceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
+                exceptionDispatchInfo.Throw();
+            }
+
+            return InputFormatterResult.Failure();
+
+            void ErrorHandler(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs eventArgs)
+            {
+                successful = false;
+
+                // When ErrorContext.Path does not include ErrorContext.Member, add Member to form full path.
+                var path = eventArgs.ErrorContext.Path;
+                var member = eventArgs.ErrorContext.Member?.ToString();
+                var addMember = !string.IsNullOrEmpty(member);
+                if (addMember)
+                {
+                    // Path.Member case (path.Length < member.Length) needs no further checks.
+                    if (path.Length == member.Length)
                     {
-                        if (model == null && !context.TreatEmptyInputAsDefaultValue)
+                        // Add Member in Path.Memb case but not for Path.Path.
+                        addMember = !string.Equals(path, member, StringComparison.Ordinal);
+                    }
+                    else if (path.Length > member.Length)
+                    {
+                        // Finally, check whether Path already ends with Member.
+                        if (member[0] == '[')
                         {
-                            // Some nonempty inputs might deserialize as null, for example whitespace,
-                            // or the JSON-encoded value "null". The upstream BodyModelBinder needs to
-                            // be notified that we don't regard this as a real input so it can register
-                            // a model binding error.
-                            return InputFormatterResult.NoValue();
+                            addMember = !path.EndsWith(member, StringComparison.Ordinal);
                         }
                         else
                         {
-                            return InputFormatterResult.Success(model);
+                            addMember = !path.EndsWith("." + member, StringComparison.Ordinal);
                         }
                     }
-
-                    if (!(exception is JsonException || exception is OverflowException))
-                    {
-                        var exceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
-                        exceptionDispatchInfo.Throw();
-                    }
-
-                    return InputFormatterResult.Failure();
                 }
+
+                if (addMember)
+                {
+                    path = ModelNames.CreatePropertyModelName(path, member);
+                }
+
+                // Handle path combinations such as ""+"Property", "Parent"+"Property", or "Parent"+"[12]".
+                var key = ModelNames.CreatePropertyModelName(context.ModelName, path);
+
+                exception = eventArgs.ErrorContext.Error;
+
+                var metadata = GetPathMetadata(context.Metadata, path);
+                var modelStateException = WrapExceptionForModelState(exception);
+                context.ModelState.TryAddModelError(key, modelStateException, metadata);
+
+                _logger.JsonInputException(exception);
+
+                // Error must always be marked as handled
+                // Failure to do so can cause the exception to be rethrown at every recursive level and
+                // overflow the stack for x64 CLR processes
+                eventArgs.ErrorContext.Handled = true;
             }
         }
 

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var contentBytes = Encoding.UTF8.GetBytes(content);
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
-            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes, allowSyncReads: false);
             httpContext.Request.ContentType = "application/json";
 
             var formatterContext = CreateInputFormatterContext(typeof(User), httpContext);
@@ -52,18 +52,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             Assert.False(result.HasError);
 
             var userModel = Assert.IsType<User>(result.Model);
-            Assert.Equal("Person Name", userModel.Name);
-            Assert.Equal(30, userModel.Age);
-
-            Assert.True(httpContext.Request.Body.CanSeek);
-            httpContext.Request.Body.Seek(0L, SeekOrigin.Begin);
-
-            result = await formatter.ReadAsync(formatterContext);
-
-            // Assert
-            Assert.False(result.HasError);
-
-            userModel = Assert.IsType<User>(result.Model);
             Assert.Equal("Person Name", userModel.Name);
             Assert.Equal(30, userModel.Age);
         }
@@ -102,13 +90,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var userModel = Assert.IsType<User>(result.Model);
             Assert.Equal("Person Name", userModel.Name);
             Assert.Equal(30, userModel.Age);
-
-            Assert.False(httpContext.Request.Body.CanSeek);
-            result = await formatter.ReadAsync(formatterContext);
-
-            // Assert
-            Assert.False(result.HasError);
-            Assert.Null(result.Model);
         }
 
         [Fact]

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonPatchInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonPatchInputFormatterTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
-            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes, allowSyncReads: false);
             httpContext.Request.ContentType = "application/json";
 
             var formatterContext = CreateInputFormatterContext(typeof(JsonPatchDocument<Customer>), httpContext);
@@ -52,18 +52,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Assert
             Assert.False(result.HasError);
             var patchDocument = Assert.IsType<JsonPatchDocument<Customer>>(result.Model);
-            Assert.Equal("add", patchDocument.Operations[0].op);
-            Assert.Equal("Customer/Name", patchDocument.Operations[0].path);
-            Assert.Equal("John", patchDocument.Operations[0].value);
-
-            Assert.True(httpContext.Request.Body.CanSeek);
-            httpContext.Request.Body.Seek(0L, SeekOrigin.Begin);
-
-            result = await formatter.ReadAsync(formatterContext);
-
-            // Assert
-            Assert.False(result.HasError);
-            patchDocument = Assert.IsType<JsonPatchDocument<Customer>>(result.Model);
             Assert.Equal("add", patchDocument.Operations[0].op);
             Assert.Equal("Customer/Name", patchDocument.Operations[0].path);
             Assert.Equal("John", patchDocument.Operations[0].value);

--- a/src/Mvc/shared/Mvc.Core.TestCommon/NonSeekableReadableStream.cs
+++ b/src/Mvc/shared/Mvc.Core.TestCommon/NonSeekableReadableStream.cs
@@ -11,15 +11,17 @@ namespace Microsoft.AspNetCore.Mvc
     public class NonSeekableReadStream : Stream
     {
         private Stream _inner;
+        private readonly bool _allowSyncReads;
 
-        public NonSeekableReadStream(byte[] data)
-            : this(new MemoryStream(data))
+        public NonSeekableReadStream(byte[] data, bool allowSyncReads = true)
+            : this(new MemoryStream(data), allowSyncReads)
         {
         }
 
-        public NonSeekableReadStream(Stream inner)
+        public NonSeekableReadStream(Stream inner, bool allowSyncReads)
         {
             _inner = inner;
+            _allowSyncReads = allowSyncReads;
         }
 
         public override bool CanRead => _inner.CanRead;
@@ -61,6 +63,11 @@ namespace Microsoft.AspNetCore.Mvc
 
         public override int Read(byte[] buffer, int offset, int count)
         {
+            if (!_allowSyncReads)
+            {
+                throw new InvalidOperationException("Cannot perform synchronous reads");
+            }
+
             count = Math.Max(count, 1);
             return _inner.Read(buffer, offset, count);
         }


### PR DESCRIPTION
EnableRewind uses FileBufferingReadStream which is not disposed until the response is completed.
This results in holding on to internal buffers for significantly longer than necessary. Changing it
to return the buffers immediately improved the allocations and throughput.

|                Description |    RPS | CPU (%) | Memory (MB) | Avg. Latency (ms) | Startup (ms) | First Request (ms) | Latency (ms) | Ratio |
| -------------------------- | ------ | ------- | ----------- | ----------------- | ------------ | ------------------ | ------------ | ----- |
| Newtonsoft.Json - old - 500 bytes |  49,661 |      98 |       2,349 |              7.32 |          514 |              87.97 |         0.49 |  1.00 |
| Newtonsoft.Json - new - 500 bytes | 120,273 |      94 |         174 |              2.32 |          509 |              80.54 |         0.36 |  2.42 |
| Newtonsoft.Json - old - 2k | 29,759 |      97 |         382 |              9.11 |          556 |              80.14 |          0.5 |  1.00 |
| Newtonsoft.Json - new - 2k | 36,079 |      97 |         186 |              7.53 |          507 |              84.96 |         0.41 |  1.21 |
| Newtonsoft.Json - old - 8 kbytes | 29,784 |      98 |         343 |              9.41 |          506 |              81.49 |         0.36 |  1.00 |
| Newtonsoft.Json - new - 8 kbytes | 35,408 |      98 |         187 |              8.79 |          503 |              79.64 |         0.33 |  1.19 |
| Newtonsoft.Json - old - 40 kbytes | 2,937 |      76 |       2,004 |             89.87 |          512 |              89.18 |         0.49 |  1.00 |
| Newtonsoft.Json - new - 40 kbytes | 8,416 |      99 |         202 |              30.8 |          534 |              78.79 |         0.47 |  2.87 |
