### PR TITLE
Adds inferred [Required] for non-null ref types

### DIFF
--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -884,6 +884,7 @@ namespace Microsoft.AspNetCore.Mvc
         public System.Text.Json.Serialization.JsonSerializerOptions SerializerOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public int? SslPort { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SuppressAsyncSuffixInActionNames { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SuppressImplicitRequiredAttributeForNonNullableReferenceTypes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SuppressInputFormatterBuffering { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SuppressOutputFormatterBuffering { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool ValidateComplexTypesIfChildValidationFails { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -2818,6 +2818,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         public ValidationMetadataProviderContext(Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ModelMetadataIdentity key, Microsoft.AspNetCore.Mvc.ModelBinding.ModelAttributes attributes) { }
         public System.Collections.Generic.IReadOnlyList<object> Attributes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ModelMetadataIdentity Key { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<object> ParameterAttributes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<object> PropertyAttributes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<object> TypeAttributes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ValidationMetadata ValidationMetadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadata.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadata.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadata.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadata.cs
@@ -1,3 +1,4 @@
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadataProviderContext.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadataProviderContext.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
 
             Key = key;
             Attributes = attributes.Attributes;
+            ParameterAttributes = attributes.ParameterAttributes;
             PropertyAttributes = attributes.PropertyAttributes;
             TypeAttributes = attributes.TypeAttributes;
 
@@ -42,6 +43,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         /// Gets the <see cref="ModelMetadataIdentity"/>.
         /// </summary>
         public ModelMetadataIdentity Key { get; }
+
+        /// <summary>
+        /// Gets the parameter attributes.
+        /// </summary>
+        public IReadOnlyList<object> ParameterAttributes { get; }
 
         /// <summary>
         /// Gets the property attributes.

--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
@@ -101,6 +102,25 @@ namespace Microsoft.AspNetCore.Mvc
         /// Gets a list of <see cref="IInputFormatter"/>s that are used by this application.
         /// </summary>
         public FormatterCollection<IInputFormatter> InputFormatters { get; }
+
+        /// <summary>
+        /// Gets or sets a value that detemines if the inference of <see cref="RequiredAttribute"/> for
+        /// for properties and parameters of non-nullable reference types is suppressed. If <c>false</c> 
+        /// (the default), then all non-nullable reference types will behave as-if <c>[Required]</c> has 
+        /// been applied. If <c>true</c>, this behavior will be suppressed; nullable reference types and 
+        /// non-nullable reference types will behave the same for the purposes of validation.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This option controls whether MVC model binding and validation treats nullable and non-nullable 
+        /// reference types differently. 
+        /// </para>
+        /// <para>
+        /// By default, MVC will treat a non-nullable reference type parameters and properties as-if 
+        /// <c>[Required]</c> has been applied, resulting in validation errors when no value was bound.
+        /// </para>
+        /// </remarks>
+        public bool SuppressImplicitRequiredAttributeForNonNullableReferenceTypes { get; set; }
 
         /// <summary>
         /// Gets or sets a value that determines if buffering is disabled for input formatters that

--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -119,6 +119,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// By default, MVC will treat a non-nullable reference type parameters and properties as-if 
         /// <c>[Required]</c> has been applied, resulting in validation errors when no value was bound.
         /// </para>
+        /// <para>
+        /// MVC does not support non-nullable reference type annotations on type arguments and type parameter
+        /// contraints. The framework will not infer any validation attributes for generic-typed properties
+        /// or collection elements.
+        /// </para>
         /// </remarks>
         public bool SuppressImplicitRequiredAttributeForNonNullableReferenceTypes { get; set; }
 

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -345,7 +345,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
             // This allows the developer to specify [Required] to customize the error message, so
             // if they already have [Required] then there's no need for us to do this check.
             if (!_options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes &&
-                requiredAttribute == null && 
+                requiredAttribute == null &&
                 !context.Key.ModelType.IsValueType &&
 
                 // Look specifically at attributes on the property/parameter. [Nullable] on
@@ -419,7 +419,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
         // Internal for testing
         internal static bool IsNonNullable(IEnumerable<object> attributes)
         {
-            // [Nullable] is compiler synthesized, comparing by name. 
+            // [Nullable] is compiler synthesized, comparing by name.
             var nullableAttribute = attributes
                 .Where(a => string.Equals(a.GetType().FullName, NullableAttributeFullTypeName, StringComparison.Ordinal))
                 .FirstOrDefault();
@@ -429,15 +429,15 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
             }
 
             // We don't handle cases where generics and NNRT are used. This runs into a
-            // fundamental limitation of ModelMetadata - we a single the Type and Property/Parameter
+            // fundamental limitation of ModelMetadata - we use a single Type and Property/Parameter
             // to look up the metadata. However when generics are involved and NNRT is in use
             // the distance between the [Nullable] and member we're looking at is potentially
-            // unbounded. 
+            // unbounded.
             //
             // See: https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-reference-types.md#annotations
             if (nullableAttribute.GetType().GetField(NullableFlagsFieldName) is FieldInfo field &&
-                field.GetValue(nullableAttribute) is byte[] flags && 
-                flags.Length >= 0 && 
+                field.GetValue(nullableAttribute) is byte[] flags &&
+                flags.Length >= 0 &&
                 flags[0] == 1) // First element is the property/parameter type.
             {
                 return true;

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -346,8 +346,11 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
             // if they already have [Required] then there's no need for us to do this check.
             if (!_options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes &&
                 requiredAttribute == null && 
-                !context.Key.ModelType.IsValueType && 
-                IsNonNullable(context.Attributes))
+                !context.Key.ModelType.IsValueType &&
+
+                // Look specifically at attributes on the property/parameter. [Nullable] on
+                // the type has a different meaning.
+                IsNonNullable(context.ParameterAttributes ?? context.PropertyAttributes ?? Array.Empty<object>()))
             {
                 // Since this behavior specifically relates to non-null-ness, we will use the non-default
                 // option to tolerate empty/whitespace strings. empty/whitespace INPUT will still result in

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -349,7 +349,14 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
                 !context.Key.ModelType.IsValueType && 
                 IsNonNullable(context.Attributes))
             {
-                requiredAttribute = new RequiredAttribute();
+                // Since this behavior specifically relates to non-null-ness, we will use the non-default
+                // option to tolerate empty/whitespace strings. empty/whitespace INPUT will still result in
+                // a validation error by default because we convert empty/whitespace strings to null
+                // unless you say otherwise.
+                requiredAttribute = new RequiredAttribute()
+                {
+                    AllowEmptyStrings = true,
+                };
                 attributes.Add(requiredAttribute);
             }
 

--- a/src/Mvc/Mvc.DataAnnotations/src/DependencyInjection/MvcDataAnnotationsMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DependencyInjection/MvcDataAnnotationsMvcOptionsSetup.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             options.ModelMetadataDetailsProviders.Add(new DataAnnotationsMetadataProvider(
+                options,
                 _dataAnnotationLocalizationOptions,
                 _stringLocalizerFactory));
 

--- a/src/Mvc/Mvc.DataAnnotations/test/DataAnnotationsMetadataProviderTest.cs
+++ b/src/Mvc/Mvc.DataAnnotations/test/DataAnnotationsMetadataProviderTest.cs
@@ -1161,7 +1161,8 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
 
             // Assert
             Assert.True(context.ValidationMetadata.IsRequired);
-            Assert.Single(context.ValidationMetadata.ValidatorMetadata, m => m is RequiredAttribute);
+            var attribute = Assert.Single(context.ValidationMetadata.ValidatorMetadata, m => m is RequiredAttribute);
+            Assert.True(((RequiredAttribute)attribute).AllowEmptyStrings); // non-Default for [Required]
         }
 
         [Fact]
@@ -1185,6 +1186,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
             Assert.True(context.ValidationMetadata.IsRequired);
             var attribute = Assert.Single(context.ValidationMetadata.ValidatorMetadata, m => m is RequiredAttribute a);
             Assert.Equal("Test", ((RequiredAttribute)attribute).ErrorMessage);
+            Assert.False(((RequiredAttribute)attribute).AllowEmptyStrings); // Default for [Required]
         }
 
         [Fact]

--- a/src/Mvc/Mvc.DataAnnotations/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/src/Mvc/Mvc.DataAnnotations/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.DataAnnotations/test/ModelMetadataProviderTest.cs
+++ b/src/Mvc/Mvc.DataAnnotations/test/ModelMetadataProviderTest.cs
@@ -1052,6 +1052,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
                       {
                           new DefaultBindingMetadataProvider(),
                           new DataAnnotationsMetadataProvider(
+                              new MvcOptions(),
                               Options.Create(new MvcDataAnnotationsLocalizationOptions()),
                               stringLocalizerFactory: null),
                       }),

--- a/src/Mvc/shared/Mvc.Core.TestCommon/TestModelMetadataProvider.cs
+++ b/src/Mvc/shared/Mvc.Core.TestCommon/TestModelMetadataProvider.cs
@@ -17,10 +17,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     {
         private static DataAnnotationsMetadataProvider CreateDefaultDataAnnotationsProvider(IStringLocalizerFactory stringLocalizerFactory)
         {
-            var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
-            options.Value.DataAnnotationLocalizerProvider = (modelType, localizerFactory) => localizerFactory.Create(modelType);
+            var localizationOptions = Options.Create(new MvcDataAnnotationsLocalizationOptions());
+            localizationOptions.Value.DataAnnotationLocalizerProvider = (modelType, localizerFactory) => localizerFactory.Create(modelType);
 
-            return new DataAnnotationsMetadataProvider(options, stringLocalizerFactory);
+            return new DataAnnotationsMetadataProvider(new MvcOptions(), localizationOptions, stringLocalizerFactory);
         }
 
         // Creates a provider with all the defaults - includes data annotations
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 new DefaultBindingMetadataProvider(),
                 new DefaultValidationMetadataProvider(),
                 new DataAnnotationsMetadataProvider(
+                    new MvcOptions(),
                     Options.Create(new MvcDataAnnotationsLocalizationOptions()),
                     stringLocalizerFactory: null),
                 new DataMemberRequiredBindingMetadataProvider(),
@@ -92,6 +93,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                       new DefaultBindingMetadataProvider(),
                       new DefaultValidationMetadataProvider(),
                       new DataAnnotationsMetadataProvider(
+                          new MvcOptions(),
                           Options.Create(new MvcDataAnnotationsLocalizationOptions()),
                           stringLocalizerFactory: null),
                       detailsProvider

--- a/src/Mvc/test/Mvc.FunctionalTests/NonNullableReferenceTypesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/NonNullableReferenceTypesTest.cs
@@ -19,12 +19,6 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 {
     public class NonNullableReferenceTypesTest : IClassFixture<MvcTestFixture<BasicWebSite.StartupWithoutEndpointRouting>>
     {
-        // Some tests require comparing the actual response body against an expected response baseline
-        // so they require a reference to the assembly on which the resources are located, in order to
-        // make the tests less verbose, we get a reference to the assembly with the resources and we
-        // use it on all the rest of the tests.
-        private static readonly Assembly _resourcesAssembly = typeof(BasicTests).GetTypeInfo().Assembly;
-
         public NonNullableReferenceTypesTest(MvcTestFixture<BasicWebSite.StartupWithoutEndpointRouting> fixture)
         {
             Client = fixture.CreateDefaultClient();
@@ -42,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.GetAsync("http://localhost/NonNullable");
 
             // Assert 1
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             var content = await response.Content.ReadAsStringAsync();
 
             var document = parser.Parse(content);
@@ -66,7 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert 2
             //
             // OK means there were validation errors.
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             content = await response.Content.ReadAsStringAsync();
 
             document = parser.Parse(content);
@@ -84,7 +78,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.GetAsync("http://localhost/NonNullable");
 
             // Assert 1
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             var content = await response.Content.ReadAsStringAsync();
 
             var document = parser.Parse(content);
@@ -110,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert 2
             //
             // Redirect means there were no validation errors.
-            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.Redirect);
         }
     }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/NonNullableReferenceTypesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/NonNullableReferenceTypesTest.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading.Tasks;
+using AngleSharp.Dom.Html;
+using AngleSharp.Parser.Html;
+using BasicWebSite.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests
+{
+    public class NonNullableReferenceTypesTest : IClassFixture<MvcTestFixture<BasicWebSite.StartupWithoutEndpointRouting>>
+    {
+        // Some tests require comparing the actual response body against an expected response baseline
+        // so they require a reference to the assembly on which the resources are located, in order to
+        // make the tests less verbose, we get a reference to the assembly with the resources and we
+        // use it on all the rest of the tests.
+        private static readonly Assembly _resourcesAssembly = typeof(BasicTests).GetTypeInfo().Assembly;
+
+        public NonNullableReferenceTypesTest(MvcTestFixture<BasicWebSite.StartupWithoutEndpointRouting> fixture)
+        {
+            Client = fixture.CreateDefaultClient();
+        }
+
+        private HttpClient Client { get; set; }
+
+        [Fact]
+        public async Task CanUseNonNullableReferenceType_WithController_OmitData_ValidationErrors()
+        {
+            // Arrange
+            var parser = new HtmlParser();
+
+            // Act 1
+            var response = await Client.GetAsync("http://localhost/NonNullable");
+
+            // Assert 1
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var content = await response.Content.ReadAsStringAsync();
+
+            var document = parser.Parse(content);
+            var errors = document.QuerySelectorAll("#errors > ul > li");
+            var li = Assert.Single(errors);
+            Assert.Empty(li.TextContent);
+
+            var cookieToken = AntiforgeryTestHelper.RetrieveAntiforgeryCookie(response);
+            var formToken = document.RetrieveAntiforgeryToken();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/NonNullable");
+            request.Headers.Add("Cookie", cookieToken.Key + "=" + cookieToken.Value);
+            request.Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("__RequestVerificationToken", formToken),
+            });
+
+            // Act 2
+            response = await Client.SendAsync(request);
+
+            // Assert 2
+            //
+            // OK means there were validation errors.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            content = await response.Content.ReadAsStringAsync();
+
+            document = parser.Parse(content);
+            errors = errors = document.QuerySelectorAll("#errors > ul > li");
+            Assert.Equal(2, errors.Length); // Not validating BCL error messages
+        }
+
+        [Fact]
+        public async Task CanUseNonNullableReferenceType_WithController_SubmitData_NoError()
+        {
+            // Arrange
+            var parser = new HtmlParser();
+
+            // Act 1
+            var response = await Client.GetAsync("http://localhost/NonNullable");
+
+            // Assert 1
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var content = await response.Content.ReadAsStringAsync();
+
+            var document = parser.Parse(content);
+            var errors = document.QuerySelectorAll("#errors > ul > li");
+            var li = Assert.Single(errors);
+            Assert.Empty(li.TextContent);
+
+            var cookieToken = AntiforgeryTestHelper.RetrieveAntiforgeryCookie(response);
+            var formToken = document.RetrieveAntiforgeryToken();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/NonNullable");
+            request.Headers.Add("Cookie", cookieToken.Key + "=" + cookieToken.Value);
+            request.Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("__RequestVerificationToken", formToken),
+                new KeyValuePair<string, string>("Name", "Pranav"),
+                new KeyValuePair<string, string>("description", "Meme")
+            });
+
+            // Act 2
+            response = await Client.SendAsync(request);
+
+            // Assert 2
+            //
+            // Redirect means there were no validation errors.
+            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        }
+    }
+}

--- a/src/Mvc/test/Mvc.IntegrationTests/ComplexTypeModelBinderIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ComplexTypeModelBinderIntegrationTest.cs
@@ -1715,9 +1715,9 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
         private class Order8
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = default!;
 
-            public KeyValuePair<string, int>? ProductId { get; set; }
+            public KeyValuePair<string, int> ProductId { get; set; }
         }
 
         [Fact]
