### PR TITLE
Start using runtime properties to set StartupHook and EntrypointFilter

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
@@ -117,21 +117,26 @@ int HostFxr::InitializeForApp(int argc, const PCWSTR* argv, const std::wstring d
 
     hostfxr_initialize_parameters params;
     params.size = sizeof(hostfxr_initialize_parameters);
+    params.host_path = L"";
+
     if (!dotnetExe.empty())
     {
         std::filesystem::path dotnetExePath(dotnetExe);
 
         auto dotnetFolderPath = dotnetExePath.parent_path();
         params.dotnet_root = dotnetFolderPath.c_str();
-        params.host_path = L"";
         RETURN_IF_NOT_ZERO(m_hostfxr_initialize_for_app_fn(argc - 1, &argv[1], nullptr, &params, &m_host_context_handle));
 
     }
     else
     {
         params.dotnet_root = L"";
-        params.host_path = L"";
-        RETURN_IF_NOT_ZERO(m_hostfxr_initialize_for_app_fn(argc, argv, nullptr, &params, &m_host_context_handle));
+
+        // Initialize_for_app doesn't work with an exe name
+        std::filesystem::path applicationPath(argv[0]);
+        applicationPath.replace_extension(".dll");
+
+        RETURN_IF_NOT_ZERO(m_hostfxr_initialize_for_app_fn(argc - 1, &argv[1], applicationPath.c_str(), &params, &m_host_context_handle));
     }
 
     if (callStartupHook)

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
@@ -44,10 +44,10 @@ void HostFxr::Load(HMODULE moduleHandle)
     {
         m_hostfxr_get_native_search_directories_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_get_native_search_directories_fn>(moduleHandle, "hostfxr_get_native_search_directories");
         m_corehost_set_error_writer_fn = ModuleHelpers::GetKnownProcAddress<corehost_set_error_writer_fn>(moduleHandle, "hostfxr_set_error_writer", /* optional */ true);
-        m_hostfxr_initialize_for_app_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_initialize_for_app_fn>(moduleHandle, "hostfxr_initialize_for_app", true);
-        m_hostfxr_set_runtime_property_value_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_set_runtime_property_value_fn>(moduleHandle, "hostfxr_set_runtime_property_value", true);
-        m_hostfxr_run_app_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_run_app_fn>(moduleHandle, "hostfxr_run_app", true);
-        m_hostfxr_close_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_close_fn>(moduleHandle, "hostfxr_close", true);
+        m_hostfxr_initialize_for_app_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_initialize_for_app_fn>(moduleHandle, "hostfxr_initialize_for_app", /* optional */ true);
+        m_hostfxr_set_runtime_property_value_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_set_runtime_property_value_fn>(moduleHandle, "hostfxr_set_runtime_property_value", /* optional */ true);
+        m_hostfxr_run_app_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_run_app_fn>(moduleHandle, "hostfxr_run_app", /* optional */ true);
+        m_hostfxr_close_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_close_fn>(moduleHandle, "hostfxr_close", /* optional */ true);
     }
     catch (...)
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
@@ -108,9 +108,9 @@ HostFxrErrorRedirector HostFxr::RedirectOutput(RedirectionOutput* writer) const 
     return HostFxrErrorRedirector(m_corehost_set_error_writer_fn, writer);
 }
 
