### PR TITLE
Update log directory

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -46,14 +46,14 @@ jobs:
     # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
     # The sign settings have been configured to
 
-    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:DisableCodeSigning=true /bl:artifacts/logs/build.x64.binlog
+    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:DisableCodeSigning=true /bl:artifacts/log/build.x64.binlog
       displayName: Build x64
     # TODO: make it possible to build for one Windows architecture at a time
     # This is going to actually build x86 native assets. See https://github.com/aspnet/AspNetCore/issues/7196
 
     # Build the x86 shared framework
     # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
-    - script: ./eng/scripts/cibuild.cmd -arch x86 -NoRestore /t:BuildSharedFx /p:DisableCodeSigning=true /bl:artifacts/logs/build.x86.binlog
+    - script: ./eng/scripts/cibuild.cmd -arch x86 -NoRestore /t:BuildSharedFx /p:DisableCodeSigning=true /bl:artifacts/log/build.x86.binlog
       displayName: Build x86
 
     # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
@@ -67,7 +67,7 @@ jobs:
     # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
     # consider running code-signing inline with the other previous steps.
     # Sign check is disabled because it is run in a separate step below, after installers are built.
-    - script: ./build.cmd -ci -sign -NoRestore /t:CodeSign /p:SignType=$(_SignType) /p:DisableSignCheck=true /bl:artifacts/logs/build.codesign.binlog
+    - script: ./build.cmd -ci -sign -NoRestore /t:CodeSign /p:SignType=$(_SignType) /p:DisableSignCheck=true /bl:artifacts/log/build.codesign.binlog
       displayName: Code sign packages
 
     # Windows installers bundle both x86 and x64 assets
@@ -75,7 +75,7 @@ jobs:
       displayName: Build Installers
 
     # Run sign check to verify everything was code signed.
-    - script: ./build.cmd -ci -sign -NoRestore /t:SignCheck /p:SignType=$(_SignType) /bl:artifacts/logs/build.signcheck.binlog
+    - script: ./build.cmd -ci -sign -NoRestore /t:SignCheck /p:SignType=$(_SignType) /bl:artifacts/log/build.signcheck.binlog
       displayName: Run sign check
       condition: eq(variables['_SignType'], 'real')
 
@@ -89,7 +89,7 @@ jobs:
     - name: Windows_Installers
       path: artifacts/installers/
     - name: Windows_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 
 # Build Windows ARM
@@ -100,7 +100,7 @@ jobs:
     jobDisplayName: "Build: Windows ARM"
     agentOs: Windows
     buildScript: ./eng/scripts/cibuild.cmd
-    buildArgs: -arch arm -NoBuildNodeJS -NoBuildJava /p:SignType=$(_SignType) /bl:artifacts/logs/build.win-arm.binlog
+    buildArgs: -arch arm -NoBuildNodeJS -NoBuildJava /p:SignType=$(_SignType) /bl:artifacts/log/build.win-arm.binlog
     installNodeJs: false
     installJdk: false
     afterBuild:
@@ -115,7 +115,7 @@ jobs:
     - name: Windows_arm_Installers
       path: artifacts/installers/
     - name: Windows_arm_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 
 # Build MacOS
@@ -125,7 +125,7 @@ jobs:
     jobDisplayName: "Build: macOS"
     agentOs: macOs
     buildScript: ./eng/scripts/cibuild.sh
-    buildArgs: --no-build-nodejs --no-build-java /bl:artifacts/logs/build.macos.binlog
+    buildArgs: --no-build-nodejs --no-build-java /bl:artifacts/log/build.macos.binlog
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -140,7 +140,7 @@ jobs:
     - name: MacOS_x64_Installers
       path: artifacts/installers/
     - name: MacOS_x64_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
@@ -154,7 +154,7 @@ jobs:
     agentOs: Linux
     installNodeJs: false
     steps:
-    - script: ./eng/scripts/cibuild.sh --arch x64 --no-build-nodejs --no-build-java /bl:artifacts/logs/build.lin-x64.binlog
+    - script: ./eng/scripts/cibuild.sh --arch x64 --no-build-nodejs --no-build-java /bl:artifacts/log/build.lin-x64.binlog
       displayName: Run cibuild.sh
     - script: |
         rm -rf .dotnet/
@@ -168,7 +168,7 @@ jobs:
           /t:BuildSharedFx  \
           /p:BuildRuntimeArchive=false \
           /p:LinuxInstallerType=deb \
-          /bl:artifacts/logs/build.deb.binlog
+          /bl:artifacts/log/build.deb.binlog
       displayName: Build Debian installers
     - script: |
         rm -rf .dotnet/
@@ -182,7 +182,7 @@ jobs:
           /t:BuildSharedFx  \
           /p:BuildRuntimeArchive=false \
           /p:LinuxInstallerType=rpm \
-          /bl:artifacts/logs/build.rpm.binlog
+          /bl:artifacts/log/build.rpm.binlog
       displayName: Build RPM installers
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -197,7 +197,7 @@ jobs:
     - name: Linux_x64_Installers
       path: artifacts/installers/
     - name: Linux_x64_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
