### PR TITLE
Move service registration before hosting startups run

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -44,7 +44,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 ExecuteHostingStartups();
             });
 
-            // We need to populate the IHostingEnvironment before
+            // IHostingStartup needs to be executed before any direct methods on the builder
+            // so register these callbacks first
+            _builder.ConfigureAppConfiguration((context, configurationBuilder) =>
+            {
+                if (_hostingStartupWebHostBuilder != null)
+                {
+                    var webhostContext = GetWebHostBuilderContext(context);
+                    _hostingStartupWebHostBuilder.ConfigureAppConfiguration(webhostContext, configurationBuilder);
+                }
+            });
+
             _builder.ConfigureServices((context, services) =>
             {
                 var webhostContext = GetWebHostBuilderContext(context);
@@ -76,33 +86,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 services.TryAddSingleton<IHttpContextFactory, DefaultHttpContextFactory>();
                 services.TryAddScoped<IMiddlewareFactory, MiddlewareFactory>();
                 services.TryAddSingleton<IApplicationBuilderFactory, ApplicationBuilderFactory>();
-            });
 
-            // IHostingStartup needs to be executed before any direct methods on the builder
-            // so register these callbacks first
-            _builder.ConfigureAppConfiguration((context, configurationBuilder) =>
-            {
-                if (_hostingStartupWebHostBuilder != null)
-                {
-                    var webhostContext = GetWebHostBuilderContext(context);
-                    _hostingStartupWebHostBuilder.ConfigureAppConfiguration(webhostContext, configurationBuilder);
-                }
-            });
-
-            _builder.ConfigureServices((context, services) =>
-            {
-                if (_hostingStartupWebHostBuilder != null)
-                {
-                    var webhostContext = GetWebHostBuilderContext(context);
-                    _hostingStartupWebHostBuilder.ConfigureServices(webhostContext, services);
-                }
-            });
-
-            // This runs UseStartup
-            _builder.ConfigureServices((context, services) =>
-            {
-                var webhostContext = GetWebHostBuilderContext(context);
-                var webHostOptions = (WebHostOptions)context.Properties[typeof(WebHostOptions)];
+                // IMPORTANT: This needs to run *before* direct calls on the builder (like UseStartup)
+                _hostingStartupWebHostBuilder?.ConfigureServices(webhostContext, services);
 
                 // Support UseStartup(assemblyName)
                 if (!string.IsNullOrEmpty(webHostOptions.StartupAssembly))

--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -1472,6 +1472,19 @@ namespace Microsoft.AspNetCore.Hosting
                 var loggerProvider = new TestLoggerProvider();
                 builder.UseSetting("testhostingstartup", "0")
                        .UseSetting("testhostingstartup_chain", builder.GetSetting("testhostingstartup_chain") + "0")
+                       .ConfigureServices(services =>
+                       {
+                           // This check is required because MVC still uses the
+                           // IWebHostEnvironment instance before the container is baked
+#pragma warning disable CS0618 // Type or member is obsolete
+                           var heDescriptor = services.SingleOrDefault(s => s.ServiceType == typeof(IHostingEnvironment));
+                           Assert.NotNull(heDescriptor);
+                           Assert.NotNull(heDescriptor.ImplementationInstance);
+#pragma warning restore CS0618 // Type or member is obsolete
+                           var wheDescriptor = services.SingleOrDefault(s => s.ServiceType == typeof(IWebHostEnvironment));
+                           Assert.NotNull(wheDescriptor);
+                           Assert.NotNull(wheDescriptor.ImplementationInstance);
+                       })
                        .ConfigureServices(services => services.AddSingleton<ServiceA>())
                        .ConfigureServices(services => services.AddSingleton<ITestSink>(loggerProvider.Sink))
                        .ConfigureLogging((_, lf) => lf.AddProvider(loggerProvider))


### PR DESCRIPTION
- This allows IHostingStartup to see default service registrations and override them.
- Added a test to verify that hosting startup can see the IWebHostingEnvironment. Unfortunately this is used by MVC to get the application name before the container is baked. This was found when porting our workshop from 2.2 to 3.0

cc @DamianEdwards 