### PR TITLE
Remove HubProtocol minor version

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -72,7 +72,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         // Transient state to a connection
         private ConnectionState _connectionState;
-        private int _serverProtocolMinorVersion;
 
         /// <summary>
         /// Occurs when the connection is closed. The connection could be closed due to an error or due to either the server or client intentionally
@@ -952,8 +951,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
                                         throw new HubException(
                                             $"Unable to complete handshake with the server due to an error: {message.Error}");
                                     }
-
-                                    _serverProtocolMinorVersion = message.MinorVersion;
 
                                     break;
                                 }

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestConnection.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestConnection.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             var output = MemoryBufferWriter.Get();
             try
             {
-                HandshakeProtocol.WriteResponseMessage(new HandshakeResponseMessage(minorVersion), output);
+                HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, output);
                 response = output.ToArray();
             }
             finally

--- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netcoreapp3.0.cs
+++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netcoreapp3.0.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public JsonHubProtocol() { }
         public JsonHubProtocol(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions> options) { }
-        public int MinorVersion { get { throw null; } }
         public string Name { get { throw null; } }
         public Microsoft.AspNetCore.Connections.TransferFormat TransferFormat { get { throw null; } }
         public int Version { get { throw null; } }

--- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netstandard2.0.cs
+++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.netstandard2.0.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public JsonHubProtocol() { }
         public JsonHubProtocol(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions> options) { }
-        public int MinorVersion { get { throw null; } }
         public string Name { get { throw null; } }
         public Microsoft.AspNetCore.Connections.TransferFormat TransferFormat { get { throw null; } }
         public int Version { get { throw null; } }

--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -42,7 +42,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         private static readonly string ProtocolName = "json";
         private static readonly int ProtocolVersion = 1;
-        private static readonly int ProtocolMinorVersion = 0;
 
         /// <summary>
         /// Gets the serializer used to serialize invocation arguments and return values.
@@ -70,9 +69,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         /// <inheritdoc />
         public int Version => ProtocolVersion;
-
-        /// <inheritdoc />        
-        public int MinorVersion => ProtocolMinorVersion;
 
         /// <inheritdoc />
         public TransferFormat TransferFormat => TransferFormat.Text;

--- a/src/SignalR/common/Protocols.MessagePack/ref/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.netstandard2.0.cs
+++ b/src/SignalR/common/Protocols.MessagePack/ref/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.netstandard2.0.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public MessagePackHubProtocol() { }
         public MessagePackHubProtocol(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.MessagePackHubProtocolOptions> options) { }
-        public int MinorVersion { get { throw null; } }
         public string Name { get { throw null; } }
         public Microsoft.AspNetCore.Connections.TransferFormat TransferFormat { get { throw null; } }
         public int Version { get { throw null; } }

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -29,16 +29,12 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         private static readonly string ProtocolName = "messagepack";
         private static readonly int ProtocolVersion = 1;
-        private static readonly int ProtocolMinorVersion = 0;
 
         /// <inheritdoc />
         public string Name => ProtocolName;
 
         /// <inheritdoc />
         public int Version => ProtocolVersion;
-
-        /// <inheritdoc />
-        public int MinorVersion => ProtocolMinorVersion;
 
         /// <inheritdoc />
         public TransferFormat TransferFormat => TransferFormat.Binary;

--- a/src/SignalR/common/Protocols.NewtonsoftJson/ref/Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson.netstandard2.0.cs
+++ b/src/SignalR/common/Protocols.NewtonsoftJson/ref/Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson.netstandard2.0.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public NewtonsoftJsonHubProtocol() { }
         public NewtonsoftJsonHubProtocol(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.NewtonsoftJsonHubProtocolOptions> options) { }
