### PR TITLE
Publish the shared framework MSI to artifacts

### DIFF
--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -15,6 +15,7 @@
     <HarvestDirectorySuppressSpecificWarnings>5150;5151</HarvestDirectorySuppressSpecificWarnings>
     <HarvestDirectorySuppressRegistry>true</HarvestDirectorySuppressRegistry>
     <HarvestSource>$(IntermediateOutputPath)fx\</HarvestSource>
+    <IsProductInstaller>true</IsProductInstaller>
     <DefineConstants>$(DefineConstants);AspNetCoreSharedFrameworkSource=$(HarvestSource)</DefineConstants>
     <NamespaceGuid>$(SharedFrameworkNamespaceGuid)</NamespaceGuid>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
Publish the shared framework MSI to artifacts. This will enable the SDK to consume it directly for Visual Studio changes we're making.