### PR TITLE
Reduce Functional Test Stream Item Delay

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 for (var i = 0; i < count; i++)
                 {
                     await channel.Writer.WriteAsync(i);
-                    await Task.Delay(100);
+                    await Task.Delay(10);
                 }
 
                 channel.Writer.TryComplete();

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 for (var i = 0; i < count; i++)
                 {
                     await channel.Writer.WriteAsync(i);
-                    await Task.Delay(10);
+                    await Task.Delay(20);
                 }
 
                 channel.Writer.TryComplete();


### PR DESCRIPTION
This makes the functional tests run twice as fast.
A number of our tests use this method and when running all the variations it adds up.

