### PR TITLE
 Reduce StaticFileContext allocation/struct copy

### DIFF
--- a/src/Middleware/StaticFiles/src/StaticFileContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileContext.cs
@@ -83,36 +83,18 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         private ResponseHeaders ResponseHeaders => (_responseHeaders ??= _response.GetTypedHeaders());
 
-        public bool IsHeadMethod
-        {
-            get { return (_requestType & RequestType.IsHead) != 0; }
-        }
+        public bool IsHeadMethod => (_requestType & RequestType.IsHead) != 0;
 
-        public bool IsGetMethod
-        {
-            get { return (_requestType & RequestType.IsGet) != 0; }
-        }
+        public bool IsGetMethod => (_requestType & RequestType.IsGet) != 0;
 
-        public bool IsRangeRequest
-        {
-            get { return (_requestType & RequestType.IsRange) != 0; }
-        }
+        public bool IsRangeRequest => (_requestType & RequestType.IsRange) != 0;
 
-        public string SubPath
-        {
-            get { return _subPath.Value; }
-        }
+        public string SubPath => _subPath.Value;
 
-        public string PhysicalPath
-        {
-            get { return _fileInfo?.PhysicalPath; }
-        }
+        public string PhysicalPath => _fileInfo?.PhysicalPath;
 
-        public bool ValidateNoEndpoint()
-        {
-            // Return true because we only want to run if there is no endpoint.
-            return _context.GetEndpoint() == null;
-        }
+        // Return true because we only want to run if there is no endpoint.
+        public bool ValidateNoEndpoint() => _context.GetEndpoint() == null;
 
         public bool ValidateMethod()
         {
@@ -141,10 +123,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         }
 
         // Check if the URL matches any expected paths
-        public bool ValidatePath()
-        {
-            return Helpers.TryMatchPath(_context, _matchUrl, forDirectory: false, subpath: out _subPath);
-        }
+        public bool ValidatePath() => Helpers.TryMatchPath(_context, _matchUrl, forDirectory: false, subpath: out _subPath);
 
         public bool LookupContentType()
         {
@@ -322,10 +301,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         }
 
         public PreconditionState GetPreconditionState()
-        {
-            return GetMaxPreconditionState(_ifMatchState, _ifNoneMatchState,
-                _ifModifiedSinceState, _ifUnmodifiedSinceState);
-        }
+            => GetMaxPreconditionState(_ifMatchState, _ifNoneMatchState, _ifModifiedSinceState, _ifUnmodifiedSinceState);
 
         private static PreconditionState GetMaxPreconditionState(params PreconditionState[] states)
         {

--- a/src/Middleware/StaticFiles/src/StaticFileContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileContext.cs
@@ -83,11 +83,11 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         private ResponseHeaders ResponseHeaders => (_responseHeaders ??= _response.GetTypedHeaders());
 
-        public bool IsHeadMethod => (_requestType & RequestType.IsHead) != 0;
+        public bool IsHeadMethod => _requestType.HasFlag(RequestType.IsHead);
 
-        public bool IsGetMethod => (_requestType & RequestType.IsGet) != 0;
+        public bool IsGetMethod => _requestType.HasFlag(RequestType.IsGet);
 
-        public bool IsRangeRequest => (_requestType & RequestType.IsRange) != 0;
+        public bool IsRangeRequest => _requestType.HasFlag(RequestType.IsRange);
 
         public string SubPath => _subPath.Value;
 
@@ -105,18 +105,10 @@ namespace Microsoft.AspNetCore.StaticFiles
                 _requestType |= RequestType.IsGet;
                 isValid = true;
             }
-            else
-            {
-                _requestType &= ~RequestType.IsGet;
-            }
-            if (HttpMethods.IsHead(_method))
+            else if (HttpMethods.IsHead(_method))
             {
                 _requestType |= RequestType.IsHead;
                 isValid = true;
-            }
-            else
-            {
-                _requestType &= ~RequestType.IsHead;
             }
 
             return isValid;
@@ -359,12 +351,10 @@ namespace Microsoft.AspNetCore.StaticFiles
                     _logger.FileNotModified(SubPath);
                     await SendStatusAsync(Constants.Status304NotModified);
                     return;
-
                 case PreconditionState.PreconditionFailed:
                     _logger.PreconditionFailed(SubPath);
                     await SendStatusAsync(Constants.Status412PreconditionFailed);
                     return;
-
                 default:
                     var exception = new NotImplementedException(GetPreconditionState().ToString());
                     Debug.Fail(exception.ToString());


### PR DESCRIPTION
Lazy alloc the TypedHeaders `_requestHeaders` and `_responseHeaders`; waiting until StaticFiles is actually producing a file rather than just the middleware executing and checking if it should be serving a file.

Move `ServeStaticFile()` to `StaticFileContext` rather than passing the large struct into the method in the middleware and causing a large struct copy.

Combine the three bools `_isGet`, `_isHead` and `_isRangeRequest` in to a single `_requestType` `byte` flags enum.

Change `PreconditionState` from `int` enum to `byte` enum for the 4 states.