### PR TITLE
OpenAPI ServiceReference tool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "files.trimTrailingWhitespace": true,
-    "files.associations": {
-        "*.*proj": "xml",
-        "*.props": "xml",
-        "*.targets": "xml",
-        "*.tasks": "xml"
-    }
+  "files.trimTrailingWhitespace": true,
+  "files.associations": {
+    "*.*proj": "xml",
+    "*.props": "xml",
+    "*.targets": "xml",
+    "*.tasks": "xml"
+  }
 }

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -29,6 +29,7 @@
     <!-- These projects are meant to be executed by tests. -->
     <ProjectToExclude Include="
                       $(RepoRoot)src\Tools\dotnet-watch\test\TestProjects\**\*.csproj;
+                      $(RepoRoot)src\Tools\Tests.Common\TestProjects\**\*.csproj;
                       $(RepoRoot)src\Razor\Razor.Design\test\testassets\**\*.*proj;
                       $(RepoRoot)src\submodules\**\*.*proj;
                       $(RepoRoot)src\Installers\**\*.*proj;

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -172,6 +172,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <LatestPackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <LatestPackageReference Include="Newtonsoft.Json.Bson" Version="$(NewtonsoftJsonBsonPackageVersion)" />
+    <LatestPackageReference Include="NSwag.ApiDescription.Client" Version="$(NSwagApiDescriptionClientPackageVersion)" />
     <LatestPackageReference Include="Selenium.Support" Version="$(SeleniumSupportPackageVersion)" />
     <LatestPackageReference Include="Selenium.WebDriver" Version="$(SeleniumWebDriverPackageVersion)" />
     <LatestPackageReference Include="Selenium.WebDriver.ChromeDriver" Version="$(SeleniumWebDriverChromeDriverPackageVersion)" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -149,7 +149,9 @@ and are generated based on the last package release.
   </ItemGroup>
 
   <ItemGroup Label="MSBuild">
+    <LatestPackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
+    <LatestPackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -196,7 +196,9 @@
     <!-- Partner teams -->
     <MicrosoftAzureKeyVaultPackageVersion>2.3.2</MicrosoftAzureKeyVaultPackageVersion>
     <MicrosoftAzureStorageBlobPackageVersion>10.0.1</MicrosoftAzureStorageBlobPackageVersion>
+    <MicrosoftBuildPackageVersion>15.8.166</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>15.8.166</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.8.166</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftCodeAnalysisCommonPackageVersion>3.0.0</MicrosoftCodeAnalysisCommonPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.0.0</MicrosoftCodeAnalysisCSharpPackageVersion>
@@ -232,6 +234,7 @@
     <MonoCecilPackageVersion>0.10.1</MonoCecilPackageVersion>
     <NewtonsoftJsonBsonPackageVersion>1.0.2</NewtonsoftJsonBsonPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
+    <NSwagApiDescriptionClientPackageVersion>12.3.0</NSwagApiDescriptionClientPackageVersion>
     <SeleniumSupportPackageVersion>3.12.1</SeleniumSupportPackageVersion>
     <SeleniumWebDriverMicrosoftDriverPackageVersion>17.17134.0</SeleniumWebDriverMicrosoftDriverPackageVersion>
     <SeleniumWebDriverChromeDriverPackageVersion>2.43.0</SeleniumWebDriverChromeDriverPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -234,7 +234,7 @@
     <MonoCecilPackageVersion>0.10.1</MonoCecilPackageVersion>
     <NewtonsoftJsonBsonPackageVersion>1.0.2</NewtonsoftJsonBsonPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
-    <NSwagApiDescriptionClientPackageVersion>12.3.0</NSwagApiDescriptionClientPackageVersion>
+    <NSwagApiDescriptionClientPackageVersion>13.0.2</NSwagApiDescriptionClientPackageVersion>
     <SeleniumSupportPackageVersion>3.12.1</SeleniumSupportPackageVersion>
     <SeleniumWebDriverMicrosoftDriverPackageVersion>17.17134.0</SeleniumWebDriverMicrosoftDriverPackageVersion>
     <SeleniumWebDriverChromeDriverPackageVersion>2.43.0</SeleniumWebDriverChromeDriverPackageVersion>

--- a/src/Tools/README.md
+++ b/src/Tools/README.md
@@ -1,18 +1,23 @@
-DotNetTools
-===========
+# DotNetTools
 
-## Projects
+## Bundled tools
 
-The folder contains command-line tools for ASP.NET Core that are bundled* in the .NET Core CLI. Follow the links below for more details on each tool.
+The folder contains command-line tools for ASP.NET Core. The following tools are bundled* in the .NET Core CLI. Follow the links below for more details on each tool.
 
- - [dotnet-watch](dotnet-watch/README.md)
- - [dotnet-user-secrets](dotnet-user-secrets/README.md)
- - [dotnet-sql-cache](dotnet-sql-cache/README.md)
- - [dotnet-dev-certs](dotnet-dev-certs/README.md)
+- [dotnet-watch](dotnet-watch/README.md)
+- [dotnet-user-secrets](dotnet-user-secrets/README.md)
+- [dotnet-sql-cache](dotnet-sql-cache/README.md)
+- [dotnet-dev-certs](dotnet-dev-certs/README.md)
 
 *\*This applies to .NET Core CLI 2.1.300-preview2 and up. For earlier versions of the CLI, these tools must be installed separately.*
 
 *For 2.0 CLI and earlier, see <https://github.com/aspnet/DotNetTools/tree/rel/2.0.0/README.md> for details.*
+
+## Non-bundled tools
+
+The following tools are produced by us but not bundled in the .NET Core CLI. They must be aquired independently.
+
+- [dotnet-openapi](dotnet-openapi/README.md)
 
 ## Usage
 
@@ -23,10 +28,11 @@ dotnet watch
 dotnet user-secrets
 dotnet sql-cache
 dotnet dev-certs
+dotnet openapi
 ```
 
 Add `--help` to see more details. For example,
 
-```
+```sh
 dotnet watch --help
 ```

