### PR TITLE
Make OIDC handler skip unrecognized requests

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -515,7 +515,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 authorizationResponse = messageReceivedContext.ProtocolMessage;
                 properties = messageReceivedContext.Properties;
 
-                if (properties == null)
+                if (properties == null || properties.Items.Count == 0)
                 {
                     // Fail if state is missing, it's required for the correlation id.
                     if (string.IsNullOrEmpty(authorizationResponse.State))

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectAuthenticateTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectAuthenticateTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
+{
+    public class OpenIdConnectAuthenticateTests
+    {
+        [Fact]
+        public async Task RegularGetRequestToCallbackPathSkips()
+        {
+            // Arrange
+            var settings = new TestSettings(
+                opt =>
+                {
+                    opt.Authority = TestServerBuilder.DefaultAuthority;
+                    opt.CallbackPath = new PathString("/");
+                    opt.SkipUnrecognizedRequests = true;
+                    opt.ClientId = "Test Id";
+                });
+
+            var server = settings.CreateTestServer(handler: async context =>
+            {
+                await context.Response.WriteAsync("Hi from the callback path");
+            });
+
+            // Act
+            var transaction = await server.SendAsync("/");
+
+            // Assert
+            Assert.Equal("Hi from the callback path", transaction.ResponseText);
+        }
+
+        [Fact]
+        public async Task RegularPostRequestToCallbackPathSkips()
+        {
+            // Arrange
+            var settings = new TestSettings(
+                opt =>
+                {
+                    opt.Authority = TestServerBuilder.DefaultAuthority;
+                    opt.CallbackPath = new PathString("/");
+                    opt.SkipUnrecognizedRequests = true;
+                    opt.ClientId = "Test Id";
+                });
+
+            var server = settings.CreateTestServer(handler: async context =>
+            {
+                await context.Response.WriteAsync("Hi from the callback path");
+            });
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Post, "/");
+            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>());
+
+            var transaction = await server.SendAsync(request, cookieHeader: null);
+
+            // Assert
+            Assert.Equal("Hi from the callback path", transaction.ResponseText);
+        }
+    }
+}

--- a/src/Security/Authentication/test/OpenIdConnect/TestServerExtensions.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/TestServerExtensions.cs
@@ -16,9 +16,13 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             return SendAsync(server, url, cookieHeader: null);
         }
 
-        public static async Task<TestTransaction> SendAsync(this TestServer server, string uri, string cookieHeader)
+        public static Task<TestTransaction> SendAsync(this TestServer server, string url, string cookieHeader)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            return SendAsync(server, new HttpRequestMessage(HttpMethod.Get, url), cookieHeader);
+        }
+
+        public static async Task<TestTransaction> SendAsync(this TestServer server, HttpRequestMessage request, string cookieHeader)
+        {
             if (!string.IsNullOrEmpty(cookieHeader))
             {
                 request.Headers.Add("Cookie", cookieHeader);


### PR DESCRIPTION
 - Honor the `SkipUnrecognizedRequests` property by skipping them, as they currently throw

Addresses #10028 
