### PR TITLE
Fixup XUnit warnings when running MVC tests

### DIFF
--- a/src/Mvc/Mvc.Razor/test/RazorPageCreateModelExpressionTest.cs
+++ b/src/Mvc/Mvc.Razor/test/RazorPageCreateModelExpressionTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -20,73 +19,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 {
     public class RazorPageCreateModelExpressionTest
     {
-        public static TheoryData IdentityExpressions
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_IdentityExpressions_ForModelGivesM()
         {
-            get
-            {
-                return new TheoryData<Func<IdentityRazorPage, ModelExpression>, string>
-                {
-                    // m => m
-                    { page => page.CreateModelExpression1(), string.Empty },
-                    // m => Model
-                    { page => page.CreateModelExpression2(), string.Empty },
-                };
-            }
-        }
-
-        public static TheoryData NotQuiteIdentityExpressions
-        {
-            get
-            {
-                return new TheoryData<Func<NotQuiteIdentityRazorPage, ModelExpression>, string, Type>
-                {
-                    // m => m.Model
-                    { page => page.CreateModelExpression1(), "Model", typeof(RecursiveModel) },
-                    // m => ViewData.Model
-                    { page => page.CreateModelExpression2(), "ViewData.Model", typeof(RecursiveModel) },
-                    // m => ViewContext.ViewData.Model
-                    // This property has type object because ViewData is not exposed as ViewDataDictionary<TModel>.
-                    { page => page.CreateModelExpression3(), "ViewContext.ViewData.Model", typeof(object) },
-                };
-            }
-        }
-
-        public static TheoryData<Expression<Func<RazorPageCreateModelExpressionModel, int>>, string> IntExpressions
-        {
-            get
-            {
-                var somethingElse = 23;
-                return new TheoryData<Expression<Func<RazorPageCreateModelExpressionModel, int>>, string>
-                {
-                    { model => somethingElse, "somethingElse" },
-                    { model => model.Id, "Id" },
-                    { model => model.SubModel.Id, "SubModel.Id" },
-                    { model => model.SubModel.SubSubModel.Id, "SubModel.SubSubModel.Id" },
-                };
-            }
-        }
-
-        public static TheoryData<Expression<Func<RazorPageCreateModelExpressionModel, string>>, string> StringExpressions
-        {
-            get
-            {
-                var somethingElse = "This is something else";
-                return new TheoryData<Expression<Func<RazorPageCreateModelExpressionModel, string>>, string>
-                {
-                    { model => somethingElse, "somethingElse" },
-                    { model => model.Name, "Name" },
-                    { model => model.SubModel.Name, "SubModel.Name" },
-                    { model => model.SubModel.SubSubModel.Name, "SubModel.SubSubModel.Name" },
-                };
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(IdentityExpressions))]
-        public void CreateModelExpression_ReturnsExpectedMetadata_IdentityExpressions(
-            Func<IdentityRazorPage, ModelExpression> createModelExpression,
-            string expectedName)
-        {
+            // m => m
             // Arrange
             var viewContext = CreateViewContext();
             var modelExplorer = viewContext.ViewData.ModelExplorer.GetExplorerForProperty(
@@ -100,22 +36,78 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var page = CreateIdentityPage(viewContext);
 
             // Act
-            var modelExpression = createModelExpression(page);
+            var modelExpression = page.CreateModelExpression1();
 
             // Assert
             Assert.NotNull(modelExpression);
-            Assert.Equal(expectedName, modelExpression.Name);
+            Assert.Empty(modelExpression.Name);
             Assert.Same(modelExplorer, modelExpression.ModelExplorer);
         }
 
-        [Theory]
-        [MemberData(nameof(NotQuiteIdentityExpressions))]
-        public void CreateModelExpression_ReturnsExpectedMetadata_NotQuiteIdentityExpressions(
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_IdentityExpressions_ForModelGivesModel()
+        {
+            // m => m.Model
+            // Arrange
+            var viewContext = CreateViewContext();
+            var modelExplorer = viewContext.ViewData.ModelExplorer.GetExplorerForProperty(
+                nameof(RazorPageCreateModelExpressionModel.Name));
+            var viewData = new ViewDataDictionary<string>(viewContext.ViewData)
+            {
+                ModelExplorer = modelExplorer,
+            };
+            viewContext.ViewData = viewData;
+
+            var page = CreateIdentityPage(viewContext);
+
+            // Act
+            var modelExpression = page.CreateModelExpression2();
+
+            // Assert
+            Assert.NotNull(modelExpression);
+            Assert.Empty(modelExpression.Name);
+            Assert.Same(modelExplorer, modelExpression.ModelExplorer);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_NotQuiteIdentityExpressions_ForModelGivesMDotModel()
+        {
+            // m => m.Model
+            // Arrange
+            var expectedName = "Model";
+            var expectedType = typeof(RecursiveModel);
+
+            CreateModelExpression_NotQuiteIdentityExpressions(page => page.CreateModelExpression1(), expectedName, expectedType);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_NotQuiteIdentityExpressions_ForModelGivesViewDataDotModel()
+        {
+            // m => ViewData.Model
+            // Arrange
+            var expectedName = "ViewData.Model";
+            var expectedType = typeof(RecursiveModel);
+
+            CreateModelExpression_NotQuiteIdentityExpressions(page => page.CreateModelExpression2(), expectedName, expectedType);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_NotQuiteIdentityExpressions_ForModelGivesViewContextDotViewDataDotModel()
+        {
+            // m => ViewContext.ViewData.Model
+            // Arrange
+            var expectedName = "ViewContext.ViewData.Model";
+            // This property has type object because ViewData is not exposed as ViewDataDictionary<TModel>.
+            var expectedType = typeof(object);
+
+            CreateModelExpression_NotQuiteIdentityExpressions(page => page.CreateModelExpression3(), expectedName, expectedType);
+        }
+
+        private static void CreateModelExpression_NotQuiteIdentityExpressions(
             Func<NotQuiteIdentityRazorPage, ModelExpression> createModelExpression,
             string expectedName,
             Type expectedType)
         {
-            // Arrange
             var viewContext = CreateViewContext();
             var viewData = new ViewDataDictionary<RecursiveModel>(viewContext.ViewData);
             viewContext.ViewData = viewData;
@@ -136,38 +128,144 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             Assert.Equal(expectedType, modelExpression.Metadata.ModelType);
         }
 
-        [Theory]
-        [MemberData(nameof(IntExpressions))]
-        public void CreateModelExpression_ReturnsExpectedMetadata_IntExpressions(
-            Expression<Func<RazorPageCreateModelExpressionModel, int>> expression,
-            string expectedName)
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_IntExpressions_ForModelGivesSomethingElse()
         {
             // Arrange
+            var expected = "somethingElse";
+            var somethingElse = 23;
             var viewContext = CreateViewContext();
             var page = CreatePage(viewContext);
 
             // Act
-            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, expression);
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => somethingElse);
 
             // Assert
             Assert.NotNull(result);
             Assert.NotNull(result.Metadata);
             Assert.Equal(typeof(int), result.Metadata.ModelType);
-            Assert.Equal(expectedName, result.Name);
+            Assert.Equal(expected, result.Name);
         }
 
-        [Theory]
-        [MemberData(nameof(StringExpressions))]
-        public void CreateModelExpression_ReturnsExpectedMetadata_StringExpressions(
-            Expression<Func<RazorPageCreateModelExpressionModel, string>> expression,
-            string expectedName)
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_IntExpressions_ForModelGivesId()
         {
             // Arrange
+            var expected = "Id";
             var viewContext = CreateViewContext();
             var page = CreatePage(viewContext);
 
             // Act
-            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, expression);
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => model.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Metadata);
+            Assert.Equal(typeof(int), result.Metadata.ModelType);
+            Assert.Equal(expected, result.Name);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_IntExpressions_ForModelGivesSubModelId()
+        {
+            // Arrange
+            var expected = "SubModel.Id";
+            var viewContext = CreateViewContext();
+            var page = CreatePage(viewContext);
+
+            // Act
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => model.SubModel.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Metadata);
+            Assert.Equal(typeof(int), result.Metadata.ModelType);
+            Assert.Equal(expected, result.Name);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_IntExpressions_ForModelGivesSubSubModelId()
+        {
+            // Arrange
+            var expected = "SubModel.SubSubModel.Id";
+            var viewContext = CreateViewContext();
+            var page = CreatePage(viewContext);
+
+            // Act
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => model.SubModel.SubSubModel.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Metadata);
+            Assert.Equal(typeof(int), result.Metadata.ModelType);
+            Assert.Equal(expected, result.Name);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_StringExpressions_ForModelGivesSomethingElse()
+        {
+            // Arrange
+            var somethingElse = "This is something else";
+            var expectedName = "somethingElse";
+            var viewContext = CreateViewContext();
+            var page = CreatePage(viewContext);
+
+            // Act
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => somethingElse);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Metadata);
+            Assert.Equal(typeof(string), result.Metadata.ModelType);
+            Assert.Equal(expectedName, result.Name);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_StringExpressions_ForModelGivesName()
+        {
+            // Arrange
+            var expectedName = "Name";
+            var viewContext = CreateViewContext();
+            var page = CreatePage(viewContext);
+
+            // Act
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => model.Name);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Metadata);
+            Assert.Equal(typeof(string), result.Metadata.ModelType);
+            Assert.Equal(expectedName, result.Name);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_StringExpressions_ForModelGivesSubmodelName()
+        {
+            // Arrange
+            var expectedName = "SubModel.SubSubModel.Name";
+            var viewContext = CreateViewContext();
+            var page = CreatePage(viewContext);
+
+            // Act
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => model.SubModel.SubSubModel.Name);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Metadata);
+            Assert.Equal(typeof(string), result.Metadata.ModelType);
+            Assert.Equal(expectedName, result.Name);
+        }
+
+        [Fact]
+        public void CreateModelExpression_ReturnsExpectedMetadata_StringExpressions_ForModelGivesSubSubmodelName()
+        {
+            // Arrange
+            var expectedName = "SubModel.Name";
+            var viewContext = CreateViewContext();
+            var page = CreatePage(viewContext);
+
+            // Act
+            var result = page.ModelExpressionProvider.CreateModelExpression(page.ViewData, model => model.SubModel.Name);
 
             // Assert
             Assert.NotNull(result);

--- a/src/Mvc/Mvc.Razor/test/TagHelpers/UrlResolutionTagHelperTest.cs
+++ b/src/Mvc/Mvc.Razor/test/TagHelpers/UrlResolutionTagHelperTest.cs
@@ -108,12 +108,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
             get
             {
                 // url, expectedHref
-                return new TheoryData<HtmlString, string>
+                return new TheoryData<string, string>
                 {
-                   { new HtmlString("~/home/index.html"), "HtmlEncode[[/approot/]]home/index.html" },
-                   { new HtmlString("  ~/home/index.html"), "HtmlEncode[[/approot/]]home/index.html" },
+                   { "~/home/index.html", "HtmlEncode[[/approot/]]home/index.html" },
+                   { "  ~/home/index.html", "HtmlEncode[[/approot/]]home/index.html" },
                    {
-                        new HtmlString("~/home/index.html ~/secondValue/index.html"),
+                        "~/home/index.html ~/secondValue/index.html",
                         "HtmlEncode[[/approot/]]home/index.html ~/secondValue/index.html"
                    },
                 };
@@ -122,14 +122,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
 
         [Theory]
         [MemberData(nameof(ResolvableUrlHtmlStringData))]
-        public void Process_ResolvesTildeSlashValues_InHtmlString(object url, string expectedHref)
+        public void Process_ResolvesTildeSlashValues_InHtmlString(string url, string expectedHref)
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 tagName: "a",
                 attributes: new TagHelperAttributeList
                 {
-                    { "href", url }
+                    { "href", new HtmlString(url) }
                 },
                 getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(null));
             var urlHelperMock = new Mock<IUrlHelper>();
@@ -221,27 +221,27 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
             get
             {
                 // url
-                return new TheoryData<HtmlString>
+                return new TheoryData<string>
                 {
-                   { new HtmlString("/home/index.html") },
-                   { new HtmlString("~ /home/index.html") },
-                   { new HtmlString("/home/index.html ~/second/wontresolve.html") },
-                   { new HtmlString("~\\home\\index.html") },
-                   { new HtmlString("~\\/home/index.html") },
+                   { "/home/index.html" },
+                   { "~ /home/index.html" },
+                   { "/home/index.html ~/second/wontresolve.html" },
+                   { "~\\home\\index.html" },
+                   { "~\\/home/index.html" },
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(UnresolvableUrlHtmlStringData))]
-        public void Process_DoesNotResolveNonTildeSlashValues_InHtmlString(HtmlString url)
+        public void Process_DoesNotResolveNonTildeSlashValues_InHtmlString(string url)
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 tagName: "a",
                 attributes: new TagHelperAttributeList
                 {
-                    { "href", url }
+                    { "href", new HtmlString(url) }
                 },
                 getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(null));
             var urlHelperMock = new Mock<IUrlHelper>();


### PR DESCRIPTION
```
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageCreateModelExpressionTest.CreateModelExpression_ReturnsExpectedMetadata_IdentityExpressions'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageCreateModelExpressionTest.CreateModelExpression_ReturnsExpectedMetadata_NotQuiteIdentityExpressions'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageCreateModelExpressionTest.CreateModelExpression_ReturnsExpectedMetadata_IntExpressions'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageCreateModelExpressionTest.CreateModelExpression_ReturnsExpectedMetadata_StringExpressions'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageTest.StartTagHelperWritingScope_SetsHtmlEncoder'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageTest.AddHtmlAttributeValues_AddsToHtmlAttributesAsExpected'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorPageTest.WriteAttribute_UsesSpecifiedWriter_WritesAsExpected'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineTest.FindView_UsesViewLocationExpandersToLocateViews'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineTest.FindPage_UsesViewLocationExpander_ToExpandPaths'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelperTest.Process_ResolvesTildeSlashValues_InHtmlString'; falling back to single test case.
Microsoft.AspNetCore.Mvc.Razor.Test: Non-serializable data ('System.Object[]') found for 'Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelperTest.Process_DoesNotResolveNonTildeSlashValues_InHtmlString'; falling back to single test case.
```