### PR TITLE
Add missing app namespace to server-side Blazor template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/_Imports.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/_Imports.razor
@@ -3,4 +3,5 @@
 @using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.JSInterop
+@using RazorComponentsWeb_CSharp
 @using RazorComponentsWeb_CSharp.Shared


### PR DESCRIPTION
Fixes #10239