### PR TITLE
Components auth step 2

### DIFF
--- a/eng/GenAPI.exclusions.txt
+++ b/eng/GenAPI.exclusions.txt
@@ -4,6 +4,8 @@ T:Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame
 T:Microsoft.AspNetCore.Mvc.ApplicationModels.PageParameterModel
 T:Microsoft.AspNetCore.Mvc.ApplicationModels.PagePropertyModel
 # Manually implemented - https://github.com/aspnet/AspNetCore/issues/8825
+T:Microsoft.AspNetCore.Components.AuthorizeView
+T:Microsoft.AspNetCore.Components.CascadingAuthenticationState
 T:Microsoft.AspNetCore.Components.CascadingValue`1
 T:Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator
 T:Microsoft.AspNetCore.Components.Forms.EditForm

--- a/src/Components/Blazor/Blazor/test/WebAssemblyUriHelperTest.cs
+++ b/src/Components/Blazor/Blazor/test/WebAssemblyUriHelperTest.cs
@@ -29,6 +29,9 @@ namespace Microsoft.AspNetCore.Blazor.Services.Test
         [InlineData("scheme://host/path/", "scheme://host/path/", "")]
         [InlineData("scheme://host/path/", "scheme://host/path/more", "more")]
         [InlineData("scheme://host/path/", "scheme://host/path", "")]
+        [InlineData("scheme://host/path/", "scheme://host/path#hash", "#hash")]
+        [InlineData("scheme://host/path/", "scheme://host/path/#hash", "#hash")]
+        [InlineData("scheme://host/path/", "scheme://host/path/more#hash", "more#hash")]
         public void ComputesCorrectValidBaseRelativePaths(string baseUri, string absoluteUri, string expectedResult)
         {
             var actualResult = _uriHelper.ToBaseRelativePath(baseUri, absoluteUri);

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.Manual.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.Manual.cs
@@ -49,6 +49,32 @@ namespace Microsoft.AspNetCore.Components.RenderTree
 // Built-in components: https://github.com/aspnet/AspNetCore/issues/8825
 namespace Microsoft.AspNetCore.Components
 {
+    public partial class AuthorizeView : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        public AuthorizeView() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> Authorized { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment Authorizing { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment NotAuthorized { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; } }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        protected override System.Threading.Tasks.Task OnParametersSetAsync() { throw null; }
+    }
+
+    public partial class CascadingAuthenticationState : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
+    {
+        public CascadingAuthenticationState() { }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } private set { throw null; } }
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
+        protected override void OnInit() { }
+        void System.IDisposable.Dispose() { }
+    }
+
     public partial class CascadingValue<T> : Microsoft.AspNetCore.Components.IComponent
     {
         public CascadingValue() { }

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -16,21 +16,6 @@ namespace Microsoft.AspNetCore.Components
         public abstract System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.AuthenticationState> GetAuthenticationStateAsync();
         protected void NotifyAuthenticationStateChanged(System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.AuthenticationState> task) { }
     }
-    public partial class AuthorizeView : Microsoft.AspNetCore.Components.ComponentBase
-    {
-        public AuthorizeView() { }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> Authorized { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment Authorizing { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment NotAuthorized { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
-        protected override System.Threading.Tasks.Task OnParametersSetAsync() { throw null; }
-    }
     [Microsoft.AspNetCore.Components.BindElementAttribute("select", null, "value", "onchange")]
     [Microsoft.AspNetCore.Components.BindElementAttribute("textarea", null, "value", "onchange")]
     [Microsoft.AspNetCore.Components.BindInputElementAttribute("checkbox", null, "checked", "onchange")]
@@ -84,15 +69,6 @@ namespace Microsoft.AspNetCore.Components
         public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<float> setter, float existingValue) { throw null; }
         public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler(System.Action<string> setter, string existingValue) { throw null; }
         public static System.Action<Microsoft.AspNetCore.Components.UIEventArgs> SetValueHandler<T>(System.Action<T> setter, T existingValue) { throw null; }
-    }
-    public partial class CascadingAuthenticationState : Microsoft.AspNetCore.Components.ComponentBase, System.IDisposable
-    {
-        public CascadingAuthenticationState() { }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.RenderTree.RenderTreeBuilder builder) { }
-        protected override void OnInit() { }
-        void System.IDisposable.Dispose() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
     public sealed partial class CascadingParameterAttribute : System.Attribute

--- a/src/Components/Components/src/Auth/AuthenticationState.cs
+++ b/src/Components/Components/src/Auth/AuthenticationState.cs
@@ -12,11 +12,6 @@ namespace Microsoft.AspNetCore.Components
     public class AuthenticationState
     {
         /// <summary>
-        /// Gets a <see cref="ClaimsPrincipal"/> that describes the current user.
-        /// </summary>
-        public ClaimsPrincipal User { get; }
-
-        /// <summary>
         /// Constructs an instance of <see cref="AuthenticationState"/>.
         /// </summary>
         /// <param name="user">A <see cref="ClaimsPrincipal"/> representing the user.</param>
@@ -24,5 +19,10 @@ namespace Microsoft.AspNetCore.Components
         {
             User = user ?? throw new ArgumentNullException(nameof(user));
         }
+
+        /// <summary>
+        /// Gets a <see cref="ClaimsPrincipal"/> that describes the current user.
+        /// </summary>
+        public ClaimsPrincipal User { get; }
     }
 }

--- a/src/Components/Components/src/Auth/AuthenticationStateProvider.cs
+++ b/src/Components/Components/src/Auth/AuthenticationStateProvider.cs
@@ -12,19 +12,16 @@ namespace Microsoft.AspNetCore.Components
     public abstract class AuthenticationStateProvider
     {
         /// <summary>
-        /// Gets an <see cref="AuthenticationState"/> instance that describes
-        /// the current user.
+        /// Asynchronously gets an <see cref="AuthenticationState"/> that describes the current user.
         /// </summary>
-        /// <returns>An <see cref="AuthenticationState"/> instance that describes the current user.</returns>
+        /// <returns>A task that, when resolved, gives an <see cref="AuthenticationState"/> instance that describes the current user.</returns>
         public abstract Task<AuthenticationState> GetAuthenticationStateAsync();
 
         /// <summary>
         /// An event that provides notification when the <see cref="AuthenticationState"/>
         /// has changed. For example, this event may be raised if a user logs in or out.
         /// </summary>
-#pragma warning disable 0067 // "Never used" (it's only raised by subclasses)
         public event AuthenticationStateChangedHandler AuthenticationStateChanged;
-#pragma warning restore 0067
 
         /// <summary>
         /// Raises the <see cref="AuthenticationStateChanged"/> event.

--- a/src/Components/Components/src/UriHelperBase.cs
+++ b/src/Components/Components/src/UriHelperBase.cs
@@ -154,7 +154,10 @@ namespace Microsoft.AspNetCore.Components
                 // baseUri ends with a slash), and from that we return "something"
                 return locationAbsolute.Substring(baseUri.Length);
             }
-            else if ($"{locationAbsolute}/".Equals(baseUri, StringComparison.Ordinal))
+
+            var hashIndex = locationAbsolute.IndexOf('#');
+            var locationAbsoluteNoHash = hashIndex < 0 ? locationAbsolute : locationAbsolute.Substring(0, hashIndex);
+            if ($"{locationAbsoluteNoHash}/".Equals(baseUri, StringComparison.Ordinal))
             {
                 // Special case: for the base URI "/something/", if you're at
                 // "/something" then treat it as if you were at "/something/" (i.e.,
@@ -162,7 +165,7 @@ namespace Microsoft.AspNetCore.Components
                 // whether the server would return the same page whether or not the
                 // slash is present, but ASP.NET Core at least does by default when
                 // using PathBase.
-                return string.Empty;
+                return locationAbsolute.Substring(baseUri.Length - 1);
             }
 
             var message = $"The URI '{locationAbsolute}' is not contained by the base URI '{baseUri}'.";

--- a/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/BasicTestAppTestBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure
     public class BasicTestAppTestBase : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
     {
         public string ServerPathBase
-            => "/subdir" + (_serverFixture.UsingAspNetHost ? "#server" : "");
+            => "/subdir" + (_serverFixture.ExecutionMode == ExecutionMode.Server ? "#server" : "");
 
         public BasicTestAppTestBase(
             BrowserFixture browserFixture,

--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/ToggleExecutionModeServerFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/ToggleExecutionModeServerFixture.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures
         : ServerFixture
     {
         public string PathBase { get; set; }
-        public bool UsingAspNetHost { get; private set; }
+
+        public ExecutionMode ExecutionMode { get; set; } = ExecutionMode.Client;
 
         private AspNetSiteServerFixture.BuildWebHost _buildWebHostMethod;
         private IDisposable _serverToDispose;
@@ -18,7 +19,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures
         {
             _buildWebHostMethod = buildWebHostMethod
                 ?? throw new ArgumentNullException(nameof(buildWebHostMethod));
-            UsingAspNetHost = true;
         }
 
         protected override string StartAndGetRootUri()
@@ -46,4 +46,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures
             _serverToDispose?.Dispose();
         }
     }
+
+    public enum ExecutionMode { Client, Server }
 }

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -8,7 +8,7 @@ using OpenQA.Selenium;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.AspNetCore.Components.E2ETests.ServerExecutionTests
+namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
     public class PrerenderingTest : ServerTestBase<AspNetSiteServerFixture>
     {

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerExecutionTestExtensions.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerExecutionTestExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public static ToggleExecutionModeServerFixture<T> WithServerExecution<T>(this ToggleExecutionModeServerFixture<T> serverFixture)
         {
             serverFixture.UseAspNetHost(TestServer.Program.BuildWebHost);
+            serverFixture.ExecutionMode = ExecutionMode.Server;
             return serverFixture;
         }
     }

--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -81,4 +81,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
         }
     }
+
+    public class ServerAuthTest : AuthTest
+    {
+        public ServerAuthTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+    }
 }

--- a/src/Components/test/E2ETest/Tests/AuthTest.cs
+++ b/src/Components/test/E2ETest/Tests/AuthTest.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicTestApp;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using OpenQA.Selenium;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.Tests
+{
+    public class AuthTest : BasicTestAppTestBase
+    {
+        const string CascadingAuthenticationStateLink = "Cascading authentication state";
+
+        public AuthTest(
+            BrowserFixture browserFixture,
+            ToggleExecutionModeServerFixture<Program> serverFixture,
+            ITestOutputHelper output)
+            : base(browserFixture, serverFixture, output)
+        {
+            // Normally, the E2E tests use the Blazor dev server if they are testing
+            // client-side execution. But for the auth tests, we always have to run
+            // in "hosted on ASP.NET Core" mode, because we get the auth state from it.
+            serverFixture.UseAspNetHost(TestServer.Program.BuildWebHost);
+        }
+
+        [Fact]
+        public void CascadingAuthenticationState_Unauthenticated()
+        {
+            SignInAs(null);
+
+            var appElement = MountAndNavigateToAuthTest(CascadingAuthenticationStateLink);
+
+            Browser.Equal("False", () => appElement.FindElement(By.Id("identity-authenticated")).Text);
+            Browser.Equal(string.Empty, () => appElement.FindElement(By.Id("identity-name")).Text);
+            Browser.Equal("(none)", () => appElement.FindElement(By.Id("test-claim")).Text);
+        }
+
+        [Fact]
+        public void CascadingAuthenticationState_Authenticated()
+        {
+            SignInAs("someone cool");
+
+            var appElement = MountAndNavigateToAuthTest(CascadingAuthenticationStateLink);
+
+            Browser.Equal("True", () => appElement.FindElement(By.Id("identity-authenticated")).Text);
+            Browser.Equal("someone cool", () => appElement.FindElement(By.Id("identity-name")).Text);
+            Browser.Equal("Test claim value", () => appElement.FindElement(By.Id("test-claim")).Text);
+        }
+
+        IWebElement MountAndNavigateToAuthTest(string authLinkText)
+        {
+            Navigate(ServerPathBase);
+            var appElement = MountTestComponent<BasicTestApp.AuthTest.AuthRouter>();
+            WaitUntilExists(By.Id("auth-links"));
+            appElement.FindElement(By.LinkText(authLinkText)).Click();
+            return appElement;
+        }
+
+        void SignInAs(string usernameOrNull)
+        {
+            const string authenticationPageUrl = "/Authentication";
+            var baseRelativeUri = usernameOrNull == null
+                ? $"{authenticationPageUrl}?signout=true"
+                : $"{authenticationPageUrl}?username={usernameOrNull}";
+            Navigate(baseRelativeUri);
+            WaitUntilExists(By.CssSelector("h1#authentication"));
+        }
+    }
+}

--- a/src/Components/test/E2ETest/Tests/AuthTest.cs
+++ b/src/Components/test/E2ETest/Tests/AuthTest.cs
@@ -13,7 +13,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 {
     public class AuthTest : BasicTestAppTestBase
     {
+        // These strings correspond to the links in BasicTestApp\AuthTest\Links.razor
         const string CascadingAuthenticationStateLink = "Cascading authentication state";
+        const string AuthorizeViewCases = "AuthorizeView cases";
 
         public AuthTest(
             BrowserFixture browserFixture,
@@ -49,6 +51,23 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("True", () => appElement.FindElement(By.Id("identity-authenticated")).Text);
             Browser.Equal("someone cool", () => appElement.FindElement(By.Id("identity-name")).Text);
             Browser.Equal("Test claim value", () => appElement.FindElement(By.Id("test-claim")).Text);
+        }
+
+        [Fact]
+        public void AuthorizeViewCases_NoAuthorizationRule_Unauthenticated()
+        {
+            SignInAs(null);
+            MountAndNavigateToAuthTest(AuthorizeViewCases);
+            WaitUntilExists(By.CssSelector("#no-authorization-rule .not-authorized"));
+        }
+
+        [Fact]
+        public void AuthorizeViewCases_NoAuthorizationRule_Authenticated()
+        {
+            SignInAs("Some User");
+            var appElement = MountAndNavigateToAuthTest(AuthorizeViewCases);
+            Browser.Equal("Welcome, Some User!", () =>
+                appElement.FindElement(By.CssSelector("#no-authorization-rule .authorized")).Text);
         }
 
         IWebElement MountAndNavigateToAuthTest(string authLinkText)

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         protected override void InitializeAsyncCore()
         {
             // On WebAssembly, page reloads are expensive so skip if possible
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
             MountTestComponent<BindCasesComponent>();
             WaitUntilExists(By.Id("bind-cases"));
         }

--- a/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
+++ b/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         protected override void InitializeAsyncCore()
         {
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
             MountTestComponent<BasicTestApp.CascadingValueTest.CascadingValueSupplier>();
         }
 

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         protected override void InitializeAsyncCore()
         {
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         protected override void InitializeAsyncCore()
         {
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
             MountTestComponent<EventBubblingComponent>();
             WaitUntilExists(By.Id("event-bubbling"));
         }

--- a/src/Components/test/E2ETest/Tests/EventCallbackTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventCallbackTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         protected override void InitializeAsyncCore()
         {
             // On WebAssembly, page reloads are expensive so skip if possible
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
             MountTestComponent<BasicTestApp.EventCallbackTest.EventCallbackCases>();
         }
 

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         protected override void InitializeAsyncCore()
         {
             // On WebAssembly, page reloads are expensive so skip if possible
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Include the sync assertions only when running under WebAssembly
             var expectedValues = expectedAsyncValues;
-            if (!_serverFixture.UsingAspNetHost)
+            if (_serverFixture.ExecutionMode == ExecutionMode.Client)
             {
                 foreach (var kvp in expectedSyncValues)
                 {

--- a/src/Components/test/E2ETest/Tests/KeyTest.cs
+++ b/src/Components/test/E2ETest/Tests/KeyTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         protected override void InitializeAsyncCore()
         {
             // On WebAssembly, page reloads are expensive so skip if possible
-            Navigate(ServerPathBase, noReload: !_serverFixture.UsingAspNetHost);
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
         }
 
         [Fact]

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthHome.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthHome.razor
@@ -1,0 +1,3 @@
+@page "/AuthHome"
+
+Select an auth test below.

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
@@ -1,0 +1,29 @@
+@using Microsoft.AspNetCore.Components.Routing
+@inject IUriHelper UriHelper
+
+@*
+    This router is independent of any other router that may exist within the same project.
+    It exists so that (1) we can easily have multiple test cases that depend on the
+    CascadingAuthenticationState, and (2) we can test the integration between the router
+    and @page authorization rules.
+*@
+
+<CascadingAuthenticationState>
+    <Router AppAssembly=typeof(BasicTestApp.Program).Assembly />
+</CascadingAuthenticationState>
+
+<hr />
+<Links />
+
+@functions {
+    protected override void OnInit()
+    {
+        // Start at AuthHome, not at any other component in the same app that happens to
+        // register itself for the route ""
+        var relativeUri = UriHelper.ToBaseRelativePath(UriHelper.GetBaseUri(), UriHelper.GetAbsoluteUri());
+        if (relativeUri == string.Empty)
+        {
+            UriHelper.NavigateTo("AuthHome");
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
@@ -20,7 +20,8 @@
     {
         // Start at AuthHome, not at any other component in the same app that happens to
         // register itself for the route ""
-        var relativeUri = UriHelper.ToBaseRelativePath(UriHelper.GetBaseUri(), UriHelper.GetAbsoluteUri());
+        var absoluteUriPath = new Uri(UriHelper.GetAbsoluteUri()).GetLeftPart(UriPartial.Path);
+        var relativeUri = UriHelper.ToBaseRelativePath(UriHelper.GetBaseUri(), absoluteUriPath);
         if (relativeUri == string.Empty)
         {
             UriHelper.NavigateTo("AuthHome");

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthorizeViewCases.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthorizeViewCases.razor
@@ -1,0 +1,17 @@
+@page "/AuthorizeViewCases"
+
+<div id="no-authorization">
+    <h3>Scenario: No authorization rules</h3>
+
+    <AuthorizeView>
+        <Authorizing>
+            <p class="authorizing">Authorizing...</p>
+        </Authorizing>
+        <Authorized>
+            <p class="authorized">Welcome, @context.User.Identity.Name!</p>
+        </Authorized>
+        <NotAuthorized>
+            <p class="not-authorized">You're not logged in.</p>
+        </NotAuthorized>
+    </AuthorizeView>
+</div>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthorizeViewCases.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthorizeViewCases.razor
@@ -1,7 +1,7 @@
 @page "/AuthorizeViewCases"
 
-<div id="no-authorization">
-    <h3>Scenario: No authorization rules</h3>
+<div id="no-authorization-rule">
+    <h3>Scenario: No authorization rule</h3>
 
     <AuthorizeView>
         <Authorizing>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateChild.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateChild.razor
@@ -8,26 +8,30 @@ else
 {
     <p>
         Authenticated:
-        <span id="identity-authenticated">@user.Identity.IsAuthenticated</span>
+        <strong id="identity-authenticated">@user.Identity.IsAuthenticated</strong>
     </p>
 
     <p>
         Name:
-        <span id="identity-name">@user.Identity.Name</span>
+        <strong id="identity-name">@user.Identity.Name</strong>
     </p>
 
     <p>
         Test claim:
         @if (user.HasClaim(TestClaimPredicate) == true)
         {
-            <span id="test-claim">@user.Claims.Single(c => TestClaimPredicate(c)).Value</span>
+            <strong id="test-claim">@user.Claims.Single(c => TestClaimPredicate(c)).Value</strong>
         }
         else
         {
-            <span id="test-claim">(none)</span>
+            <strong id="test-claim">(none)</strong>
         }
     </p>
 }
+
+<hr />
+
+<p>To change the underlying authentication state, <a target="_blank" href="/Authentication">go here</a>.</p>
 
 @functions
 {

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateChild.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateChild.razor
@@ -1,0 +1,44 @@
+@using System.Security.Claims
+
+@if (user == null)
+{
+    <span id="auth-state-pending">Requesting authentication state...</span>
+}
+else
+{
+    <p>
+        Authenticated:
+        <span id="identity-authenticated">@user.Identity.IsAuthenticated</span>
+    </p>
+
+    <p>
+        Name:
+        <span id="identity-name">@user.Identity.Name</span>
+    </p>
+
+    <p>
+        Test claim:
+        @if (user.HasClaim(TestClaimPredicate) == true)
+        {
+            <span id="test-claim">@user.Claims.Single(c => TestClaimPredicate(c)).Value</span>
+        }
+        else
+        {
+            <span id="test-claim">(none)</span>
+        }
+    </p>
+}
+
+@functions
+{
+    static Predicate<Claim> TestClaimPredicate = c => c.Type == "test-claim";
+
+    ClaimsPrincipal user;
+
+    [CascadingParameter] Task<AuthenticationState> AuthenticationStateTask { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        user = (await AuthenticationStateTask).User;
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateConsumer.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateConsumer.razor
@@ -1,4 +1,7 @@
+@page "/CascadingAuthenticationStateConsumer"
 @using System.Security.Claims
+
+<h1>Cascading authentication state</h1>
 
 @if (user == null)
 {

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateConsumer.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateConsumer.razor
@@ -32,10 +32,6 @@ else
     </p>
 }
 
-<hr />
-
-<p>To change the underlying authentication state, <a target="_blank" href="/Authentication">go here</a>.</p>
-
 @functions
 {
     static Predicate<Claim> TestClaimPredicate = c => c.Type == "test-claim";

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateParent.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateParent.razor
@@ -1,0 +1,3 @@
+<CascadingAuthenticationState>
+    <BasicTestApp.AuthTest.CascadingAuthenticationStateChild />
+</CascadingAuthenticationState>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateParent.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/CascadingAuthenticationStateParent.razor
@@ -1,3 +1,0 @@
-<CascadingAuthenticationState>
-    <BasicTestApp.AuthTest.CascadingAuthenticationStateChild />
-</CascadingAuthenticationState>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/ClientSideAuthenticationStateData.cs
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/ClientSideAuthenticationStateData.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace BasicTestApp.AuthTest
+{
+    // DTO shared between server and client
+    public class ClientSideAuthenticationStateData
+    {
+        public bool IsAuthenticated { get; set; }
+
+        public string UserName { get; set; }
+
+        public Dictionary<string, string> ExposedClaims { get; set; }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/Links.razor
@@ -1,0 +1,5 @@
+@using Microsoft.AspNetCore.Components.Routing
+<ul>
+    <li><NavLink href="AuthHome" Match=NavLinkMatch.All>Home</NavLink></li>
+    <li><NavLink href="CascadingAuthenticationStateConsumer">Cascading authentication state</NavLink></li>
+</ul>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/Links.razor
@@ -1,5 +1,8 @@
 @using Microsoft.AspNetCore.Components.Routing
-<ul>
-    <li><NavLink href="AuthHome" Match=NavLinkMatch.All>Home</NavLink></li>
-    <li><NavLink href="CascadingAuthenticationStateConsumer">Cascading authentication state</NavLink></li>
-</ul>
+    <ul>
+        <li><NavLink href="AuthHome" Match=NavLinkMatch.All>Home</NavLink></li>
+        <li><NavLink href="CascadingAuthenticationStateConsumer">Cascading authentication state</NavLink></li>
+        <li><NavLink href="AuthorizeViewCases">AuthorizeView cases</NavLink></li>
+    </ul>
+
+<p>To change the underlying authentication state, <a target="_blank" href="/Authentication">go here</a>.</p>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/Links.razor
@@ -1,8 +1,8 @@
 @using Microsoft.AspNetCore.Components.Routing
-    <ul>
-        <li><NavLink href="AuthHome" Match=NavLinkMatch.All>Home</NavLink></li>
-        <li><NavLink href="CascadingAuthenticationStateConsumer">Cascading authentication state</NavLink></li>
-        <li><NavLink href="AuthorizeViewCases">AuthorizeView cases</NavLink></li>
-    </ul>
+<ul id="auth-links">
+    <li><NavLink href="AuthHome" Match=NavLinkMatch.All>Home</NavLink></li>
+    <li><NavLink href="CascadingAuthenticationStateConsumer">Cascading authentication state</NavLink></li>
+    <li><NavLink href="AuthorizeViewCases">AuthorizeView cases</NavLink></li>
+</ul>
 
 <p>To change the underlying authentication state, <a target="_blank" href="/Authentication">go here</a>.</p>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/ServerAuthenticationStateProvider.cs
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/ServerAuthenticationStateProvider.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.AuthTest
+{
+    // This is intended to be similar to the authentication stateprovider included by default
+    // with the client-side Blazor "Hosted in ASP.NET Core" template
+    public class ServerAuthenticationStateProvider : AuthenticationStateProvider
+    {
+        private readonly HttpClient _httpClient;
+
+        public ServerAuthenticationStateProvider(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+        {
+            var uri = new Uri(_httpClient.BaseAddress, "/api/User");
+            var data = await _httpClient.GetJsonAsync<ClientSideAuthenticationStateData>(uri.AbsoluteUri);
+            ClaimsIdentity identity;
+            if (data.IsAuthenticated)
+            {
+                var claims = new[] { new Claim(ClaimTypes.Name, data.UserName) }
+                    .Concat(data.ExposedClaims.Select(c => new Claim(c.Key, c.Value)));
+                identity = new ClaimsIdentity(claims, "Server authentication");
+            }
+            else
+            {
+                identity = new ClaimsIdentity();
+            }
+
+            return new AuthenticationState(new ClaimsPrincipal(identity));
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -54,6 +54,7 @@
         <option value="BasicTestApp.KeyCasesComponent">Key cases</option>
         <option value="BasicTestApp.ReorderingFocusComponent">Reordering focus retention</option>
         <option value="BasicTestApp.RouterTest.UriHelperComponent">UriHelper Test</option>
+        <option value="BasicTestApp.AuthTest.CascadingAuthenticationStateParent">Cascading authentication state</option>
     </select>
 
   @if (SelectedComponentType != null)

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -55,6 +55,7 @@
         <option value="BasicTestApp.ReorderingFocusComponent">Reordering focus retention</option>
         <option value="BasicTestApp.RouterTest.UriHelperComponent">UriHelper Test</option>
         <option value="BasicTestApp.AuthTest.CascadingAuthenticationStateParent">Cascading authentication state</option>
+        <option value="BasicTestApp.AuthTest.AuthRouter">Auth cases</option>
     </select>
 
   @if (SelectedComponentType != null)

--- a/src/Components/test/testassets/BasicTestApp/Startup.cs
+++ b/src/Components/test/testassets/BasicTestApp/Startup.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.InteropServices;
+using BasicTestApp.AuthTest;
 using Microsoft.AspNetCore.Blazor.Http;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,6 +14,7 @@ namespace BasicTestApp
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton<AuthenticationStateProvider, ServerAuthenticationStateProvider>();
         }
 
         public void Configure(IComponentsApplicationBuilder app)

--- a/src/Components/test/testassets/TestServer/Components.TestServer.csproj
+++ b/src/Components/test/testassets/TestServer/Components.TestServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Blazor.Server" />
     <Reference Include="Microsoft.AspNetCore.Cors" />
     <Reference Include="Microsoft.AspNetCore.Mvc" />

--- a/src/Components/test/testassets/TestServer/Controllers/UserController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/UserController.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using BasicTestApp.AuthTest;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Components.TestServer.Controllers
+{
+    [Route("api/[controller]")]
+    public class UserController : Controller
+    {
+        // GET api/user
+        [HttpGet]
+        public ClientSideAuthenticationStateData Get()
+        {
+            // Servers are not expected to expose everything from the server-side ClaimsPrincipal
+            // to the client. It's up to the developer to choose what kind of authentication state
+            // data is needed on the client so it can display suitable options in the UI.
+
+            return new ClientSideAuthenticationStateData
+            {
+                IsAuthenticated = User.Identity.IsAuthenticated,
+                UserName = User.Identity.Name,
+                ExposedClaims = User.Claims
+                    .Where(c => c.Type == "test-claim")
+                    .ToDictionary(c => c.Type, c => c.Value)
+            };
+        }
+    }
+}

--- a/src/Components/test/testassets/TestServer/Pages/Authentication.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/Authentication.cshtml
@@ -7,7 +7,7 @@
     <title>Authentication</title>
 </head>
 <body>
-    <h1>Authentication</h1>
+    <h1 id="authentication">Authentication</h1>
     <p>
         This is a completely fake login mechanism for automated test purposes.
         It accepts any username, with no password.

--- a/src/Components/test/testassets/TestServer/Pages/Authentication.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/Authentication.cshtml
@@ -1,0 +1,72 @@
+@page
+@using Microsoft.AspNetCore.Authentication
+@using System.Security.Claims
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Authentication</title>
+</head>
+<body>
+    <h1>Authentication</h1>
+    <p>
+        This is a completely fake login mechanism for automated test purposes.
+        It accepts any username, with no password.
+    </p>
+    <p>
+        <strong>Obviously you should not do this in real applications.</strong>
+        See also: <a href="https://docs.microsoft.com/aspnet/core/security">documentation on configuring a real login system.</a>
+    </p>
+
+    <fieldset>
+        <h3>Sign in</h3>
+
+        @* Do not use method="get" for real login forms. This is just to simplify E2E tests. *@
+        <form method="get">
+            <p>
+                User name:
+                <input name="username" />
+            </p>
+            <p>
+                <button type="submit">Submit</button>
+            </p>
+        </form>
+    </fieldset>
+
+    <fieldset>
+        <h3>Status</h3>
+        <p>
+            Authenticated: <strong>@User.Identity.IsAuthenticated</strong>
+            Username: <strong>@User.Identity.Name</strong>
+        </p>
+        <a href="Authentication?signout=true">Sign out</a>
+    </fieldset>
+</body>
+</html>
+
+@functions {
+    public async Task<IActionResult> OnGet()
+    {
+        if (Request.Query["signout"] == "true")
+        {
+            await HttpContext.SignOutAsync();
+            return Redirect("Authentication");
+        }
+
+        var username = Request.Query["username"];
+        if (!string.IsNullOrEmpty(username))
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Name, username),
+                new Claim("test-claim", "Test claim value"),
+            };
+
+            await HttpContext.SignInAsync(
+                new ClaimsPrincipal(new ClaimsIdentity(claims, "FakeAuthenticationType")));
+
+            return Redirect("Authentication");
+        }
+
+        return Page();
+    }
+}

--- a/src/Components/test/testassets/TestServer/Startup.cs
+++ b/src/Components/test/testassets/TestServer/Startup.cs
@@ -1,4 +1,5 @@
 using BasicTestApp;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Hosting;
@@ -28,6 +29,7 @@ namespace TestServer
                 options.AddPolicy("AllowAll", _ => { /* Controlled below */ });
             });
             services.AddServerSideBlazor();
+            services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -50,6 +52,7 @@ namespace TestServer
                     .AllowCredentials();
             });
 
+            app.UseAuthentication();
 
             // Mount the server-side Blazor app on /subdir
             app.Map("/subdir", subdirApp =>
@@ -70,6 +73,7 @@ namespace TestServer
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapRazorPages();
             });
 
             // Separately, mount a prerendered server-side Blazor app on /prerendered


### PR DESCRIPTION
This PR is mainly about E2E tests for the previous auth work (#10227). It also contains a few commits that address remaining CR feedback from #10227.

Things to note:

 * I had to do a bit of refactoring on how E2E tests decide whether to run client-side or server-side. Previously, the "hosting environment" (dev server, or the TestServer app) and "execution environment" (client-side or server-side) were coupled together as concepts. But the new AuthTests have to do both client-side and server-side execution while running on TestServer, since that's what supplies the auth state. The net result is that the E2E test code is now just more explicit about execution environment in many places, so this is good anyway.
 * From looking at the `ServerAuthenticationStateProvider`, `ClientSideAuthenticationStateData`, and `UserController` classes, you can now get a sense of how this feels when doing client-side Blazor. It's more involved than for server-side Blazor, because we have to fetch the authentication state from the server via an API request.