-int HostFxr::InitializeForApp(int argc, PCWSTR* argv, const std::wstring dotnetExe) const noexcept
+int HostFxr::InitializeForApp(int argc, PCWSTR* argv, const std::wstring& dotnetExe) const noexcept
 {
-    if (m_hostfxr_initialize_for_dotnet_commandline_fn == nullptr)
+    if (m_hostfxr_initialize_for_dotnet_commandline_fn == nullptr || m_hostfxr_main_fn != nullptr)
     {
         return 0;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -10,8 +10,8 @@
 struct hostfxr_initialize_parameters
 {
     size_t size;
-    const PCWSTR host_path;
-    const PCWSTR dotnet_root;
+    PCWSTR host_path;
+    PCWSTR dotnet_root;
 };
 
 typedef INT(*hostfxr_get_native_search_directories_fn) (INT argc, CONST PCWSTR* argv, PWSTR buffer, DWORD buffer_size, DWORD* required_buffer_size);
@@ -22,6 +22,7 @@ typedef int(*hostfxr_initialize_for_app_fn)(int argc, PCWSTR* argv, PCWSTR app_p
 typedef int(*hostfxr_set_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PCWSTR value);
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
 typedef int(*hostfxr_close)(void* hostfxr_context_handle);
+typedef int(*hostfxr_get_runtime_properties_fn)(void* hostfxr_context_handle, size_t* count, PWSTR* keys, PWSTR* values);
 
 struct ErrorContext
 {
@@ -80,6 +81,7 @@ public:
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
     int InitializeForApp(DWORD argc, PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters) const noexcept; // todo const this
+    int GetRuntimeProperties();
 
 private:
     HandleWrapper<ModuleHandleTraits> m_hHostFxrDll;
@@ -88,6 +90,7 @@ private:
     hostfxr_initialize_for_app_fn m_hostfxr_initialize_for_app_fn;
     hostfxr_set_runtime_property_value_fn m_hostfxr_set_runtime_property_value_fn;
     hostfxr_run_app_fn m_hostfxr_run_app_fn;
+    hostfxr_get_runtime_properties_fn m_hostfxr_get_runtime_properties_fn;
     corehost_set_error_writer_fn m_corehost_set_error_writer_fn;
     hostfxr_close m_hostfxr_close_fn;
     void* m_host_context_handle;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -84,7 +84,7 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
-    int InitializeForApp(int argc, PCWSTR* argv, const std::wstring m_dotnetExeKnownLocation) const noexcept;
+    int InitializeForApp(int argc, PCWSTR* argv, const std::wstring& m_dotnetExeKnownLocation) const noexcept;
     void Close() const noexcept;
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -25,7 +25,7 @@ typedef corehost_error_writer_fn(*corehost_set_error_writer_fn) (corehost_error_
 typedef int(*hostfxr_initialize_for_app_fn)(int argc, const PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
 typedef int(*hostfxr_set_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PCWSTR value);
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
-typedef int(*hostfxr_close)(void* hostfxr_context_handle);
+typedef int(*hostfxr_close_fn)(void* hostfxr_context_handle);
 
 struct ErrorContext
 {
@@ -83,7 +83,8 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
-    int InitializeForApp(int argc, const PCWSTR* argv, const std::wstring m_dotnetExeKnownLocation, bool callStartupHook) const noexcept; // todo const this
+    int InitializeForApp(int argc, const PCWSTR* argv, const std::wstring m_dotnetExeKnownLocation, bool callStartupHook) const noexcept;
+    void Close() const noexcept;
 
 private:
     HandleWrapper<ModuleHandleTraits> m_hHostFxrDll;
@@ -93,6 +94,6 @@ private:
     hostfxr_set_runtime_property_value_fn m_hostfxr_set_runtime_property_value_fn;
     hostfxr_run_app_fn m_hostfxr_run_app_fn;
     corehost_set_error_writer_fn m_corehost_set_error_writer_fn;
-    hostfxr_close m_hostfxr_close_fn;
+    hostfxr_close_fn m_hostfxr_close_fn;
     void* m_host_context_handle;
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -22,7 +22,7 @@ typedef INT(*hostfxr_get_native_search_directories_fn) (INT argc, CONST PCWSTR* 
 typedef INT(*hostfxr_main_fn) (DWORD argc, CONST PCWSTR argv[]);
 typedef void(*corehost_error_writer_fn) (const WCHAR* message);
 typedef corehost_error_writer_fn(*corehost_set_error_writer_fn) (corehost_error_writer_fn error_writer);
-typedef int(*hostfxr_initialize_for_app_fn)(int argc, const PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
+typedef int(*hostfxr_initialize_for_dotnet_runtime_fn)(int argc, const PCWSTR* argv, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
 typedef int(*hostfxr_set_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PCWSTR value);
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
 typedef int(*hostfxr_close_fn)(void* hostfxr_context_handle);
@@ -83,14 +83,14 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
-    int InitializeForApp(int argc, const PCWSTR* argv, const std::wstring m_dotnetExeKnownLocation, bool callStartupHook) const noexcept;
+    int InitializeForApp(int argc, PCWSTR* argv, const std::wstring m_dotnetExeKnownLocation) const noexcept;
     void Close() const noexcept;
 
 private:
     HandleWrapper<ModuleHandleTraits> m_hHostFxrDll;
     hostfxr_main_fn m_hostfxr_main_fn;
     hostfxr_get_native_search_directories_fn m_hostfxr_get_native_search_directories_fn;
-    hostfxr_initialize_for_app_fn m_hostfxr_initialize_for_app_fn;
+    hostfxr_initialize_for_dotnet_runtime_fn m_hostfxr_initialize_for_dotnet_commandline_fn;
     hostfxr_set_runtime_property_value_fn m_hostfxr_set_runtime_property_value_fn;
     hostfxr_run_app_fn m_hostfxr_run_app_fn;
     corehost_set_error_writer_fn m_corehost_set_error_writer_fn;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -7,10 +7,21 @@
 #include "exceptions.h"
 #include "RedirectionOutput.h"
 
+struct hostfxr_initialize_parameters
+{
+    size_t size;
+    const PCWSTR host_path;
+    const PCWSTR dotnet_root;
+};
+
 typedef INT(*hostfxr_get_native_search_directories_fn) (INT argc, CONST PCWSTR* argv, PWSTR buffer, DWORD buffer_size, DWORD* required_buffer_size);
 typedef INT(*hostfxr_main_fn) (DWORD argc, CONST PCWSTR argv[]);
 typedef void(*corehost_error_writer_fn) (const WCHAR* message);
 typedef corehost_error_writer_fn(*corehost_set_error_writer_fn) (corehost_error_writer_fn error_writer);
+typedef int(*hostfxr_initialize_for_app_fn)(int argc, PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
+typedef int(*hostfxr_set_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PCWSTR value);
+typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
+typedef int(*hostfxr_close)(void* hostfxr_context_handle);
 
 struct ErrorContext
 {
@@ -49,7 +60,8 @@ public:
         corehost_set_error_writer_fn corehost_set_error_writer_fn) noexcept
         : m_hostfxr_main_fn(hostfxr_main_fn),
           m_hostfxr_get_native_search_directories_fn(hostfxr_get_native_search_directories_fn),
-          m_corehost_set_error_writer_fn(corehost_set_error_writer_fn)
+          m_corehost_set_error_writer_fn(corehost_set_error_writer_fn),
+          m_host_context_handle(nullptr)
     {
     }
 
@@ -66,10 +78,17 @@ public:
     int GetNativeSearchDirectories(INT argc, CONST PCWSTR* argv, PWSTR buffer, DWORD buffer_size, DWORD* required_buffer_size) const noexcept;
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
+    int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
+    int InitializeForApp(DWORD argc, PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters) const noexcept; // todo const this
 
 private:
     HandleWrapper<ModuleHandleTraits> m_hHostFxrDll;
     hostfxr_main_fn m_hostfxr_main_fn;
     hostfxr_get_native_search_directories_fn m_hostfxr_get_native_search_directories_fn;
+    hostfxr_initialize_for_app_fn m_hostfxr_initialize_for_app_fn;
+    hostfxr_set_runtime_property_value_fn m_hostfxr_set_runtime_property_value_fn;
+    hostfxr_run_app_fn m_hostfxr_run_app_fn;
     corehost_set_error_writer_fn m_corehost_set_error_writer_fn;
+    hostfxr_close m_hostfxr_close_fn;
+    void* m_host_context_handle;
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -16,6 +16,7 @@ struct hostfxr_initialize_parameters
 
 #define DOTNETCORE_STARTUP_HOOK  L"STARTUP_HOOKS"
 #define DOTNETCORE_USE_ENTRYPOINT_FILTER L"USE_ENTRYPOINT_FILTER"
+#define DOTNETCORE_STACK_SIZE L"DEFAULT_STACK_SIZE"
 #define ASPNETCORE_STARTUP_ASSEMBLY L"Microsoft.AspNetCore.Server.IIS"
 
 typedef INT(*hostfxr_get_native_search_directories_fn) (INT argc, CONST PCWSTR* argv, PWSTR buffer, DWORD buffer_size, DWORD* required_buffer_size);

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -14,6 +14,10 @@ struct hostfxr_initialize_parameters
     PCWSTR dotnet_root;
 };
 
+#define DOTNETCORE_STARTUP_HOOK  L"STARTUP_HOOKS"
+#define DOTNETCORE_USE_ENTRYPOINT_FILTER L"USE_ENTRYPOINT_FILTER"
+#define ASPNETCORE_STARTUP_ASSEMBLY L"Microsoft.AspNetCore.Server.IIS"
+
 typedef INT(*hostfxr_get_native_search_directories_fn) (INT argc, CONST PCWSTR* argv, PWSTR buffer, DWORD buffer_size, DWORD* required_buffer_size);
 typedef INT(*hostfxr_main_fn) (DWORD argc, CONST PCWSTR argv[]);
 typedef void(*corehost_error_writer_fn) (const WCHAR* message);
@@ -80,7 +84,7 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
-    int InitializeForApp(DWORD argc, PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters) const noexcept; // todo const this
+    int InitializeForApp(int argc, PCWSTR* argv, std::wstring m_dotnetExeKnownLocation) const noexcept; // todo const this
     int GetRuntimeProperties();
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -22,11 +22,10 @@ typedef INT(*hostfxr_get_native_search_directories_fn) (INT argc, CONST PCWSTR* 
 typedef INT(*hostfxr_main_fn) (DWORD argc, CONST PCWSTR argv[]);
 typedef void(*corehost_error_writer_fn) (const WCHAR* message);
 typedef corehost_error_writer_fn(*corehost_set_error_writer_fn) (corehost_error_writer_fn error_writer);
-typedef int(*hostfxr_initialize_for_app_fn)(int argc, PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
+typedef int(*hostfxr_initialize_for_app_fn)(int argc, const PCWSTR* argv, PCWSTR app_path, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
 typedef int(*hostfxr_set_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PCWSTR value);
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
 typedef int(*hostfxr_close)(void* hostfxr_context_handle);
-typedef int(*hostfxr_get_runtime_properties_fn)(void* hostfxr_context_handle, size_t* count, PWSTR* keys, PWSTR* values);
 
 struct ErrorContext
 {
@@ -84,8 +83,7 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
-    int InitializeForApp(int argc, PCWSTR* argv, std::wstring m_dotnetExeKnownLocation, bool callStartupHook) const noexcept; // todo const this
-    int GetRuntimeProperties();
+    int InitializeForApp(int argc, const PCWSTR* argv, const std::wstring m_dotnetExeKnownLocation, bool callStartupHook) const noexcept; // todo const this
 
 private:
     HandleWrapper<ModuleHandleTraits> m_hHostFxrDll;
@@ -94,7 +92,6 @@ private:
     hostfxr_initialize_for_app_fn m_hostfxr_initialize_for_app_fn;
     hostfxr_set_runtime_property_value_fn m_hostfxr_set_runtime_property_value_fn;
     hostfxr_run_app_fn m_hostfxr_run_app_fn;
-    hostfxr_get_runtime_properties_fn m_hostfxr_get_runtime_properties_fn;
     corehost_set_error_writer_fn m_corehost_set_error_writer_fn;
     hostfxr_close m_hostfxr_close_fn;
     void* m_host_context_handle;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -84,7 +84,7 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
-    int InitializeForApp(int argc, PCWSTR* argv, std::wstring m_dotnetExeKnownLocation) const noexcept; // todo const this
+    int InitializeForApp(int argc, PCWSTR* argv, std::wstring m_dotnetExeKnownLocation, bool callStartupHook) const noexcept; // todo const this
     int GetRuntimeProperties();
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/exceptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/exceptions.h
@@ -89,6 +89,8 @@
 #define SUCCEEDED_LOG(hr)                                       SUCCEEDED(LOG_IF_FAILED(hr))
 #define FAILED_LOG(hr)                                          FAILED(LOG_IF_FAILED(hr))
 
+#define RETURN_IF_NOT_ZERO(val)                                 do { if ((val) != 0) { return val; }} while (0, 0)
+
 inline thread_local IHttpTraceContext* g_traceContext;
 
  __declspec(noinline) inline VOID TraceHRESULT(LOCATION_ARGUMENTS HRESULT hr)

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/exceptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/exceptions.h
@@ -89,7 +89,8 @@
 #define SUCCEEDED_LOG(hr)                                       SUCCEEDED(LOG_IF_FAILED(hr))
 #define FAILED_LOG(hr)                                          FAILED(LOG_IF_FAILED(hr))
 
-#define RETURN_IF_NOT_ZERO(val)                                 do { if ((val) != 0) { return val; }} while (0, 0)
+#define RETURN_INT_IF_NOT_ZERO(val)                                 do { if ((val) != 0) { return val; }} while (0, 0)
+#define RETURN_IF_NOT_ZERO(val)                                 do { if ((val) != 0) { return; }} while (0, 0)
 
 inline thread_local IHttpTraceContext* g_traceContext;
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -248,10 +248,10 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         params.host_path = L"";
 
         // TODO This is horrible for now...
-        auto value = context->m_hostFxr.InitializeForApp(context->m_argc, context->m_argv.get(), m_dotnetExeKnownLocation);
-        if (value != 0)
+        auto startupReturnCode = context->m_hostFxr.InitializeForApp(context->m_argc, context->m_argv.get(), m_dotnetExeKnownLocation, m_pConfig->QueryCallStartupHook());
+        if (startupReturnCode != 0)
         {
-            // TODO log errors
+            throw InvalidOperationException(format(L"Error occured when initializing inprocess application, Return code: 0x%x", startupReturnCode));
             return;
         }
         // TODO make these configurable via handler settings

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -254,7 +254,7 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         }
 
         RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_USE_ENTRYPOINT_FILTER, L"1"));
-        RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(L"DefaultStackSize", m_pConfig->QueryStackSize().c_str()));
+        RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_STACK_SIZE, m_pConfig->QueryStackSize().c_str()));
 
         bool clrThreadExited;
         {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -248,11 +248,16 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         params.host_path = L"";
 
         // TODO This is horrible for now...
-        auto value = context->m_hostFxr.InitializeForApp(context->m_argc - 1, &(context->m_argv.get()[1]), nullptr, &params);
-
+        auto value = context->m_hostFxr.InitializeForApp(context->m_argc, context->m_argv.get(), m_dotnetExeKnownLocation);
+        if (value != 0)
+        {
+            // TODO log errors
+            return;
+        }
         // TODO make these configurable via handler settings
         value = context->m_hostFxr.SetRuntimePropertyValue(L"STARTUP_HOOKS", ASPNETCORE_STARTUP_ASSEMBLY);
         value = context->m_hostFxr.SetRuntimePropertyValue(L"USE_ENTRYPOINT_FILTER", L"1");
+
         LOG_LAST_ERROR_IF(!SetEnvironmentVariable(L"COMPlus_DefaultStackSize", m_pConfig->QueryStackSize().c_str()));
 
         bool clrThreadExited;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -301,6 +301,8 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
             LOG_INFOF(L"Clr thread wait ended: clrThreadExited: %d", clrThreadExited);
         }
 
+        context->m_hostFxr.Close();
+
         // At this point CLR thread either finished or timed out, abandon it.
         m_clrThread.detach();
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -241,7 +241,6 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
             LOG_INFOF(L"Setting current directory to %s", this->QueryApplicationPhysicalPath().c_str());
         }
 
-        // TODO This is horrible for now...
         auto startupReturnCode = context->m_hostFxr.InitializeForApp(context->m_argc, context->m_argv.get(), m_dotnetExeKnownLocation);
         if (startupReturnCode != 0)
         {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -252,7 +252,6 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         if (startupReturnCode != 0)
         {
             throw InvalidOperationException(format(L"Error occured when initializing inprocess application, Return code: 0x%x", startupReturnCode));
-            return;
         }
         // TODO make these configurable via handler settings
         value = context->m_hostFxr.SetRuntimePropertyValue(L"STARTUP_HOOKS", ASPNETCORE_STARTUP_ASSEMBLY);

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -298,8 +298,6 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
             LOG_INFOF(L"Clr thread wait ended: clrThreadExited: %d", clrThreadExited);
         }
 
-        context->m_hostFxr.Close();
-
         // At this point CLR thread either finished or timed out, abandon it.
         m_clrThread.detach();
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
@@ -15,8 +15,6 @@ typedef BOOL(WINAPI * PFN_SHUTDOWN_HANDLER) (void* pvShutdownHandlerContext);
 typedef REQUEST_NOTIFICATION_STATUS(WINAPI * PFN_ASYNC_COMPLETION_HANDLER)(void *pvManagedHttpContext, HRESULT hrCompletionStatus, DWORD cbCompletion);
 typedef void(WINAPI * PFN_REQUESTS_DRAINED_HANDLER) (void* pvShutdownHandlerContext);
 
-#define DOTNETCORE_STARTUP_HOOK  L"DOTNET_STARTUP_HOOKS"
-#define ASPNETCORE_STARTUP_ASSEMBLY L"Microsoft.AspNetCore.Server.IIS"
 class IN_PROCESS_APPLICATION : public InProcessApplicationBase
 {
 public:


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/9520.

We still don't have support for stack size FYI.

See https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/native-hosting.md#initialize-host-context for more details of the APIs if curious.