### PR TITLE
Use Arcade version suffixes for local (3.0.0-dev) and PR builds (3.0.0-ci)

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -202,7 +202,7 @@ See ["Artifacts"](./Artifacts.md) for more explanation of the different folders 
 - Update the versions on `PackageReference` items in your .csproj project file to point to the version from your local build.
   ```xml
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.0.0-preview-0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.0.0-dev" />
   </ItemGroup>
   ```
 

--- a/src/Components/Blazor/BlazorExtension/src/Microsoft.VisualStudio.BlazorExtension.csproj
+++ b/src/Components/Blazor/BlazorExtension/src/Microsoft.VisualStudio.BlazorExtension.csproj
@@ -48,7 +48,7 @@
       is used by our build system.
     -->
     <VsixVersionPrefix>16.0</VsixVersionPrefix>
-    <VsixVersionSuffix Condition="'$(BuildNumberSuffix)'=='t000'">424242.424242</VsixVersionSuffix>
+    <VsixVersionSuffix Condition="'$(OfficialBuild)'!='true'">424242.424242</VsixVersionSuffix>
     <VsixVersionSuffix Condition="'$(VsixVersionSuffix)'==''">$(BuildNumberSuffix.Replace('-', '.'))</VsixVersionSuffix>
     <VsixVersion>$(VsixVersionPrefix).$(VsixVersionSuffix)</VsixVersion>
 

--- a/src/Installers/Windows/Wix.props
+++ b/src/Installers/Windows/Wix.props
@@ -4,7 +4,7 @@
     <!-- Used for generating stable upgrade codes for bundles -->
     <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).0</Version>
     <!-- Actual upgrade code used in bundles to ensure upgrades withing a version band, e.g. 3.0.0.xxx -->
-    <BundleVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(_BuildNumberShortDate)</BundleVersion>
+    <BundleVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(FileRevisionVersion)</BundleVersion>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Lang Condition="'$(Lang)' == ''">ENU</Lang>

--- a/src/ProjectTemplates/scripts/Run-Angular-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Angular-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "angular" "angular" "Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0.0-preview5-t000.nupkg" $true
+Test-Template "angular" "angular" "Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0.0-dev.nupkg" $true

--- a/src/ProjectTemplates/scripts/Run-EmptyWeb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-EmptyWeb-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "web" "web" "Microsoft.DotNet.Web.ProjectTemplates.3.0.3.0.0-preview4-t000.nupkg" $false
+Test-Template "web" "web" "Microsoft.DotNet.Web.ProjectTemplates.3.0.3.0.0-dev.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
@@ -6,4 +6,4 @@ param()
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapp" "webapp -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.3.0.3.0.0-preview4-t000.nupkg" $false
+Test-Template "webapp" "webapp -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.3.0.3.0.0-dev.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-React-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-React-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "react" "react" "Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0.0-preview4-t000.nupkg" $true
+Test-Template "react" "react" "Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0.0-dev.nupkg" $true

--- a/src/ProjectTemplates/scripts/Run-ReactRedux-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-ReactRedux-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "reactredux" "reactredux" "Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0.0-preview4-t000.nupkg" $true
+Test-Template "reactredux" "reactredux" "Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0.0-dev.nupkg" $true

--- a/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.3.0.3.0.0-preview4-t000.nupkg" $false
+Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.3.0.3.0.0-dev.nupkg" $false

--- a/src/ProjectTemplates/test/Infrastructure/TemplateTests.props.in
+++ b/src/ProjectTemplates/test/Infrastructure/TemplateTests.props.in
@@ -19,7 +19,7 @@
       LatestRuntimeFrameworkVersion="${MicrosoftAspNetCoreAppPackageVersion}"
       TargetingPackName="Microsoft.AspNetCore.App.Ref"
       TargetingPackVersion="${MicrosoftAspNetCoreAppPackageVersion}"
-      RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
+      RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
       RuntimePackRuntimeIdentifiers="${SupportedRuntimeIdentifiers}" />
   </ItemGroup>
 

--- a/src/ProjectTemplates/test/Infrastructure/TemplateTests.props.in
+++ b/src/ProjectTemplates/test/Infrastructure/TemplateTests.props.in
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestoreSources>${RestoreSources}</RestoreSources>
+    <!-- This sets an option which prevents the tests from rolling forward into a newer shared framework. -->
+    <UserRuntimeConfig>$(MSBuildThisFileDirectory)runtimeconfig.norollforward.json</UserRuntimeConfig>
     <!-- Workaround https://github.com/dotnet/cli/issues/10528 -->
     <BundledNETCorePlatformsPackageVersion>${MicrosoftNETCorePlatformsPackageVersion}</BundledNETCorePlatformsPackageVersion>
   </PropertyGroup>

