### PR TITLE
unify the `PasswrodOptions` Required or Require

### DIFF
--- a/src/Identity/Extensions.Core/src/PasswordOptions.cs
+++ b/src/Identity/Extensions.Core/src/PasswordOptions.cs
@@ -11,12 +11,12 @@ namespace Microsoft.AspNetCore.Identity
         /// <summary>
         /// Gets or sets the minimum length a password must be. Defaults to 6.
         /// </summary>
-        public int RequiredLength { get; set; } = 6;
+        public int RequireLength { get; set; } = 6;
 
         /// <summary>
         /// Gets or sets the minimum number of unique characters which a password must contain. Defaults to 1.
         /// </summary>
-        public int RequiredUniqueChars { get; set; } = 1;
+        public int RequireUniqueChars { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets a flag indicating if passwords must contain a non-alphanumeric character. Defaults to true.

--- a/src/Identity/Extensions.Core/src/PasswordValidator.cs
+++ b/src/Identity/Extensions.Core/src/PasswordValidator.cs
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.Identity
             }
             var errors = new List<IdentityError>();
             var options = manager.Options.Password;
-            if (string.IsNullOrWhiteSpace(password) || password.Length < options.RequiredLength)
+            if (string.IsNullOrWhiteSpace(password) || password.Length < options.RequireLength)
             {
-                errors.Add(Describer.PasswordTooShort(options.RequiredLength));
+                errors.Add(Describer.PasswordTooShort(options.RequireLength));
             }
             if (options.RequireNonAlphanumeric && password.All(IsLetterOrDigit))
             {
@@ -68,9 +68,9 @@ namespace Microsoft.AspNetCore.Identity
             {
                 errors.Add(Describer.PasswordRequiresUpper());
             }
-            if (options.RequiredUniqueChars >= 1 && password.Distinct().Count() < options.RequiredUniqueChars)
+            if (options.RequireUniqueChars >= 1 && password.Distinct().Count() < options.RequireUniqueChars)
             {
-                errors.Add(Describer.PasswordRequiresUniqueChars(options.RequiredUniqueChars));
+                errors.Add(Describer.PasswordRequiresUniqueChars(options.RequireUniqueChars));
             }
             return
                 Task.FromResult(errors.Count == 0

--- a/src/Identity/test/Identity.Test/IdentityOptionsTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityOptionsTest.cs
@@ -24,8 +24,8 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.True(options.Password.RequireLowercase);
             Assert.True(options.Password.RequireNonAlphanumeric);
             Assert.True(options.Password.RequireUppercase);
-            Assert.Equal(6, options.Password.RequiredLength);
-            Assert.Equal(1, options.Password.RequiredUniqueChars);
+            Assert.Equal(6, options.Password.RequireLength);
+            Assert.Equal(1, options.Password.RequireUniqueChars);
 
             Assert.Equal("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+", options.User.AllowedUserNameCharacters);
             Assert.False(options.User.RequireUniqueEmail);
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [Fact]
         public void CanCustomizeIdentityOptions()
         {
-            var services = new ServiceCollection().Configure<IdentityOptions>(options => options.Password.RequiredLength = -1);
+            var services = new ServiceCollection().Configure<IdentityOptions>(options => options.Password.RequireLength = -1);
             services.AddIdentity<PocoUser,PocoRole>();
             var serviceProvider = services.BuildServiceProvider();
 
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.True(myOptions.Password.RequireDigit);
             Assert.True(myOptions.Password.RequireNonAlphanumeric);
             Assert.True(myOptions.Password.RequireUppercase);
-            Assert.Equal(1, myOptions.Password.RequiredUniqueChars);
-            Assert.Equal(-1, myOptions.Password.RequiredLength);
+            Assert.Equal(1, myOptions.Password.RequireUniqueChars);
+            Assert.Equal(-1, myOptions.Password.RequireLength);
         }
 
         [Fact]

--- a/src/Identity/test/Identity.Test/PasswordValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/PasswordValidatorTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [Theory]
         [InlineData("a")]
         [InlineData("aaaaaaaaaaa")]
-        public async Task FailsWithoutRequiredNonAlphanumericTests(string input)
+        public async Task FailsWithoutRequireNonAlphanumericTests(string input)
         {
             var manager = MockHelpers.TestUserManager<PocoUser>();
             var valid = new PasswordValidator<PocoUser>();
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [InlineData("@")]
         [InlineData("abcd@e!ld!kajfd")]
         [InlineData("!!!!!!")]
-        public async Task SucceedsWithRequiredNonAlphanumericTests(string input)
+        public async Task SucceedsWithRequireNonAlphanumericTests(string input)
         {
             var manager = MockHelpers.TestUserManager<PocoUser>();
             var valid = new PasswordValidator<PocoUser>();
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [InlineData("a", 2)]
         [InlineData("aaaaaaaaaaa", 2)]
         [InlineData("abcdabcdabcdabcdabcdabcdabcd", 5)]
-        public async Task FailsWithoutRequiredUniqueCharsTests(string input, int uniqueChars)
+        public async Task FailsWithoutRequireUniqueCharsTests(string input, int uniqueChars)
         {
             var manager = MockHelpers.TestUserManager<PocoUser>();
             var valid = new PasswordValidator<PocoUser>();
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [InlineData("!@#$%", 5)]
         [InlineData("a", 1)]
         [InlineData("this is a long password with many chars", 10)]
-        public async Task SucceedsWithRequiredUniqueCharsTests(string input, int uniqueChars)
+        public async Task SucceedsWithRequireUniqueCharsTests(string input, int uniqueChars)
         {
             var manager = MockHelpers.TestUserManager<PocoUser>();
             var valid = new PasswordValidator<PocoUser>();
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [InlineData("a_b9de", Errors.Upper)]
         [InlineData("abcd@e!ld!kaj9Fd", Errors.None)]
         [InlineData("aB1@df", Errors.None)]
-        public async Task UberMixedRequiredTests(string input, Errors errorMask)
+        public async Task UberMixedRequireTests(string input, Errors errorMask)
         {
             const string alphaError = "Passwords must have at least one non alphanumeric character.";
             const string upperError = "Passwords must have at least one uppercase ('A'-'Z').";

--- a/src/Identity/test/Identity.Test/PasswordValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/PasswordValidatorTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.Options.Password.RequireNonAlphanumeric = true;
             manager.Options.Password.RequireLowercase = false;
             manager.Options.Password.RequireDigit = false;
-            manager.Options.Password.RequiredLength = 0;
+            manager.Options.Password.RequireLength = 0;
             IdentityResultAssert.IsFailure(await valid.ValidateAsync(manager, null, input),
                 "Passwords must have at least one non alphanumeric character.");
         }
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.Options.Password.RequireNonAlphanumeric = true;
             manager.Options.Password.RequireLowercase = false;
             manager.Options.Password.RequireDigit = false;
-            manager.Options.Password.RequiredLength = 0;
+            manager.Options.Password.RequireLength = 0;
             IdentityResultAssert.IsSuccess(await valid.ValidateAsync(manager, null, input));
         }
 
@@ -109,8 +109,8 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.Options.Password.RequireNonAlphanumeric = false;
             manager.Options.Password.RequireLowercase = false;
             manager.Options.Password.RequireDigit = false;
-            manager.Options.Password.RequiredLength = 0;
-            manager.Options.Password.RequiredUniqueChars = uniqueChars;
+            manager.Options.Password.RequireLength = 0;
+            manager.Options.Password.RequireUniqueChars = uniqueChars;
             IdentityResultAssert.IsFailure(await valid.ValidateAsync(manager, null, input),
                 String.Format("Passwords must use at least {0} different characters.", uniqueChars));
         }
@@ -130,8 +130,8 @@ namespace Microsoft.AspNetCore.Identity.Test
             manager.Options.Password.RequireNonAlphanumeric = false;
             manager.Options.Password.RequireLowercase = false;
             manager.Options.Password.RequireDigit = false;
-            manager.Options.Password.RequiredLength = 0;
-            manager.Options.Password.RequiredUniqueChars = uniqueChars;
+            manager.Options.Password.RequireLength = 0;
+            manager.Options.Password.RequireUniqueChars = uniqueChars;
             IdentityResultAssert.IsSuccess(await valid.ValidateAsync(manager, null, input));
         }
 


### PR DESCRIPTION
`AddDefaultIdentity()` PasswordOptions should have a way unify the grammer

![image](https://user-images.githubusercontent.com/10666633/57963785-08997800-7954-11e9-8d8a-e1775727f18a.png)

