### PR TITLE
suppress ExecutionContext by default in TestServer

### DIFF
--- a/src/Hosting/TestHost/ref/Microsoft.AspNetCore.TestHost.netcoreapp3.0.cs
+++ b/src/Hosting/TestHost/ref/Microsoft.AspNetCore.TestHost.netcoreapp3.0.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNetCore.TestHost
         public System.Uri BaseAddress { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Http.Features.IFeatureCollection Features { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Hosting.IWebHost Host { get { throw null; } }
+        public bool PreserveExecutionContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Net.Http.HttpClient CreateClient() { throw null; }
         public System.Net.Http.HttpMessageHandler CreateHandler() { throw null; }
         public Microsoft.AspNetCore.TestHost.RequestBuilder CreateRequest(string path) { throw null; }

--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -45,6 +45,8 @@ namespace Microsoft.AspNetCore.TestHost
 
         internal bool AllowSynchronousIO { get; set; }
 
+        internal bool PreserveExecutionContext { get; set; }
+
         /// <summary>
         /// This adapts HttpRequestMessages to ASP.NET Core requests, dispatches them through the pipeline, and returns the
         /// associated HttpResponseMessage.
@@ -117,7 +119,7 @@ namespace Microsoft.AspNetCore.TestHost
                 responseBody = context.Response.Body;
             });
 
-            var httpContext = await contextBuilder.SendAsync(cancellationToken);
+            var httpContext = await contextBuilder.SendAsync(cancellationToken, PreserveExecutionContext);
 
             var response = new HttpResponseMessage();
             response.StatusCode = (HttpStatusCode)httpContext.Response.StatusCode;

--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.TestHost
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO);
+            var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO, PreserveExecutionContext);
 
             Stream responseBody = null;
             var requestContent = request.Content ?? new StreamContent(Stream.Null);
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.TestHost
                 responseBody = context.Response.Body;
             });
 
-            var httpContext = await contextBuilder.SendAsync(cancellationToken, PreserveExecutionContext);
+            var httpContext = await contextBuilder.SendAsync(cancellationToken);
 
             var response = new HttpResponseMessage();
             response.StatusCode = (HttpStatusCode)httpContext.Response.StatusCode;

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -62,11 +62,12 @@ namespace Microsoft.AspNetCore.TestHost
         {
             var registration = cancellationToken.Register(AbortRequest);
 
-            // Everything inside this function happens in the SERVER's ExecutionContext (unless PreserveExecutionContext is true)
+            // Everything inside this function happens in the SERVER's execution context (unless PreserveExecutionContext is true)
             async Task RunRequestAsync()
             {
                 // This will configure IHttpContextAccessor so it needs to happen INSIDE this function,
-                // since we are now inside the Server's ExecutionContext. If it happens out
+                // since we are now inside the Server's execution context. If it happens outside this context,
+                // it will be lost when we abandon the execution context.
                 _testContext = _application.CreateContext(_httpContext.Features);
 
                 try

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -92,7 +93,13 @@ namespace Microsoft.AspNetCore.TestHost
             }
             else
             {
-                ThreadPool.UnsafeQueueUserWorkItem(_ => { _ = RunRequestAsync(); }, null);
+                // Capture the current culture and restore it inside the server execution context.
+                var currentCulture = CultureInfo.CurrentCulture;
+                ThreadPool.UnsafeQueueUserWorkItem(_ =>
+                {
+                    CultureInfo.CurrentCulture = currentCulture;
+                    _ = RunRequestAsync();
+                }, null);
             }
 
             return _responseTcs.Task;

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -94,11 +94,8 @@ namespace Microsoft.AspNetCore.TestHost
             }
             else
             {
-                // Capture the current culture and restore it inside the server execution context.
-                var currentCulture = CultureInfo.CurrentCulture;
                 ThreadPool.UnsafeQueueUserWorkItem(_ =>
                 {
-                    CultureInfo.CurrentCulture = currentCulture;
                     _ = RunRequestAsync();
                 }, null);
             }

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -83,12 +83,12 @@ namespace Microsoft.AspNetCore.TestHost
         /// <remarks>
         /// Defaults to false.
         /// </remarks>
-        public bool AllowSynchronousIO { get; set; } = false;
+        public bool AllowSynchronousIO { get; set; }
 
         /// <summary>
         /// Gets or sets a value that controls if <see cref="ExecutionContext"/> and <see cref="AsyncLocal{T}"/> values are preserved from the client to the server.
         /// </summary>
