### PR TITLE
Work around potential race in PipeWriter

### DIFF
--- a/src/Servers/Kestrel/Core/test/TimingPipeFlusherTests.cs
+++ b/src/Servers/Kestrel/Core/test/TimingPipeFlusherTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class TimingPipeFlusherTests
+    {
+        [Fact]
+        public async Task IfFlushIsCalledAgainBeforeTheLastFlushCompletedItWaitsForTheLastCall()
+        {
+            var mockPipeWriter = new Mock<PipeWriter>();
+            var pipeWriterFlushTcsArray = new[] {
+                new TaskCompletionSource<FlushResult>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<FlushResult>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<FlushResult>(TaskCreationOptions.RunContinuationsAsynchronously),
+            };
+            var pipeWriterFlushCallCount = 0;
+
+            mockPipeWriter.Setup(p => p.FlushAsync(CancellationToken.None)).Returns(() =>
+            {
+                return new ValueTask<FlushResult>(pipeWriterFlushTcsArray[pipeWriterFlushCallCount++].Task);
+            });
+
+            var timingPipeFlusher = new TimingPipeFlusher(mockPipeWriter.Object, null, null);
+
+            var flushTask0 = timingPipeFlusher.FlushAsync();
+            var flushTask1 = timingPipeFlusher.FlushAsync();
+            var flushTask2 = timingPipeFlusher.FlushAsync();
+
+            Assert.False(flushTask0.IsCompleted);
+            Assert.False(flushTask1.IsCompleted);
+            Assert.False(flushTask2.IsCompleted);
+            Assert.Equal(1, pipeWriterFlushCallCount);
+
+            pipeWriterFlushTcsArray[0].SetResult(default);
+            await flushTask0.AsTask().DefaultTimeout();
+
+            Assert.True(flushTask0.IsCompleted);
+            Assert.False(flushTask1.IsCompleted);
+            Assert.False(flushTask2.IsCompleted);
+            Assert.True(pipeWriterFlushCallCount <= 2);
+
+            pipeWriterFlushTcsArray[1].SetResult(default);
+            await flushTask1.AsTask().DefaultTimeout();
+
+            Assert.True(flushTask0.IsCompleted);
+            Assert.True(flushTask1.IsCompleted);
+            Assert.False(flushTask2.IsCompleted);
+            Assert.True(pipeWriterFlushCallCount <= 3);
+
+            pipeWriterFlushTcsArray[2].SetResult(default);
+            await flushTask2.AsTask().DefaultTimeout();
+
+            Assert.True(flushTask0.IsCompleted);
+            Assert.True(flushTask1.IsCompleted);
+            Assert.True(flushTask2.IsCompleted);
+            Assert.Equal(3, pipeWriterFlushCallCount);
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.Libuv/test/LibuvOutputConsumerTests.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/test/LibuvOutputConsumerTests.cs
@@ -553,15 +553,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                     Assert.False(task1Waits.IsFaulted);
 
                     // following tasks should wait.
-                    var task3Canceled = outputProducer.WriteDataAsync(fullBuffer, cancellationToken: abortedSource.Token);
+                    var task2Canceled = outputProducer.WriteDataAsync(fullBuffer, cancellationToken: abortedSource.Token);
 
                     // Give time for tasks to percolate
                     await _mockLibuv.OnPostTask;
 
-                    // Third task is not completed
-                    Assert.False(task3Canceled.IsCompleted);
-                    Assert.False(task3Canceled.IsCanceled);
-                    Assert.False(task3Canceled.IsFaulted);
+                    // Second task is not completed
+                    Assert.False(task2Canceled.IsCompleted);
+                    Assert.False(task2Canceled.IsCanceled);
+                    Assert.False(task2Canceled.IsFaulted);
 
                     abortedSource.Cancel();
 
@@ -571,29 +571,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                         await _libuvThread.PostAsync(cb => cb(0), triggerNextCompleted);
                     }
 
-                    // First task is  completed
+                    // First task is completed
                     Assert.True(task1Waits.IsCompleted);
                     Assert.False(task1Waits.IsCanceled);
                     Assert.False(task1Waits.IsFaulted);
 
-                    // A final write guarantees that the error is observed by OutputProducer,
-                    // but doesn't return a canceled/faulted task.
-                    var task4Success = outputProducer.WriteDataAsync(fullBuffer);
-                    Assert.True(task4Success.IsCompleted);
-                    Assert.False(task4Success.IsCanceled);
-                    Assert.False(task4Success.IsFaulted);
+                    // Second task is now canceled
+                    await Assert.ThrowsAsync<OperationCanceledException>(() => task2Canceled);
+                    Assert.True(task2Canceled.IsCanceled);
 
-                    // Third task is now canceled
-                    await Assert.ThrowsAsync<OperationCanceledException>(() => task3Canceled);
-                    Assert.True(task3Canceled.IsCanceled);
+                    // A final write can still succeed.
+                    var task3Success = outputProducer.WriteDataAsync(fullBuffer);
 
                     await _mockLibuv.OnPostTask;
 
-                    // Complete the 4th write
+                    // Complete the 3rd write
                     while (completeQueue.TryDequeue(out var triggerNextCompleted))
                     {
                         await _libuvThread.PostAsync(cb => cb(0), triggerNextCompleted);
                     }
+
+                    Assert.True(task3Success.IsCompleted);
+                    Assert.False(task3Success.IsCanceled);
+                    Assert.False(task3Success.IsFaulted);;
                 }
             });
         }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1LargeWritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1LargeWritingBenchmark.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http.Features;