@@ -210,7 +210,7 @@ jobs:
     jobDisplayName: "Build: Linux ARM"
     agentOs: Linux
     buildScript: ./eng/scripts/cibuild.sh
-    buildArgs: --arch arm --no-build-nodejs --no-build-java /bl:artifacts/logs/build.lin-arm.binlog
+    buildArgs: --arch arm --no-build-nodejs --no-build-java /bl:artifacts/log/build.lin-arm.binlog
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -225,7 +225,7 @@ jobs:
     - name: Linux_arm_Installers
       path: artifacts/installers/
     - name: Linux_arm_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
@@ -238,7 +238,7 @@ jobs:
     jobDisplayName: "Build: Linux ARM64"
     agentOs: Linux
     buildScript: ./eng/scripts/cibuild.sh
-    buildArgs: --arch arm64 --no-build-nodejs --no-build-java /bl:artifacts/logs/build.arm64.binlog
+    buildArgs: --arch arm64 --no-build-nodejs --no-build-java /bl:artifacts/log/build.arm64.binlog
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -253,7 +253,7 @@ jobs:
     - name: Linux_arm64_Installers
       path: artifacts/installers/
     - name: Linux_arm64_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
@@ -266,7 +266,7 @@ jobs:
     jobDisplayName: "Build: Linux Musl x64"
     agentOs: Linux
     buildScript: ./dockerbuild.sh alpine
-    buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch x64 --os-name linux-musl --no-build-nodejs --no-build-java /bl:artifacts/logs/build.musl.binlog
+    buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch x64 --os-name linux-musl --no-build-nodejs --no-build-java /bl:artifacts/log/build.musl.binlog
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -281,7 +281,7 @@ jobs:
     - name: Linux_musl_x64_Installers
       path: artifacts/installers/
     - name: Linux_musl_x64_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
@@ -294,7 +294,7 @@ jobs:
     jobDisplayName: "Build: Linux Musl ARM64"
     agentOs: Linux
     buildScript: ./dockerbuild.sh ubuntu-alpine37
-    buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch arm64 --os-name linux-musl --no-build-nodejs --no-build-java /bl:artifacts/logs/build.musl.binlog
+    buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch arm64 --os-name linux-musl --no-build-nodejs --no-build-java /bl:artifacts/log/build.musl.binlog
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -309,7 +309,7 @@ jobs:
     - name: Linux_musl_arm64_Installers
       path: artifacts/installers/
     - name: Linux_musl_arm64_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 - template: jobs/codesign-xplat.yml
   parameters:
@@ -334,7 +334,7 @@ jobs:
       continueOnError: true
     artifacts:
     - name: Windows_Test_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 
 - template: jobs/default-build.yml
@@ -351,7 +351,7 @@ jobs:
       displayName: Build Repo
     artifacts:
     - name: Windows_Test_Templates_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 
 - template: jobs/default-build.yml
@@ -372,7 +372,7 @@ jobs:
       continueOnError: true
     artifacts:
     - name: MacOS_Test_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true
 
 - template: jobs/default-build.yml
@@ -395,5 +395,5 @@ jobs:
       continueOnError: true
     artifacts:
     - name: Linux_Test_Logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true

--- a/.azure/pipelines/helix-test.yml
+++ b/.azure/pipelines/helix-test.yml
@@ -15,11 +15,11 @@ jobs:
     agentOs: Windows
     timeoutInMinutes: 240
     steps:
-    - script: .\build.cmd -all -ci /t:Helix /p:IsHelixJob=true /bl:$env:BUILD_SOURCESDIRECTORY\artifacts\logs\SendToHelix.binlog
+    - script: .\build.cmd -all -ci /t:Helix /p:IsHelixJob=true /bl:$env:BUILD_SOURCESDIRECTORY\artifacts\log\SendToHelix.binlog
       displayName: Run build.cmd helix target
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
     artifacts:
     - name: Helix_logs
-      path: artifacts/logs/
+      path: artifacts/log/
       publishOnError: true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -210,7 +210,7 @@ jobs:
     condition: always()
     inputs:
       testRunner: junit
-      testResultsFiles: '**/artifacts/logs/**/*.junit.xml'
+      testResultsFiles: '**/artifacts/log/**/*.junit.xml'
       buildConfiguration: $(BuildConfiguration)
       buildPlatform: $(AgentOsName)
   - task: PublishTestResults@2

--- a/.azure/pipelines/signalr-daily-tests.yml
+++ b/.azure/pipelines/signalr-daily-tests.yml
@@ -16,5 +16,5 @@ jobs:
     jobDisplayName: "SignalR Daily Tests"
     artifacts:
     - name: Windows_Logs
-      path: ../../artifacts/logs/
+      path: ../../artifacts/log/
       publishOnError: true

