### PR TITLE
Remove gRPC template workarounds

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" Generator="MSBuild:Compile"/>
-    <Content Include="@(Protobuf)" />
-    <None Remove="@(Protobuf)" />
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/202. Requires changes from https://github.com/grpc/grpc/pull/18678 and https://github.com/grpc/grpc-dotnet/pull/231 to ensure DesignTime Build is still triggered.