-        public bool PreserveExecutionContext { get; set; } = false;
+        public bool PreserveExecutionContext { get; set; }
 
         private IHttpApplication<Context> Application
         {

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -78,15 +78,12 @@ namespace Microsoft.AspNetCore.TestHost
         public IFeatureCollection Features { get; }
 
         /// <summary>
-        /// Gets or sets a value that controls whether synchronous IO is allowed for the <see cref="HttpContext.Request"/> and <see cref="HttpContext.Response"/>
+        /// Gets or sets a value that controls whether synchronous IO is allowed for the <see cref="HttpContext.Request"/> and <see cref="HttpContext.Response"/>. The default value is <see langword="false" />.
         /// </summary>
-        /// <remarks>
-        /// Defaults to false.
-        /// </remarks>
         public bool AllowSynchronousIO { get; set; }
 
         /// <summary>
-        /// Gets or sets a value that controls if <see cref="ExecutionContext"/> and <see cref="AsyncLocal{T}"/> values are preserved from the client to the server.
+        /// Gets or sets a value that controls if <see cref="ExecutionContext"/> and <see cref="AsyncLocal{T}"/> values are preserved from the client to the server. The default value is <see langword="false" />.
         /// </summary>
         public bool PreserveExecutionContext { get; set; }
 

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -85,6 +85,11 @@ namespace Microsoft.AspNetCore.TestHost
         /// </remarks>
         public bool AllowSynchronousIO { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets a value that controls if <see cref="ExecutionContext"/> and <see cref="AsyncLocal{T}"/> values are preserved from the client to the server.
+        /// </summary>
+        public bool PreserveExecutionContext { get; set; } = false;
+
         private IHttpApplication<Context> Application
         {
             get => _application ?? throw new InvalidOperationException("The server has not been started or no web application was configured.");
@@ -93,7 +98,7 @@ namespace Microsoft.AspNetCore.TestHost
         public HttpMessageHandler CreateHandler()
         {
             var pathBase = BaseAddress == null ? PathString.Empty : PathString.FromUriComponent(BaseAddress);
-            return new ClientHandler(pathBase, Application) { AllowSynchronousIO = AllowSynchronousIO };
+            return new ClientHandler(pathBase, Application) { AllowSynchronousIO = AllowSynchronousIO, PreserveExecutionContext = PreserveExecutionContext };
         }
 
         public HttpClient CreateClient()
@@ -104,7 +109,7 @@ namespace Microsoft.AspNetCore.TestHost
         public WebSocketClient CreateWebSocketClient()
         {
             var pathBase = BaseAddress == null ? PathString.Empty : PathString.FromUriComponent(BaseAddress);
-            return new WebSocketClient(pathBase, Application) { AllowSynchronousIO = AllowSynchronousIO };
+            return new WebSocketClient(pathBase, Application) { AllowSynchronousIO = AllowSynchronousIO, PreserveExecutionContext = PreserveExecutionContext };
         }
 
         /// <summary>
@@ -147,7 +152,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
             builder.Configure(configureContext);
             // TODO: Wrap the request body if any?
-            return await builder.SendAsync(cancellationToken).ConfigureAwait(false);
+            return await builder.SendAsync(cancellationToken, PreserveExecutionContext).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.TestHost
                 throw new ArgumentNullException(nameof(configureContext));
             }
 
-            var builder = new HttpContextBuilder(Application, AllowSynchronousIO);
+            var builder = new HttpContextBuilder(Application, AllowSynchronousIO, PreserveExecutionContext);
             builder.Configure(context =>
             {
                 var request = context.Request;
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
             builder.Configure(configureContext);
             // TODO: Wrap the request body if any?
-            return await builder.SendAsync(cancellationToken, PreserveExecutionContext).ConfigureAwait(false);
+            return await builder.SendAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/Hosting/TestHost/src/WebSocketClient.cs
+++ b/src/Hosting/TestHost/src/WebSocketClient.cs
@@ -47,6 +47,7 @@ namespace Microsoft.AspNetCore.TestHost
         }
 
         internal bool AllowSynchronousIO { get; set; }
+        internal bool PreserveExecutionContext { get; set; }
 
         public async Task<WebSocket> ConnectAsync(Uri uri, CancellationToken cancellationToken)
         {
@@ -86,7 +87,7 @@ namespace Microsoft.AspNetCore.TestHost
                 ConfigureRequest?.Invoke(context.Request);
             });
 
-            var httpContext = await contextBuilder.SendAsync(cancellationToken);
+            var httpContext = await contextBuilder.SendAsync(cancellationToken, PreserveExecutionContext);
 
             if (httpContext.Response.StatusCode != StatusCodes.Status101SwitchingProtocols)
             {

--- a/src/Hosting/TestHost/src/WebSocketClient.cs
+++ b/src/Hosting/TestHost/src/WebSocketClient.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.TestHost
         public async Task<WebSocket> ConnectAsync(Uri uri, CancellationToken cancellationToken)
         {
             WebSocketFeature webSocketFeature = null;
-            var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO);
+            var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO, PreserveExecutionContext);
             contextBuilder.Configure(context =>
             {
                 var request = context.Request;
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.TestHost
                 ConfigureRequest?.Invoke(context.Request);
             });
 
-            var httpContext = await contextBuilder.SendAsync(cancellationToken, PreserveExecutionContext);
+            var httpContext = await contextBuilder.SendAsync(cancellationToken);
 
             if (httpContext.Response.StatusCode != StatusCodes.Status101SwitchingProtocols)
             {

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -478,39 +478,5 @@ namespace Microsoft.AspNetCore.TestHost
 
             Assert.Same(value, capturedValue);
         }
-
-        [Fact]
-        public async Task CurrentCultureIsPreservedAcrossClientServerBoundary()
-        {
-            // Set the current culture
-            CultureInfo.CurrentCulture = new CultureInfo("fr-CA");
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Run(async (context) =>
-                    {
-                        if (context.Request.Path.StartsWithSegments("/number"))
-                        {
-                            await context.Response.WriteAsync((4.32).ToString());
-                        }
-                        else
-                        {
-                            await context.Response.WriteAsync(CultureInfo.CurrentCulture.Name);
-                        }
-                    });
-                });
-            var server = new TestServer(builder);
-            var client = server.CreateClient();
-
-            var resp = await client.GetAsync("/number");
-            resp.EnsureSuccessStatusCode();
-            var content = await resp.Content.ReadAsStringAsync();
-            Assert.Equal("4,32", content);
-
-            resp = await client.GetAsync("/name");
-            resp.EnsureSuccessStatusCode();
-            content = await resp.Content.ReadAsStringAsync();
-            Assert.Equal("fr-CA", content);
-        }
     }
 }

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -662,59 +662,6 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("otherhost:5678", responseBody);
         }
 
