### PR TITLE
Remove useless ToString

### DIFF
--- a/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenStore.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenStore.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Antiforgery
 
             if (_options.Cookie.Path != null)
             {
-                options.Path = _options.Cookie.Path.ToString();
+                options.Path = _options.Cookie.Path;
             }
             else
             {

--- a/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     case 3:
                         return new KeyValuePair<string, object>("ContentLength", _request.ContentLength);
                     case 4:
-                        return new KeyValuePair<string, object>("Scheme", _request.Scheme.ToString());
+                        return new KeyValuePair<string, object>("Scheme", _request.Scheme);
                     case 5:
                         return new KeyValuePair<string, object>("Host", _request.Host.ToString());
                     case 6:

--- a/src/Http/Http/src/Internal/BindingAddress.cs
+++ b/src/Http/Http/src/Internal/BindingAddress.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Http.Internal
             }
             else
             {
-                return Scheme.ToLowerInvariant() + "://" + Host.ToLowerInvariant() + ":" + Port.ToString(CultureInfo.InvariantCulture) + PathBase.ToString(CultureInfo.InvariantCulture);
+                return Scheme.ToLowerInvariant() + "://" + Host.ToLowerInvariant() + ":" + Port.ToString(CultureInfo.InvariantCulture) + PathBase;
             }
         }
 


### PR DESCRIPTION
`_options.Cookie.Path` is already a string, so ToString is useless