### PR TITLE
Betterize Hosting Log

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -114,6 +114,7 @@ namespace Microsoft.AspNetCore.Hosting
             public HttpContext HttpContext { get; set; }
             public IDisposable Scope { get; set; }
             public Activity Activity { get; set; }
+            internal HostingRequestStartingLog StartLog { get; set; }
 
             public long StartTimestamp { get; set; }
             internal bool HasDiagnosticListener { get; set; }
@@ -125,6 +126,7 @@ namespace Microsoft.AspNetCore.Hosting
 
                 Scope = null;
                 Activity = null;
+                StartLog = null;
 
                 StartTimestamp = 0;
                 HasDiagnosticListener = false;

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Hosting
             // IsEnabled isn't checked in the caller, startTimestamp > 0 is used as a fast proxy check
             // but that may be because diagnostics are enabled, which also uses startTimestamp,
             // so check if we logged the start event
-            if (context.StartLog is object)
+            if (context.StartLog != null)
             {
                 var elapsed = new TimeSpan((long)(TimestampToTicks * (currentTimestamp - startTimestamp)));
 

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Hosting
                     }
 
                     // Non-inline
-                    LogRequestStarting(httpContext);
+                    LogRequestStarting(context);
                 }
             }
             context.StartTimestamp = startTimestamp;
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 currentTimestamp = Stopwatch.GetTimestamp();
                 // Non-inline
-                LogRequestFinished(httpContext, startTimestamp, currentTimestamp);
+                LogRequestFinished(context, startTimestamp, currentTimestamp);
             }
 
             if (_diagnosticListener.IsEnabled())