-        public int MinorVersion { get { throw null; } }
         public string Name { get { throw null; } }
         public Newtonsoft.Json.JsonSerializer PayloadSerializer { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Connections.TransferFormat TransferFormat { get { throw null; } }

--- a/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
@@ -33,7 +33,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         private static readonly string ProtocolName = "json";
         private static readonly int ProtocolVersion = 1;
-        private static readonly int ProtocolMinorVersion = 0;
 
         /// <summary>
         /// Gets the serializer used to serialize invocation arguments and return values.
@@ -61,9 +60,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         /// <inheritdoc />
         public int Version => ProtocolVersion;
-
-        /// <inheritdoc />        
-        public int MinorVersion => ProtocolMinorVersion;
 
         /// <inheritdoc />
         public TransferFormat TransferFormat => TransferFormat.Text;

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netcoreapp3.0.cs
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netcoreapp3.0.cs
@@ -61,11 +61,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     public partial class HandshakeResponseMessage : Microsoft.AspNetCore.SignalR.Protocol.HubMessage
     {
         public static readonly Microsoft.AspNetCore.SignalR.Protocol.HandshakeResponseMessage Empty;
-        public HandshakeResponseMessage(int minorVersion) { }
-        public HandshakeResponseMessage(int? minorVersion, string error) { }
         public HandshakeResponseMessage(string error) { }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public int MinorVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public abstract partial class HubInvocationMessage : Microsoft.AspNetCore.SignalR.Protocol.HubMessage
     {
@@ -101,7 +98,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     }
     public partial interface IHubProtocol
     {
-        int MinorVersion { get; }
         string Name { get; }
         Microsoft.AspNetCore.Connections.TransferFormat TransferFormat { get; }
         int Version { get; }

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netstandard2.0.cs
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netstandard2.0.cs
@@ -61,11 +61,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     public partial class HandshakeResponseMessage : Microsoft.AspNetCore.SignalR.Protocol.HubMessage
     {
         public static readonly Microsoft.AspNetCore.SignalR.Protocol.HandshakeResponseMessage Empty;
-        public HandshakeResponseMessage(int minorVersion) { }
-        public HandshakeResponseMessage(int? minorVersion, string error) { }
         public HandshakeResponseMessage(string error) { }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public int MinorVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public abstract partial class HubInvocationMessage : Microsoft.AspNetCore.SignalR.Protocol.HubMessage
     {
@@ -101,7 +98,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     }
     public partial interface IHubProtocol
     {
-        int MinorVersion { get; }
         string Name { get; }
         Microsoft.AspNetCore.Connections.TransferFormat TransferFormat { get; }
         int Version { get; }

--- a/src/SignalR/common/SignalR.Common/src/Protocol/HandshakeProtocol.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/HandshakeProtocol.cs
@@ -23,8 +23,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         private static ReadOnlySpan<byte> ProtocolPropertyNameBytes => new byte[] { (byte)'p', (byte)'r', (byte)'o', (byte)'t', (byte)'o', (byte)'c', (byte)'o', (byte)'l' };
         private const string ProtocolVersionPropertyName = "version";
         private static ReadOnlySpan<byte> ProtocolVersionPropertyNameBytes => new byte[] { (byte)'v', (byte)'e', (byte)'r', (byte)'s', (byte)'i', (byte)'o', (byte)'n' };
-        private const string MinorVersionPropertyName = "minorVersion";
-        private static ReadOnlySpan<byte> MinorVersionPropertyNameBytes => new byte[] { (byte)'m', (byte)'i', (byte)'n', (byte)'o', (byte)'r', (byte)'V', (byte)'e', (byte)'r', (byte)'s', (byte)'i', (byte)'o', (byte)'n' };
         private const string ErrorPropertyName = "error";
         private static ReadOnlySpan<byte> ErrorPropertyNameBytes => new byte[] { (byte)'e', (byte)'r', (byte)'r', (byte)'o', (byte)'r' };
         private const string TypePropertyName = "type";
@@ -40,7 +38,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 var memoryBufferWriter = MemoryBufferWriter.Get();
                 try
                 {
-                    WriteResponseMessage(new HandshakeResponseMessage(protocol.MinorVersion), memoryBufferWriter);
+                    WriteResponseMessage(HandshakeResponseMessage.Empty, memoryBufferWriter);
                     result = memoryBufferWriter.ToArray();
                     _messageCache.TryAdd(protocol, result);
                 }
@@ -100,8 +98,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                     writer.WriteString(ErrorPropertyNameBytes, responseMessage.Error);
                 }
 
-                writer.WriteNumber(MinorVersionPropertyNameBytes, responseMessage.MinorVersion);
-
                 writer.WriteEndObject();
                 writer.Flush();
                 Debug.Assert(writer.CurrentDepth == 0);
@@ -133,7 +129,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             reader.CheckRead();
             reader.EnsureObjectStart();
 
-            int? minorVersion = null;
             string error = null;
 
             while (reader.CheckRead())
@@ -150,10 +145,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                     {
                         error = reader.ReadAsString(ErrorPropertyName);
                     }
-                    else if (reader.TextEquals(MinorVersionPropertyNameBytes))
-                    {
-                        minorVersion = reader.ReadAsInt32(MinorVersionPropertyName);
-                    }
                     else
                     {
                         reader.Skip();
@@ -169,7 +160,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 }
             };
 
-            responseMessage = new HandshakeResponseMessage(minorVersion, error);
+            responseMessage = new HandshakeResponseMessage(error);
             return true;
         }
 

--- a/src/SignalR/common/SignalR.Common/src/Protocol/HandshakeResponseMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/HandshakeResponseMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.SignalR.Protocol
@@ -19,33 +19,12 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         public string Error { get; }
 
         /// <summary>
-        /// Highest minor protocol version that the server supports.
-        /// </summary>
-        public int MinorVersion { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="HandshakeResponseMessage"/> class.
         /// An error response does need a minor version. Since the handshake has failed, any extra data will be ignored.
         /// </summary>
         /// <param name="error">Error encountered by the server, indicating why the handshake has failed.</param>
-        public HandshakeResponseMessage(string error) : this(null, error) { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HandshakeResponseMessage"/> class.
-        /// A reponse with a minor version indicates success, and doesn't require an error field.
-        /// </summary>
-        /// <param name="minorVersion">The highest protocol minor version that the server supports.</param>
-        public HandshakeResponseMessage(int minorVersion) : this(minorVersion, null) { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HandshakeResponseMessage"/> class.
-        /// </summary>
-        /// <param name="error">Error encountered by the server, indicating why the handshake has failed.</param>
-        /// <param name="minorVersion">The highest protocol minor version that the server supports.</param>
-        public HandshakeResponseMessage(int? minorVersion, string error)
+        public HandshakeResponseMessage(string error)
         {
-            // MinorVersion defaults to 0, because old servers don't send a minor version 
-            MinorVersion = minorVersion ?? 0;
             Error = error;
         }
     }

--- a/src/SignalR/common/SignalR.Common/src/Protocol/IHubProtocol.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/IHubProtocol.cs
@@ -23,11 +23,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         int Version { get; }
 
         /// <summary>
-        /// Gets the minor version of the protocol.
-        /// </summary>
-        int MinorVersion { get; }
-
-        /// <summary>
         /// Gets the transfer format of the protocol.
         /// </summary>
         TransferFormat TransferFormat { get; }

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/HandshakeProtocolTests.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/HandshakeProtocolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
@@ -57,17 +57,6 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             Assert.True(HandshakeProtocol.TryParseResponseMessage(ref message, out var response));
 
             Assert.Equal("dummy", response.Error);
-        }
-
-        [Theory]
-        [InlineData("{\"error\":\"\",\"minorVersion\":34}\u001e", 34)]
-        [InlineData("{\"error\":\"flump flump flump\",\"minorVersion\":112}\u001e", 112)]
-        public void ParsingResponseMessageGivesMinorVersion(string json, int version)
-        {
-            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(json));
-
-            Assert.True(HandshakeProtocol.TryParseResponseMessage(ref message, out var response));
-            Assert.Equal(version, response.MinorVersion);
         }
 
         [Fact]

--- a/src/SignalR/perf/Microbenchmarks/HandshakeProtocolBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HandshakeProtocolBenchmark.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             var memoryBufferWriter = MemoryBufferWriter.Get();
             try
             {
-                HandshakeProtocol.WriteResponseMessage(new HandshakeResponseMessage(1), memoryBufferWriter);
+                HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, memoryBufferWriter);
                 result = memoryBufferWriter.ToArray();
             }
             finally

--- a/src/SignalR/perf/Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -178,7 +178,6 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             public string Name => _name;
 
             public int Version => _innerProtocol.Version;
-            public int MinorVersion => _innerProtocol.MinorVersion;
 
             public TransferFormat TransferFormat => _innerProtocol.TransferFormat;
 

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -441,7 +441,7 @@ namespace Microsoft.AspNetCore.SignalR
 
                                     Log.HandshakeComplete(_logger, Protocol.Name);
 
-                                    await WriteHandshakeResponseAsync(new HandshakeResponseMessage(Protocol.MinorVersion));
+                                    await WriteHandshakeResponseAsync(HandshakeResponseMessage.Empty);
                                     return true;
                                 }
                             }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -3063,7 +3063,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 var testProtocol = new Mock<IHubProtocol>();
                 testProtocol.Setup(m => m.Name).Returns("CustomProtocol");
-                testProtocol.Setup(m => m.MinorVersion).Returns(112);
                 testProtocol.Setup(m => m.IsVersionSupported(It.IsAny<int>())).Returns(true);
                 testProtocol.Setup(m => m.TransferFormat).Returns(TransferFormat.Binary);
 
@@ -3075,7 +3074,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     var connectionHandlerTask = await client.ConnectAsync(connectionHandler).OrTimeout();
 
                     Assert.NotNull(client.HandshakeResponseMessage);
-                    Assert.Equal(112, client.HandshakeResponseMessage.MinorVersion);
 
                     client.Dispose();
                     await connectionHandlerTask.OrTimeout();


### PR DESCRIPTION
Fixes: #5320 
We introduced the HubProtocol minor version in 3.0. We don't plan on using it (we can add it back later if we change our minds) and it's a breaking change so let's remove it,
