### PR TITLE
Blazor server-side template TemperatureF property fix

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Data/WeatherForecast.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Data/WeatherForecast.cs
@@ -8,7 +8,7 @@ namespace RazorComponentsWeb_CSharp.Data
 
         public int TemperatureC { get; set; }
 
-        public int TemperatureF { get; set; }
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
         public string Summary { get; set; }
     }


### PR DESCRIPTION
The [Blazor-hosted templates](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Shared/WeatherForecast.cs) were updated to use a computed property for `TemperatureF`, this was not replicated on the [server-side template](https://github.com/aspnet/AspNetCore/blob/master/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Data/WeatherForecast.cs).

Summary of the changes
 - Changed `TemperatureF` to use the same calculation

Addresses #9955 
