### PR TITLE
Avoid using exception filters for AOT runtimes

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -208,12 +208,16 @@ namespace Microsoft.AspNetCore.Components
                 {
                     await task;
                 }
-                catch when (task.IsCanceled)
+                catch // avoiding exception filters for AOT runtime support
                 {
                     // Ignore exceptions from task cancelletions.
                     // Awaiting a canceled task may produce either an OperationCanceledException (if produced as a consequence of
                     // CancellationToken.ThrowIfCancellationRequested()) or a TaskCanceledException (produced as a consequence of awaiting Task.FromCanceled).
                     // It's much easier to check the state of the Task (i.e. Task.IsCanceled) rather than catch two distinct exceptions.
+                     if (!task.IsCanceled)
+                     {
+                        throw;
+                     }
                 }
 
                 // Don't call StateHasChanged here. CallOnParametersSetAsync should handle that for us.
@@ -247,10 +251,15 @@ namespace Microsoft.AspNetCore.Components
             {
                 await task;
             }
-            catch when (task.IsCanceled)
+            catch // avoiding exception filters for AOT runtime support
             {
                 // Ignore exceptions from task cancelletions, but don't bother issuing a state change.
-                return;
+                if (task.IsCanceled)
+                {
+                    return;
+                }
+
+                throw;
             }
 
             StateHasChanged();

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -523,12 +523,13 @@ namespace Microsoft.AspNetCore.Components.Rendering
             {
                 await updateDisplayTask;
             }
-            catch when (updateDisplayTask.IsCanceled)
+            catch // avoiding exception filters for AOT runtimes
             {
-                return;
-            }
-            catch when (updateDisplayTask.IsFaulted)
-            {
+                if (updateDisplayTask.IsCanceled)
+                {
+                    return;
+                }
+
                 HandleException(updateDisplayTask.Exception);
                 return;
             }


### PR DESCRIPTION
LLVM does not currently have IR to represent filter expressions and mono relies on LLVM IR when AOTing. Removing the exception filters allow these methods to function properly in AOT and mixed (AOT+interpreter) modes for WebAssembly
