### PR TITLE
Revert "Remove CancelableEnumerator (#10099)"

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -403,12 +403,13 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             IHubActivator<THub> hubActivator, THub hub, CancellationTokenSource streamCts, HubMethodInvocationMessage hubMethodInvocationMessage)
         {
             string error = null;
+
             try
             {
-                await foreach(var item in enumerable.WithCancellation(streamCts.Token))
+                await foreach (var streamItem in enumerable)
                 {
                     // Send the stream item
-                    await connection.WriteAsync(new StreamItemMessage(invocationId, item));
+                    await connection.WriteAsync(new StreamItemMessage(invocationId, streamItem));
                 }
             }
             catch (ChannelClosedException ex)


### PR DESCRIPTION
We need to be sure to dispose the cts registration. 
And the actual fix here is to get rid of all of our CancelableEnumerable and use the now (hopefully) supported built in cancellation  for `IAsyncEnumerable`. Using the `[EnumeratorCancellation]` attribute to flow and combine tokens.