### PR TITLE
Add --mutex option to yarn commands

### DIFF
--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -18,7 +18,7 @@
 
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
-    <Yarn Command="install --mutex file $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
+    <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
   </Target>
 
   <Target Name="PrepareForBuild">

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -18,7 +18,7 @@
 
   <Target Name="Restore">
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
-    <Yarn Command="install $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
+    <Yarn Command="install --mutex file $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
   </Target>
 
   <Target Name="PrepareForBuild">

--- a/src/Middleware/CORS/test/FunctionalTests/CORS.FunctionalTests.npmproj
+++ b/src/Middleware/CORS/test/FunctionalTests/CORS.FunctionalTests.npmproj
@@ -12,10 +12,5 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
-  <Target Name="InstallPuppeteer" BeforeTargets="Restore">
-    <!-- Explicitly install puppeteer. This will install the bundled Chromium as part of restore instead of as part of execution -->
-    <Yarn Command="add puppeteer" />
-  </Target>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
+++ b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
@@ -21,7 +21,7 @@
 
   <Target Name="YarnInstall">
     <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
-    <Yarn Command="install" />
+    <Yarn Command="install --mutex file" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">

--- a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
+++ b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
@@ -21,7 +21,7 @@
 
   <Target Name="YarnInstall">
     <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
-    <Yarn Command="install --mutex file" />
+    <Yarn Command="install --mutex network" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -25,7 +25,7 @@
 
   <Target Name="YarnInstall">
     <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
-    <Yarn Command="install" />
+    <Yarn Command="install --mutex file" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -25,7 +25,7 @@
 
   <Target Name="YarnInstall">
     <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
-    <Yarn Command="install --mutex file" />
+    <Yarn Command="install --mutex network" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -11,7 +11,7 @@
       Importance="High"
       Text="Prerequisites were not enforced at build time. Running Yarn or the E2E tests might fail as a result. Check /src/Shared/E2ETesting/Readme.md for instructions." />
 
-    <Yarn Command="install" />
+    <Yarn Command="install --mutex file" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -11,7 +11,7 @@
       Importance="High"
       Text="Prerequisites were not enforced at build time. Running Yarn or the E2E tests might fail as a result. Check /src/Shared/E2ETesting/Readme.md for instructions." />
 
-    <Yarn Command="install --mutex file" />
+    <Yarn Command="install --mutex network" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">


### PR DESCRIPTION
Attempt to improve reliability of running yarn commands. Our project structure might cause yarn to be launched multiple times. According to yarn docs, this option should avoid conflicts between multiple instances of yarn.
https://yarnpkg.com/en/docs/cli/#toc-concurrency-and-mutex

Also, testing to see if removing the `yarn add puppeteer ` command helps with reliability and perf. The puppeteer package is already part of the package.json file for the CORS functional tests.

cref https://github.com/aspnet/AspNetCore-Internal/issues/2383