### PR TITLE
Improve detection of JDK on Windows

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -23,7 +23,6 @@ jobs:
     jobName: Code_check
     jobDisplayName: Code check
     agentOs: Windows
-    installJdk: false
     steps:
     - powershell: ./eng/scripts/CodeCheck.ps1 -ci
       displayName: Run eng/scripts/CodeCheck.ps1

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -120,7 +120,7 @@ jobs:
     BuildDirectory: ${{ parameters.buildDirectory }}
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     TeamName: AspNetCore
-    ${{ if eq(parameters.agentOs, 'Windows') }}:
+    ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:
       JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
     ${{ if or(ne(parameters.codeSign, true), ne(variables['System.TeamProject'], 'internal')) }}:
       _SignType: ''

--- a/build.ps1
+++ b/build.ps1
@@ -334,7 +334,7 @@ if ($BuildJava) {
     }
 
     if (-not $foundJdk) {
-        Write-Error "Could not find java.exe. Install the JDK and put $JAVA_HOME\bin on the system PATH."
+        Write-Error "Could not find the JDK. Install the JDK and put $JAVA_HOME\bin on the system PATH. See $PSScriptRoot\docs\BuildFromSource.md for details."
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -308,7 +308,7 @@ if (($All -or $BuildJava) -and -not $NoBuildJava) {
     $javac = Get-Command javac -ErrorAction Ignore
     if ($env:JAVA_HOME) {
         if (-not (Test-Path "${env:JAVA_HOME}\bin\javac.exe")) {
-            Write-Error "The env var JAVA_HOME was set, but ${env:JAVA_HOME}\bin\java.exe does not exist. Remove JAVA_HOME or update it to the correct location for the JDK. See https://www.bing.com/search?q=java_home for details."
+            Write-Error "The environment variable JAVA_HOME was set, but ${env:JAVA_HOME}\bin\javac.exe does not exist. Remove JAVA_HOME or update it to the correct location for the JDK. See https://www.bing.com/search?q=java_home for details."
         }
         $foundJdk = $true
     }
@@ -334,7 +334,7 @@ if (($All -or $BuildJava) -and -not $NoBuildJava) {
     }
 
     if (-not $foundJdk) {
-        Write-Error "Could not find the JDK. Install the JDK and put $JAVA_HOME\bin on the system PATH. See $PSScriptRoot\docs\BuildFromSource.md for details."
+        Write-Error "Could not find the JDK. See $PSScriptRoot\docs\BuildFromSource.md for details on this requirement."
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -303,6 +303,41 @@ $MSBuildArguments += "/p:_RunSign=$Sign"
 $MSBuildArguments += "/p:TargetArchitecture=$Architecture"
 $MSBuildArguments += "/p:TargetOsName=win"
 
+if ($BuildJava) {
+    $foundJdk = $false
+    $javac = Get-Command javac -ErrorAction Ignore
+    if ($env:JAVA_HOME) {
+        if (-not (Test-Path "${env:JAVA_HOME}\bin\javac.exe")) {
+            Write-Error "The env var JAVA_HOME was set, but ${env:JAVA_HOME}\bin\java.exe does not exist. Remove JAVA_HOME or update it to the correct location for the JDK. See https://www.bing.com/search?q=java_home for details."
+        }
+        $foundJdk = $true
+    }
+    elseif ($javac) {
+        $foundJdk = $true
+        $javaHome = Split-Path -Parent (Split-Path -Parent $javac.Path)
+        $env:JAVA_HOME = $javaHome
+        Write-Host -f Magenta "Detected JDK in $javaHome"
+    }
+    else {
+        try {
+            $jdkVersion = (Get-Item HKLM:\SOFTWARE\JavaSoft\JDK | Get-ItemProperty -name CurrentVersion).CurrentVersion
+            $javaHome = (Get-Item HKLM:\SOFTWARE\JavaSoft\JDK\$jdkVersion | Get-ItemProperty -Name JavaHome).JavaHome
+            if (Test-Path "${env:JAVA_HOME}\bin\java.exe") {
+                $env:JAVA_HOME = $javaHome
+                Write-Host -f Magenta "Detected JDK $jdkVersion in $env:JAVA_HOME"
+                $foundJdk = $true
+            }
+        }
+        catch {
+            Write-Verbose "Failed to detect Java: $_"
+        }
+    }
+
+    if (-not $foundJdk) {
+        Write-Error "Could not find java.exe. Install the JDK and put $JAVA_HOME\bin on the system PATH."
+    }
+}
+
 Import-Module -Force -Scope Local (Join-Path $korebuildPath 'KoreBuild.psd1')
 
 try {

--- a/build.ps1
+++ b/build.ps1
@@ -303,7 +303,7 @@ $MSBuildArguments += "/p:_RunSign=$Sign"
 $MSBuildArguments += "/p:TargetArchitecture=$Architecture"
 $MSBuildArguments += "/p:TargetOsName=win"
 
-if ($BuildJava) {
+if (($All -or $BuildJava) -and -not $NoBuildJava) {
     $foundJdk = $false
     $javac = Get-Command javac -ErrorAction Ignore
     if ($env:JAVA_HOME) {

--- a/build.ps1
+++ b/build.ps1
@@ -305,18 +305,21 @@ $MSBuildArguments += "/p:TargetOsName=win"
 
 if (($All -or $BuildJava) -and -not $NoBuildJava) {
     $foundJdk = $false
-    $javac = Get-Command javac -ErrorAction Ignore
+    $javac = Get-Command javac -ErrorAction Ignore -CommandType Application
     if ($env:JAVA_HOME) {
         if (-not (Test-Path "${env:JAVA_HOME}\bin\javac.exe")) {
             Write-Error "The environment variable JAVA_HOME was set, but ${env:JAVA_HOME}\bin\javac.exe does not exist. Remove JAVA_HOME or update it to the correct location for the JDK. See https://www.bing.com/search?q=java_home for details."
         }
-        $foundJdk = $true
+        else {
+            Write-Host -f Magenta "Detected JDK in ${env:JAVA_HOME} (via JAVA_HOME)"
+            $foundJdk = $true
+        }
     }
     elseif ($javac) {
         $foundJdk = $true
         $javaHome = Split-Path -Parent (Split-Path -Parent $javac.Path)
         $env:JAVA_HOME = $javaHome
-        Write-Host -f Magenta "Detected JDK in $javaHome"
+        Write-Host -f Magenta "Detected JDK in $javaHome (via PATH)"
     }
     else {
         try {
@@ -324,7 +327,7 @@ if (($All -or $BuildJava) -and -not $NoBuildJava) {
             $javaHome = (Get-Item HKLM:\SOFTWARE\JavaSoft\JDK\$jdkVersion | Get-ItemProperty -Name JavaHome).JavaHome
             if (Test-Path "${env:JAVA_HOME}\bin\java.exe") {
                 $env:JAVA_HOME = $javaHome
-                Write-Host -f Magenta "Detected JDK $jdkVersion in $env:JAVA_HOME"
+                Write-Host -f Magenta "Detected JDK $jdkVersion in $env:JAVA_HOME (via registry)"
                 $foundJdk = $true
             }
         }

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -20,7 +20,9 @@ Building ASP.NET Core on Windows requires:
         ```
 * Git. <https://git-scm.org>
 * NodeJS. LTS version of 10.14.2 or newer <https://nodejs.org>
-* Java Development Kit (JDK) v8 with Java Runtime Environment (JRE) v8. See https://www.oracle.com/technetwork/java/javase/downloads/index.html
+* Java Development Kit 11 or newer. Either:
+    * OpenJDK <https://jdk.java.net/>
+    * Oracle's JDK <https://www.oracle.com/technetwork/java/javase/downloads/index.html>
 
 ### macOS/Linux
 
@@ -31,8 +33,8 @@ Building ASP.NET Core on macOS or Linux requires:
 * At least 10 GB of disk space and a good internet connection (our build scripts download a lot of tools and dependencies)
 * Git <https://git-scm.org>
 * NodeJS. LTS version of 10.14.2 or newer <https://nodejs.org>
-* Java Development Kit 10 or newer. Either:
-    * OpenJDK <http://jdk.java.net/10/>
+* Java Development Kit 11 or newer. Either:
+    * OpenJDK <https://jdk.java.net/>
     * Oracle's JDK <https://www.oracle.com/technetwork/java/javase/downloads/index.html>
 
 ## Clone the source code


### PR DESCRIPTION
This improves JDK detection to fail the build early if java is missing, but will be required later to build.

This helps with the following scenarios:
* Windows dev installs JDK via MSI but didn't set the JAVA_HOME env var. 
* Windows dev already has JDK on PATH, but JAVA_HOME doesn't match
* JAVA_HOME is set, but points to location which is missing JDK

cc @ryanbrandenburg @anurse