### PR TITLE
Add System.Text.Json protocol to the SignalR functional tests

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1674,7 +1674,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         public static Dictionary<string, IHubProtocol> HubProtocols =>
             new Dictionary<string, IHubProtocol>
             {
-                { "json", new NewtonsoftJsonHubProtocol() },
+                { "json", new JsonHubProtocol() },
+                { "newtonsoft-json", new NewtonsoftJsonHubProtocol() },
                 { "messagepack", new MessagePackHubProtocol() },
             };
 


### PR DESCRIPTION
We have another protocol to run our functional tests against.