@@ -1869,13 +1869,15 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(default, model.ProductId);
 
-            Assert.Single(modelState);
-            Assert.Equal(0, modelState.ErrorCount);
-            Assert.True(modelState.IsValid);
+            Assert.Equal(1, modelState.ErrorCount);
+            Assert.False(modelState.IsValid);
 
             var entry = Assert.Single(modelState, e => e.Key == "parameter.Name").Value;
             Assert.Equal("bill", entry.AttemptedValue);
             Assert.Equal("bill", entry.RawValue);
+
+            entry = Assert.Single(modelState, e => e.Key == "parameter.ProductId.Key").Value;
+            Assert.Single(entry.Errors);
         }
 
         [Fact]
@@ -1916,9 +1918,11 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Null(model.Name);
             Assert.Equal(default, model.ProductId);
 
-            Assert.Empty(modelState);
-            Assert.Equal(0, modelState.ErrorCount);
-            Assert.True(modelState.IsValid);
+            Assert.Equal(1, modelState.ErrorCount);
+            Assert.False(modelState.IsValid);
+
+            var entry = Assert.Single(modelState, e => e.Key == "ProductId.Key").Value;
+            Assert.Single(entry.Errors);
         }
 
         private class Car4

--- a/src/Mvc/test/Mvc.IntegrationTests/ComplexTypeModelBinderIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ComplexTypeModelBinderIntegrationTest.cs
@@ -1717,7 +1717,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
         {
             public string Name { get; set; }
 
-            public KeyValuePair<string, int> ProductId { get; set; }
+            public KeyValuePair<string, int>? ProductId { get; set; }
         }
 
         [Fact]

