### PR TITLE
Disable SameSite for AzureAd and B2C cookies 

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
 
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
@@ -29,6 +30,7 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
             options.LoginPath = $"/AzureAD/Account/SignIn/{AzureADScheme}";
             options.LogoutPath = $"/AzureAD/Account/SignOut/{AzureADScheme}";
             options.AccessDeniedPath = "/AzureAD/Account/AccessDenied";
+            options.Cookie.SameSite = SameSiteMode.None;
         }
 
         public void Configure(CookieAuthenticationOptions options)

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
 
 using System;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -74,6 +75,14 @@ namespace Microsoft.AspNetCore.Authentication
             Assert.True(openIdOptions.UseTokenLifetime);
             Assert.Equal("/signin-oidc", openIdOptions.CallbackPath);
             Assert.Equal(AzureADDefaults.CookieScheme, openIdOptions.SignInScheme);
+
+            var cookieAuthenticationOptionsMonitor = provider.GetService<IOptionsMonitor<CookieAuthenticationOptions>>();
+            Assert.NotNull(cookieAuthenticationOptionsMonitor);
+            var cookieAuthenticationOptions = cookieAuthenticationOptionsMonitor.Get(AzureADDefaults.CookieScheme);
+            Assert.Equal("/AzureAD/Account/SignIn/AzureAD", cookieAuthenticationOptions.LoginPath);
+            Assert.Equal("/AzureAD/Account/SignOut/AzureAD", cookieAuthenticationOptions.LogoutPath);
+            Assert.Equal("/AzureAD/Account/AccessDenied", cookieAuthenticationOptions.AccessDeniedPath);
+            Assert.Equal(SameSiteMode.None, cookieAuthenticationOptions.Cookie.SameSite);
         }
 
         [Fact]

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CCookieOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CCookieOptionsConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
 
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.AzureADB2C.UI
@@ -29,6 +30,7 @@ namespace Microsoft.AspNetCore.Authentication.AzureADB2C.UI
             options.LoginPath = $"/AzureADB2C/Account/SignIn/{azureADB2CScheme}";
             options.LogoutPath = $"/AzureADB2C/Account/SignOut/{azureADB2CScheme}";
             options.AccessDeniedPath = "/AzureADB2C/Account/AccessDenied";
+            options.Cookie.SameSite = SameSiteMode.None;
         }
 
         public void Configure(CookieAuthenticationOptions options)

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/AzureAdB2CAuthenticationBuilderExtensionsTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/AzureAdB2CAuthenticationBuilderExtensionsTests.cs
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
 
 using System;
+using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -88,6 +89,14 @@ namespace Microsoft.AspNetCore.Authentication
             var remoteFailureHanlder = openIdOptions.Events.OnRemoteFailure;
             Assert.NotNull(remoteFailureHanlder);
             Assert.IsType<AzureADB2COpenIDConnectEventHandlers>(redirectHandler.Target);
+
+            var cookieAuthenticationOptionsMonitor = provider.GetService<IOptionsMonitor<CookieAuthenticationOptions>>();
+            Assert.NotNull(cookieAuthenticationOptionsMonitor);
+            var cookieAuthenticationOptions = cookieAuthenticationOptionsMonitor.Get(AzureADB2CDefaults.CookieScheme);
+            Assert.Equal("/AzureADB2C/Account/SignIn/AzureADB2C", cookieAuthenticationOptions.LoginPath);
+            Assert.Equal("/AzureADB2C/Account/SignOut/AzureADB2C", cookieAuthenticationOptions.LogoutPath);
+            Assert.Equal("/AzureADB2C/Account/AccessDenied", cookieAuthenticationOptions.AccessDeniedPath);
+            Assert.Equal(SameSiteMode.None, cookieAuthenticationOptions.Cookie.SameSite);
         }
 
         [Fact]


### PR DESCRIPTION
#9115
 https://github.com/aspnet/Announcements/issues/348

We've previously disabled SameSite for many OAuth/OIDC scenarios, but we haven't done it for the cookies added by AddAzureAd and AddAzureAdB2C.

The workaround for these scenarios is not discoverable. Disable them by default.