--- a/.azure/pipelines/tools/SetupTestEnvironment.ps1
+++ b/.azure/pipelines/tools/SetupTestEnvironment.ps1
@@ -5,7 +5,7 @@ param(
 
 if (!($DumpFolder))
 {
-    $DumpFolder = "$PSScriptRoot\..\..\..\artifacts\logs\dumps"
+    $DumpFolder = "$PSScriptRoot\..\..\..\artifacts\log\dumps"
 }
 if (!(Test-Path $DumpFolder))
 {

--- a/build/repo.props
+++ b/build/repo.props
@@ -19,6 +19,7 @@
     <ArtifactsNonShippingPackagesDir>$(ArtifactsPackagesDir)NonShipping\</ArtifactsNonShippingPackagesDir>
     <InstallersOutputPath>$(ArtifactsDir)installers\$(Configuration)\</InstallersOutputPath>
     <VisualStudioSetupOutputPath>$(ArtifactsDir)VSSetup\$(Configuration)\</VisualStudioSetupOutputPath>
+    <LogOutputDir>$(ArtifactsDir)log\</LogOutputDir>
 
     <SignCheckExclusionsFile>$(RepoRoot)eng\signcheck.exclusions.txt</SignCheckExclusionsFile>
 

--- a/eng/tools/XplatPackageSigner/sign-packages.cmd
+++ b/eng/tools/XplatPackageSigner/sign-packages.cmd
@@ -12,4 +12,4 @@ IF "%DirToSign%"=="" (
 SET RepoRoot=%~dp0..\..\..
 SET Project=%~dp0\XplatPackageSigner.proj
 
-%RepoRoot%\build.cmd -NoRestore -projects %project% /p:DirectoryToSign=%DirToSign% /bl:%RepoRoot%\artifacts\logs\XplatSign.binlog
+%RepoRoot%\build.cmd -NoRestore -projects %project% /p:DirectoryToSign=%DirToSign% /bl:%RepoRoot%\artifacts\log\XplatSign.binlog

--- a/src/Installers/Windows/build.ps1
+++ b/src/Installers/Windows/build.ps1
@@ -38,7 +38,7 @@ try {
             -ci:$ci `
             -sign `
             -BuildInstallers `
-            "-bl:$repoRoot/artifacts/logs/installers.msbuild.binlog" `
+            "-bl:$repoRoot/artifacts/log/installers.msbuild.binlog" `
             @msbuildargs `
             @AdditionalArgs
 }

--- a/src/SignalR/clients/ts/FunctionalTests/func.jest.config.js
+++ b/src/SignalR/clients/ts/FunctionalTests/func.jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
         "ts-jest": {
             "tsConfigFile": "../tsconfig.jest.json",
             "skipBabel": true,
-            
+
             // Needed in order to properly process the JS files
             // We run 'tsc --noEmit' to get TS diagnostics before the test instead
             "enableTsDiagnostics": false,
@@ -18,7 +18,7 @@ module.exports = {
     },
     reporters: [
         "default",
-        ["../common/node_modules/jest-junit/index.js", { "output": "../../../../../artifacts/logs/" + `${process.platform}` + ".node.functional.junit.xml" }]
+        ["../common/node_modules/jest-junit/index.js", { "output": "../../../../../artifacts/log/" + `${process.platform}` + ".node.functional.junit.xml" }]
     ],
     transform: {
         "^.+\\.(jsx?|tsx?)$": "../common/node_modules/ts-jest"

--- a/src/SignalR/clients/ts/FunctionalTests/scripts/karma.base.conf.js
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/karma.base.conf.js
@@ -48,7 +48,7 @@ try {
                 reporters: [...defaultReporters, ...(config.reporters || [])],
 
                 junitReporter: {
-                    outputDir: "../../../../../artifacts/logs",
+                    outputDir: "../../../../../artifacts/log",
                     outputFile: `${process.platform}` + ".functionaltest.junit.xml",
                 },
             });

--- a/src/SignalR/clients/ts/jest.config.js
+++ b/src/SignalR/clients/ts/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     reporters: [
         "default",
-        ["./common/node_modules/jest-junit/index.js", { "output": "../../../../artifacts/logs/" + `${process.platform}` + ".signalr.junit.xml" }]
+        ["./common/node_modules/jest-junit/index.js", { "output": "../../../../artifacts/log/" + `${process.platform}` + ".signalr.junit.xml" }]
     ],
     transform: {
         "^.+\\.tsx?$": "./common/node_modules/ts-jest"


### PR DESCRIPTION
Addresses https://github.com/aspnet/AspNetCore/issues/7316. 

The issue is that the log directory for functional test logs is by default [`$(RepoRoot)artifacts\log\`](https://github.com/aspnet/Extensions/blob/f41cfded3c12eec0efea89ece1dafe43afa9c6b8/src/Logging/Logging.Testing/src/build/Microsoft.Extensions.Logging.Testing.props#L6) but our ci configuration publishes `artifacts\logs\` instead.

There's a bunch of different ways to fix this:
1. Change the directory in ci.yml
2. Change the default functional test log from artifacts\log to artifacts\logs
3. Set an environment variable to override the default log output dir.

I opted for 1. but can easily go with another approach, especially if artifacts/logs/ is a better conventionl.