--- a/src/Mvc/test/Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var parameter = new ParameterDescriptor()
             {
                 Name = "parameter",
-                ParameterType = typeof(KeyValuePair<string, int>)
+                ParameterType = typeof(KeyValuePair<string, int>?)
             };
 
             var testContext = ModelBindingTestHelper.GetTestContext(request =>
@@ -482,7 +482,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var parameter = new ParameterDescriptor()
             {
                 Name = "parameter",
-                ParameterType = typeof(KeyValuePair<string, Person>)
+                ParameterType = typeof(KeyValuePair<string, Person>?)
             };
 
             var testContext = ModelBindingTestHelper.GetTestContext(request =>

--- a/src/Mvc/test/Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var parameter = new ParameterDescriptor()
             {
                 Name = "parameter",
-                ParameterType = typeof(KeyValuePair<string, int>?)
+                ParameterType = typeof(KeyValuePair<string, int>)
             };
 
             var testContext = ModelBindingTestHelper.GetTestContext(request =>
@@ -337,9 +337,11 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             Assert.Equal(new KeyValuePair<string, int>(), modelBindingResult.Model);
 
-            Assert.Empty(modelState);
-            Assert.Equal(0, modelState.ErrorCount);
-            Assert.True(modelState.IsValid);
+            Assert.Equal(1, modelState.ErrorCount);
+            Assert.False(modelState.IsValid);
+
+            var entry = Assert.Single(modelState, kvp => kvp.Key == "Key").Value;
+            Assert.Single(entry.Errors);
         }
 
         private class Person
@@ -482,7 +484,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var parameter = new ParameterDescriptor()
             {
                 Name = "parameter",
-                ParameterType = typeof(KeyValuePair<string, Person>?)
+                ParameterType = typeof(KeyValuePair<string, Person>)
             };
 
             var testContext = ModelBindingTestHelper.GetTestContext(request =>
@@ -500,9 +502,14 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             Assert.Equal(new KeyValuePair<string, Person>(), modelBindingResult.Model);
 
-            Assert.Empty(modelState);
-            Assert.Equal(0, modelState.ErrorCount);
-            Assert.True(modelState.IsValid);
+            Assert.Equal(2, modelState.ErrorCount);
+            Assert.False(modelState.IsValid);
+
+            var entry = Assert.Single(modelState, kvp => kvp.Key == "Key").Value;
+            Assert.Single(entry.Errors);
+
+            entry = Assert.Single(modelState, kvp => kvp.Key == "Value").Value;
+            Assert.Single(entry.Errors);
         }
 
         [Fact]

--- a/src/Mvc/test/Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
+++ b/src/Mvc/test/Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mvc/test/Mvc.IntegrationTests/NullableReferenceTypeIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/NullableReferenceTypeIntegrationTest.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.IntegrationTests
+{
+    public class NullableReferenceTypeIntegrationTest
+    {
+#nullable enable
+        private class Person1
+        {
+            public string FirstName { get; set; } = default!;
+        }
+#nullable restore
+
+        [Fact]
+        public async Task BindProperty_WithNonNullableReferenceType_NoData_ValidationError()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "Parameter1",
+                BindingInfo = new BindingInfo(),
+                ParameterType = typeof(Person1)
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var modelBindingResult = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.True(modelBindingResult.IsModelSet);
+
+            // Model
+            var boundPerson = Assert.IsType<Person1>(modelBindingResult.Model);
+            Assert.Null(boundPerson.FirstName);
+
+            // ModelState
+            Assert.False(modelState.IsValid);
+            Assert.Collection(
+                modelState.OrderBy(kvp => kvp.Key),
+                kvp =>
+                {
+                    Assert.Equal("FirstName", kvp.Key);
+                    Assert.Equal(ModelValidationState.Invalid, kvp.Value.ValidationState);
+
+                    // Not validating framework error message.
+                    Assert.Single(kvp.Value.Errors);
+                });
+        }
+
+#nullable enable
+        private class Person2
+        {
+            public string? FirstName { get; set; }
+        }
+#nullable restore
+
+        [Fact]
+        public async Task BindProperty_WithNullableReferenceType_NoData_NoValidationError()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "Parameter1",
+                BindingInfo = new BindingInfo(),
+                ParameterType = typeof(Person2)
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var modelBindingResult = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.True(modelBindingResult.IsModelSet);
+
+            // Model
+            var boundPerson = Assert.IsType<Person2>(modelBindingResult.Model);
+            Assert.Null(boundPerson.FirstName);
+
+            // ModelState
+            Assert.True(modelState.IsValid);
+        }
+
+#nullable enable
+        private class Person3
+        {
+            [Required(ErrorMessage = "Test")]
+            public string FirstName { get; set; } = default!;
+        }
+#nullable restore
+
+        [Fact]
+        public async Task BindProperty_WithNonNullableReferenceType_NoData_ValidationError_CustomMessage()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "Parameter1",
+                BindingInfo = new BindingInfo(),
+                ParameterType = typeof(Person3)
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var modelBindingResult = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.True(modelBindingResult.IsModelSet);
+
+            // Model
+            var boundPerson = Assert.IsType<Person3>(modelBindingResult.Model);
+            Assert.Null(boundPerson.FirstName);
+
+            // ModelState
+            Assert.False(modelState.IsValid);
+            Assert.Collection(
+                modelState.OrderBy(kvp => kvp.Key),
+                kvp =>
+                {
+                    Assert.Equal("FirstName", kvp.Key);
+                    Assert.Equal(ModelValidationState.Invalid, kvp.Value.ValidationState);
+
+                    var error = Assert.Single(kvp.Value.Errors);
+                    Assert.Equal("Test", error.ErrorMessage);
+                });
+        }
+
+#nullable enable
+        private void NonNullableParameter(string param1)
+        {
+        }
+#nullable restore
+
+        [Fact]
+        public async Task BindParameter_WithNonNullableReferenceType_NoData_ValidationError()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "param1",
+                BindingInfo = new BindingInfo(),
+                ParameterType = typeof(string)
+            };
+
+            var method = GetType().GetMethod(nameof(NonNullableParameter), BindingFlags.NonPublic | BindingFlags.Instance);
+            var parameterInfo = method.GetParameters().Single();
+            var modelMetadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var modelMetadata = modelMetadataProvider.GetMetadataForParameter(parameterInfo);
+
+            var testContext = ModelBindingTestHelper.GetTestContext();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var modelBindingResult = await parameterBinder.BindModelAsync(
+                parameter,
+                testContext,
+                modelMetadataProvider,
+                modelMetadata);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.False(modelBindingResult.IsModelSet);
+
+            // Model
+            Assert.Null(modelBindingResult.Model);
+
+            // ModelState
+            Assert.False(modelState.IsValid);
+            Assert.Collection(
+                modelState.OrderBy(kvp => kvp.Key),
+                kvp =>
+                {
+                    Assert.Equal("param1", kvp.Key);
+                    Assert.Equal(ModelValidationState.Invalid, kvp.Value.ValidationState);
+
+                    // Not validating framework error message.
+                    Assert.Single(kvp.Value.Errors);
+                });
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/NonNullableController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/NonNullableController.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+using BasicWebSite.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BasicWebSite.Controllers
+{
+    public class NonNullableController : Controller
+    {
+        public ActionResult Index()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public ActionResult Index(NonNullablePerson person, string description)
+        {
+            if (ModelState.IsValid)
+            {
+                return RedirectToAction();
+            }
+
+            return View(person);
+        }
+
+        public class NonNullablePerson
+        {
+            public string Name { get; set; } = default!;
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/BasicWebSite/Views/NonNullable/Index.cshtml
+++ b/src/Mvc/test/WebSites/BasicWebSite/Views/NonNullable/Index.cshtml
@@ -1,0 +1,10 @@
+﻿@model BasicWebSite.Controllers.NonNullableController.NonNullablePerson
+@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+
+<div asp-validation-summary="All" id="errors"></div>
+
+<form asp-action="Index">
+    <p>Name:</p>
+    <input asp-for="Name" />
+    <button type="submit">Submit</button>
+</form>


### PR DESCRIPTION
Follow up from #9194

This change adds the automatic inference of [Required] for non-nullable
properties and parameters. This means that if you opt into nullable
context in C#8, we'll start treating those types as-if you put
[Required] on them.

This provides a nice invariant to rely on, namely that MVC will honor
your declared nullability contract OR report a validation error. This
reinforces the guidance already published by the C# team for using
POCOs/DTOs with nullability. See
https://github.com/aspnet/specs/blob/master/notes/3_0/nullable.md for my
analysis on the topic.