### PR TITLE
fix #9130 by fixing source revision embedding

### DIFF
--- a/src/Servers/IIS/build/native.targets
+++ b/src/Servers/IIS/build/native.targets
@@ -15,7 +15,7 @@
     <MessageFile Remove="@(MessageFile)" />
   </ItemGroup>
 
-  <Target Name="CreateVersionHeader" BeforeTargets="PrepareForBuild">
+  <Target Name="CreateVersionHeader" DependsOnTargets="InitializeSourceControlInformation" BeforeTargets="PrepareForBuild">
     <ItemGroup>
       <VersionHeaderContents Include="// Copyright (c) .NET Foundation. All rights reserved." />
       <VersionHeaderContents Include="// Licensed under the MIT License. See LICENSE.txt in the project root for license information." />
@@ -27,7 +27,7 @@
       <VersionHeaderContents Include="#define ProductVersion $(AspNetCoreModuleVersionMajor),$(AspNetCoreMinorVersion),$(AssemblyBuild),$(AspNetCorePatchVersion)" />
       <VersionHeaderContents Include="#define ProductVersionStr &quot;$(AspNetCoreModuleVersionMajor).$(AspNetCoreMinorVersion).$(AssemblyBuild).$(AspNetCorePatchVersion)\0&quot;" />
       <VersionHeaderContents Include="#define PlatformToolset &quot;$(PlatformToolset)\0&quot;" />
-      <VersionHeaderContents Include="#define CommitHash &quot;$(CommitHash)\0&quot;" />
+      <VersionHeaderContents Include="#define CommitHash &quot;$(SourceRevisionId)\0&quot;" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #9130 

(at least it should, I'll verify the actual Event Log scenario as part of "acceptance" testing)

We removed our `CommitHash` property in order to use the built-in `SourceRevisionId` property but didn't update ANCM.

Looks good on my machine:

![image](https://user-images.githubusercontent.com/7574/57048057-75f49b80-6c27-11e9-8f26-4a2f83010bb8.png)

I'll check the output artifacts as well.