--- a/src/Tools/Shared/CommandLine/CommandLineApplicationExtensions.cs
+++ b/src/Tools/Shared/CommandLine/CommandLineApplicationExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.CommandLineUtils
 {
@@ -18,6 +19,13 @@ namespace Microsoft.Extensions.CommandLineUtils
             => app.OnExecute(() =>
                 {
                     action();
+                    return 0;
+                });
+
+        public static void OnExecute(this CommandLineApplication app, Func<Task> func)
+            => app.OnExecute(async () =>
+                {
+                    await func();
                     return 0;
                 });
 

--- a/src/Tools/Shared/TestHelpers/TemporaryCSharpProject.cs
+++ b/src/Tools/Shared/TestHelpers/TemporaryCSharpProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-namespace Microsoft.DotNet.Watcher.Tools.Tests
+namespace Microsoft.Extensions.Tools.Internal
 {
     public class TemporaryCSharpProject
     {
         private const string Template =
- @"<Project Sdk=""Microsoft.NET.Sdk"">
+ @"<Project Sdk=""{2}"">
   <PropertyGroup>
     {0}
     <OutputType>Exe</OutputType>
@@ -23,18 +23,21 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
         private readonly string _filename;
         private readonly TemporaryDirectory _directory;
-        private List<string> _items = new List<string>();
-        private List<string> _properties = new List<string>();
+        private readonly List<string> _items = new List<string>();
+        private readonly List<string> _properties = new List<string>();
 
-        public TemporaryCSharpProject(string name, TemporaryDirectory directory)
+        public TemporaryCSharpProject(string name, TemporaryDirectory directory, string sdk)
         {
             Name = name;
             _filename = name + ".csproj";
             _directory = directory;
+            Sdk = sdk;
         }
 
         public string Name { get; }
         public string Path => System.IO.Path.Combine(_directory.Root, _filename);
+
+        public string Sdk { get; }
 
         public TemporaryCSharpProject WithTargetFrameworks(params string[] tfms)
         {
@@ -95,7 +98,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
         public void Create()
         {
-            _directory.CreateFile(_filename, string.Format(Template, string.Join("\r\n", _properties), string.Join("\r\n", _items)));
+            _directory.CreateFile(_filename, string.Format(Template, string.Join("\r\n", _properties), string.Join("\r\n", _items), Sdk));
         }
 
         public class ItemSpec

--- a/src/Tools/Shared/TestHelpers/TemporaryDirectory.cs
+++ b/src/Tools/Shared/TestHelpers/TemporaryDirectory.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace Microsoft.DotNet.Watcher.Tools.Tests
+namespace Microsoft.Extensions.Tools.Internal
 {
     public class TemporaryDirectory : IDisposable
     {
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
         public TemporaryDirectory()
         {
-            Root = Path.Combine(Path.GetTempPath(), "dotnet-watch-tests", Guid.NewGuid().ToString("N"));
+            Root = Path.Combine(Path.GetTempPath(), "dotnet-tool-tests", Guid.NewGuid().ToString("N"));
         }
 
         private TemporaryDirectory(string path, TemporaryDirectory parent)
@@ -34,22 +34,32 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
         public string Root { get; }
 
-        public TemporaryCSharpProject WithCSharpProject(string name)
+        public TemporaryCSharpProject WithCSharpProject(string name, string sdk = "Microsoft.NET.Sdk")
         {
-            var project = new TemporaryCSharpProject(name, this);
+            var project = new TemporaryCSharpProject(name, this, sdk);
             _projects.Add(project);
             return project;
         }
 
-        public TemporaryCSharpProject WithCSharpProject(string name, out TemporaryCSharpProject project)
+        public TemporaryCSharpProject WithCSharpProject(string name, out TemporaryCSharpProject project, string sdk = "Microsoft.NET.Sdk")
         {
-            project = WithCSharpProject(name);
+            project = WithCSharpProject(name, sdk);
             return project;
         }
 
         public TemporaryDirectory WithFile(string name, string contents = "")
         {
             _files[name] = contents;
+            return this;
+        }
+
+        public TemporaryDirectory WithContentFile(string name)
+        {
+            using (var stream = File.OpenRead(Path.Combine("TestContent", $"{name}.txt")))
+            using (var streamReader = new StreamReader(stream))
+            {
+                _files[name] = streamReader.ReadToEnd();
+            }
             return this;
         }
 

--- a/src/Tools/Tools.sln
+++ b/src/Tools/Tools.sln
@@ -7,11 +7,21 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-watch", "dotnet-watc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-watch.Tests", "dotnet-watch\test\dotnet-watch.Tests.csproj", "{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-dev-certs", "dotnet-dev-certs\src\dotnet-dev-certs.csproj", "{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E01EE27B-6CF9-4707-9849-5BA2ABA825F2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.DeveloperCertificates.XPlat", "FirstRunCertGenerator\src\Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj", "{7BBDBDA2-299F-4C36-8338-23C525901DE0}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{2C485EAF-E4DE-4D14-8AE1-330641E17D44}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.DeveloperCertificates.XPlat.Tests", "FirstRunCertGenerator\test\Microsoft.AspNetCore.DeveloperCertificates.XPlat.Tests.csproj", "{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-dev-certs", "dotnet-dev-certs\src\dotnet-dev-certs.csproj", "{98550159-E04E-44EB-A969-E5BF12444B94}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-sql-cache", "dotnet-sql-cache\src\dotnet-sql-cache.csproj", "{216AF7F1-5B05-477E-B8D3-86F6059F268A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-user-secrets", "dotnet-user-secrets\src\dotnet-user-secrets.csproj", "{5FE62357-2915-4890-813A-D82656BDC4DD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-user-secrets.Tests", "dotnet-user-secrets\test\dotnet-user-secrets.Tests.csproj", "{25F8DCC4-4571-42F7-BA0F-5C2D5A802297}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-openapi", "dotnet-openapi\src\dotnet-openapi.csproj", "{16F0A420-F785-4669-B3D0-C7550C546889}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-openapi.Tests", "dotnet-openapi\test\dotnet-openapi.Tests.csproj", "{4922C862-D173-4E59-8F5E-23AEC2D59061}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-sql-cache", "dotnet-sql-cache\src\dotnet-sql-cache.csproj", "{15FB0E39-1A28-4325-AD3C-76352516C80D}"
 EndProject
@@ -45,9 +55,43 @@ Global
 		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98550159-E04E-44EB-A969-E5BF12444B94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98550159-E04E-44EB-A969-E5BF12444B94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98550159-E04E-44EB-A969-E5BF12444B94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98550159-E04E-44EB-A969-E5BF12444B94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{216AF7F1-5B05-477E-B8D3-86F6059F268A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{216AF7F1-5B05-477E-B8D3-86F6059F268A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{216AF7F1-5B05-477E-B8D3-86F6059F268A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{216AF7F1-5B05-477E-B8D3-86F6059F268A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FE62357-2915-4890-813A-D82656BDC4DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FE62357-2915-4890-813A-D82656BDC4DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FE62357-2915-4890-813A-D82656BDC4DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FE62357-2915-4890-813A-D82656BDC4DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25F8DCC4-4571-42F7-BA0F-5C2D5A802297}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25F8DCC4-4571-42F7-BA0F-5C2D5A802297}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25F8DCC4-4571-42F7-BA0F-5C2D5A802297}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25F8DCC4-4571-42F7-BA0F-5C2D5A802297}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16F0A420-F785-4669-B3D0-C7550C546889}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16F0A420-F785-4669-B3D0-C7550C546889}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16F0A420-F785-4669-B3D0-C7550C546889}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16F0A420-F785-4669-B3D0-C7550C546889}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4922C862-D173-4E59-8F5E-23AEC2D59061}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4922C862-D173-4E59-8F5E-23AEC2D59061}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4922C862-D173-4E59-8F5E-23AEC2D59061}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4922C862-D173-4E59-8F5E-23AEC2D59061}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E16F10C8-5FC3-420B-AB33-D6E5CBE89B75} = {E01EE27B-6CF9-4707-9849-5BA2ABA825F2}
+		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C} = {2C485EAF-E4DE-4D14-8AE1-330641E17D44}
+		{98550159-E04E-44EB-A969-E5BF12444B94} = {E01EE27B-6CF9-4707-9849-5BA2ABA825F2}
+		{216AF7F1-5B05-477E-B8D3-86F6059F268A} = {E01EE27B-6CF9-4707-9849-5BA2ABA825F2}
+		{5FE62357-2915-4890-813A-D82656BDC4DD} = {E01EE27B-6CF9-4707-9849-5BA2ABA825F2}
+		{25F8DCC4-4571-42F7-BA0F-5C2D5A802297} = {2C485EAF-E4DE-4D14-8AE1-330641E17D44}
+		{16F0A420-F785-4669-B3D0-C7550C546889} = {E01EE27B-6CF9-4707-9849-5BA2ABA825F2}
+		{4922C862-D173-4E59-8F5E-23AEC2D59061} = {2C485EAF-E4DE-4D14-8AE1-330641E17D44}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EC668D8E-97B9-4758-9E5C-2E5DD6B9137B}

--- a/src/Tools/Tools.sln
+++ b/src/Tools/Tools.sln
@@ -23,8 +23,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-openapi", "dotnet-op
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-openapi.Tests", "dotnet-openapi\test\dotnet-openapi.Tests.csproj", "{4922C862-D173-4E59-8F5E-23AEC2D59061}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-sql-cache", "dotnet-sql-cache\src\dotnet-sql-cache.csproj", "{15FB0E39-1A28-4325-AD3C-76352516C80D}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,22 +37,6 @@ Global
 		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{15FB0E39-1A28-4325-AD3C-76352516C80D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{98550159-E04E-44EB-A969-E5BF12444B94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{98550159-E04E-44EB-A969-E5BF12444B94}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98550159-E04E-44EB-A969-E5BF12444B94}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Tools/build.cmd
+++ b/src/Tools/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET RepoRoot=%~dp0..\..
+%RepoRoot%\build.cmd -projects %~dp0\**\*.*proj %*

--- a/src/Tools/build.sh
+++ b/src/Tools/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/build.sh" --projects "$DIR/**/*.*proj" "$@"

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -104,10 +104,10 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 app.HelpOption("-h|--help");
 
                 app.OnExecute(() =>
-                    {
-                        app.ShowHelp();
-                        return Success;
-                    });
+                {
+                    app.ShowHelp();
+                    return Success;
+                });
 
                 return app.Execute(args);
             }

--- a/src/Tools/dotnet-openapi/README.md
+++ b/src/Tools/dotnet-openapi/README.md
@@ -1,0 +1,83 @@
+# dotnet-openapi
+
+`dotnet-openapi` is a tool which can be used to manage OpenAPI references within your project.
+
+## Commands
+
+### Add Commands
+
+#### Add Project
+
+##### Options
+
+| Short option | Long option | Description | Example |
+|-------|------|-------|---------|
+| -v|--verbose | Show verbose output. |dotnet openapi add project *-v* ../Ref/ProjRef.csproj |
+| -p|--project | The project to operate on. |dotnet openapi add project *--project .\Ref.csproj* ../Ref/ProjRef.csproj |
+
+##### Arguments
+
+|  Argument  | Description | Example |
+|-------------|-------------|---------|
+| source-file | The source to create a reference from. Must be a project file. |dotnet openapi add project *../Ref/ProjRef.csproj* |
+
+#### Add File
+
+##### Options
+
+| Short option| Long option| Description | Example |
+|-------|------|-------|---------|
+| -v|--verbose | Show verbose output. |dotnet openapi add file *-v* .\openapi.json |
+| -p|--project | The project to operate on. |dotnet openapi add file *--project .\Ref.csproj* .\openapi.json |
+
+##### Arguments
+
+|  Argument  | Description | Example |
+|-------------|-------------|---------|
+| source-file | The source to create a reference from. Must be an openapi file. |dotnet openapi add file *.\openapi.json* |
+
+#### Add URL
+
+##### Options
+
+| Short option| Long option| Description | Example |
+|-------|------|-------------|---------|
+| -v|--verbose | Show verbose output. |dotnet openapi add url *-v* <http://contoso.com/openapi.json> |
+| -p|--project | The project to operate on. |dotnet openapi add url *--project .\Ref.csproj* <http://contoso.com/openapi.json> |
+| -o|--output-file | The file to create a local copy of. |dotnet openapi add url <https://contoso.com/openapi.json> *--output-file myclient.json* |
+
+##### Arguments
+
+|  Argument  | Description | Example |
+|-------------|-------------|---------|
+| source-file | The source to create a reference from. Must be a URL. |dotnet openapi add url <https://contoso.com/openapi.json> |
+
+### Remove
+
+##### Options
+
+| Short option| Long option| Description| Example |
+|-------|------|------------|---------|
+| -v|--verbose | Show verbose output. |dotnet openapi remove *-v*|
+| -p|--project | The project to operate on. |dotnet openapi remove *--project .\Ref.csproj* .\openapi.json |
+
+#### Arguments
+
+|  Argument  | Description| Example |
+| ------------|------------|---------|
+| source-file | The source to remove the reference to. |dotnet openapi remove *.\openapi.json* |
+
+### Refresh
+
+#### Options
+
+| Short option| Long option| Description | Example |
+|-------|------|-------------|---------|
+| -v|--verbose | Show verbose output. | dotnet openapi refresh *-v* <https://contoso.com/openapi.json> |
+| -p|--project | The project to operate on. | dotnet openapi refresh *--project .\Ref.csproj* <https://contoso.com/openapi.json> |
+
+#### Arguments
+
+|  Argument  | Description | Example |
+| ------------|-------------|---------|
+| source-file | The URL to refresh the reference from. | dotnet openapi refresh *<https://contoso.com/openapi.json*> |

