### PR TITLE
Mark flaky Angular Template test

### DIFF
--- a/src/ProjectTemplates/startvs.cmd
+++ b/src/ProjectTemplates/startvs.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+%~dp0..\..\startvs.cmd %~dp0ProjectTemplates.sln

--- a/src/ProjectTemplates/test/SpaTemplateTest/AngularTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/AngularTemplateTest.cs
@@ -3,6 +3,8 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,6 +17,7 @@ namespace Templates.Test.SpaTemplateTest
             : base(projectFactory, browserFixture, output) { }
 
         [Fact]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2422", FlakyOn.All)]
         public Task AngularTemplate_Works()
             => SpaTemplateImplAsync("angularnoauth", "angular", useLocalDb: false, usesAuth: false);
 


### PR DESCRIPTION
Issue: https://github.com/aspnet/AspNetCore-Internal/issues/2422

Marking the Angualr template test as flaky. Also added the startvs script to the ProjectTemplates directory
cc @aspnet/build 