### PR TITLE
Disable test reporting for flaky tests on Helix

### DIFF
--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -52,7 +52,7 @@ if errorlevel 1 (
 
 set FLAKY_FILTER="Flaky:All=true|Flaky:Helix:All=true|Flaky:Helix:Queue:All=true|Flaky:Helix:Queue:%HELIX%=true"
 echo Running known-flaky tests.
-%DOTNET_ROOT%\dotnet vstest %target% --logger:trx --TestCaseFilter:%FLAKY_FILTER%
+%DOTNET_ROOT%\dotnet vstest %target% --TestCaseFilter:%FLAKY_FILTER%
 if errorlevel 1 (
     echo Failure in flaky test 1>&2
     REM DO NOT EXIT and DO NOT SET EXIT_CODE to 1

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -81,7 +81,7 @@ if [ $nonflaky_exitcode != 0 ]; then
 fi
 FLAKY_FILTER="Flaky:All=true|Flaky:Helix:All=true|Flaky:Helix:Queue:All=true|Flaky:Helix:Queue:$HELIX=true"
 echo "Running known-flaky tests."
-$DOTNET_ROOT/dotnet vstest $1 --logger:trx --TestCaseFilter:"$FLAKY_FILTER"
+$DOTNET_ROOT/dotnet vstest $1 --TestCaseFilter:"$FLAKY_FILTER"
 if [ $? != 0 ]; then
     echo "Flaky tests failed!" 1>&2
     # DO NOT EXIT


### PR DESCRIPTION
While I look into https://github.com/aspnet/AspNetCore-Internal/issues/2482. We might want to disable test reporting of flaky Helix tests so the PR checks are more meaningful.

WIP don't review yet.