### PR TITLE
Docs: Fix branch link

### DIFF
--- a/src/SignalR/perf/benchmarkapps/BenchmarkServer/README.md
+++ b/src/SignalR/perf/benchmarkapps/BenchmarkServer/README.md
@@ -3,7 +3,7 @@
 This project is to assist in Benchmarking SignalR.
 It makes it easier to test local changes than having the App in the Benchmarks repo by letting us make changes in signalr branches and using the example commandline below to run the benchmarks against our branches.
 
-The SignalRWorker that runs against this server is located at https://github.com/aspnet/benchmarks/blob/dev/src/BenchmarksClient/Workers/SignalRWorker.cs.
+The SignalRWorker that runs against this server is located at https://github.com/aspnet/benchmarks/blob/master/src/BenchmarksClient/Workers/SignalRWorker.cs.
 
 ## Usage
 
@@ -14,4 +14,4 @@ The SignalRWorker that runs against this server is located at https://github.com
 
 `benchmarks --server <server-endpoint> --client <client-endpoint> -p TransportType=WebSockets -p HubProtocol=messagepack -j https://raw.githubusercontent.com/aspnet/SignalR/dev/benchmarks/BenchmarkServer/signalr.json`
 
-5. For more info/commands see https://github.com/aspnet/benchmarks/blob/dev/src/BenchmarksDriver/README.md
+5. For more info/commands see https://github.com/aspnet/benchmarks/blob/master/src/BenchmarksDriver/README.md


### PR DESCRIPTION
`dev` no longer exists.