@@ -167,30 +167,34 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogRequestStarting(HttpContext httpContext)
+        private void LogRequestStarting(HostingApplication.Context context)
         {
             // IsEnabled is checked in the caller, so if we are here just log
+            var startLog = new HostingRequestStartingLog(context.HttpContext);
+            context.StartLog = startLog;
+
             _logger.Log(
                 logLevel: LogLevel.Information,
                 eventId: LoggerEventIds.RequestStarting,
-                state: new HostingRequestStartingLog(httpContext),
+                state: startLog,
                 exception: null,
                 formatter: HostingRequestStartingLog.Callback);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void LogRequestFinished(HttpContext httpContext, long startTimestamp, long currentTimestamp)
+        private void LogRequestFinished(HostingApplication.Context context, long startTimestamp, long currentTimestamp)
         {
             // IsEnabled isn't checked in the caller, startTimestamp > 0 is used as a fast proxy check
-            // but that may be because diagnostics are enabled, which also uses startTimestamp, so check here
-            if (_logger.IsEnabled(LogLevel.Information))
+            // but that may be because diagnostics are enabled, which also uses startTimestamp,
+            // so check if we logged the start event
+            if (context.StartLog is object)
             {
                 var elapsed = new TimeSpan((long)(TimestampToTicks * (currentTimestamp - startTimestamp)));
 
                 _logger.Log(
                     logLevel: LogLevel.Information,
                     eventId: LoggerEventIds.RequestFinished,
-                    state: new HostingRequestFinishedLog(httpContext, elapsed),
+                    state: new HostingRequestFinishedLog(context, elapsed),
                     exception: null,
                     formatter: HostingRequestFinishedLog.Callback);
             }

--- a/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
@@ -9,51 +9,56 @@ using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Hosting
 {
+    using static HostingRequestStartingLog;
+
     internal class HostingRequestFinishedLog : IReadOnlyList<KeyValuePair<string, object>>
     {
         internal static readonly Func<object, Exception, string> Callback = (state, exception) => ((HostingRequestFinishedLog)state).ToString();
 
-        private readonly HttpContext _httpContext;
-        private readonly TimeSpan _elapsed;
+        private readonly HostingApplication.Context _context;
 
         private string _cachedToString;
+        public TimeSpan Elapsed { get; }
 
-        public int Count => 3;
+        public int Count => 11;
 
         public KeyValuePair<string, object> this[int index]
         {
             get
             {
-                switch (index)
+                var request = _context.HttpContext.Request;
+                var response = _context.HttpContext.Response;
+
+                return index switch
                 {
-                    case 0:
-                        return new KeyValuePair<string, object>("ElapsedMilliseconds", _elapsed.TotalMilliseconds);
-                    case 1:
-                        return new KeyValuePair<string, object>("StatusCode", _httpContext.Response.StatusCode);
-                    case 2:
-                        return new KeyValuePair<string, object>("ContentType", _httpContext.Response.ContentType);
-                    default:
-                        throw new IndexOutOfRangeException(nameof(index));
-                }
+                    0 => new KeyValuePair<string, object>("ElapsedMilliseconds", Elapsed.TotalMilliseconds),
+                    1 => new KeyValuePair<string, object>(nameof(response.StatusCode), response.StatusCode),
+                    2 => new KeyValuePair<string, object>(nameof(response.ContentType), response.ContentType),
+                    3 => new KeyValuePair<string, object>(nameof(response.ContentLength), response.ContentLength),
+                    4 => new KeyValuePair<string, object>(nameof(request.Protocol), request.Protocol),
+                    5 => new KeyValuePair<string, object>(nameof(request.Method), request.Method),
+                    6 => new KeyValuePair<string, object>(nameof(request.Scheme), request.Scheme),
+                    7 => new KeyValuePair<string, object>(nameof(request.Host), request.Host.ToString()),
+                    8 => new KeyValuePair<string, object>(nameof(request.PathBase), request.PathBase.ToString()),
+                    9 => new KeyValuePair<string, object>(nameof(request.Path), request.Path.ToString()),
+                    10 => new KeyValuePair<string, object>(nameof(request.QueryString), request.QueryString.ToString()),
+                    _ => throw new IndexOutOfRangeException(nameof(index)),
+                };
             }
         }
 
-        public HostingRequestFinishedLog(HttpContext httpContext, TimeSpan elapsed)
+        public HostingRequestFinishedLog(HostingApplication.Context context, TimeSpan elapsed)
         {
-            _httpContext = httpContext;
-            _elapsed = elapsed;
+            _context = context;
+            Elapsed = elapsed;
         }
 
         public override string ToString()
         {
             if (_cachedToString == null)
             {
-                _cachedToString = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "Request finished in {0}ms {1} {2}",
-                    _elapsed.TotalMilliseconds,
-                    _httpContext.Response.StatusCode,
-                    _httpContext.Response.ContentType);
+                var response = _context.HttpContext.Response;
+                _cachedToString = $"Request finished {_context.StartLog.ToStringWithoutPreamble()} - {response.StatusCode.ToString(CultureInfo.InvariantCulture)} {ValueOrEmptyMarker(response.ContentLength)} {ValueOrEmptyMarker(response.ContentType)} {Elapsed.TotalMilliseconds.ToString("0.0000", CultureInfo.InvariantCulture)}ms";
             }
 
             return _cachedToString;

--- a/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
@@ -38,10 +38,10 @@ namespace Microsoft.AspNetCore.Hosting
                     4 => new KeyValuePair<string, object>(nameof(request.Protocol), request.Protocol),
                     5 => new KeyValuePair<string, object>(nameof(request.Method), request.Method),
                     6 => new KeyValuePair<string, object>(nameof(request.Scheme), request.Scheme),
-                    7 => new KeyValuePair<string, object>(nameof(request.Host), request.Host.ToString()),
-                    8 => new KeyValuePair<string, object>(nameof(request.PathBase), request.PathBase.ToString()),
-                    9 => new KeyValuePair<string, object>(nameof(request.Path), request.Path.ToString()),
-                    10 => new KeyValuePair<string, object>(nameof(request.QueryString), request.QueryString.ToString()),
+                    7 => new KeyValuePair<string, object>(nameof(request.Host), request.Host.Value),
+                    8 => new KeyValuePair<string, object>(nameof(request.PathBase), request.PathBase.Value),
+                    9 => new KeyValuePair<string, object>(nameof(request.Path), request.Path.Value),
+                    10 => new KeyValuePair<string, object>(nameof(request.QueryString), request.QueryString.Value),
                     _ => throw new IndexOutOfRangeException(nameof(index)),
                 };
             }
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Hosting
             if (_cachedToString == null)
             {
                 var response = _context.HttpContext.Response;
-                _cachedToString = $"Request finished {_context.StartLog.ToStringWithoutPreamble()} - {response.StatusCode.ToString(CultureInfo.InvariantCulture)} {ValueOrEmptyMarker(response.ContentLength)} {ValueOrEmptyMarker(response.ContentType)} {Elapsed.TotalMilliseconds.ToString("0.0000", CultureInfo.InvariantCulture)}ms";
+                _cachedToString = $"Request finished {_context.StartLog.ToStringWithoutPreamble()} - {response.StatusCode.ToString(CultureInfo.InvariantCulture)} {ValueOrEmptyMarker(response.ContentLength)} {EscapedValueOrEmptyMarker(response.ContentType)} {Elapsed.TotalMilliseconds.ToString("0.0000", CultureInfo.InvariantCulture)}ms";
             }
 
             return _cachedToString;

--- a/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Hosting
@@ -69,7 +70,8 @@ namespace Microsoft.AspNetCore.Hosting
             => ToString().Substring(LogPreamble.Length);
 
         internal static string EscapedValueOrEmptyMarker(string potentialValue)
-            => potentialValue?.Length > 0 ? Uri.EscapeDataString(potentialValue) : EmptyEntry;
+            // Encode space as +
+            => potentialValue?.Length > 0 ? potentialValue.Replace(' ', '+') : EmptyEntry;
 
         internal static string ValueOrEmptyMarker<T>(T? potentialValue) where T : struct, IFormattable
             => potentialValue?.ToString(null, CultureInfo.InvariantCulture) ?? EmptyEntry;

--- a/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
@@ -29,10 +29,10 @@ namespace Microsoft.AspNetCore.Hosting
             2 => new KeyValuePair<string, object>(nameof(_request.ContentType), _request.ContentType),
             3 => new KeyValuePair<string, object>(nameof(_request.ContentLength), _request.ContentLength),
             4 => new KeyValuePair<string, object>(nameof(_request.Scheme), _request.Scheme),
-            5 => new KeyValuePair<string, object>(nameof(_request.Host), _request.Host.ToString()),
-            6 => new KeyValuePair<string, object>(nameof(_request.PathBase), _request.PathBase.ToString()),
-            7 => new KeyValuePair<string, object>(nameof(_request.Path), _request.Path.ToString()),
-            8 => new KeyValuePair<string, object>(nameof(_request.QueryString), _request.QueryString.ToString()),
+            5 => new KeyValuePair<string, object>(nameof(_request.Host), _request.Host.Value),
+            6 => new KeyValuePair<string, object>(nameof(_request.PathBase), _request.PathBase.Value),
+            7 => new KeyValuePair<string, object>(nameof(_request.Path), _request.Path.Value),
+            8 => new KeyValuePair<string, object>(nameof(_request.QueryString), _request.QueryString.Value),
             _ => throw new IndexOutOfRangeException(nameof(index)),
         };
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Hosting
             if (_cachedToString == null)
             {
                 var request = _request;
-                _cachedToString = $"{LogPreamble}{request.Protocol} {request.Method} {request.Scheme}://{request.Host}{request.PathBase}{request.Path}{request.QueryString} {ValueOrEmptyMarker(request.ContentType)} {ValueOrEmptyMarker(request.ContentLength)}"; ;
+                _cachedToString = $"{LogPreamble}{request.Protocol} {request.Method} {request.Scheme}://{request.Host.Value}{request.PathBase.Value}{request.Path.Value}{request.QueryString.Value} {EscapedValueOrEmptyMarker(request.ContentType)} {ValueOrEmptyMarker(request.ContentLength)}"; ;
             }
 
             return _cachedToString;
