### PR TITLE
Do not throw when a status code with a codefix appears multiple times…

### DIFF
--- a/src/Mvc/Mvc.Api.Analyzers/src/AddResponseTypeAttributeCodeFixAction.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/AddResponseTypeAttributeCodeFixAction.cs
@@ -169,7 +169,12 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 }
 
                 var statusCode = metadata.IsDefaultResponse ? 200 : metadata.StatusCode;
-                statusCodes.Add(statusCode, (statusCode, metadata.ReturnType));
+                if (!statusCodes.ContainsKey(statusCode))
+                {
+                    // If a status code appears multiple times in the actual metadata, pick the first one to
+                    // appear in the codefix
+                    statusCodes.Add(statusCode, (statusCode, metadata.ReturnType));
+                }
             }
 
             return statusCodes.Values;

--- a/src/Mvc/Mvc.Api.Analyzers/test/AddResponseTypeAttributeCodeFixProviderIntegrationTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/AddResponseTypeAttributeCodeFixProviderIntegrationTest.cs
@@ -51,6 +51,9 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         [Fact]
         public Task CodeFixAddsStatusCodesFromObjectInitializer() => RunTest();
 
+        [Fact]
+        public Task CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError() => RunTest();
+
         private async Task RunTest([CallerMemberName] string testMethod = "")
         {
             // Arrange

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Input.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError : ControllerBase
+    {
+        public List<CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel> Values { get; } = 
+            new List<CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel>();
+
+        public ActionResult<CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel> GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return NotFound();
+            }
+
+            var model = Values.FirstOrDefault(m => m.Id == id);
+            if (model == null)
+            {
+                return NotFound();
+            }
+
+            return model;
+        }
+    }
+
+    public class CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Output.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError : ControllerBase
+    {
+        public List<CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel> Values { get; } = 
+            new List<CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel>();
+
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesDefaultResponseType]
+        public ActionResult<CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel> GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return NotFound();
+            }
+
+            var model = Values.FirstOrDefault(m => m.Id == id);
+            if (model == null)
+            {
+                return NotFound();
+            }
+
+            return model;
+        }
+    }
+
+    public class CodeFixWorksWhenMultipleIdenticalStatusCodesAreInErrorModel
+    {
+        public int Id { get; set; }
+    }
+}


### PR DESCRIPTION
… in the method body

Fixes https://github.com/aspnet/AspNetCore/issues/4480

## Impact
This is a bug fix in an analyzer that currently crashes when running in to a fairly common scenario.

Workaround
No workaround is available outside of not using the analyzer.

Risk
Since no user code \ production scenario is impacted, and since users have to manually upgrade the package to get this change, this is a fairly low risk change.