### PR TITLE
SignalR: Fix linux build

### DIFF
--- a/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
+++ b/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             return new CancelableTypedAsyncEnumerable<T>(asyncEnumerable, cts);
         }
 
-        public static async IAsyncEnumerable<object> MakeAsyncEnumerableFromChannel<T>(ChannelReader<T> channel, CancellationToken cancellationToken = default)
+        public static async IAsyncEnumerable<object> MakeAsyncEnumerableFromChannel<T>(ChannelReader<T> channel, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await foreach (var item in channel.ReadAllAsync(cancellationToken))
             {


### PR DESCRIPTION
Needed when building the BenchmarkServer on linux.

Not needed when building on Windows.