@@ -68,8 +68,8 @@ namespace Microsoft.AspNetCore.Hosting
         internal string ToStringWithoutPreamble()
             => ToString().Substring(LogPreamble.Length);
 
-        internal static string ValueOrEmptyMarker(string potentialValue)
-            => potentialValue?.Length > 0 ? potentialValue : EmptyEntry;
+        internal static string EscapedValueOrEmptyMarker(string potentialValue)
+            => potentialValue?.Length > 0 ? Uri.EscapeDataString(potentialValue) : EmptyEntry;
 
         internal static string ValueOrEmptyMarker<T>(T? potentialValue) where T : struct, IFormattable
             => potentialValue?.ToString(null, CultureInfo.InvariantCulture) ?? EmptyEntry;

--- a/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
@@ -11,6 +11,9 @@ namespace Microsoft.AspNetCore.Hosting
 {
     internal class HostingRequestStartingLog : IReadOnlyList<KeyValuePair<string, object>>
     {
+        private const string LogPreamble = "Request starting ";
+        private const string EmptyEntry = "-";
+
         internal static readonly Func<object, Exception, string> Callback = (state, exception) => ((HostingRequestStartingLog)state).ToString();
 
         private readonly HttpRequest _request;
@@ -19,35 +22,19 @@ namespace Microsoft.AspNetCore.Hosting
 
         public int Count => 9;
 
-        public KeyValuePair<string, object> this[int index]
+        public KeyValuePair<string, object> this[int index] => index switch
         {
-            get
-            {
-                switch (index)
-                {
-                    case 0:
-                        return new KeyValuePair<string, object>("Protocol", _request.Protocol);
-                    case 1:
-                        return new KeyValuePair<string, object>("Method", _request.Method);
-                    case 2:
-                        return new KeyValuePair<string, object>("ContentType", _request.ContentType);
-                    case 3:
-                        return new KeyValuePair<string, object>("ContentLength", _request.ContentLength);
-                    case 4:
-                        return new KeyValuePair<string, object>("Scheme", _request.Scheme);
-                    case 5:
-                        return new KeyValuePair<string, object>("Host", _request.Host.ToString());
-                    case 6:
-                        return new KeyValuePair<string, object>("PathBase", _request.PathBase.ToString());
-                    case 7:
-                        return new KeyValuePair<string, object>("Path", _request.Path.ToString());
-                    case 8:
-                        return new KeyValuePair<string, object>("QueryString", _request.QueryString.ToString());
-                    default:
-                        throw new IndexOutOfRangeException(nameof(index));
-                }
-            }
-        }
+            0 => new KeyValuePair<string, object>(nameof(_request.Protocol), _request.Protocol),
+            1 => new KeyValuePair<string, object>(nameof(_request.Method), _request.Method),
+            2 => new KeyValuePair<string, object>(nameof(_request.ContentType), _request.ContentType),
+            3 => new KeyValuePair<string, object>(nameof(_request.ContentLength), _request.ContentLength),
+            4 => new KeyValuePair<string, object>(nameof(_request.Scheme), _request.Scheme),
+            5 => new KeyValuePair<string, object>(nameof(_request.Host), _request.Host.ToString()),
+            6 => new KeyValuePair<string, object>(nameof(_request.PathBase), _request.PathBase.ToString()),
+            7 => new KeyValuePair<string, object>(nameof(_request.Path), _request.Path.ToString()),
+            8 => new KeyValuePair<string, object>(nameof(_request.QueryString), _request.QueryString.ToString()),
+            _ => throw new IndexOutOfRangeException(nameof(index)),
+        };
 
         public HostingRequestStartingLog(HttpContext httpContext)
         {
@@ -58,18 +45,8 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (_cachedToString == null)
             {
-                _cachedToString = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "Request starting {0} {1} {2}://{3}{4}{5}{6} {7} {8}",
-                    _request.Protocol,
-                    _request.Method,
-                    _request.Scheme,
-                    _request.Host.Value,
-                    _request.PathBase.Value,
-                    _request.Path.Value,
-                    _request.QueryString.Value,
-                    _request.ContentType,
-                    _request.ContentLength);
+                var request = _request;
+                _cachedToString = $"{LogPreamble}{request.Protocol} {request.Method} {request.Scheme}://{request.Host}{request.PathBase}{request.Path}{request.QueryString} {ValueOrEmptyMarker(request.ContentType)} {ValueOrEmptyMarker(request.ContentLength)}"; ;
             }
 
             return _cachedToString;
@@ -87,5 +64,14 @@ namespace Microsoft.AspNetCore.Hosting
         {
             return GetEnumerator();
         }
+
+        internal string ToStringWithoutPreamble()
+            => ToString().Substring(LogPreamble.Length);
+
+        internal static string ValueOrEmptyMarker(string potentialValue)
+            => potentialValue?.Length > 0 ? potentialValue : EmptyEntry;
+
+        internal static string ValueOrEmptyMarker<T>(T? potentialValue) where T : struct, IFormattable
+            => potentialValue?.ToString(null, CultureInfo.InvariantCulture) ?? EmptyEntry;
     }
 }

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 await stopTask.DefaultTimeout();
             }
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Request finished in"));
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Request finished "));
             Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closing."));
             Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
         }