--- a/src/Tools/dotnet-openapi/src/Application.cs
+++ b/src/Tools/dotnet-openapi/src/Application.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
+using Microsoft.DotNet.OpenApi.Commands;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace Microsoft.DotNet.OpenApi
+{
+    internal class Application : CommandLineApplication
+    {
+        static Application()
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+
+        public Application(
+            string workingDirectory,
+            Func<string, Task<Stream>> downloadProvider,
+            TextWriter output = null,
+            TextWriter error = null)
+        {
+            DownloadProvider = downloadProvider;
+            Out = output ?? Out;
+            Error = error ?? Error;
+
+            WorkingDirectory = workingDirectory;
+
+            Name = "openapi";
+            FullName = "OpenApi reference management tool";
+            Description = "OpenApi reference management operations.";
+            ShortVersionGetter = GetInformationalVersion;
+
+            HelpOption("-?|-h|--help");
+
+            Invoke = () => {
+                ShowHelp();
+                return 0;
+            };
+
+            Commands.Add(new AddCommand(this));
+            Commands.Add(new RemoveCommand(this));
+            Commands.Add(new RefreshCommand(this));
+        }
+
+        public Func<string, Task<Stream>> DownloadProvider { get; }
+
+        public string WorkingDirectory { get; }
+
+        public new int Execute(params string[] args)
+        {
+            try
+            {
+                return base.Execute(args);
+            }
+            catch (AggregateException ex) when (ex.InnerException != null)
+            {
+                foreach (var innerException in ex.Flatten().InnerExceptions)
+                {
+                    Error.WriteLine(innerException.Message);
+                    if (!(innerException is ArgumentException))
+                    {
+                        Error.WriteLine(innerException.StackTrace);
+                    }
+                }
+                return 1;
+            }
+
+            catch (ArgumentException ex)
+            {
+                // Don't show a call stack when we have unneeded arguments, just print the error message.
+                // The code that throws this exception will print help, so no need to do it here.
+                Error.WriteLine(ex.Message);
+                return 1;
+            }
+            catch (CommandParsingException ex)
+            {
+                // Don't show a call stack when we have unneeded arguments, just print the error message.
+                // The code that throws this exception will print help, so no need to do it here.
+                Error.WriteLine(ex.Message);
+                return 1;
+            }
+            catch (OperationCanceledException)
+            {
+                // This is a cancellation, not a failure.
+                Error.WriteLine("Cancelled");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                Error.WriteLine(ex.Message);
+                Error.WriteLine(ex.StackTrace);
+                return 1;
+            }
+        }
+
+        private string GetInformationalVersion()
+        {
+            var assembly = typeof(Application).GetTypeInfo().Assembly;
+            var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attribute.InformationalVersion;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/CodeGenerator.cs
+++ b/src/Tools/dotnet-openapi/src/CodeGenerator.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.DotNet.OpenApi
+{
+    public enum CodeGenerator
+    {
+        NSwagCSharp
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/AddCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/AddCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal class AddCommand : BaseCommand
+    {
+        private const string CommandName = "add";
+
+        public AddCommand(Application parent)
+            : base(parent, CommandName)
+        {
+            Commands.Add(new AddFileCommand(this));
+            Commands.Add(new AddProjectCommand(this));
+            Commands.Add(new AddURLCommand(this));
+        }
+
+        internal new Application Parent => (Application)base.Parent;
+
+        protected override Task<int> ExecuteCoreAsync()
+        {
+            ShowHelp();
+            return Task.FromResult(0);
+        }
+
+        protected override bool ValidateArguments()
+        {
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/AddFileCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/AddFileCommand.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal class AddFileCommand : BaseCommand
+    {
+        private const string CommandName = "file";
+
+        public AddFileCommand(AddCommand parent)
+            : base(parent, CommandName)
+        {
+            _sourceFileArg = Argument(SourceProjectArgName, $"The openapi file to add. This must be a path to local openapi file(s)", multipleValues: true);
+        }
+
+        internal readonly CommandArgument _sourceFileArg;
+
+        private readonly string[] ApprovedExtensions = new[] { ".json", ".yaml", ".yml" };
+
+        protected override async Task<int> ExecuteCoreAsync()
+        {
+            var projectFilePath = ResolveProjectFile(ProjectFileOption);
+
+            Ensure.NotNullOrEmpty(_sourceFileArg.Value, SourceProjectArgName);
+
+            foreach (var sourceFile in _sourceFileArg.Values)
+            {
+                var codeGenerator = CodeGenerator.NSwagCSharp;
+                EnsurePackagesInProject(projectFilePath, codeGenerator);
+                if (IsLocalFile(sourceFile))
+                {
+                    if (ApprovedExtensions.Any(e => sourceFile.EndsWith(e)))
+                    {
+                        await Warning.WriteLineAsync($"The extension for the given file '{sourceFile}' should have been one of: {string.Join(",", ApprovedExtensions)}.");
+                        await Warning.WriteLineAsync($"The reference has been added, but may fail at build-time if the format is not correct.");
+                    }
+                    AddServiceReference(OpenApiReference, projectFilePath, sourceFile);
+                }
+                else
+                {
+                    throw new ArgumentException($"{SourceProjectArgName} of '{sourceFile}' was not valid. Valid values are a JSON file or a YAML file");
+                }
+            }
+
+            return 0;
+        }
+
+        private bool IsLocalFile(string file)
+        {
+            return File.Exists(GetFullPath(file));
+        }
+
+        protected override bool ValidateArguments()
+        {
+            Ensure.NotNullOrEmpty(_sourceFileArg.Value, SourceProjectArgName);
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/AddProjectCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/AddProjectCommand.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal class AddProjectCommand :  BaseCommand
+    {
+        private const string CommandName = "project";
+
+        public AddProjectCommand(BaseCommand parent)
+            : base(parent, CommandName)
+        {
+            _sourceProjectArg = Argument(SourceProjectArgName, $"The openapi project to add. This must be the path to project file(s) containing openapi endpoints", multipleValues: true);
+        }
+
+        internal readonly CommandArgument _sourceProjectArg;
+
+        protected override Task<int> ExecuteCoreAsync()
+        {
+            var projectFilePath = ResolveProjectFile(ProjectFileOption);
+
+            foreach (var sourceFile in _sourceProjectArg.Values)
+            {
+                var codeGenerator = CodeGenerator.NSwagCSharp;
+                EnsurePackagesInProject(projectFilePath, codeGenerator);
+                if (IsProjectFile(sourceFile))
+                {
+                    AddServiceReference(OpenApiProjectReference, projectFilePath, sourceFile);
+                }
+                else
+                {
+                    throw new ArgumentException($"{SourceProjectArgName} of '{sourceFile}' was not valid. Valid values must be project file(s)");
+                }
+            }
+
+            return Task.FromResult(0);
+        }
+
+        protected override bool ValidateArguments()
+        {
+            Ensure.NotNullOrEmpty(_sourceProjectArg.Value, SourceProjectArgName);
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/AddURLCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/AddURLCommand.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal class AddURLCommand : BaseCommand
+    {
+        private const string CommandName = "url";
+        private const string DefaultOpenAPIDir = "openapi";
+        private const string DefaultOpenAPIFile = "openapi.json";
+
+        private const string OutputFileName = "--output-file";
+
+        public AddURLCommand(AddCommand parent)
+            : base(parent, CommandName)
+        {
+            _outputFileOption = Option(OutputFileName, "The destination to download the remote Open API file to.", CommandOptionType.SingleValue);
+            _sourceFileArg = Argument(SourceProjectArgName, $"The openapi file to add. This must be a URL to a remote openapi file.", multipleValues: true);
+        }
+
+        internal readonly CommandOption _outputFileOption;
+
+        internal readonly CommandArgument _sourceFileArg;
+
+        protected override async Task<int> ExecuteCoreAsync()
+        {
+            var projectFilePath = ResolveProjectFile(ProjectFileOption);
+
+            var sourceFile = Ensure.NotNullOrEmpty(_sourceFileArg.Value, SourceProjectArgName);
+
+            string outputFile;
+            if (_outputFileOption.HasValue())
+            {
+                outputFile = _outputFileOption.Value();
+            }
+            else
+            {
+                outputFile = Path.Combine(DefaultOpenAPIDir, DefaultOpenAPIFile);
+            }
+            var codeGenerator = CodeGenerator.NSwagCSharp;
+            EnsurePackagesInProject(projectFilePath, codeGenerator);
+
+            if (IsUrl(sourceFile))
+            {
+                var destination = GetFullPath(outputFile);
+                // We have to download the file from that URL, save it to a local file, then create a AddServiceLocalReference
+                // Use this task https://github.com/aspnet/AspNetCore/commit/91dcbd44c10af893374cfb36dc7a009caa4818d0#diff-ea7515a116529b85ad5aa8e06e4acc8e
+                await DownloadToFileAsync(sourceFile, destination, overwrite: false);
+
+                AddServiceReference(OpenApiReference, projectFilePath, outputFile, sourceFile);
+            }
+            else
+            {
+                Error.Write($"{SourceProjectArgName} was not valid. Valid values are URLs");
+                return 1;
+            }
+
+            return 0;
+        }
+
+        protected override bool ValidateArguments()
+        {
+            Ensure.NotNullOrEmpty(_sourceFileArg.Value, SourceProjectArgName);
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/BaseCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/BaseCommand.cs
@@ -1,0 +1,340 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal abstract class BaseCommand : CommandLineApplication
+    {
+        protected string WorkingDirectory;
+
+        protected const string SourceProjectArgName = "source-file";
+        public const string OpenApiReference = "OpenApiReference";
+        public const string OpenApiProjectReference = "OpenApiProjectReference";
+        protected const string SourceUrlAttrName = "SourceUrl";
+
+        public BaseCommand(CommandLineApplication parent, string name)
+        {
+            Parent = parent;
+            Name = name;
+            Out = parent.Out ?? Out;
+            Error = parent.Error ?? Error;
+
+            ProjectFileOption = Option("-p|--project", "The project to add a reference to", CommandOptionType.SingleValue);
+
+            Help = HelpOption("-?|-h|--help");
+            if (Parent is Application)
+            {
+                WorkingDirectory = ((Application)Parent).WorkingDirectory;
+            }
+            else
+            {
+                WorkingDirectory = ((Application)Parent.Parent).WorkingDirectory;
+            }
+
+            OnExecute(ExecuteAsync);
+        }
+
+        public CommandOption ProjectFileOption { get; }
+
+        internal CommandOption Help { get; }
+
+        public TextWriter Warning
+        {
+            get { return Out; }
+        }
+
+        protected abstract Task<int> ExecuteCoreAsync();
+
+        protected abstract bool ValidateArguments();
+
+        private async Task<int> ExecuteAsync()
+        {
+            if (!ValidateArguments() || Help.HasValue())
+            {
+                ShowHelp();
+                return 1;
+            }
+
+            return await ExecuteCoreAsync();
+        }
+
+        internal FileInfo ResolveProjectFile(CommandOption projectOption)
+        {
+            string project;
+            if (projectOption.HasValue())
+            {
+                project = projectOption.Value();
+                project = GetFullPath(project);
+                if (!File.Exists(project))
+                {
+                    throw new ArgumentException($"The project '{project}' does not exist.");
+                }
+            }
+            else
+            {
+                var projects = Directory.GetFiles(WorkingDirectory, "*.csproj", SearchOption.TopDirectoryOnly);
+                if (projects.Length == 0)
+                {
+                    throw new ArgumentException("No project files were found in the current directory. Either move to a new directory or provide the project explicitly");
+                }
+                if (projects.Length > 1)
+                {
+                    throw new ArgumentException("More than one project was found in this directory, either remove a duplicate or explicitly provide the project.");
+                }
+
+                project = projects[0];
+            }
+
+            return new FileInfo(project);
+        }
+
+        protected Project LoadProject(FileInfo projectFile)
+        {
+            var project = ProjectCollection.GlobalProjectCollection.LoadProject(
+                projectFile.FullName,
+                globalProperties: null,
+                toolsVersion: null);
+            project.ReevaluateIfNecessary();
+            return project;
+        }
+
+        internal bool IsProjectFile(string file)
+        {
+            return File.Exists(Path.GetFullPath(file)) && file.EndsWith(".csproj");
+        }
+
+        internal bool IsUrl(string file)
+        {
+            return Uri.TryCreate(file, UriKind.Absolute, out var _) && file.StartsWith("http");
+        }
+
+        internal void AddServiceReference(
+            string tagName,
+            FileInfo projectFile,
+            string sourceFile,
+            string sourceUrl = null)
+        {
+            var project = LoadProject(projectFile);
+            var items = project.GetItems(tagName);
+            var fileItems = items.Where((i) => {
+                return string.Equals(GetFullPath(i.EvaluatedInclude), GetFullPath(sourceFile), StringComparison.Ordinal);
+            });
+
+            if (fileItems.Count() > 1)
+            {
+                Warning.Write($"More than one reference to {sourceFile} already exists. Duplicate references could lead to unexpected behavior.");
+                return;
+            }
+
+            if (sourceUrl != null)
+            {
+                if(items.Any(i => string.Equals(i.GetMetadataValue(SourceUrlAttrName), sourceUrl)))
+                {
+                    Warning.Write($"A reference to '{sourceUrl}' already exists in '{project.FullPath}'.");
+                    return;
+                }
+            }
+
+            if (fileItems.Count() == 0)
+            {
+                var metadata = new Dictionary<string, string>();
+
+                if (!string.IsNullOrEmpty(sourceUrl))
+                {
+                    metadata[SourceUrlAttrName] = sourceUrl;
+                }
+
+                project.AddElementWithAttributes(tagName, sourceFile, metadata);
+            }
+            else
+            {
+                Warning.Write($"A reference to '{sourceFile}' already exists in '{project.FullPath}'.");
+                return;
+            }
+        }
+
+        internal async Task DownloadToFileAsync(string url, string destinationPath, bool overwrite)
+        {
+            Application application;
+            if (Parent is Application)
+            {
+                application = (Application)Parent;
+            }
+            else
+            {
+                application = (Application)Parent.Parent;
+            }
+
+            var content = await application.DownloadProvider(url);
+            await WriteToFileAsync(content, destinationPath, overwrite);
+        }
+
+        internal void EnsurePackagesInProject(FileInfo projectFile, CodeGenerator codeGenerator)
+        {
+            var packages = GetServicePackages(codeGenerator);
+            foreach (var (packageId, version) in packages)
+            {
+                var args = new string[] {
+                    "add",
+                    "package",
+                    packageId,
+                    "--version",
+                    version,
+                    "--no-restore"
+                };
+
+                var muxer = DotNetMuxer.MuxerPathOrDefault();
+                if(string.IsNullOrEmpty(muxer))
+                {
+                    throw new ArgumentException($"dotnet was not found on the path.");
+                }
+
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = muxer,
+                    Arguments = string.Join(" ", args),
+                    WorkingDirectory = projectFile.Directory.FullName,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                };
+
+                var process = Process.Start(startInfo);
+
+                if (!process.WaitForExit(20*1000))
+                {
+                    throw new ArgumentException($"Adding package `{packageId}` to `{projectFile.Directory}` took too long.");
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    Error.Write(process.StandardError.ReadToEnd());
+                    Error.Write(process.StandardOutput.ReadToEnd());
+                    throw new ArgumentException($"Could not add package `{packageId}` to `{projectFile.Directory}`");
+                }
+            }
+        }
+
+        internal string GetFullPath(string path)
+        {
+            return Path.IsPathFullyQualified(path)
+                ? Path.GetFullPath(path)
+                : Path.GetFullPath(path, WorkingDirectory);
+        }
+
+        private static IEnumerable<Tuple<string, string>> GetServicePackages(CodeGenerator type)
+        {
+            var name = Enum.GetName(typeof(CodeGenerator), type);
+            var attributes = typeof(Program).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>();
+            var attribute = attributes.Single(a => string.Equals(a.Key, name, StringComparison.OrdinalIgnoreCase));
+
+            var packages = attribute.Value.Split(';', StringSplitOptions.RemoveEmptyEntries);
+            var result = new List<Tuple<string, string>>();
+            foreach (var package in packages)
+            {
+                var tmp = package.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                Debug.Assert(tmp.Length == 2);
+                result.Add(new Tuple<string, string>(tmp[0], tmp[1]));
+            }
+
+            return result;
+        }
+
+        private static byte[] GetHash(Stream stream)
+        {
+            SHA256 algorithm;
+            try
+            {
+                algorithm = SHA256.Create();
+            }
+            catch (TargetInvocationException)
+            {
+                // SHA256.Create is documented to throw this exception on FIPS-compliant machines. See
+                // https://msdn.microsoft.com/en-us/library/z08hz7ad Fall back to a FIPS-compliant SHA256 algorithm.
+                algorithm = new SHA256CryptoServiceProvider();
+            }
+
+            using (algorithm)
+            {
+                return algorithm.ComputeHash(stream);
+            }
+        }
+
+        private async Task WriteToFileAsync(Stream content, string destinationPath, bool overwrite)
+        {
+            content.Seek(0, SeekOrigin.Begin);
+            destinationPath = GetFullPath(destinationPath);
+            var destinationExists = File.Exists(destinationPath);
+            if (destinationExists && !overwrite)
+            {
+                throw new ArgumentException($"File '{destinationPath}' already exists. Aborting to avoid interference.");
+            }
+
+            await Out.WriteLineAsync($"Downloading to '{destinationPath}'.");
+            var reachedCopy = false;
+            try
+            {
+                if (destinationExists)
+                {
+                    // Check hashes before using the downloaded information.
+                    var downloadHash = GetHash(content);
+
+                    byte[] destinationHash;
+                    using (var destinationStream = File.OpenRead(destinationPath))
+                    {
+                        destinationHash = GetHash(destinationStream);
+                    }
+
+                    var sameHashes = downloadHash.Length == destinationHash.Length;
+                    for (var i = 0; sameHashes && i < downloadHash.Length; i++)
+                    {
+                        sameHashes = downloadHash[i] == destinationHash[i];
+                    }
+
+                    if (sameHashes)
+                    {
+                        await Out.WriteLineAsync($"Not overwriting existing and matching file '{destinationPath}'.");
+                        return;
+                    }
+                }
+                else
+                {
+                    // May need to create directory to hold the file.
+                    var destinationDirectory = Path.GetDirectoryName(destinationPath);
+                    if (!string.IsNullOrEmpty(destinationDirectory))
+                    {
+                        Directory.CreateDirectory(destinationDirectory);
+                    }
+                }
+
+                // Create or overwrite the destination file.
+                reachedCopy = true;
+                using (var fileStream = new FileStream(destinationPath, FileMode.OpenOrCreate, FileAccess.Write))
+                {
+                    fileStream.Seek(0, SeekOrigin.Begin);
+                    content.Seek(0, SeekOrigin.Begin);
+                    await content.CopyToAsync(fileStream);
+                }
+            }
+            catch (Exception ex)
+            {
+                await Error.WriteLineAsync($"Downloading failed.");
+                await Error.WriteLineAsync(ex.ToString());
+                if (reachedCopy)
+                {
+                    File.Delete(destinationPath);
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/RefreshCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/RefreshCommand.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal class RefreshCommand : BaseCommand
+    {
+        private const string CommandName = "refresh";
+
+        public RefreshCommand(Application parent) : base(parent, CommandName)
+        {
+            _sourceFileArg = Argument(SourceProjectArgName, $"The openapi reference to refresh.");
+        }
+
+        internal readonly CommandArgument _sourceFileArg;
+
+        protected override async Task<int> ExecuteCoreAsync()
+        {
+            var projectFile = ResolveProjectFile(ProjectFileOption);
+
+            var sourceFile = Ensure.NotNullOrEmpty(_sourceFileArg.Value, SourceProjectArgName);
+
+            if (IsUrl(sourceFile))
+            {
+                var destination = FindReferenceFromUrl(projectFile, sourceFile);
+
+                await DownloadToFileAsync(sourceFile, destination, overwrite: true);
+            }
+            else
+            {
+                throw new ArgumentException($"'dotnet openapi refresh' must be given a URL");
+            }
+
+            return 0;
+        }
+
+        private string FindReferenceFromUrl(FileInfo projectFile, string url)
+        {
+            var project = LoadProject(projectFile);
+            var openApiReferenceItems = project.GetItems(OpenApiReference);
+
+            foreach (ProjectItem item in openApiReferenceItems)
+            {
+                var attrUrl = item.GetMetadataValue(SourceUrlAttrName);
+                if (string.Equals(attrUrl, url, StringComparison.Ordinal))
+                {
+                    return item.EvaluatedInclude;
+                }
+            }
+
+            throw new ArgumentException("There was no openapi reference to refresh with the given URL.");
+        }
+
+        protected override bool ValidateArguments()
+        {
+            Ensure.NotNullOrEmpty(_sourceFileArg.Value, SourceProjectArgName);
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Commands/RemoveCommand.cs
+++ b/src/Tools/dotnet-openapi/src/Commands/RemoveCommand.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.OpenApi.Commands
+{
+    internal class RemoveCommand : BaseCommand
+    {
+        private const string CommandName = "remove";
+
+        public RemoveCommand(Application parent) : base(parent, CommandName)
+        {
+            _sourceProjectArg = Argument(SourceProjectArgName, $"The openapi reference to remove. Must represent a reference which is already in this project", multipleValues: true);
+        }
+
+        internal readonly CommandArgument _sourceProjectArg;
+
+        protected override Task<int> ExecuteCoreAsync()
+        {
+            var projectFile = ResolveProjectFile(ProjectFileOption);
+
+            var sourceFile = Ensure.NotNullOrEmpty(_sourceProjectArg.Value, SourceProjectArgName);
+
+            if (IsProjectFile(sourceFile))
+            {
+                RemoveServiceReference(OpenApiProjectReference, projectFile, sourceFile);
+            }
+            else
+            {
+                var file = RemoveServiceReference(OpenApiReference, projectFile, sourceFile);
+
+                if(file != null)
+                {
+                    File.Delete(GetFullPath(file));
+                }
+            }
+
+            return Task.FromResult(0);
+        }
+
+        private string RemoveServiceReference(string tagName, FileInfo projectFile, string sourceFile)
+        {
+            var project = LoadProject(projectFile);
+            var openApiReferenceItems = project.GetItems(tagName);
+
+            foreach (ProjectItem item in openApiReferenceItems)
+            {
+                var include = item.EvaluatedInclude;
+                var sourceUrl = item.HasMetadata(SourceUrlAttrName) ? item.GetMetadataValue(SourceUrlAttrName) : null;
+                if (string.Equals(include, sourceFile, StringComparison.Ordinal)
+                    || string.Equals(sourceUrl, sourceFile))
+                {
+                    project.RemoveItem(item);
+                    project.Save();
+                    return include;
+                }
+            }
+
+            Warning.Write($"No openapi reference was found with the file '{sourceFile}'");
+            return null;
+        }
+
+        protected override bool ValidateArguments()
+        {
+            Ensure.NotNullOrEmpty(_sourceProjectArg.Value, SourceProjectArgName);
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/DebugMode.cs
+++ b/src/Tools/dotnet-openapi/src/DebugMode.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+
+namespace Microsoft.DotNet.OpenApi
+{
+    internal static class DebugMode
+    {
+        public static void HandleDebugSwitch(ref string[] args)
+        {
+            if (args.Length > 0 && string.Equals("--debug", args[0], StringComparison.OrdinalIgnoreCase))
+            {
+                args = args.Skip(1).ToArray();
+
+                Console.WriteLine("Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+                while (!Debugger.IsAttached)
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(3));
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Program.cs
+++ b/src/Tools/dotnet-openapi/src/Program.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.OpenApi
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            var outputWriter = new StringWriter();
+            var errorWriter = new StringWriter();
+
+            DebugMode.HandleDebugSwitch(ref args);
+
+            try
+            {
+                var application = new Application(
+                    Directory.GetCurrentDirectory(),
+                    DownloadAsync,
+                    outputWriter,
+                    errorWriter);
+
+                var result = application.Execute(args);
+
+                return result;
+            }
+            catch(Exception ex)
+            {
+                Console.Error.WriteLine("Unexpected error:");
+                Console.Error.WriteLine(ex.ToString());
+            }
+            finally
+            {
+                var output = outputWriter.ToString();
+                var error = errorWriter.ToString();
+
+                outputWriter.Dispose();
+                errorWriter.Dispose();
+
+                Console.Write(output);
+                Console.Error.Write(error);
+            }
+
+            return 1;
+        }
+
+        public static async Task<Stream> DownloadAsync(string url)
+        {
+            using (var client = new HttpClient())
+            {
+                return await client.GetStreamAsync(url);
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/ProjectExtensions.cs
+++ b/src/Tools/dotnet-openapi/src/ProjectExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.DotNet.OpenApi
+{
+    public static class ProjectExtensions
+    {
+        public static void AddElementWithAttributes(this Project project, string tagName, string include, IDictionary<string, string> metadata)
+        {
+            var item = project.AddItem(tagName, include).Single();
+            foreach (var kvp in metadata)
+            {
+                item.Xml.AddMetadata(kvp.Key, kvp.Value, expressAsAttribute: true);
+            }
+
+            project.Save();
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/src/Properties/AssemblyInfo.cs
+++ b/src/Tools/dotnet-openapi/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.DotNet.Open.Api.Tools.Tests, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Tools/dotnet-openapi/src/dotnet-openapi.csproj
+++ b/src/Tools/dotnet-openapi/src/dotnet-openapi.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>exe</OutputType>
+    <Description>Command line tool to add an openapi service reference</Description>
+    <RootNamespace>Microsoft.DotNet.Openapi.Tools</RootNamespace>
+    <PackAsTool>true</PackAsTool>
+    <!-- This package is for internal use only. It contains a CLI tool. -->
+    <IsShippingPackage>false</IsShippingPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(ToolSharedSourceRoot)CommandLine\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <Reference Include="Microsoft.Build.Locator" />
+    <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>NSwagCSharp</_Parameter1>
+      <_Parameter2>NSwag.ApiDescription.Client:$(NSwagApiDescriptionClientPackageVersion);Newtonsoft.Json:$(NewtonsoftJsonPackageVersion)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/src/Tools/dotnet-openapi/test/OpenApiAddFileTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiAddFileTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;

--- a/src/Tools/dotnet-openapi/test/OpenApiAddFileTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiAddFileTests.cs
@@ -1,0 +1,216 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.DotNet.OpenApi.Tests;
+using Microsoft.Extensions.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.OpenApi.Add.Tests
+{
+    public class OpenApiAddFileTests : OpenApiTestBase
+    {
+        public OpenApiAddFileTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void OpenApi_Empty_ShowsHelp()
+        {
+            var app = GetApplication();
+            var run = app.Execute(new string[] { });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            Assert.Contains("Usage: openapi ", _output.ToString());
+        }
+
+        [Fact]
+        public void OpenApi_NoProjectExists()
+        {
+            var app = GetApplication();
+            _tempDir.Create();
+            var run = app.Execute(new string[] { "add", "file", "randomfile.json"});
+
+            Assert.Contains("No project files were found in the current directory", _error.ToString());
+            Assert.DoesNotContain(":line ", _error.ToString());
+            Assert.Equal(1, run);
+        }
+
+        [Fact]
+        public void OpenApi_ExplicitProject_Missing()
+        {
+            var app = GetApplication();
+            _tempDir.Create();
+            var csproj = "fake.csproj";
+            var run = app.Execute(new string[] { "add", "file", "--project", csproj, "randomfile.json" });
+
+            Assert.Contains($"The project '{Path.Combine(_tempDir.Root, csproj)}' does not exist.", _error.ToString());
+            Assert.Equal(1, run);
+        }
+
+        [Fact]
+        public void OpenApi_Add_Empty_ShowsHelp()
+        {
+            var app = GetApplication();
+            var run = app.Execute(new string[] { "add" });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            Assert.Contains("Usage: openapi ", _output.ToString());
+        }
+
+        [Fact]
+        public async Task OpenApi_Add_ReuseItemGroup()
+        {
+            var project = CreateBasicProject(withOpenApi: true);
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "file", project.NSwagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var secondRun = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, secondRun);
+
+            var csproj = new FileInfo(project.Project.Path);
+            string content;
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                content = await reader.ReadToEndAsync();
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.Contains($"<OpenApiReference Include=\"{project.NSwagJsonFile}\"", content);
+            }
+            var projXml = new XmlDocument();
+            projXml.Load(csproj.FullName);
+
+            var openApiRefs = projXml.GetElementsByTagName(Commands.BaseCommand.OpenApiReference);
+            Assert.Same(openApiRefs[0].ParentNode, openApiRefs[1].ParentNode);
+        }
+
+        [Fact]
+        public void OpenApi_Add__File_EquivilentPaths()
+        {
+            var project = CreateBasicProject(withOpenApi: true);
+            var nswagJsonFile = project.NSwagJsonFile;
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "file", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            app = GetApplication();
+            var absolute = Path.GetFullPath(nswagJsonFile, project.Project.Dir().Root);
+            run = app.Execute(new[] { "add", "file", absolute});
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var csproj = new FileInfo(project.Project.Path);
+            var projXml = new XmlDocument();
+            projXml.Load(csproj.FullName);
+
+            var openApiRefs = projXml.GetElementsByTagName(Commands.BaseCommand.OpenApiReference);
+            Assert.Single(openApiRefs);
+        }
+
+        [Fact]
+        public async Task OpenApi_Add_FromJson()
+        {
+            var project = CreateBasicProject(withOpenApi: true);
+            var nswagJsonFile = project.NSwagJsonFile;
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "file", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            // csproj contents
+            var csproj = new FileInfo(project.Project.Path);
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\"", content);
+            }
+
+            // Build project and make sure it compiles
+            var buildProc = ProcessEx.Run(_outputHelper, _tempDir.Root, "dotnet", "build");
+            await buildProc.Exited;
+            Assert.True(buildProc.ExitCode == 0, $"Build failed: {buildProc.Output}");
+
+            // Run project and make sure it doesn't crash
+            using (var runProc = ProcessEx.Run(_outputHelper, _tempDir.Root, "dotnet", "run"))
+            {
+                Thread.Sleep(100);
+                Assert.False(runProc.HasExited, $"Run failed with: {runProc.Output}");
+            }
+        }
+
+        [Fact]
+        public async Task OpenApi_Add_File_UseProjectOption()
+        {
+            var project = CreateBasicProject(withOpenApi: true);
+            var nswagJsonFIle = project.NSwagJsonFile;
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "file", "--project", project.Project.Path, nswagJsonFIle });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            // csproj contents
+            var csproj = new FileInfo(project.Project.Path);
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFIle}\"", content);
+            }
+        }
+
+        [Fact]
+        public async Task OpenApi_Add_MultipleTimes_OnlyOneReference()
+        {
+            var project = CreateBasicProject(withOpenApi: true);
+            var nswagJsonFile = project.NSwagJsonFile;
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "file", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            app = GetApplication();
+            run = app.Execute(new[] { "add", "file", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            // csproj contents
+            var csproj = new FileInfo(project.Project.Path);
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                var escapedPkgRef = Regex.Escape("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"");
+                Assert.Single(Regex.Matches(content, escapedPkgRef));
+                var escapedApiRef = Regex.Escape($"<OpenApiReference Include=\"{nswagJsonFile}\"");
+                Assert.Single(Regex.Matches(content, escapedApiRef));
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/OpenApiAddProjectTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiAddProjectTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.DotNet.OpenApi.Tests;
+using Microsoft.Extensions.Tools.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.OpenApi.Add.Tests
+{
+    public class OpenApiAddProjectTests : OpenApiTestBase
+    {
+        public OpenApiAddProjectTests(ITestOutputHelper output) : base(output){}
+
+        [Fact]
+        public async Task OpenApi_Add_GlobbingOpenApi()
+        {
+            var project = CreateBasicProject(withOpenApi: true);
+
+            using (var refProj1 = project.Project.Dir().SubDir("refProj1"))
+            using (var refProj2 = project.Project.Dir().SubDir("refProj2"))
+            {
+                var project1 = refProj1.WithCSharpProject("refProj");
+                project1
+                    .WithTargetFrameworks("netcoreapp3.0")
+                    .Dir()
+                    .Create();
+
+                var project2 = refProj2.WithCSharpProject("refProj2");
+                project2
+                    .WithTargetFrameworks("netcoreapp3.0")
+                    .Dir()
+                    .Create();
+
+                var app = GetApplication();
+
+                var run = app.Execute(new[] { "add", "project", project1.Path, project2.Path});
+
+                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+                Assert.Equal(0, run);
+
+                // csproj contents
+                using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
+                using (var reader = new StreamReader(csprojStream))
+                {
+                    var content = await reader.ReadToEndAsync();
+                    Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                    Assert.Contains($"<OpenApiProjectReference Include=\"{project1.Path}\"", content);
+                    Assert.Contains($"<OpenApiProjectReference Include=\"{project2.Path}\"", content);
+                }
+            }
+        }
+
+        [Fact]
+        public void OpenApi_Add_Project_EquivilentPaths()
+        {
+            var project = CreateBasicProject(withOpenApi: false);
+
+            using (var refProj = new TemporaryDirectory())
+            {
+                var refProjName = "refProj";
+                var csproj = refProj.WithCSharpProject(refProjName);
+                csproj
+                    .WithTargetFrameworks("netcoreapp3.0")
+                    .Dir()
+                    .Create();
+
+                var app = GetApplication();
+                var run = app.Execute(new[] { "add", "project", csproj.Path});
+
+                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+                Assert.Equal(0, run);
+
+                app = GetApplication();
+                run = app.Execute(new[] { "add", "project", Path.Combine(csproj.Path, "..", "refProj.csproj")});
+
+                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+                Assert.Equal(0, run);
+
+                var projXml = new XmlDocument();
+                projXml.Load(project.Project.Path);
+
+                var openApiRefs = projXml.GetElementsByTagName(Commands.BaseCommand.OpenApiProjectReference);
+                Assert.Single(openApiRefs);
+            }
+        }
+
+        [Fact]
+        public async Task OpenApi_Add_FromCsProj()
+        {
+            var project = CreateBasicProject(withOpenApi: false);
+
+            using (var refProj = new TemporaryDirectory())
+            {
+                var refProjName = "refProj";
+                refProj
+                    .WithCSharpProject(refProjName)
+                    .WithTargetFrameworks("netcoreapp3.0")
+                    .Dir()
+                    .Create();
+
+                var app = GetApplication();
+                var refProjFile = Path.Join(refProj.Root, $"{refProjName}.csproj");
+                var run = app.Execute(new[] { "add", "project", refProjFile });
+
+                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+                Assert.Equal(0, run);
+
+                // csproj contents
+                using(var csprojStream = new FileInfo(project.Project.Path).OpenRead())
+                using(var reader = new StreamReader(csprojStream))
+                {
+                    var content = await reader.ReadToEndAsync();
+                    Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                    Assert.Contains($"<OpenApiProjectReference Include=\"{refProjFile}\"", content);
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.DotNet.OpenApi.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.OpenApi.Add.Tests
+{
+    public class OpenApiAddURLTests : OpenApiTestBase
+    {
+        public OpenApiAddURLTests(ITestOutputHelper output) : base(output){ }
+
+        [Fact]
+        public async Task OpenApi_Add_Url()
+        {
+            var project = CreateBasicProject(withOpenApi: false);
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var expectedJsonName = Path.Combine("openapi", "openapi.json");
+
+            // csproj contents
+            using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.Contains(
+    $@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}"" />", content);
+            }
+
+            Assert.True(File.Exists(expectedJsonName));
+            using (var jsonStream = new FileInfo(expectedJsonName).OpenRead())
+            using (var reader = new StreamReader(jsonStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Equal(Content, content);
+            }
+        }
+
+
+        [Fact]
+        public async Task OpenApi_Add_Url_OutputFile()
+        {
+            var project = CreateBasicProject(withOpenApi: false);
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--output-file", Path.Combine("outputdir", "file.yaml") });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var expectedJsonName = Path.Combine("outputdir", "file.yaml");
+
+            // csproj contents
+            using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.Contains(
+    $@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}"" />", content);
+            }
+
+            var resultFile = Path.Combine(_tempDir.Root, expectedJsonName);
+            Assert.True(File.Exists(resultFile));
+            using (var jsonStream = new FileInfo(resultFile).OpenRead())
+            using (var reader = new StreamReader(jsonStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Equal(Content, content);
+            }
+        }
+
+        [Fact]
+        public void OpenApi_Add_URL_MultipleTimes_OnlyOneReference()
+        {
+            var project = CreateBasicProject(withOpenApi: false);
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            app = GetApplication();
+            run = app.Execute(new[] { "add", "url", "--output-file", "openapi.yaml", FakeOpenApiUrl });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            // csproj contents
+            var csproj = new FileInfo(project.Project.Path);
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = reader.ReadToEnd();
+                var escapedPkgRef = Regex.Escape("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"");
+                Assert.Single(Regex.Matches(content, escapedPkgRef));
+                var escapedApiRef = Regex.Escape($"SourceUrl=\"{FakeOpenApiUrl}\"");
+                Assert.Single(Regex.Matches(content, escapedApiRef));
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -38,8 +38,9 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
     $@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}"" />", content);
             }
 
-            Assert.True(File.Exists(expectedJsonName));
-            using (var jsonStream = new FileInfo(expectedJsonName).OpenRead())
+            var jsonFile = Path.Combine(_tempDir.Root, expectedJsonName);
+            Assert.True(File.Exists(jsonFile));
+            using (var jsonStream = new FileInfo(jsonFile).OpenRead())
             using (var reader = new StreamReader(jsonStream))
             {
                 var content = await reader.ReadToEndAsync();

--- a/src/Tools/dotnet-openapi/test/OpenApiRefreshTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiRefreshTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.OpenApi.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.OpenApi.Refresh.Tests
+{
+    public class OpenApiRefreshTests : OpenApiTestBase
+    {
+        public OpenApiRefreshTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public async Task OpenApi_Refresh_Basic()
+        {
+            CreateBasicProject(withOpenApi: false);
+
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var expectedJsonPath = Path.Combine(_tempDir.Root, "openapi", "openapi.json");
+            var json = await File.ReadAllTextAsync(expectedJsonPath);
+            json += "trash";
+            await File.WriteAllTextAsync(expectedJsonPath, json);
+
+            var firstWriteTime = File.GetLastWriteTime(expectedJsonPath);
+
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+
+            app = GetApplication();
+            run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
+            Assert.True(firstWriteTime < secondWriteTime, $"File wasn't updated! {firstWriteTime} {secondWriteTime}");
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/OpenApiRemoveTests.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiRemoveTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.OpenApi.Tests;
+using Microsoft.Extensions.Tools.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.OpenApi.Remove.Tests
+{
+    public class OpenApiRemoveTests : OpenApiTestBase
+    {
+        public OpenApiRemoveTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public async Task OpenApi_Remove_File()
+        {
+            var nswagJsonFile = "openapi.json";
+            _tempDir
+                .WithCSharpProject("testproj")
+                .WithTargetFrameworks("netcoreapp3.0")
+                .Dir()
+                .WithContentFile(nswagJsonFile)
+                .WithContentFile("Startup.cs")
+                .Create();
+
+            var add = GetApplication();
+            var run = add.Execute(new[] { "add", "file", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            // csproj contents
+            var csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\"", content);
+            }
+
+            var remove = GetApplication();
+            var removeRun = remove.Execute(new[] { "remove", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, removeRun);
+
+            // csproj contents
+            csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                // Don't remove the package reference, they might have taken other dependencies on it
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.DoesNotContain($"<OpenApiReference Include=\"{nswagJsonFile}\"", content);
+            }
+            Assert.False(File.Exists(Path.Combine(_tempDir.Root, nswagJsonFile)));
+        }
+
+        [Fact]
+        public async Task OpenApi_Remove_ViaUrl()
+        {
+            _tempDir
+                .WithCSharpProject("testproj")
+                .WithTargetFrameworks("netcoreapp3.0")
+                .Dir()
+                .WithContentFile("Startup.cs")
+                .Create();
+
+            var url = "https://contoso.com/swagger.json";
+            var add = GetApplication();
+            var run = add.Execute(new[] { "add", "url", url});
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var remove = GetApplication();
+            var removeRun = remove.Execute(new[] { "remove", url});
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, removeRun);
+
+            // csproj contents
+            var csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                // Don't remove the package reference, they might have taken other dependencies on it
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.DoesNotContain($"<OpenApiReference", content);
+            }
+        }
+
+        [Fact]
+        public async Task OpenApi_Remove_Project()
+        {
+            _tempDir
+               .WithCSharpProject("testproj")
+               .WithTargetFrameworks("netcoreapp3.0")
+               .Dir()
+               .WithContentFile("Startup.cs")
+               .Create();
+
+            using(var refProj = new TemporaryDirectory())
+            {
+                var refProjName = "refProj";
+                refProj
+                    .WithCSharpProject(refProjName)
+                    .WithTargetFrameworks("netcoreapp3.0")
+                    .Dir()
+                    .Create();
+
+                var app = GetApplication();
+                var refProjFile = Path.Join(refProj.Root, $"{refProjName}.csproj");
+                var run = app.Execute(new[] { "add", "project", refProjFile });
+
+                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+                Assert.Equal(0, run);
+
+                // csproj contents
+                using (var csprojStream = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj")).OpenRead())
+                using (var reader = new StreamReader(csprojStream))
+                {
+                    var content = await reader.ReadToEndAsync();
+                    Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                    Assert.Contains($"<OpenApiProjectReference Include=\"{refProjFile}\"", content);
+                }
+
+                var remove = GetApplication();
+                run = app.Execute(new[] { "remove", refProjFile });
+
+                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+                Assert.Equal(0, run);
+
+                // csproj contents
+                using (var csprojStream = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj")).OpenRead())
+                using (var reader = new StreamReader(csprojStream))
+                {
+                    var content = await reader.ReadToEndAsync();
+                    Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                    Assert.DoesNotContain($"<OpenApiProjectReference Include=\"{refProjFile}\"", content);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task OpenApi_Remove_Multiple()
+        {
+            var nswagJsonFile = "openapi.json";
+            var swagFile2 = "swag2.json";
+            _tempDir
+                .WithCSharpProject("testproj")
+                .WithTargetFrameworks("netcoreapp3.0")
+                .Dir()
+                .WithContentFile(nswagJsonFile)
+                .WithFile(swagFile2)
+                .WithContentFile("Startup.cs")
+                .Create();
+
+            var add = GetApplication();
+            var run = add.Execute(new[] { "add", "file", nswagJsonFile });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            add = GetApplication();
+            run = add.Execute(new[] { "add", "file", swagFile2});
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, run);
+
+            var remove = GetApplication();
+            var removeRun = remove.Execute(new[] { "remove", nswagJsonFile, swagFile2 });
+
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, removeRun);
+
+            // csproj contents
+            var csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
+            using (var csprojStream = csproj.OpenRead())
+            using (var reader = new StreamReader(csprojStream))
+            {
+                var content = await reader.ReadToEndAsync();
+                // Don't remove the package reference, they might have taken other dependencies on it
+                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+                Assert.DoesNotContain($"<OpenApiReference Include=\"{nswagJsonFile}\"", content);
+            }
+            Assert.False(File.Exists(Path.Combine(_tempDir.Root, nswagJsonFile)));
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/OpenApiTestBase.cs
+++ b/src/Tools/dotnet-openapi/test/OpenApiTestBase.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Tools.Internal;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.OpenApi.Tests
+{
+    public class OpenApiTestBase : IDisposable
+    {
+        protected readonly TemporaryDirectory _tempDir;
+        protected readonly TextWriter _output = new StringWriter();
+        protected readonly TextWriter _error = new StringWriter();
+        protected readonly ITestOutputHelper _outputHelper;
+
+        protected const string Content = @"{""x-generator"": ""NSwag""}";
+        protected const string FakeOpenApiUrl = "https://contoso.com/openapi.json";
+
+        public OpenApiTestBase(ITestOutputHelper output)
+        {
+            _tempDir = new TemporaryDirectory();
+            _outputHelper = output;
+        }
+
+        public TemporaryNSwagProject CreateBasicProject(bool withOpenApi)
+        {
+            var nswagJsonFile = "openapi.json";
+            var project = _tempDir
+                .WithCSharpProject("testproj", sdk: "Microsoft.NET.Sdk.Web")
+                .WithTargetFrameworks("netcoreapp3.0");
+            var tmp = project.Dir();
+
+            if (withOpenApi)
+            {
+                tmp = tmp.WithContentFile(nswagJsonFile);
+            }
+
+            tmp.WithContentFile("Startup.cs")
+                .Create();
+
+            return new TemporaryNSwagProject(project, nswagJsonFile);
+        }
+
+        internal Application GetApplication()
+        {
+            AnnounceTestStart();
+
+            return new Application(
+                _tempDir.Root,
+                DownloadMock, _output, _error);
+        }
+
+        private void AnnounceTestStart()
+        {
+            var type = _outputHelper.GetType();
+            var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            var test = (ITest)testMember.GetValue(_outputHelper);
+            _outputHelper.WriteLine($"Starting test '{test.DisplayName}'");
+        }
+
+        private Task<Stream> DownloadMock(string url)
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+
+            _outputHelper.WriteLine($"Content to write: {Content}");
+            writer.Write(Content);
+            writer.Flush();
+            stream.Position = 0;
+
+            return Task.FromResult((Stream)stream);
+        }
+
+        public void Dispose()
+        {
+            _outputHelper.WriteLine(_output.ToString());
+            _tempDir.Dispose();
+        }
+    }
+
+    public class TemporaryNSwagProject
+    {
+        public TemporaryNSwagProject(TemporaryCSharpProject project, string jsonFile)
+        {
+            Project = project;
+            NSwagJsonFile = jsonFile;
+        }
+
+        public TemporaryCSharpProject Project { get; set; }
+        public string NSwagJsonFile { get; set; }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/ProcessEx.cs
+++ b/src/Tools/dotnet-openapi/test/ProcessEx.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal class ProcessEx : IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly Process _process;
+        private readonly StringBuilder _stderrCapture = new StringBuilder();
+        private readonly StringBuilder _stdoutCapture = new StringBuilder();
+        private readonly object _pipeCaptureLock = new object();
+        private BlockingCollection<string> _stdoutLines = new BlockingCollection<string>();
+        private TaskCompletionSource<int> _exited;
+
+        private ProcessEx(ITestOutputHelper output, Process proc)
+        {
+            _output = output;
+
+            _process = proc;
+            proc.EnableRaisingEvents = true;
+            proc.OutputDataReceived += OnOutputData;
+            proc.ErrorDataReceived += OnErrorData;
+            proc.Exited += OnProcessExited;
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+
+            _exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public Task Exited => _exited.Task;
+
+        public bool HasExited => _process.HasExited;
+
+        public string Output
+        {
+            get
+            {
+                lock (_pipeCaptureLock)
+                {
+                    return _stdoutCapture.ToString();
+                }
+            }
+        }
+
+        public int ExitCode => _process.ExitCode;
+
+        public static ProcessEx Run(ITestOutputHelper output, string workingDirectory, string command, string args = null, IDictionary<string, string> envVars = null)
+        {
+            var startInfo = new ProcessStartInfo(command, args)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = workingDirectory
+            };
+
+            if (envVars != null)
+            {
+                foreach (var envVar in envVars)
+                {
+                    startInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
+                }
+            }
+
+            output.WriteLine($"==> {startInfo.FileName} {startInfo.Arguments} [{startInfo.WorkingDirectory}]");
+            var proc = Process.Start(startInfo);
+
+            return new ProcessEx(output, proc);
+        }
+
+        private void OnErrorData(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+            {
+                return;
+            }
+
+            lock (_pipeCaptureLock)
+            {
+                _stderrCapture.AppendLine(e.Data);
+            }
+
+            _output.WriteLine("[ERROR] " + e.Data);
+        }
+
+        private void OnOutputData(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+            {
+                return;
+            }
+
+            lock (_pipeCaptureLock)
+            {
+                _stdoutCapture.AppendLine(e.Data);
+            }
+
+            _output.WriteLine(e.Data);
+
+            if (_stdoutLines != null)
+            {
+                _stdoutLines.Add(e.Data);
+            }
+        }
+
+        private void OnProcessExited(object sender, EventArgs e)
+        {
+            _process.WaitForExit();
+            _stdoutLines.CompleteAdding();
+            _stdoutLines = null;
+            _exited.TrySetResult(_process.ExitCode);
+        }
+
+        public void Dispose()
+        {
+            if (_process != null && !_process.HasExited)
+            {
+                _process.KillTree();
+            }
+
+            _process.CancelOutputRead();
+            _process.CancelErrorRead();
+
+            _process.ErrorDataReceived -= OnErrorData;
+            _process.OutputDataReceived -= OnOutputData;
+            _process.Exited -= OnProcessExited;
+            _process.Dispose();
+
+            if(_stdoutLines != null)
+            {
+                _stdoutLines.Dispose();
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-openapi/test/Properties/AssemblyInfo.cs
+++ b/src/Tools/dotnet-openapi/test/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Tools/dotnet-openapi/test/TestContent/Startup.cs.txt
+++ b/src/Tools/dotnet-openapi/test/TestContent/Startup.cs.txt
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
+
+namespace SimpleWebSite
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Example 1
+            services
+                .AddMvcCore()
+                .AddAuthorization()
+                .AddFormatterMappings(m => m.SetMediaTypeMappingForFormat("js", new MediaTypeHeaderValue("application/json")))
+                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseMvcWithDefaultRoute();
+        }
+
+        public static void Main(string[] args)
+        {
+            var host = CreateWebHostBuilder(args)
+                .Build();
+
+            host.Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            new WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseStartup<Startup>()
+                .UseKestrel()
+                .UseIISIntegration();
+    }
+}

--- a/src/Tools/dotnet-openapi/test/TestContent/openapi.json.txt
+++ b/src/Tools/dotnet-openapi/test/TestContent/openapi.json.txt
@@ -1,0 +1,514 @@
+{
+  "x-generator": "NSwag v11.17.15.0 (NJsonSchema v9.10.53.0 (Newtonsoft.Json v10.0.0.0))",
+  "openapi": "2.0",
+  "info": {
+    "title": "My Title",
+    "version": "1.0.0"
+  },
+  "host": "localhost:44370",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "application/json-patch+json",
+    "text/json",
+    "application/*+json",
+    "multipart/form-data"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_AddPet",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            },
+            "x-nullable": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_EditPet",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            },
+            "x-nullable": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          }
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_FindByStatus",
+        "consumes": [
+          "application/json-patch+json",
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "x-nullable": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/findByCategory": {
+      "get": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_FindByCategory",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "category",
+            "in": "query",
+            "required": true,
+            "x-nullable": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          }
+        }
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_FindById",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_EditPet2",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          },
+          {
+            "type": "integer",
+            "name": "Id",
+            "in": "formData",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          },
+          {
+            "type": "integer",
+            "name": "Age",
+            "in": "formData",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          },
+          {
+            "type": "integer",
+            "name": "Category.Id",
+            "in": "formData",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          },
+          {
+            "type": "string",
+            "name": "Category.Name",
+            "in": "formData",
+            "required": true,
+            "x-nullable": true
+          },
+          {
+            "type": "boolean",
+            "name": "HasVaccinations",
+            "in": "formData",
+            "required": true,
+            "x-nullable": false
+          },
+          {
+            "type": "string",
+            "name": "Name",
+            "in": "formData",
+            "required": true,
+            "x-nullable": true
+          },
+          {
+            "type": "array",
+            "name": "Images",
+            "in": "formData",
+            "required": true,
+            "collectionFormat": "multi",
+            "x-nullable": true,
+            "items": {
+              "$ref": "#/definitions/Image"
+            }
+          },
+          {
+            "type": "array",
+            "name": "Tags",
+            "in": "formData",
+            "required": true,
+            "collectionFormat": "multi",
+            "x-nullable": true,
+            "items": {
+              "$ref": "#/definitions/Tag"
+            }
+          },
+          {
+            "type": "string",
+            "name": "Status",
+            "in": "formData",
+            "required": true,
+            "x-nullable": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_DeletePet",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "Pet"
+        ],
+        "operationId": "Pet_UploadImage",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "format": "int32",
+            "x-nullable": false
+          },
+          {
+            "type": "file",
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "x-nullable": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          },
+          "400": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SerializableError"
+            }
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "age",
+        "hasVaccinations",
+        "name",
+        "status"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "age": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 150.0,
+          "minimum": 0.0
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "hasVaccinations": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 50,
+          "minLength": 2
+        },
+        "images": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Image"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    },
+    "Category": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "SerializableError": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      ]
+    },
+    "ApiResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/Tools/dotnet-openapi/test/dotnet-openapi.Tests.csproj
+++ b/src/Tools/dotnet-openapi/test/dotnet-openapi.Tests.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AssemblyName>Microsoft.DotNet.Open.Api.Tools.Tests</AssemblyName>
+    <DefaultItemExcludes>$(DefaultItemExcludes);TestProjects\**\*</DefaultItemExcludes>
+    <TestGroupName>DotNetAddServiceReferenceToolsTests</TestGroupName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(ToolSharedSourceRoot)TestHelpers\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />
+    <Content Include="TestContent\*" LinkBase="TestContent\" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="$(SharedSourceRoot)Process\ProcessExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <ProjectReference Include="..\src\dotnet-openapi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>TestSettings:RestoreSources</_Parameter1>
+      <_Parameter2>$(RestoreSources)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>TestSettings:RuntimeFrameworkVersion</_Parameter1>
+      <_Parameter2>$(RuntimeFrameworkVersion)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>RepoRoot</_Parameter1>
+      <_Parameter2>$(RepoRoot)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <Target Name="CleanTestProjects" BeforeTargets="CoreCompile">
+    <RemoveDir Directories="$(TargetDir)TestProjects" Condition="Exists('$(TargetDir)TestProjects')" />
+  </Target>
+
+  <Target Name="PublishDotNetOpenApiOnBuild" BeforeTargets="Build">
+    <MSBuild Projects="..\src\dotnet-openapi.csproj" Targets="Publish" Properties="PublishDir=$(OutputPath)\tool\;Configuration=$(Configuration)" />
+  </Target>
+
+  <Target Name="PublishDotNetOpenApiOnPublish" BeforeTargets="Publish">
+    <MSBuild Projects="..\src\dotnet-openapi.csproj" Targets="Publish" Properties="PublishDir=$(PublishDir)\tool\;Configuration=$(Configuration)" />
+  </Target>
+</Project>

--- a/src/Tools/dotnet-openapi/test/xunit.runner.json
+++ b/src/Tools/dotnet-openapi/test/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "longRunningTestSeconds": 30,
+  "diagnosticMessages": true,
+  "maxParallelThreads": -1
+}

--- a/src/Tools/dotnet-watch/src/PrefixConsoleReporter.cs
+++ b/src/Tools/dotnet-watch/src/PrefixConsoleReporter.cs
@@ -11,18 +11,20 @@ namespace Microsoft.DotNet.Watcher
     {
         private object _lock = new object();
 
-        public PrefixConsoleReporter(IConsole console, bool verbose, bool quiet)
+        private readonly string _prefix;
+
+        public PrefixConsoleReporter(string prefix, IConsole console, bool verbose, bool quiet)
             : base(console, verbose, quiet)
-        { }
+        {
+            _prefix = prefix;
+        }
 
         protected override void WriteLine(TextWriter writer, string message, ConsoleColor? color)
         {
-            const string prefix = "watch : ";
-
             lock (_lock)
             {
                 Console.ForegroundColor = ConsoleColor.DarkGray;
-                writer.Write(prefix);
+                writer.Write(_prefix);
                 Console.ResetColor();
 
                 base.WriteLine(writer, message, color);

--- a/src/Tools/dotnet-watch/src/Program.cs
+++ b/src/Tools/dotnet-watch/src/Program.cs
@@ -15,17 +15,17 @@ namespace Microsoft.DotNet.Watcher
     public class Program : IDisposable
     {
         private readonly IConsole _console;
-        private readonly string _workingDir;
+        private readonly string _workingDirectory;
         private readonly CancellationTokenSource _cts;
         private IReporter _reporter;
 
-        public Program(IConsole console, string workingDir)
+        public Program(IConsole console, string workingDirectory)
         {
             Ensure.NotNull(console, nameof(console));
-            Ensure.NotNullOrEmpty(workingDir, nameof(workingDir));
+            Ensure.NotNullOrEmpty(workingDirectory, nameof(workingDirectory));
 
             _console = console;
-            _workingDir = workingDir;
+            _workingDirectory = workingDirectory;
             _cts = new CancellationTokenSource();
             _console.CancelKeyPress += OnCancelKeyPress;
             _reporter = CreateReporter(verbose: true, quiet: false, console: _console);
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Watcher
             string projectFile;
             try
             {
-                projectFile = MsBuildProjectFinder.FindMsBuildProject(_workingDir, project);
+                projectFile = MsBuildProjectFinder.FindMsBuildProject(_workingDirectory, project);
             }
             catch (FileNotFoundException ex)
             {
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Watcher
             string projectFile;
             try
             {
-                projectFile = MsBuildProjectFinder.FindMsBuildProject(_workingDir, project);
+                projectFile = MsBuildProjectFinder.FindMsBuildProject(_workingDirectory, project);
             }
             catch (FileNotFoundException ex)
             {
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Watcher
         }
 
         private static IReporter CreateReporter(bool verbose, bool quiet, IConsole console)
-            => new PrefixConsoleReporter(console, verbose || CliContext.IsGlobalVerbose(), quiet);
+            => new PrefixConsoleReporter("watch : ", console, verbose || CliContext.IsGlobalVerbose(), quiet);
 
         public void Dispose()
         {

--- a/src/Tools/dotnet-watch/src/dotnet-watch.csproj
+++ b/src/Tools/dotnet-watch/src/dotnet-watch.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(SharedSourceRoot)Process\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Process\ProcessExtensions.cs" />
     <Compile Include="$(ToolSharedSourceRoot)CommandLine\**\*.cs" />
     <None Include="assets\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Tools/dotnet-watch/test/AssertEx.cs
+++ b/src/Tools/dotnet-watch/test/AssertEx.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Xunit;
 using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Watcher.Tools.Tests

--- a/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
+++ b/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -113,17 +113,20 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         public async Task MultiTfm()
         {
             _tempDir
-               .SubDir("src")
-                   .SubDir("Project1")
-                       .WithCSharpProject("Project1", out var target)
-                       .WithTargetFrameworks("netcoreapp1.0", "net451")
-                       .WithProperty("EnableDefaultCompileItems", "false")
-                       .WithItem("Compile", "Class1.netcore.cs", "'$(TargetFramework)'=='netcoreapp1.0'")
-                       .WithItem("Compile", "Class1.desktop.cs", "'$(TargetFramework)'=='net451'")
-                       .Dir()
-                       .WithFile("Class1.netcore.cs")
-                       .WithFile("Class1.desktop.cs")
-                       .WithFile("Class1.notincluded.cs");
+                .SubDir("src")
+                    .SubDir("Project1")
+                        .WithCSharpProject("Project1", out var target)
+                        .WithTargetFrameworks("netcoreapp1.0", "net451")
+                        .WithProperty("EnableDefaultCompileItems", "false")
+                        .WithItem("Compile", "Class1.netcore.cs", "'$(TargetFramework)'=='netcoreapp1.0'")
+                        .WithItem("Compile", "Class1.desktop.cs", "'$(TargetFramework)'=='net451'")
+                        .Dir()
+                        .WithFile("Class1.netcore.cs")
+                        .WithFile("Class1.desktop.cs")
+                        .WithFile("Class1.notincluded.cs")
+                    .Up()
+                .Up()
+                .Create();
 
             var fileset = await GetFileSet(target);
 
@@ -155,7 +158,10 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
                         .WithTargetFrameworks("netcoreapp1.0", "net451")
                         .WithProjectReference(proj2)
                         .Dir()
-                        .WithFile("Class1.cs");
+                        .WithFile("Class1.cs")
+                    .Up()
+                .Up()
+                .Create();
 
             var fileset = await GetFileSet(target);
 

--- a/src/Tools/dotnet-watch/test/Utilities/TestProjectGraph.cs
+++ b/src/Tools/dotnet-watch/test/Utilities/TestProjectGraph.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools.Tests
 {
@@ -10,7 +11,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
     {
         private readonly TemporaryDirectory _directory;
         private Action<TemporaryCSharpProject> _onCreate;
-        private Dictionary<string, TemporaryCSharpProject> _projects = new Dictionary<string, TemporaryCSharpProject>();
+        private readonly Dictionary<string, TemporaryCSharpProject> _projects = new Dictionary<string, TemporaryCSharpProject>();
         public TestProjectGraph(TemporaryDirectory directory)
         {
             _directory = directory;
@@ -28,8 +29,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
         public TemporaryCSharpProject GetOrCreate(string projectName)
         {
-            TemporaryCSharpProject sourceProj;
-            if (!_projects.TryGetValue(projectName, out sourceProj))
+            if (!_projects.TryGetValue(projectName, out TemporaryCSharpProject sourceProj))
             {
                 sourceProj = _directory.SubDir(projectName).WithCSharpProject(projectName);
                 _onCreate?.Invoke(sourceProj);

--- a/src/Tools/dotnet-watch/test/dotnet-watch.Tests.csproj
+++ b/src/Tools/dotnet-watch/test/dotnet-watch.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>


### PR DESCRIPTION
The OpenAPI part of https://github.com/aspnet/specs/pull/276.

#### Description
Create a CLI tool which can be used to add OpenAPIReferences to a project, to be used by the Service Reference feature to generate a client for the given service.

#### Customer impact
Without this tool customers will have to either add service references by hand or through Visual Studio.

#### Regression?
No, this is an entirely new package.

#### Risk
Very low chance of breaking existing workflows since the tool is not currently available. Moderate-to-high risk of unintended behavior in the tool since it's entirely new code which hasn't yet been exercised by users.