### PR TITLE
Expose JsonSerializerOptions directly in SignalR

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -45,7 +45,7 @@ namespace FunctionalTests
             {
                 // we are running the same tests with JSON and MsgPack protocols and having
                 // consistent casing makes it cleaner to verify results
-                options.PayloadSerializerSettings.PropertyNamingPolicy = null;
+                options.PayloadSerializerOptions.PropertyNamingPolicy = null;
             })
             .AddMessagePackProtocol();
 

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -45,7 +45,7 @@ namespace FunctionalTests
             {
                 // we are running the same tests with JSON and MsgPack protocols and having
                 // consistent casing makes it cleaner to verify results
-                options.UseCamelCase = false;
+                options.PayloadSerializerSettings.PropertyNamingPolicy = null;
             })
             .AddMessagePackProtocol();
 

--- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netcoreapp3.0.cs
+++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netcoreapp3.0.cs
@@ -6,10 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     public partial class JsonHubProtocolOptions
     {
         public JsonHubProtocolOptions() { }
-        public bool AllowTrailingCommas { get { throw null; } set { } }
-        public bool IgnoreNullValues { get { throw null; } set { } }
-        public bool UseCamelCase { get { throw null; } set { } }
-        public bool WriteIndented { get { throw null; } set { } }
+        public System.Text.Json.Serialization.JsonSerializerOptions PayloadSerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }
 namespace Microsoft.AspNetCore.SignalR.Protocol

--- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netcoreapp3.0.cs
+++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netcoreapp3.0.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     public partial class JsonHubProtocolOptions
     {
         public JsonHubProtocolOptions() { }
-        public System.Text.Json.Serialization.JsonSerializerOptions PayloadSerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Text.Json.Serialization.JsonSerializerOptions PayloadSerializerOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }
 namespace Microsoft.AspNetCore.SignalR.Protocol

--- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netstandard2.0.cs
+++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netstandard2.0.cs
@@ -6,10 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     public partial class JsonHubProtocolOptions
     {
         public JsonHubProtocolOptions() { }
-        public bool AllowTrailingCommas { get { throw null; } set { } }
-        public bool IgnoreNullValues { get { throw null; } set { } }
-        public bool UseCamelCase { get { throw null; } set { } }
-        public bool WriteIndented { get { throw null; } set { } }
+        public System.Text.Json.Serialization.JsonSerializerOptions PayloadSerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }
 namespace Microsoft.AspNetCore.SignalR.Protocol

--- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netstandard2.0.cs
+++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netstandard2.0.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     public partial class JsonHubProtocolOptions
     {
         public JsonHubProtocolOptions() { }
-        public System.Text.Json.Serialization.JsonSerializerOptions PayloadSerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Text.Json.Serialization.JsonSerializerOptions PayloadSerializerOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }
 namespace Microsoft.AspNetCore.SignalR.Protocol

--- a/src/SignalR/common/Protocols.Json/src/JsonHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.Json/src/JsonHubProtocolOptions.cs
@@ -11,30 +11,9 @@ namespace Microsoft.AspNetCore.SignalR
     /// </summary>
     public class JsonHubProtocolOptions
     {
-        internal readonly JsonSerializerOptions _serializerOptions;
-
-        public JsonHubProtocolOptions()
-        {
-            _serializerOptions = JsonHubProtocol.CreateDefaultSerializerSettings();
-        }
-
-        public bool IgnoreNullValues { get => _serializerOptions.IgnoreNullValues; set => _serializerOptions.IgnoreNullValues = value; }
-        public bool WriteIndented { get => _serializerOptions.WriteIndented; set => _serializerOptions.WriteIndented = value; }
-        public bool AllowTrailingCommas { get => _serializerOptions.AllowTrailingCommas; set => _serializerOptions.AllowTrailingCommas = value; }
-        public bool UseCamelCase
-        {
-            get => _serializerOptions.PropertyNamingPolicy == JsonNamingPolicy.CamelCase;
-            set
-            {
-                if (value)
-                {
-                    _serializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                }
-                else
-                {
-                    _serializerOptions.PropertyNamingPolicy = null;
-                }
-            }
-        }
+        /// <summary>
+        /// Gets or sets the settings used to serialize invocation arguments and return values.
+        /// </summary>
+        public JsonSerializerOptions PayloadSerializerSettings { get; set; } = JsonHubProtocol.CreateDefaultSerializerSettings();
     }
 }

--- a/src/SignalR/common/Protocols.Json/src/JsonHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.Json/src/JsonHubProtocolOptions.cs
@@ -14,6 +14,6 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets or sets the settings used to serialize invocation arguments and return values.
         /// </summary>
-        public JsonSerializerOptions PayloadSerializerSettings { get; set; } = JsonHubProtocol.CreateDefaultSerializerSettings();
+        public JsonSerializerOptions PayloadSerializerOptions { get; set; } = JsonHubProtocol.CreateDefaultSerializerSettings();
     }
 }

--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// <param name="options">The options used to initialize the protocol.</param>
         public JsonHubProtocol(IOptions<JsonHubProtocolOptions> options)
         {
-            _payloadSerializerOptions = options.Value._serializerOptions;
+            _payloadSerializerOptions = options.Value.PayloadSerializerSettings;
         }
 
         /// <inheritdoc />

--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// <param name="options">The options used to initialize the protocol.</param>
         public JsonHubProtocol(IOptions<JsonHubProtocolOptions> options)
         {
-            _payloadSerializerOptions = options.Value.PayloadSerializerSettings;
+            _payloadSerializerOptions = options.Value.PayloadSerializerOptions;
         }
 
         /// <inheritdoc />

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTests.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         {
             var protocolOptions = new JsonHubProtocolOptions()
             {
-                PayloadSerializerSettings = new JsonSerializerOptions()
+                PayloadSerializerOptions = new JsonSerializerOptions()
                 {
                     IgnoreNullValues = ignoreNullValues,
                     PropertyNamingPolicy = useCamelCase ? JsonNamingPolicy.CamelCase : null

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTests.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.Options;
@@ -24,8 +25,11 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         {
             var protocolOptions = new JsonHubProtocolOptions()
             {
-                IgnoreNullValues = ignoreNullValues,
-                UseCamelCase = useCamelCase,
+                PayloadSerializerSettings = new JsonSerializerOptions()
+                {
+                    IgnoreNullValues = ignoreNullValues,
+                    PropertyNamingPolicy = useCamelCase ? JsonNamingPolicy.CamelCase : null
+                }
             };
 
             return new JsonHubProtocol(Options.Create(protocolOptions));


### PR DESCRIPTION
We now use a binary instead of sources so we can expose the json options directly!