### PR DESCRIPTION
Output something more useful for `HostingRequestFinishedLog` (which can get intermixed when multiple parallel requests); so it becomes the more interesting event given context; since its kinda junky currently unless you are also outputting full scopes (even then you need to do matching).

Before
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop/
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 31.180400000000002ms 404
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop/index.html
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 1.6021ms 200 text/html
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop/js/aoa.avatar.js
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 2.6724ms 200 application/octet-stream
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop:26347/textures/spacedrop2048_right1.dds
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop:26347/textures/spacedrop2048_left2.dds
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop:26347/textures/spacedrop2048_top3.dds
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop:26347/textures/spacedrop2048_bottom4.dds
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop:26347/textures/spacedrop2048_back6.dds
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop:26347/textures/spacedrop2048_front5.dds
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 46.6755ms 200 application/octet-stream
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 2.5938000000000003ms 200 application/octet-stream
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 2.7852ms 200 application/octet-stream
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 246.4214ms 200 application/octet-stream
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 280.962ms 200 application/octet-stream
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 2.2681ms 200 application/octet-stream
```

After
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop/index.html - -
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/1.1 GET http://ben-laptop/index.html - - - 200 2348 text/html 76.8050ms
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://ben-laptop/js/aoa.avatar.js - -
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/1.1 GET http://ben-laptop/js/aoa.avatar.js - - - 200 39852 application/octet-stream 8.6488ms
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 POST http://ben-laptop/form application/x-www-form-urlencoded 19
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/1.1 POST http://ben-laptop/form application/x-www-form-urlencoded 19 - 404 0 - 8.1129ms
```

Also improve the more detailed semantic logged output

Before
![image](https://user-images.githubusercontent.com/1142958/57453322-05203580-725e-11e9-80fe-1d2313e3949b.png)

After
![image](https://user-images.githubusercontent.com/1142958/57462055-0d816c00-7270-11e9-82b4-6c1367d8576b.png)

Resolves #10097
Resolves https://github.com/aspnet/AspNetCore/issues/10556
Resolves https://github.com/aspnet/AspNetCore/issues/10557

/cc @davidfowl 