### PR TITLE
Fix components event dispatch ordering + E2E test fixes

### DIFF
--- a/src/Components/Blazor/Blazor/ref/Microsoft.AspNetCore.Blazor.netstandard2.0.cs
+++ b/src/Components/Blazor/Blazor/ref/Microsoft.AspNetCore.Blazor.netstandard2.0.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         public WebAssemblyRenderer(System.IServiceProvider serviceProvider) : base (default(System.IServiceProvider)) { }
         public System.Threading.Tasks.Task AddComponentAsync(System.Type componentType, string domElementSelector) { throw null; }
         public System.Threading.Tasks.Task AddComponentAsync<TComponent>(string domElementSelector) where TComponent : Microsoft.AspNetCore.Components.IComponent { throw null; }
+        public override System.Threading.Tasks.Task DispatchEventAsync(int eventHandlerId, Microsoft.AspNetCore.Components.UIEventArgs eventArgs) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override void HandleException(System.Exception exception) { }
         protected override System.Threading.Tasks.Task UpdateDisplayAsync(in Microsoft.AspNetCore.Components.Rendering.RenderBatch batch) { throw null; }

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -158,21 +158,20 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             }
         }
 
-        private void ProcessNextDeferredEvent()
+        private async void ProcessNextDeferredEvent()
         {
             var info = deferredIncomingEvents.Dequeue();
-            var task = DispatchEventAsync(info.EventHandlerId, info.EventArgs);
-            task.ContinueWith(_ =>
+            var taskCompletionSource = info.TaskCompletionSource;
+
+            try
             {
-                if (task.Exception != null)
-                {
-                    info.TaskCompletionSource.SetException(task.Exception);
-                }
-                else
-                {
-                    info.TaskCompletionSource.SetResult(null);
-                }
-            });
+                await DispatchEventAsync(info.EventHandlerId, info.EventArgs);
+                taskCompletionSource.SetResult(null);
+            }
+            catch (Exception ex)
+            {
+                taskCompletionSource.SetException(ex);
+            }
         }
 
         readonly struct IncomingEventInfo

--- a/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/Blazor/Blazor/src/Rendering/WebAssemblyRenderer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Services;
 using Microsoft.AspNetCore.Components;