--- a/src/ProjectTemplates/test/Infrastructure/runtimeconfig.norollforward.json
+++ b/src/ProjectTemplates/test/Infrastructure/runtimeconfig.norollforward.json
@@ -1,0 +1,3 @@
+{
+  "rollForward": "Disable"
+}

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -126,6 +126,8 @@
       Properties=""
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.props" />
 
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)Infrastructure\runtimeconfig.norollforward.json" DestinationFolder="$(TestTemplateCreationFolder)" UseHardLinksIfPossible="true" />
+
     <Delete Files="$(TestTemplateTestsProps)" />
 
   </Target>

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -126,6 +126,7 @@
       Properties=""
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.props" />
 
+    <!-- Workaround https://github.com/dotnet/core-setup/issues/6420 - there is no MSBuild setting for rollforward yet -->
     <Copy SourceFiles="$(MSBuildThisFileDirectory)Infrastructure\runtimeconfig.norollforward.json" DestinationFolder="$(TestTemplateCreationFolder)" UseHardLinksIfPossible="true" />
 
     <Delete Files="$(TestTemplateTestsProps)" />

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -769,6 +770,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         }
 
         [Theory]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2465", FlakyOn.All)]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         [LogLevel(LogLevel.Trace)]
         public async Task CanCancelIAsyncEnumerableClientToServerUpload(string protocolName, HttpTransportType transportType, string path)

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspnet/signalr-protocol-msgpack",
-  "version": "3.0.0-preview4-t000",
+  "version": "3.0.0-dev",
   "description": "MsgPack Protocol support for ASP.NET Core SignalR",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspnet/signalr",
-  "version": "3.0.0-preview4-t000",
+  "version": "3.0.0-dev",
   "description": "ASP.NET Core SignalR Client",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/version.props
+++ b/version.props
@@ -17,10 +17,10 @@
     <AspNetCoreModuleVersionRevision>$(AspNetCorePatchVersion)</AspNetCoreModuleVersionRevision>
 
     <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>
-    <OfficialBuildId Condition="'$(OfficialBuildId)' == '' AND '$(IsOfficialBuild)' == 'true'">$([System.DateTime]::Now.ToString('yyyyMMdd')).1</OfficialBuildId>
+    <OfficialBuild Condition="'$(OfficialBuildId)' != '' AND '$(BUILD_REASON)' != 'PullRequest'">true</OfficialBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(OfficialBuildId)' != '' ">
+  <PropertyGroup Condition=" '$(OfficialBuild)' == 'true' ">
     <!-- This *mostly*  implements core versioning. Spec: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md -->
     <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
 
@@ -40,15 +40,17 @@
     <BuildNumberSuffix>$(_BuildNumberShortDate)-$(VersionSuffixBuildOfTheDayPadded)</BuildNumberSuffix>
 
     <FileRevisionVersion>$(_BuildNumberShortDate)</FileRevisionVersion>
+    <VersionSuffix>$(PreReleaseLabel)-$(BuildNumberSuffix)</VersionSuffix>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(OfficialBuildId)' == '' ">
-    <BuildNumberSuffix>t000</BuildNumberSuffix>
+  <PropertyGroup Condition=" '$(OfficialBuild)' != 'true' ">
+    <BuildNumberSuffix>0</BuildNumberSuffix>
     <FileRevisionVersion>42424</FileRevisionVersion>
+    <VersionSuffix Condition="'$(CI)' != 'true'">dev</VersionSuffix>
+    <VersionSuffix Condition="'$(CI)' == 'true'">ci</VersionSuffix>
   </PropertyGroup>
 
    <PropertyGroup>
-    <VersionSuffix>$(PreReleaseLabel)-$(BuildNumberSuffix)</VersionSuffix>
     <BrandingVersionSuffix>$(PreReleaseBrandingLabel) Build $(BuildNumberSuffix)</BrandingVersionSuffix>
 
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->


### PR DESCRIPTION
Part of #7280 (Convert to Arcade)

This updates our versioning to better match Arcades https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md

Effective changes
* Local builds will build and produce packages as 3.0.0-dev
* PR builds will build and produce packages as 3.0.0-ci

Everything else should remain the same