### PR TITLE
Fix #10185 remove .NET framework requirement from VSIX

### DIFF
--- a/src/Components/Blazor/BlazorExtension/src/source.extension.vsixmanifest
+++ b/src/Components/Blazor/BlazorExtension/src/source.extension.vsixmanifest
@@ -14,9 +14,6 @@
     <Installation AllUsers="true">
          <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,)" />
     </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
-    </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.VsPackage"  d:Source="File" Path="Templates.pkgdef" />


### PR DESCRIPTION
Fixes #10185 by working around a VS bug. 

This is safe to remove because we will always target the minimum version that VS requires - so this metadata is totally redundant for us.

I tested this locally and it resolves the issue that blocks install on 16.1 preview 3 + .NET 4.8