-        [Fact]
-        public async Task AsyncLocalValueOnClientIsNotPreserved()
-        {
-            var asyncLocal = new AsyncLocal<object>();
-            var value = new object();
-            asyncLocal.Value = value;
-
-            object capturedValue = null;
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Run((context) =>
-                    {
-                        capturedValue = asyncLocal.Value;
-                        return context.Response.WriteAsync("Done");
-                    });
-                });
-            var server = new TestServer(builder);
-            var client = server.CreateClient();
-
-            var resp = await client.GetAsync("/");
-
-            Assert.NotSame(value, capturedValue);
-        }
-
-        [Fact]
-        public async Task AsyncLocalValueOnClientIsPreservedIfPreserveExecutionContextIsTrue()
-        {
-            var asyncLocal = new AsyncLocal<object>();
-            var value = new object();
-            asyncLocal.Value = value;
-
-            object capturedValue = null;
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Run((context) =>
-                    {
-                        capturedValue = asyncLocal.Value;
-                        return context.Response.WriteAsync("Done");
-                    });
-                });
-            var server = new TestServer(builder)
-            {
-                PreserveExecutionContext = true
-            };
-            var client = server.CreateClient();
-
-            var resp = await client.GetAsync("/");
-
-            Assert.Same(value, capturedValue);
-        }
-
         public class TestDiagnosticListener
         {
             public class OnBeginRequestEventData

--- a/src/Hosting/WindowsServices/src/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/src/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
@@ -15,5 +15,10 @@
   <ItemGroup>
     <Reference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="WebHostService.cs">
+      <SubType>Component</SubType>
+    </Compile>
+  </ItemGroup>
 
 </Project>

--- a/src/Hosting/WindowsServices/src/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/src/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
@@ -15,10 +15,5 @@
   <ItemGroup>
     <Reference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Update="WebHostService.cs">
-      <SubType>Component</SubType>
-    </Compile>
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
fixes #7975

Currently, the `ExecutionContext` flows from client to server in `TestServer`. This seems odd because the server should be a separate instance. Also, it causes problems when you are running two different apps through `TestServer` (such as when you are testing IdentityServer and such). This change changes `TestServer`'s client logic to force a new `ExecutionContext` when issuing HTTP requests.

There is a `PreserveExecutionContext` property to turn the old behavior back on. Also I had to modify where `IHttpApplication.CreateContext` is called since that's what sets the `IHttpContextAccessor`. If it's set before we dispatch to the thread pool (thus dropping the EC) the accessor value will be lost when we abandon the EC!

I'm reliably informed that there is an MVC test or two depend on the AsyncLocal flow, so I'll fix those in this PR.

