### PR TITLE
Pass catchAll ValueTuple via in

### DIFF
--- a/src/Http/Routing/src/Matching/Candidate.cs
+++ b/src/Http/Routing/src/Matching/Candidate.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             int score,
             KeyValuePair<string, object>[] slots,
             (string parameterName, int segmentIndex, int slotIndex)[] captures,
-            (string parameterName, int segmentIndex, int slotIndex) catchAll,
+            in (string parameterName, int segmentIndex, int slotIndex) catchAll,
             (RoutePatternPathSegment pathSegment, int segmentIndex)[] complexSegments,
             KeyValuePair<string, IRouteConstraint>[] constraints)
         {


### PR DESCRIPTION
Its a 16 bytes 3 field struct (16 bytes not passed via register on Windows; 3 fields so can't be decomposed to 2 registers on SystemV)

In the callee (`Candidate` constructor) its simply copied to a field (no register benefits); and a single field is read once (no register benefits). The single read is a field so no danger from readonly defensive copy.

So no change in callee.

In the caller (`DfaMatcherBuilder.CreateCandidate`) it is only assigned to as a whole after which it is passed to the constructor.

If the Jit chose to store it in a `xmm` register; pass-by-value would then need to copy to stack to pass the reference to the copy as a pointer. If the Jit chose not to store it as a register (likely) then pass-by-value will create a second stack copy and then pass that by reference.

Passing via `in` will cut out the second copy if the Jit uses stack for the value; and remove the register use in the first case (going straight to stack); so its a net advantage for the caller and no difference for the callee.

/cc @JamesNK @rynowak @davidfowl 