### PR TITLE
add support for both env vars in #7916 fix

### DIFF
--- a/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
+++ b/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
@@ -80,7 +80,9 @@ namespace Microsoft.AspNetCore.DataProtection.Internal
         private static bool IsProcessRunningInContainer()
         {
             // Official .NET Core images (Windows and Linux) set this. So trust it if it's there.
-            if(string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINERS"), "true", StringComparison.OrdinalIgnoreCase))
+            // We check both DOTNET_RUNNING_IN_CONTAINER (the current name) and DOTNET_RUNNING_IN_CONTAINERS (a deprecated name used in some images).
+            if(string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINERS"), "true", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }


### PR DESCRIPTION
Thanks @DavidSimner for saving me from having to wait for end-to-end verification to find this ;).

I decided to support both the (now deprecated) `DOTNET_RUNNING_IN_CONTAINERS` variable (used in https://github.com/dotnet/dotnet-docker/blob/4fd3b74fc5b7444f39f3fdcffa45eef467bccb24/2.1/aspnet/nanoserver-1803/amd64/Dockerfile and https://github.com/dotnet/dotnet-docker/blob/4fd3b74fc5b7444f39f3fdcffa45eef467bccb24/2.1/aspnet/nanoserver-1809/amd64/Dockerfile) as well as `DOTNET_RUNNING_IN_CONTAINER` (the intended variable name). The check is done once per process at start-up.

Since we know the value we expect is `true`, I didn't do what we've done for other "boolean" environment variables and add logic to support both `1` and `true`. I could do that if we felt it was useful though.