@@ -17,6 +18,9 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
     public class WebAssemblyRenderer : Renderer
     {
         private readonly int _webAssemblyRendererId;
+
+        private bool isDispatchingEvent;
+        private Queue<IncomingEventInfo> deferredIncomingEvents = new Queue<IncomingEventInfo>();
 
         /// <summary>
         /// Constructs an instance of <see cref="WebAssemblyRenderer"/>.
@@ -108,6 +112,80 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             else
             {
                 Console.Error.WriteLine(exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public override Task DispatchEventAsync(int eventHandlerId, UIEventArgs eventArgs)
+        {
+            // Be sure we only run one event handler at once. Although they couldn't run
+            // simultaneously anyway (there's only one thread), they could run nested on
+            // the stack if somehow one event handler triggers another event synchronously.
+            // We need event handlers not to overlap because (a) that's consistent with
+            // server-side Blazor which uses a sync context, and (b) the rendering logic
+            // relies completely on the idea that within a given scope it's only building
+            // or processing one batch at a time.
+            //
+            // The only currently known case where this makes a difference is in the E2E
+            // tests in ReorderingFocusComponent, where we hit what seems like a Chrome bug
+            // where mutating the DOM cause an element's "change" to fire while its "input"
+            // handler is still running (i.e., nested on the stack) -- this doesn't happen
+            // in Firefox. Possibly a future version of Chrome may fix this, but even then,
+            // it's conceivable that DOM mutation events could trigger this too.
+
+            if (isDispatchingEvent)
+            {
+                var info = new IncomingEventInfo(eventHandlerId, eventArgs);
+                deferredIncomingEvents.Enqueue(info);
+                return info.TaskCompletionSource.Task;
+            }
+            else
+            {
+                try
+                {
+                    isDispatchingEvent = true;
+                    return base.DispatchEventAsync(eventHandlerId, eventArgs);
+                }
+                finally
+                {
+                    isDispatchingEvent = false;
+
+                    if (deferredIncomingEvents.Count > 0)
+                    {
+                        ProcessNextDeferredEvent();
+                    }
+                }
+            }
+        }
+
+        private void ProcessNextDeferredEvent()
+        {
+            var info = deferredIncomingEvents.Dequeue();
+            var task = DispatchEventAsync(info.EventHandlerId, info.EventArgs);
+            task.ContinueWith(_ =>
+            {
+                if (task.Exception != null)
+                {
+                    info.TaskCompletionSource.SetException(task.Exception);
+                }
+                else
+                {
+                    info.TaskCompletionSource.SetResult(null);
+                }
+            });
+        }
+
+        readonly struct IncomingEventInfo
+        {
+            public readonly int EventHandlerId;
+            public readonly UIEventArgs EventArgs;
+            public readonly TaskCompletionSource<object> TaskCompletionSource;
+
+            public IncomingEventInfo(int eventHandlerId, UIEventArgs eventArgs)
+            {
+                EventHandlerId = eventHandlerId;
+                EventArgs = eventArgs;
+                TaskCompletionSource = new TaskCompletionSource<object>();
             }
         }
     }

--- a/src/Components/Browser/src/RendererRegistryEventDispatcher.cs
+++ b/src/Components/Browser/src/RendererRegistryEventDispatcher.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
@@ -14,10 +13,6 @@ namespace Microsoft.AspNetCore.Components.Browser
     /// </summary>
     public static class RendererRegistryEventDispatcher
     {
-        private static bool isDispatchingEvent;
-        private static Queue<IncomingEventInfo> deferredIncomingEvents
-            = new Queue<IncomingEventInfo>();
-
         /// <summary>
         /// For framework use only.
         /// </summary>
@@ -25,62 +20,9 @@ namespace Microsoft.AspNetCore.Components.Browser
         public static Task DispatchEvent(
             BrowserEventDescriptor eventDescriptor, string eventArgsJson)
         {
-            // Be sure we only run one event handler at once. Although they couldn't run
-            // simultaneously anyway (there's only one thread), they could run nested on
-            // the stack if somehow one event handler triggers another event synchronously.
-            // We need event handlers not to overlap because (a) that's consistent with
-            // server-side Blazor which uses a sync context, and (b) the rendering logic
-            // relies completely on the idea that within a given scope it's only building
-            // or processing one batch at a time.
-            //
-            // The only currently known case where this makes a difference is in the E2E
-            // tests in ReorderingFocusComponent, where we hit what seems like a Chrome bug
-            // where mutating the DOM cause an element's "change" to fire while its "input"
-            // handler is still running (i.e., nested on the stack) -- this doesn't happen
-            // in Firefox. Possibly a future version of Chrome may fix this, but even then,
-            // it's conceivable that DOM mutation events could trigger this too.
-
-            if (isDispatchingEvent)
-            {
-                var info = new IncomingEventInfo(eventDescriptor, eventArgsJson);
-                deferredIncomingEvents.Enqueue(info);
-                return info.TaskCompletionSource.Task;
-            }
-            else
-            {
-                isDispatchingEvent = true;
-                try
-                {
-                    var eventArgs = ParseEventArgsJson(eventDescriptor.EventArgsType, eventArgsJson);
-                    var renderer = RendererRegistry.Current.Find(eventDescriptor.BrowserRendererId);
-                    return renderer.DispatchEventAsync(eventDescriptor.EventHandlerId, eventArgs);
-                }
-                finally
-                {
-                    isDispatchingEvent = false;
-                    if (deferredIncomingEvents.Count > 0)
-                    {
-                        ProcessNextDeferredEvent();
-                    }
-                }
-            }
-        }
-
-        private static void ProcessNextDeferredEvent()
-        {
-            var info = deferredIncomingEvents.Dequeue();
-            var task = DispatchEvent(info.EventDescriptor, info.EventArgsJson);
-            task.ContinueWith(_ =>
-            {
-                if (task.Exception != null)
-                {
-                    info.TaskCompletionSource.SetException(task.Exception);
-                }
-                else
-                {
-                    info.TaskCompletionSource.SetResult(null);
-                }
-            });
+            var eventArgs = ParseEventArgsJson(eventDescriptor.EventArgsType, eventArgsJson);
+            var renderer = RendererRegistry.Current.Find(eventDescriptor.BrowserRendererId);
+            return renderer.DispatchEventAsync(eventDescriptor.EventHandlerId, eventArgs);
         }
 
         private static UIEventArgs ParseEventArgsJson(string eventArgsType, string eventArgsJson)
@@ -135,20 +77,6 @@ namespace Microsoft.AspNetCore.Components.Browser
             /// For framework use only.
             /// </summary>
             public string EventArgsType { get; set; }
-        }
-
-        readonly struct IncomingEventInfo
-        {
-            public readonly BrowserEventDescriptor EventDescriptor;
-            public readonly string EventArgsJson;
-            public readonly TaskCompletionSource<object> TaskCompletionSource;
-
-            public IncomingEventInfo(BrowserEventDescriptor eventDescriptor, string eventArgsJson)
-            {
-                EventDescriptor = eventDescriptor;
-                EventArgsJson = eventArgsJson;
-                TaskCompletionSource = new TaskCompletionSource<object>();
-            }
         }
     }
 }

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -710,7 +710,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         protected internal virtual void AddToRenderQueue(int componentId, Microsoft.AspNetCore.Components.RenderFragment renderFragment) { }
         protected internal int AssignRootComponentId(Microsoft.AspNetCore.Components.IComponent component) { throw null; }
         public static Microsoft.AspNetCore.Components.Rendering.IDispatcher CreateDefaultDispatcher() { throw null; }