@@ -18,20 +16,15 @@ using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
-    public class Http1WritingBenchmark
+    public class Http1LargeWritingBenchmark
     {
-        // Standard completed task
-        private static readonly Func<object, Task> _syncTaskFunc = (obj) => Task.CompletedTask;
-        // Non-standard completed task
-        private static readonly Task _pseudoAsyncTask = Task.FromResult(27);
-        private static readonly Func<object, Task> _pseudoAsyncTaskFunc = (obj) => _pseudoAsyncTask;
-
         private TestHttp1Connection _http1Connection;
         private DuplexPipe.DuplexPipePair _pair;
         private MemoryPool<byte> _memoryPool;
         private Task _consumeResponseBodyTask;
 
-        private readonly byte[] _writeData = Encoding.ASCII.GetBytes("Hello, World!");
+        // Keep this divisable by 10 so it can be evenly segmented.
+        private readonly byte[] _writeData = new byte[10 * 1024 * 1024];
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -41,65 +34,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             _consumeResponseBodyTask = ConsumeResponseBody();
         }
 
-        [Params(true, false)]
-        public bool WithHeaders { get; set; }
-
-        [Params(true, false)]
-        public bool Chunked { get; set; }
-
-        [Params(Startup.None, Startup.Sync, Startup.Async)]
-        public Startup OnStarting { get; set; }
-
         [IterationSetup]
         public void Setup()
         {
             _http1Connection.Reset();
-            if (Chunked)
-            {
-                _http1Connection.RequestHeaders.Add("Transfer-Encoding", "chunked");
-            }
-            else
-            {
-                _http1Connection.RequestHeaders.ContentLength = _writeData.Length;
-            }
-
-            if (!WithHeaders)
-            {
-                _http1Connection.FlushAsync().GetAwaiter().GetResult();
-            }
-
-            ResetState();
-        }
-
-        private void ResetState()
-        {
-            if (WithHeaders)
-            {
-                _http1Connection.ResetState();
-
-                switch (OnStarting)
-                {
-                    case Startup.Sync:
-                        _http1Connection.OnStarting(_syncTaskFunc, null);
-                        break;
-                    case Startup.Async:
-                        _http1Connection.OnStarting(_pseudoAsyncTaskFunc, null);
-                        break;
-                }
-            }
+            _http1Connection.RequestHeaders.ContentLength = _writeData.Length;
+            _http1Connection.FlushAsync().GetAwaiter().GetResult();
         }
 
         [Benchmark]
         public Task WriteAsync()
         {
-            ResetState();
+            return _http1Connection.ResponseBody.WriteAsync(_writeData, 0, _writeData.Length, default);
+        }
 
-            return _http1Connection.ResponseBody.WriteAsync(_writeData, 0, _writeData.Length, default(CancellationToken));
+        [Benchmark]
+        public Task WriteSegmentsUnawaitedAsync()
+        {
+            // Write a 10th the of the data at a time
+            var segmentSize = _writeData.Length / 10;
+
+            for (int i = 0; i < 9; i++)
+            {
+                // Ignore the first nine tasks.
+                _ = _http1Connection.ResponseBody.WriteAsync(_writeData, i * segmentSize, segmentSize, default);
+            }
+
+            return _http1Connection.ResponseBody.WriteAsync(_writeData, 9 * segmentSize, segmentSize, default);
         }
 
         private TestHttp1Connection MakeHttp1Connection()
         {
-            var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
+            var options = new PipeOptions(_memoryPool, useSynchronizationContext: false);
             var pair = DuplexPipe.CreateConnectionPair(options, options);
             _pair = pair;
 
@@ -139,13 +105,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
 
             reader.Complete();
-        }
-
-        public enum Startup
-        {
-            None,
-            Sync,
-            Async
         }
 
         [GlobalCleanup]


### PR DESCRIPTION
- Make sure we always await the last flush task before calling FlushAsync
  again instead of preemptively calling FlushAsync and checking to see
  if the ValueTask is incomplete before bothering to acquire the _flushLock
- This now acquires the _flushLock fore every call to Response.Body.WriteAsync
  whereas this only happened for truly async writes before.
- I don't think this is a big concern since this should normally be uncontested,
  and DefaultPipeWriter.FlushAsync/GetResult already acquire a lock.

Addresses #8843

@benaadams

This really just #10126, but GitHub wouldn't let me reopen the PR.