### PR TITLE
In components E2E tests, always wait for initial render after each MountTestComponent call

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
@@ -33,11 +33,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
 
             // Wait until we've torn down any earlier component
             testSelector.SelectByValue("none");
-            WaitUntilExists(By.Id("no-test-selected"));
+            WaitUntilExists(By.Id("no-test-selected"), timeoutSeconds: 30);
 
             // Wait until we've done the initial render for the new component
             testSelector.SelectByValue(componentTypeName);
-            return WaitUntilExists(By.TagName("app"));
+            return WaitUntilExists(By.TagName("app"), timeoutSeconds: 30);
         }
 
         protected SelectElement WaitUntilTestSelectorReady()

--- a/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
@@ -30,9 +30,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
         {
             var componentTypeName = typeof(TComponent).FullName;
             var testSelector = WaitUntilTestSelectorReady();
+
+            // Wait until we've torn down any earlier component
             testSelector.SelectByValue("none");
+            WaitUntilExists(By.Id("no-test-selected"));
+
+            // Wait until we've done the initial render for the new component
             testSelector.SelectByValue(componentTypeName);
-            return Browser.FindElement(By.TagName("app"));
+            return WaitUntilExists(By.TagName("app"));
         }
 
         protected SelectElement WaitUntilTestSelectorReady()

--- a/src/Components/test/E2ETest/Properties/AssemblyInfo.cs
+++ b/src/Components/test/E2ETest/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+// Parallelism causes issues with the server-side execution tests. It's not clear why, since
+// we have separate browser and server instances for different test collections (i.e., classes)
+// so they should be entirely isolated anyway. When parallelism is on, we can observe intermittent
+// interference between test classes, for example test A observing the UI state of test B, which
+// suggests that either Selenium has thread-safety issues that direct commands to the wrong
+// browser instance, or something in our tracking of browser instances goes wrong.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Components/test/E2ETest/Tests/ClientSideHostingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ClientSideHostingTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         private void WaitUntilLoaded()
         {
             new WebDriverWait(Browser, TimeSpan.FromSeconds(30)).Until(
-                driver => driver.FindElement(By.TagName("app")).Text != "Loading...");
+                driver => driver.FindElement(By.Id("no-test-selected")));
         }
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -61,9 +61,16 @@
   <hr />
 </div>
 
-<app>
-    @((RenderFragment)RenderSelectedComponent)
-</app>
+@if (SelectedComponentType != null)
+{
+    <app>
+        @((RenderFragment)RenderSelectedComponent)
+    </app>
+}
+else
+{
+    <div id="no-test-selected">Select a test case from the dropdown</div>
+}
 
 @functions {
     string SelectedComponentTypeName { get; set; } = "none";
@@ -73,10 +80,7 @@
 
     void RenderSelectedComponent(RenderTreeBuilder builder)
     {
-        if (SelectedComponentType != null)
-        {
-            builder.OpenComponent(0, SelectedComponentType);
-            builder.CloseComponent();
-        }
+        builder.OpenComponent(0, SelectedComponentType);
+        builder.CloseComponent();
     }
 }

--- a/src/Shared/E2ETesting/WaitAssert.cs
+++ b/src/Shared/E2ETesting/WaitAssert.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.E2ETesting
 
     public static class WaitAssert
     {
-        public static TimeSpan DefaultTimeout = TimeSpan.FromSeconds(3);
+        public static TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
         public static void Equal<T>(this IWebDriver driver, T expected, Func<T> actual)
             => WaitAssertCore(driver, () => Assert.Equal(expected, actual()));


### PR DESCRIPTION
This *might* wipe out a huge amount of the flakiness we've experienced in the last few days.

I said we needed something unique to signal the start of each test case, but thinking a step further, that should be unnecessary. We can explicitly wait for the last test case to be removed from the DOM, and then wait for the DOM to be updated a further time for the new test case.