### PR TITLE
Improve robustness of components Bind and EventBubbling E2E tests

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
@@ -38,9 +38,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
         protected SelectElement WaitUntilTestSelectorReady()
         {
             var elemToFind = By.CssSelector("#test-selector > select");
-            new WebDriverWait(Browser, TimeSpan.FromSeconds(30)).Until(
-                driver => driver.FindElement(elemToFind) != null);
+            WaitUntilExists(elemToFind, timeoutSeconds: 30);
             return new SelectElement(Browser.FindElement(elemToFind));
+        }
+
+        protected IWebElement WaitUntilExists(By findBy, int timeoutSeconds = 10)
+        {
+            IWebElement result = null;
+            new WebDriverWait(Browser, TimeSpan.FromSeconds(timeoutSeconds))
+                .Until(driver => (result = driver.FindElement(findBy)) != null);
+            return result;
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
@@ -28,6 +27,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // On WebAssembly, page reloads are expensive so skip if possible
             Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
             MountTestComponent<BindCasesComponent>();
+            WaitUntilExists(By.Id("bind-cases"));
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
             MountTestComponent<EventBubblingComponent>();
+            WaitUntilExists(By.Id("event-bubbling"));
         }
 
         [Fact]

--- a/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
@@ -1,3 +1,5 @@
+<h3 id="bind-cases">Bind cases</h3>
+
 <h2>Textbox</h2>
 <p>
     Initially blank:

--- a/src/Components/test/testassets/BasicTestApp/EventBubblingComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/EventBubblingComponent.razor
@@ -1,4 +1,4 @@
-﻿<h3>Bubbling standard event</h3>
+<h3 id="event-bubbling">Bubbling standard event</h3>
 
 <div onclick="@(() => LogEvent("parent onclick"))">
     <button id="button-with-onclick" onclick="@(() => LogEvent("target onclick"))">Button with onclick handler</button>


### PR DESCRIPTION
Hopefully addresses https://github.com/aspnet/AspNetCore/pull/10054#issuecomment-490298528

Judging from the stack traces, it looks like `ServerBindTest` and `ServerEventBubblingTest` are both exposed to the risk that after `MountTestComponent<T>`, the test proceeds too quickly and tries to start operating on things before the component has done its initial render. This PR puts in an extra "wait" in the `InitializeAsyncCore` for both so that they pause until the initial render has definitely happened.