-        public System.Threading.Tasks.Task DispatchEventAsync(int eventHandlerId, Microsoft.AspNetCore.Components.UIEventArgs eventArgs) { throw null; }
+        public virtual System.Threading.Tasks.Task DispatchEventAsync(int eventHandlerId, Microsoft.AspNetCore.Components.UIEventArgs eventArgs) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         protected abstract void HandleException(System.Exception exception);

--- a/src/Components/Components/src/Forms/InputComponents/InputNumber.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputNumber.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         static bool TryParseFloat(string value, out T result)
         {
             var success = float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue);
-            if (success)
+            if (success && !float.IsInfinity(parsedValue))
             {
                 result = (T)(object)parsedValue;
                 return true;
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         static bool TryParseDouble(string value, out T result)
         {
             var success = double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue);
-            if (success)
+            if (success && !double.IsInfinity(parsedValue))
             {
                 result = (T)(object)parsedValue;
                 return true;

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// A <see cref="Task"/> which will complete once all asynchronous processing related to the event
         /// has completed.
         /// </returns>
-        public Task DispatchEventAsync(int eventHandlerId, UIEventArgs eventArgs)
+        public virtual Task DispatchEventAsync(int eventHandlerId, UIEventArgs eventArgs)
         {
             EnsureSynchronizationContext();
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -57,4 +57,28 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
         }
     }
+
+    public class ServerEventCallbackTest : EventCallbackTest
+    {
+        public ServerEventCallbackTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+    }
+
+    public class ServerFormsTest : FormsTest
+    {
+        public ServerFormsTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+    }
+
+    public class ServerKeyTest : KeyTest
+    {
+        public ServerKeyTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+    }
 }

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -210,6 +210,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified valid", () => expiryDateInput.GetAttribute("class"));
 
             // Can become invalid
+            expiryDateInput.Clear();
             expiryDateInput.SendKeys("111111111");
             Browser.Equal("modified invalid", () => expiryDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The OptionalExpiryDate field must be a date." }, messagesAccessor);

--- a/src/Components/test/E2ETest/Tests/KeyTest.cs
+++ b/src/Components/test/E2ETest/Tests/KeyTest.cs
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             var appElem = MountTestComponent<ReorderingFocusComponent>();
             Func<IWebElement> textboxFinder = () => appElem.FindElement(By.CssSelector(".incomplete-items .item-1 input[type=text]"));
-            var textToType = "Hello this is a long string that should be typed";
+            var textToType = "Hello there!";
             var expectedTextTyped = "";
 
             textboxFinder().Clear();
@@ -221,17 +221,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             textboxFinder().Click();
             while (textToType.Length > 0)
             {
-                var nextBlockLength = Math.Min(5, textToType.Length);
-                var nextBlock = textToType.Substring(0, nextBlockLength);
-                textToType = textToType.Substring(nextBlockLength);
-                expectedTextTyped += nextBlock;
+                var nextChar = textToType.Substring(0, 1);
+                textToType = textToType.Substring(1);
+                expectedTextTyped += nextChar;
 
                 // Send keys to whatever has focus
-                new Actions(Browser).SendKeys(nextBlock).Perform();
+                new Actions(Browser).SendKeys(nextChar).Perform();
                 Browser.Equal(expectedTextTyped, () => textboxFinder().GetAttribute("value"));
 
                 // We delay between typings to ensure the events aren't all collapsed into one.
-                await Task.Delay(100);
+                await Task.Delay(50);
             }
 
             // Verify that after all this, we can still move the edited item


### PR DESCRIPTION
I eventually found that the newly-introduced components E2E test flakiness was actually due to a real product bug that I created in the "key support" feature.

As a workaround to what seems like a Chrome bug (or at least a bizarre inconsistency between Chrome and Firefox), I had put in some new logic to ensure events are only ever dispatched in series, and are not nested inside each other. This was only intended to affect client-side execution, since the same problem can't occur on the server because of its sync context. However, I made a mistake and put the change into `RendererRegistryEventDispatcher` which is actually shared between server and client (I had thought it was client only). Therefore the queuing system I implemented was inadvertently being shared across all users on the server, creating random timing effects where it's possible for one user's event to be dispatched to a different user. Hence the interference between simultaneous tests.

The fix here is to move the new dispatch logic into a place where it really only runs on the client, where there really only is one user.

Secondly, while trying to verify this through E2E tests, I noticed that we were missing server-side execution coverage for some of the E2E test classes. Once I added that, I found that some minor tweaks were needed to create consistency between the two environments and have all tests pass everywhere.

What we can learn from this:

 * Big PRs are bad because nobody can really review them. Maybe if the "key support" PR was a series of much smaller ones, someone might have noticed that I was introducing a serious defect where state would leak between users.
 * It's not great that we have to remember to manually add "server" versions of any new E2E test classes we add. We forgot about several until now. I don't have a proposal to fix this right now because we have more urgent things to do, so I'm just going to try to point this out when people next add new E2E test classes.
 * It's good that our E2E runner blasts the machine as fast as it can with as many tests as possible in parallel. This can uncover reliability issues that you'd never see if you just ran tests one at a time locally.
 * ... anything else?