### PR TITLE
Move iisexpress test to other IIS machines

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -36,10 +36,10 @@
     <!-- Disabled until https://github.com/dotnet/core-eng/issues/5506 is resolved -->
     <!-- <HelixAvailableTargetQueue Condition="'$(IsWindowsOnlyTest)' == 'true'" Include="Windows.7.Amd64.Open" /> -->
 
-    <HelixContent Include="..\..\..\tools\update_schema.ps1" />
-    <HelixContent Include="..\..\..\tools\UpdateIISExpressCertificate.ps1" />
-    <HelixContent Include="..\..\..\tools\TestCert.pfx" />
-    <HelixContent Include="..\..\..\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml" />
+    <HelixContent Include="$(RepositoryRoot)src\Servers\IIS\tools\update_schema.ps1" />
+    <HelixContent Include="$(RepositoryRoot)src\Servers\IIS\tools\UpdateIISExpressCertificate.ps1" />
+    <HelixContent Include="$(RepositoryRoot)src\Servers\IIS\tools\TestCert.pfx" />
+    <HelixContent Include="$(RepositoryRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml" />
 
     <HelixPreCommand Include="call RunPowershell.cmd update_schema.ps1 || exit /b 1" />
     <HelixPreCommand Include="call RunPowershell.cmd UpdateIISExpressCertificate.ps1 || exit /b 1" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -31,8 +31,8 @@
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true'">
     <HelixAvailablePlatform Include="Windows" />
 
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" Platform="Windows"/>
-    <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows"/>
+    <HelixAvailableTargetQueue Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
     <!-- Disabled until https://github.com/dotnet/core-eng/issues/5506 is resolved -->
     <!-- <HelixAvailableTargetQueue Condition="'$(IsWindowsOnlyTest)' == 'true'" Include="Windows.7.Amd64.Open" /> -->
 

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -6,7 +6,7 @@
   </ItemDefinitionGroup>
 
   <!-- this file is shared between Helix.proj and .csproj files -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailablePlatform Include="Windows" />
     <HelixAvailablePlatform Include="OSX" />
     <HelixAvailablePlatform Include="Linux" />
@@ -26,5 +26,22 @@
     <HelixAvailableTargetQueue Include="Fedora.28.Amd64.Open" Platform="Linux" />
 
     <!--  TODO: re-enable Debian.9.Arm64.Open and Ubuntu.1804.Arm64.Open    -->
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true'">
+    <HelixAvailablePlatform Include="Windows" />
+
+    <HelixProjectTargetQueue  Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" />
+    <HelixProjectTargetQueue  Include="Windows.81.Amd64.Open" />
+    <!-- Disabled until https://github.com/dotnet/core-eng/issues/5506 is resolved -->
+    <!-- <HelixProjectTargetQueue Condition="'$(IsWindowsOnlyTest)' == 'true'" Include="Windows.7.Amd64.Open" /> -->
+
+    <HelixContent Include="..\..\..\tools\update_schema.ps1" />
+    <HelixContent Include="..\..\..\tools\UpdateIISExpressCertificate.ps1" />
+    <HelixContent Include="..\..\..\tools\TestCert.pfx" />
+    <HelixContent Include="..\..\..\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml" />
+
+    <HelixPreCommand Include="call RunPowershell.cmd update_schema.ps1 || exit /b 1" />
+    <HelixPreCommand Include="call RunPowershell.cmd UpdateIISExpressCertificate.ps1 || exit /b 1" />
   </ItemGroup>
 </Project>

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -31,10 +31,10 @@
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true'">
     <HelixAvailablePlatform Include="Windows" />
 
-    <HelixProjectTargetQueue  Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" />
-    <HelixProjectTargetQueue  Include="Windows.81.Amd64.Open" />
+    <HelixAvailableTargetQueue Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" Platform="Windows"/>
+    <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows"/>
     <!-- Disabled until https://github.com/dotnet/core-eng/issues/5506 is resolved -->
-    <!-- <HelixProjectTargetQueue Condition="'$(IsWindowsOnlyTest)' == 'true'" Include="Windows.7.Amd64.Open" /> -->
+    <!-- <HelixAvailableTargetQueue Condition="'$(IsWindowsOnlyTest)' == 'true'" Include="Windows.7.Amd64.Open" /> -->
 
     <HelixContent Include="..\..\..\tools\update_schema.ps1" />
     <HelixContent Include="..\..\..\tools\UpdateIISExpressCertificate.ps1" />

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -42,9 +42,7 @@ Usage: dotnet build /t:Helix src/MyTestProject.csproj
 
     <ItemGroup>
       <!-- Include default queues based on platform -->
-      <_HelixProjectTargetQueue Include="%(HelixAvailableTargetQueue.Identity)" Condition="'$(_SelectedPlatforms.Contains(%(Platform)))' == 'true' AND '%(EnableByDefault)' == 'true'" />
-      <!-- Unconditionally include queues defined by project  -->
-      <_HelixProjectTargetQueue Include="%(HelixProjectTargetQueue.Identity)" />
+      <_HelixProjectTargetQueue Include="%(HelixAvailableTargetQueue.Identity)" Condition="'%(HelixAvailableTargetQueue.Identity)' != '' AND '$(_SelectedPlatforms.Contains('%(Platform)'))' == 'true' AND '%(EnableByDefault)' == 'true'" />
 
       <_HelixApplicableTargetQueue Include="%(_HelixProjectTargetQueue.Identity)" Condition="'%(Identity)' == '$(HelixTargetQueue)'" />
     </ItemGroup>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -42,7 +42,7 @@ Usage: dotnet build /t:Helix src/MyTestProject.csproj
 
     <ItemGroup>
       <!-- Include default queues based on platform -->
