### PR TITLE
Skip Java detection on restore if not building

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -303,7 +303,7 @@ $MSBuildArguments += "/p:_RunSign=$Sign"
 $MSBuildArguments += "/p:TargetArchitecture=$Architecture"
 $MSBuildArguments += "/p:TargetOsName=win"
 
-if (($All -or $BuildJava) -and -not $NoBuildJava) {
+if ($RunBuild -and ($All -or $BuildJava) -and -not $NoBuildJava) {
     $foundJdk = $false
     $javac = Get-Command javac -ErrorAction Ignore -CommandType Application
     if ($env:JAVA_HOME) {


### PR DESCRIPTION
Currently with the latest changes to `build.ps1`, restore fails if `JAVA_HOME` is not set even if it is not actually needed.

```
❯ .\restore.cmd
Downloading KoreBuild 3.0.0-build-20190515.1
C:\Users\Ale\Workspace\dotnet\aspnet\AspNetCore\build.ps1 : Could not find the JDK. See
C:\Users\Ale\Workspace\dotnet\aspnet\AspNetCore\docs\BuildFromSource.md for details on this requirement.
At line:1 char:126
+ ... ulture = '';& 'C:\Users\Ale\Workspace\dotnet\aspnet\AspNetCore\build. ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,build.ps1
```