### PR TITLE
Make sure read is async first before cancelling.

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/1798", FlakyOn.All)]
         public async Task ReaderThrowsCancelledException()
         {
-            var requestStartedCompletionSource = CreateTaskCompletionSource();
+            var readIsAsyncCompletionSource = CreateTaskCompletionSource();
             var requestCompletedCompletionSource = CreateTaskCompletionSource();
 
             Exception exception = null;
@@ -191,10 +191,11 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             var data = new byte[1024];
             using (var testServer = await TestServer.Create(async ctx =>
             {
-                requestStartedCompletionSource.SetResult(true);
                 try
                 {
-                    await ctx.Request.Body.ReadAsync(data, cancellationTokenSource.Token);
+                    var task = ctx.Request.Body.ReadAsync(data, cancellationTokenSource.Token);
+                    readIsAsyncCompletionSource.SetResult(true);
+                    await task;
                 }
                 catch (Exception e)
                 {
@@ -207,7 +208,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                 using (var connection = testServer.CreateConnection())
                 {
                     await SendContentLength1Post(connection);
-                    await requestStartedCompletionSource.Task.DefaultTimeout();
+                    await readIsAsyncCompletionSource.Task.DefaultTimeout();
                     cancellationTokenSource.Cancel();
                     await requestCompletedCompletionSource.Task.DefaultTimeout();
                 }

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalFact]
-        [Repeat(100)]
+        [Repeat(500)]
         public async Task ReaderThrowsCancelledException()
         {
             var readIsAsyncCompletionSource = CreateTaskCompletionSource();

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/1798", FlakyOn.All)]
+        [Repeat(100)]
         public async Task ReaderThrowsCancelledException()
         {
             var readIsAsyncCompletionSource = CreateTaskCompletionSource();

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalFact]
-        public async Task WriterThrowsCancelledException()
+        public async Task WriterThrowsCanceledException()
         {
             var requestStartedCompletionSource = CreateTaskCompletionSource();
             var requestCompletedCompletionSource = CreateTaskCompletionSource();
@@ -179,8 +179,8 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalFact]
-        [Repeat(500)]
-        public async Task ReaderThrowsCancelledException()
+        [Repeat]
+        public async Task ReaderThrowsCanceledException()
         {
             var readIsAsyncCompletionSource = CreateTaskCompletionSource();
             var requestCompletedCompletionSource = CreateTaskCompletionSource();


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1798.

We currently have two theories for why this test is flaky:
1. ReadAsync isn't going async, which doesn't seem to be the case as we have a test that confirms ReadAsync goes async everytime.
2. CTS.Cancel isn't being picked up in the PipeReader, which causes ReadAsync to not be canceled.

I'm thinking it's the second now. If this test isn't flaky now, I'm going to start investigating Pipelines.