-      <_HelixProjectTargetQueue Include="%(HelixAvailableTargetQueue.Identity)" Condition="'%(HelixAvailableTargetQueue.Identity)' != '' AND '$(_SelectedPlatforms.Contains('%(Platform)'))' == 'true' AND '%(EnableByDefault)' == 'true'" />
+      <_HelixProjectTargetQueue Include="%(HelixAvailableTargetQueue.Identity)" Condition="'%(HelixAvailableTargetQueue.Identity)' != '' AND '$(_SelectedPlatforms.Contains(%(Platform)))' == 'true' AND '%(EnableByDefault)' == 'true'" />
 
       <_HelixApplicableTargetQueue Include="%(_HelixProjectTargetQueue.Identity)" Condition="'%(Identity)' == '$(HelixTargetQueue)'" />
     </ItemGroup>

--- a/src/Servers/HttpSys/test/Directory.Build.props
+++ b/src/Servers/HttpSys/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- HttpSys tests are Windows-only -->
-    <IsWindowsOnlyTest>true<IsWindowsOnlyTest>
+    <IsWindowsOnlyTest>true</IsWindowsOnlyTest>
   </PropertyGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/Directory.Build.props
+++ b/src/Servers/IIS/IIS/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- IIS tests are Windows-only -->
-    <IsWindowsOnlyTest>true<IsWindowsOnlyTest>
+    <IsWindowsOnlyTest>true</IsWindowsOnlyTest>
   </PropertyGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/Directory.Build.props
+++ b/src/Servers/IIS/IIS/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- HttpSys tests are Windows-only -->
+    <!-- IIS tests are Windows-only -->
     <IsWindowsOnlyTest>true<IsWindowsOnlyTest>
   </PropertyGroup>
 

--- a/src/Servers/IIS/IIS/test/FunctionalTest.props
+++ b/src/Servers/IIS/IIS/test/FunctionalTest.props
@@ -10,25 +10,6 @@
     <Content Include="..\Common.FunctionalTests\AppHostConfig\*.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
-    <HelixProjectPlatform Remove="Linux;OSX" />
-    <!-- Remove all default platforms for full IIS -->
-    <HelixProjectPlatform Condition="'$(IsIISTest)' == 'true'" Remove="@(HelixProjectPlatform)" />
-
-    <HelixProjectTargetQueue Condition="'$(IsIISTest)' == 'true'" Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" />
-    <HelixProjectTargetQueue Condition="'$(IsIISTest)' == 'true'" Include="Windows.81.Amd64.Open" />
-    <!-- Disabled until https://github.com/dotnet/core-eng/issues/5506 is resolved -->
-    <!-- <HelixProjectTargetQueue Condition="'$(IsIISTest)' == 'true'" Include="Windows.7.Amd64.Open" /> -->
-
-    <HelixContent Include="..\..\..\tools\update_schema.ps1" />
-    <HelixContent Include="..\..\..\tools\UpdateIISExpressCertificate.ps1" />
-    <HelixContent Include="..\..\..\tools\TestCert.pfx" />
-    <HelixContent Include="..\..\..\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml" />
-
-    <HelixPreCommand Include="call RunPowershell.cmd update_schema.ps1 || exit /b 1" />
-    <HelixPreCommand Include="call RunPowershell.cmd UpdateIISExpressCertificate.ps1 || exit /b 1" />
-  </ItemGroup>
-
   <Target Name="BuildAssets" AfterTargets="Build">
     <MSBuild Projects="@(ProjectReference)" Targets="PublishTestsAssets" SkipNonexistentTargets="true" BuildInParallel="True">
       <Output TaskParameter="TargetOutputs" ItemName="PublishedTestAsset" />

--- a/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.BackwardsCompatibility.FunctionalTests/IIS.BackwardsCompatibility.FunctionalTests.csproj
@@ -5,7 +5,6 @@
     <TestGroupName>IISBackwardsCompatibility.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISBackwardsCompatibilityTests)' == 'true' ">true</SkipTests>
-    <IsIISTest>true</IsIISTest>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />

--- a/src/Servers/IIS/IIS/test/IIS.ForwardsCompatibility.FunctionalTests/IIS.ForwardsCompatibility.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.ForwardsCompatibility.FunctionalTests/IIS.ForwardsCompatibility.FunctionalTests.csproj
@@ -5,7 +5,6 @@
     <TestGroupName>IISForwardsCompatibility.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISForwardsCompatibilityTests)' == 'true' ">true</SkipTests>
-    <IsIISTest>true</IsIISTest>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -6,7 +6,6 @@
     <TestGroupName>IIS.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISTests)' == 'true' ">true</SkipTests>
-    <IsIISTest>true</IsIISTest>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />

--- a/src/Servers/IIS/IIS/test/IIS.Tests/IIS.Tests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/IIS.Tests.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <InProcessTestSite>true</InProcessTestSite>
-    <IsIISTest>true</IsIISTest>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <TestGroupName>IISExpress.FunctionalTests</TestGroupName>
+    <IsIISTest>true</IsIISTest>
     <SkipTests Condition=" '$(SkipIISExpressTests)' == 'true' ">true</SkipTests>
   </PropertyGroup>
 

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <TestGroupName>IISExpress.FunctionalTests</TestGroupName>
-    <IsIISTest>true</IsIISTest>
     <SkipTests Condition=" '$(SkipIISExpressTests)' == 'true' ">true</SkipTests>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2512.

IISExpress tests weren't marked as IISTests. We need to see if the Win10 machine that has IIS on it also has IISExpress.