### PR TITLE
[Templating] Make Selenium tests run sequentially, run yarn once

### DIFF
--- a/src/ProjectTemplates/test/SpaTemplateTest/AngularTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/AngularTemplateTest.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Templates.Test.SpaTemplateTest
 {
+    [Collection("SpaTemplateTests")]
     public class AngularTemplateTest : SpaTemplateTestBase
     {
         public AngularTemplateTest(ProjectFactoryFixture projectFactory, BrowserFixture browserFixture, ITestOutputHelper output)

--- a/src/ProjectTemplates/test/SpaTemplateTest/ReactReduxTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/ReactReduxTemplateTest.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Templates.Test.SpaTemplateTest
 {
+    [Collection("SpaTemplateTests")]
     public class ReactReduxTemplateTest : SpaTemplateTestBase
     {
         public ReactReduxTemplateTest(ProjectFactoryFixture projectFactory, BrowserFixture browserFixture, ITestOutputHelper output)

--- a/src/ProjectTemplates/test/SpaTemplateTest/ReactTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/ReactTemplateTest.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Templates.Test.SpaTemplateTest
 {
+    [Collection("SpaTemplateTests")]
     public class ReactTemplateTest : SpaTemplateTestBase
     {
         public ReactTemplateTest(ProjectFactoryFixture projectFactory, BrowserFixture browserFixture, ITestOutputHelper output)

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -5,13 +5,13 @@
   <!-- Ensuring that everything is ready before build -->
 
   <Target Name="EnsureNodeJSRestored" Condition="'$(SeleniumE2ETestsSupported)' == 'true'" BeforeTargets="Build">
-    <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
+    <Message Text="Running yarn install on $(MSBuildProjectFile)" Condition="!Exists('$(MSBuildThisProjectFileDirectory)node_modules') and '$(CI)' == 'true'" Importance="High" />
 
     <Message Condition="'$(EnforcePrerequisites)' == ''"
       Importance="High"
       Text="Prerequisites were not enforced at build time. Running Yarn or the E2E tests might fail as a result. Check /src/Shared/E2ETesting/Readme.md for instructions." />
 
-    <Yarn Command="install --mutex network" />
+    <Yarn Command="install --mutex network" Condition="!Exists('$(MSBuildThisProjectFileDirectory)node_modules') and '$(CI)' == 'true'" />
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -3,9 +3,10 @@
   <Sdk Name="Yarn.MSBuild" />
 
   <!-- Ensuring that everything is ready before build -->
+
   <PropertyGroup Condition="'$(BuildNodeJs)' == 'true' or '$(CI)' != 'true'">
-    <_ShouldRunNpmRestoreCommands
-      Condition="'$(CI)' != 'true' or !Exists('$(MSBuildThisProjectFileDirectory)node_modules')">true</_ShouldRunNpmRestoreCommands>
+    <_AlreadyRestored Condition="!Exists('$(MSBuildThisProjectFileDirectory)node_modules')">true</_AlreadyRestored>
+    <_ShouldRunNpmRestoreCommands Condition="'$(CI)' != 'true' or $(_AlreadyRestored) == ''">true</_ShouldRunNpmRestoreCommands>
   </PropertyGroup>
 
   <Target Name="EnsureNodeJSRestored" Condition="'$(SeleniumE2ETestsSupported)' == 'true'" BeforeTargets="Build">
@@ -19,6 +20,9 @@
   </Target>
 
   <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
+    <Message Importance="high" Text="BuildNodeJs=$(BuildNodeJs)">
+    <Message Importance="high" Text="Exists('(MSBuildThisProjectFileDirectory)node_modules')=Exists('$(MSBuildThisProjectFileDirectory)node_modules')">
+    <Message Importance="high" Text="CI=$(CI)">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>EnsureNodeJSRestored</Targets>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -3,7 +3,7 @@
   <Sdk Name="Yarn.MSBuild" />
 
   <!-- Ensuring that everything is ready before build -->
-  <PropertyGroup Condition="'$(BuildNodeJs)' == 'true'">
+  <PropertyGroup Condition="'$(BuildNodeJs)' == 'true' or '$(CI)' != 'true'">
     <_ShouldRunNpmRestoreCommands
       Condition="'$(CI)' != 'true' or !Exists('$(MSBuildThisProjectFileDirectory)node_modules')">true</_ShouldRunNpmRestoreCommands>
   </PropertyGroup>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -3,18 +3,22 @@
   <Sdk Name="Yarn.MSBuild" />
 
   <!-- Ensuring that everything is ready before build -->
+  <PropertyGroup Condition="'$(BuildNodeJs)' == 'true'">
+    <_ShouldRunNpmRestoreCommands
+      Condition="'$(CI)' != 'true' or !Exists('$(MSBuildThisProjectFileDirectory)node_modules')">true</_ShouldRunNpmRestoreCommands>
+  </PropertyGroup>
 
   <Target Name="EnsureNodeJSRestored" Condition="'$(SeleniumE2ETestsSupported)' == 'true'" BeforeTargets="Build">
-    <Message Text="Running yarn install on $(MSBuildProjectFile)" Condition="!Exists('$(MSBuildThisProjectFileDirectory)node_modules') and '$(CI)' == 'true'" Importance="High" />
+    <Message Text="Running yarn install on $(MSBuildProjectFile)" Condition=" '$(_ShouldRunNpmRestoreCommands)' == 'true' " Importance="High" />
 
     <Message Condition="'$(EnforcePrerequisites)' == ''"
       Importance="High"
       Text="Prerequisites were not enforced at build time. Running Yarn or the E2E tests might fail as a result. Check /src/Shared/E2ETesting/Readme.md for instructions." />
 
-    <Yarn Command="install --mutex network" Condition="!Exists('$(MSBuildThisProjectFileDirectory)node_modules') and '$(CI)' == 'true'" />
+    <Yarn Command="install --mutex network" Condition=" '$(_ShouldRunNpmRestoreCommands)' == 'true' " />
   </Target>
 
-  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)" Condition="'$(BuildNodeJs)' == 'true'">
+  <Target Name="_IsCustomRestoreTargetSupported" Returns="@(CustomRestoreTargets)">
     <ItemGroup>
       <CustomRestoreTargets Include="$(MSBuildProjectFullPath)">
         <Targets>EnsureNodeJSRestored</Targets>


### PR DESCRIPTION
* Makes Selenium E2E tests run sequentially based on @SteveSandersonMS investigation.
  * This should not have a great impact as things requiring npm are already sequential and the selenium bits should be relatively fast compared to the rest of the elements in the test.
* Avoids running npm as part of the E2E testing infrastructure if yarn was already run as part of CI builds.