### PR TITLE
Make dotnet-sql-cache an OOB package

### DIFF
--- a/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
+++ b/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
@@ -6,8 +6,7 @@
     <Description>Command line tool to create tables and indexes in a Microsoft SQL Server database for distributed caching.</Description>
     <PackageTags>cache;distributedcache;sqlserver</PackageTags>
     <PackAsTool>true</PackAsTool>
-    <!-- This package is for internal use only. It contains a CLI which is bundled in the .NET Core SDK. -->
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
React to https://github.com/dotnet/core-sdk/pull/2014, which removes the `dotnet sql-cache` command from shipping in the box.
Part of https://github.com/aspnet/AspNetCore/issues/3752 and also a reaction to #10013 

Users who still need this command will be able to install this tool by running:
```
dotnet tool install -g dotnet-sql-cache
```

cc @DamianEdwards @divega @Pilchie 