### PR TITLE
Add components solution filter file

### DIFF
--- a/src/Components/ComponentsNoDeps.slnf
+++ b/src/Components/ComponentsNoDeps.slnf
@@ -1,0 +1,35 @@
+{
+  "solution": {
+    "path": "Components.sln",
+    "projects": [
+      "Analyzers\\src\\Microsoft.AspNetCore.Components.Analyzers.csproj",
+      "Analyzers\\test\\Microsoft.AspNetCore.Components.Analyzers.Tests.csproj",
+      "Blazor\\Blazor\\src\\Microsoft.AspNetCore.Blazor.csproj",
+      "Blazor\\Blazor\\test\\Microsoft.AspNetCore.Blazor.Tests.csproj",
+      "Blazor\\Build\\src\\Microsoft.AspNetCore.Blazor.Build.csproj",
+      "Blazor\\Build\\test\\Microsoft.AspNetCore.Blazor.Build.Tests.csproj",
+      "Blazor\\DevServer\\src\\Microsoft.AspNetCore.Blazor.DevServer.csproj",
+      "Blazor\\Server\\src\\Microsoft.AspNetCore.Blazor.Server.csproj",
+      "Blazor\\Templates\\src\\Microsoft.AspNetCore.Blazor.Templates.csproj",
+      "Blazor\\testassets\\HostedInAspNet.Client\\HostedInAspNet.Client.csproj",
+      "Blazor\\testassets\\HostedInAspNet.Server\\HostedInAspNet.Server.csproj",
+      "Blazor\\testassets\\Microsoft.AspNetCore.Blazor.E2EPerformance\\Microsoft.AspNetCore.Blazor.E2EPerformance.csproj",
+      "Blazor\\testassets\\MonoSanityClient\\MonoSanityClient.csproj",
+      "Blazor\\testassets\\MonoSanity\\MonoSanity.csproj",
+      "Blazor\\testassets\\StandaloneApp\\StandaloneApp.csproj",
+      "Browser\\src\\Microsoft.AspNetCore.Components.Browser.csproj",
+      "Components\\perf\\Microsoft.AspNetCore.Components.Performance.csproj",
+      "Components\\src\\Microsoft.AspNetCore.Components.csproj",
+      "Components\\test\\Microsoft.AspNetCore.Components.Tests.csproj",
+      "Server\\src\\Microsoft.AspNetCore.Components.Server.csproj",
+      "Server\\test\\Microsoft.AspNetCore.Components.Server.Tests.csproj",
+      "blazor\\BlazorExtension\\src\\Microsoft.VisualStudio.BlazorExtension.csproj",
+      "test\\E2ETest\\Microsoft.AspNetCore.Components.E2ETests.csproj",
+      "test\\testassets\\BasicTestApp\\BasicTestApp.csproj",
+      "test\\testassets\\ComponentsApp.App\\ComponentsApp.App.csproj",
+      "test\\testassets\\ComponentsApp.Server\\ComponentsApp.Server.csproj",
+      "test\\testassets\\TestContentPackage\\TestContentPackage.csproj",
+      "test\\testassets\\TestServer\\TestServer.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
I'm still figuring out whether there are any drawbacks or problems with this, but so far it seems to be working great. Opening this PR now in case others have insight into the practicality of it.

Previously, if dependency projects were not loaded in the solution, the build would fail in VS. However with the current version of VS (16.1.0 Preview 3), it now appears to handle this scenario just fine, assuming you've already done at least one command-line build.

This PR adds a [solution filter file](https://docs.microsoft.com/en-us/visualstudio/ide/filtered-solutions?view=vs-2019) `ComponentsNoDeps.slnf` you can optionally use instead of `Components.sln`. This makes VS only load the 28 projects under `src/Components` and *not* the whole set of 94 projects if transitive project references are included. For me, this means:

 * VS open in a couple of seconds compared with about 30 seconds before
 * A cold (first-time) full-solution build is now about 15-20 seconds (mostly spent in the Mono linker) versus about 1-2 minutes before.
 * A warm (not much changed) full-solution build is now about 10 seconds versus about 30 seconds before
 * Test explorer and debugging still work and are much quicker starting/updating

Am I really behind the curve and everyone else was already doing this? Or has this only just become possible?