### PR TITLE
Remove unnecessary restore feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,11 +4,6 @@
     <clear />
     <!--
       Restore sources should be defined in build/sources.props.
-      The only allowed feed here is myget.org/aspnet-tools which is required to work around
-      https://github.com/Microsoft/msbuild/issues/2914
     -->
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="myget.org aspnetcore-tools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,9 @@
     <clear />
     <!--
       Restore sources should be defined in build/sources.props.
+      The only allowed feed here is dotnet-core which is required to work around
+      https://github.com/Microsoft/msbuild/issues/2914
     -->
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/build/sources.props
+++ b/build/sources.props
@@ -15,17 +15,16 @@
       https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://api.nuget.org/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
+    </RestoreSources>
+    <!-- TODO remove this once we remove usages of Internal.AspNetCore.Sdk. -->
+    <RestoreSources>
+      $(RestoreSources);
       https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
-      https://vside.myget.org/F/devcore/api/v3/index.json;
-      https://vside.myget.org/F/vsmac/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json;
+    </RestoreSources>
+    <!-- TODO remove this once we move Microsoft.Internal.AspNetCore.H2Spec.All to a non-myget feed -->
+    <RestoreSources>
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
     </RestoreSources>
 
     <!-- In an orchestrated build, this may be overriden to other Azure feeds. -->

--- a/build/sources.props
+++ b/build/sources.props
@@ -26,6 +26,11 @@
       $(RestoreSources);
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
     </RestoreSources>
+    <!-- Only used to fetch Microsoft.NETFramework.ReferenceAssemblies for x-plat netfx builds. -->
+    <RestoreSources Condition=" '$(OS)' != 'Windows_NT' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
+    </RestoreSources>
 
     <!-- In an orchestrated build, this may be overriden to other Azure feeds. -->
     <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)'==''">https://dotnetcli.blob.core.windows.net/dotnet/</DotNetAssetRootUrl>

--- a/src/Middleware/CORS/test/FunctionalTests/package.json
+++ b/src/Middleware/CORS/test/FunctionalTests/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "jest": "^23.6.0",
     "merge": "^1.2.1",
-    "puppeteer": "^1.14.0"
+    "puppeteer": "^1.15.0"
   },
   "dependencies": {},
   "scripts": {

--- a/src/Middleware/CORS/test/FunctionalTests/yarn.lock
+++ b/src/Middleware/CORS/test/FunctionalTests/yarn.lock
@@ -2826,10 +2826,10 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.14.0.tgz#828c1926b307200d5fc8289b99df4e13e962d339"
-  integrity sha512-SayS2wUX/8LF8Yo2Rkpc5nkAu4Jg3qu+OLTDSOZtisVQMB2Z5vjlY2TdPi/5CgZKiZroYIiyUN3sRX63El9iaw==
+puppeteer@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.15.0.tgz#1680fac13e51f609143149a5b7fa99eec392b34f"
+  integrity sha512-D2y5kwA9SsYkNUmcBzu9WZ4V1SGHiQTmgvDZSx6sRYFsgV25IebL4V6FaHjF6MbwLK9C6f3G3pmck9qmwM8H3w==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
Should improve restore perf by reducing number of restore feeds used from 16 to 7.

(Also, including latest changes to yarn.lock caused by release of new version of puppeteer)