### PR TITLE
Put request trailers in a separate collection

### DIFF
--- a/src/Http/Http.Abstractions/ref/Microsoft.AspNetCore.Http.Abstractions.netcoreapp3.0.cs
+++ b/src/Http/Http.Abstractions/ref/Microsoft.AspNetCore.Http.Abstractions.netcoreapp3.0.cs
@@ -373,6 +373,13 @@ namespace Microsoft.AspNetCore.Http
         public string ToUriComponent() { throw null; }
     }
     public delegate System.Threading.Tasks.Task RequestDelegate(Microsoft.AspNetCore.Http.HttpContext context);
+    public static partial class RequestTrailerExtensions
+    {
+        public static bool CheckTrailersAvailable(this Microsoft.AspNetCore.Http.HttpRequest request) { throw null; }
+        public static Microsoft.Extensions.Primitives.StringValues GetDeclaredTrailers(this Microsoft.AspNetCore.Http.HttpRequest request) { throw null; }
+        public static Microsoft.Extensions.Primitives.StringValues GetTrailer(this Microsoft.AspNetCore.Http.HttpRequest request, string trailerName) { throw null; }
+        public static bool SupportsTrailers(this Microsoft.AspNetCore.Http.HttpRequest request) { throw null; }
+    }
     public static partial class ResponseTrailerExtensions
     {
         public static void AppendTrailer(this Microsoft.AspNetCore.Http.HttpResponse response, string trailerName, Microsoft.Extensions.Primitives.StringValues trailerValues) { }

--- a/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
@@ -13,9 +13,14 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public static class RequestTrailerExtensions
     {
+        /// <summary>
+        /// Gets the request "Trailer" header that lists which trailers to expect after the body.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
         public static StringValues GetDeclaredTrailers(this HttpRequest request)
         {
-            return request.Headers[HeaderNames.Trailer];
+            return request.Headers.GetCommaSeparatedValues(HeaderNames.Trailer);
         }
 
         /// <summary>
@@ -36,7 +41,7 @@ namespace Microsoft.AspNetCore.Http
         /// <returns></returns>
         public static bool CheckTrailersAvailable(this HttpRequest request)
         {
-            return request.HttpContext.Features.Get<IHttpRequestTrailersFeature>()?.Trailers != null;
+            return request.HttpContext.Features.Get<IHttpRequestTrailersFeature>()?.Available == true;
         }
 
         /// <summary>
@@ -51,11 +56,7 @@ namespace Microsoft.AspNetCore.Http
             var feature = request.HttpContext.Features.Get<IHttpRequestTrailersFeature>();
             if (feature == null)
             {
-                throw new NotSupportedException("This server does not support request trailers.");
-            }
-            if (feature.Trailers == null)
-            {
-                throw new InvalidOperationException("The trailers are not available yet. Did you finish reading the request body?");
+                throw new NotSupportedException("This request does not support trailers.");
             }
 
             return feature.Trailers[trailerName];

--- a/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        /// Indicates if the server supports receiving trailer headers.
+        /// Indicates if the request supports receiving trailer headers.
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        /// Checks if the server supports trailers and they are available to be read now.
+        /// Checks if the request supports trailers and they are available to be read now.
         /// This does not mean that there are any trailers to read.
         /// </summary>
         /// <param name="request"></param>

--- a/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Http
+{
+    /// <summary>
+    /// HttpRequest extensions for working with request trailing headers.
+    /// </summary>
+    public static class RequestTrailerExtensions
+    {
+        public static StringValues GetDeclaredTrailers(this HttpRequest request)
+        {
+            return request.Headers[HeaderNames.Trailer];
+        }
+
+        /// <summary>
+        /// Indicates if the server supports receiving trailer headers.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static bool SupportsTrailers(this HttpRequest request)
+        {
+            return request.HttpContext.Features.Get<IHttpRequestTrailersFeature>() != null;
+        }
+
+        /// <summary>
+        /// Checks if the server supports trailers and they are available to be read now.
+        /// This does not mean that there are any trailers to read.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static bool CheckTrailersAvailable(this HttpRequest request)
+        {
+            return request.HttpContext.Features.Get<IHttpRequestTrailersFeature>()?.Trailers != null;
+        }
+
+        /// <summary>
+        /// Gets the requested trailing header from the response. Check <see cref="SupportsTrailers"/>
+        /// or a NotSupportedException may be thrown.
+        /// Check <see cref="CheckTrailersAvailable" /> or an InvalidOperationException may be thrown.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="trailerName"></param>
+        public static StringValues GetTrailer(this HttpRequest request, string trailerName)
+        {
+            var feature = request.HttpContext.Features.Get<IHttpRequestTrailersFeature>();
+            if (feature == null)
+            {
+                throw new NotSupportedException("This server does not support request trailers.");
+            }
+            if (feature.Trailers == null)
+            {
+                throw new InvalidOperationException("The trailers are not available yet. Did you finish reading the request body?");
+            }
+
+            return feature.Trailers[trailerName];
+        }
+    }
+}

--- a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
+++ b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
@@ -195,6 +195,11 @@ namespace Microsoft.AspNetCore.Http.Features
         System.Threading.CancellationToken RequestAborted { get; set; }
         void Abort();
     }
+    public partial interface IHttpRequestTrailersFeature
+    {
+        bool Available { get; }
+        Microsoft.AspNetCore.Http.IHeaderDictionary Trailers { get; }
+    }
     public partial interface IHttpResponseFeature
     {
         System.IO.Stream Body { get; set; }

--- a/src/Http/Http.Features/src/IHttpRequestTrailersFeature.cs
+++ b/src/Http/Http.Features/src/IHttpRequestTrailersFeature.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Http.Features
 {
     /// <summary>
@@ -9,8 +11,15 @@ namespace Microsoft.AspNetCore.Http.Features
     public interface IHttpRequestTrailersFeature
     {
         /// <summary>
-        /// The trailing headers received. This will return null if the request body has not been read yet.
-        /// If there are no trailers this will return an empty collection.
+        /// Indicates if the <see cref="Trailers"/> are available yet. They may not be available until the
+        /// request body is fully read.
+        /// </summary>
+        bool Available { get; }
+
+        /// <summary>
+        /// The trailing headers received. This will throw <see cref="InvalidOperationException"/> if <see cref="Available"/>
+        /// returns false. They may not be available until the request body is fully read. If there are no trailers this will
+        /// return an empty collection.
         /// </summary>
         IHeaderDictionary Trailers { get; }
     }

--- a/src/Http/Http.Features/src/IHttpRequestTrailersFeature.cs
+++ b/src/Http/Http.Features/src/IHttpRequestTrailersFeature.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    /// <summary>
+    /// This feature exposes HTTP request trailer headers, either for HTTP/1.1 chunked bodies or HTTP/2 trailing headers.
+    /// </summary>
+    public interface IHttpRequestTrailersFeature
+    {
+        /// <summary>
+        /// The trailing headers received. This will return null if the request body has not been read yet.
+        /// If there are no trailers this will return an empty collection.
+        /// </summary>
+        IHeaderDictionary Trailers { get; }
+    }
+}

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -276,6 +276,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public static string GetAsciiOrUTF8StringNonNullCharacters(this System.Span<byte> span) { throw null; }
         public static string GetAsciiStringEscaped(this System.Span<byte> span, int maxChars) { throw null; }
         public static string GetAsciiStringNonNullCharacters(this System.Span<byte> span) { throw null; }
+        public static string GetHeaderName(this System.Span<byte> span) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static bool GetKnownHttpScheme(this System.Span<byte> span, out Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpScheme knownScheme) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static bool GetKnownMethod(this System.Span<byte> span, out Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod method, out int length) { throw null; }
         public static Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod GetKnownMethod(string value) { throw null; }

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -602,4 +602,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2MinDataRateNotSupported" xml:space="preserve">
     <value>This feature is not supported for HTTP/2 requests except to disable it entirely by setting the rate to null.</value>
   </data>
+  <data name="RequestTrailersNotAvailable" xml:space="preserve">
+    <value>The request trailers are not available yet. They may not be available until the full request body is read.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -35,7 +35,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             : base(context)
         {
             RequestKeepAlive = keepAlive;
-
             _requestBodyPipe = CreateRequestBodyPipe(context);
         }
 
@@ -301,7 +300,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // _consumedBytes aren't tracked for trailer headers, since headers have separate limits.
             if (_mode == Mode.TrailerHeaders)
             {
-                if (_context.TakeMessageHeaders(readableBuffer, out consumed, out examined))
+                if (_context.TakeMessageHeaders(readableBuffer, trailers: true, out consumed, out examined))
                 {
                     _mode = Mode.Complete;
                 }
@@ -489,6 +488,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 consumed = trailerBuffer.End;
                 AddAndCheckConsumedBytes(2);
                 _mode = Mode.Complete;
+                // No trailers
+                _context.OnTrailersComplete();
             }
             else
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         break;
                     }
                 case RequestProcessingStatus.ParsingHeaders:
-                    if (TakeMessageHeaders(buffer, out consumed, out examined))
+                    if (TakeMessageHeaders(buffer, trailers: false, out consumed, out examined))
                     {
                         _requestProcessingStatus = RequestProcessingStatus.AppStarted;
                     }
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return result;
         }
 
-        public bool TakeMessageHeaders(ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
+        public bool TakeMessageHeaders(ReadOnlySequence<byte> buffer, bool trailers, out SequencePosition consumed, out SequencePosition examined)
         {
             // Make sure the buffer is limited
             bool overLength = false;
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 overLength = true;
             }
 
-            var result = _parser.ParseHeaders(new Http1ParsingHandler(this), buffer, out consumed, out examined, out var consumedBytes);
+            var result = _parser.ParseHeaders(new Http1ParsingHandler(this, trailers), buffer, out consumed, out examined, out var consumedBytes);
             _remainingRequestHeadersBytesAllowed -= consumedBytes;
 
             if (!result && overLength)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -212,6 +212,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _context.Input.AdvanceTo(consumed);
                     _finalAdvanceCalled = true;
+                    _context.OnTrailersComplete();
                 }
 
                 return;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -150,6 +150,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 // TODO may push more into the wrapper rather than just calling into the message body
                 // NBD for now.
+                context.EnableRequestTrailersFeature();
                 return new Http1ChunkedEncodingMessageBody(keepAlive, context);
             }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -129,6 +129,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     BadHttpRequestException.Throw(RequestRejectionReason.UpgradeRequestCannotHavePayload);
                 }
 
+                context.OnTrailersComplete(); // No trailers for these.
                 return new Http1UpgradeMessageBody(context);
             }
 
@@ -150,7 +151,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 // TODO may push more into the wrapper rather than just calling into the message body
                 // NBD for now.
-                context.EnableRequestTrailersFeature();
                 return new Http1ChunkedEncodingMessageBody(keepAlive, context);
             }
 
@@ -174,6 +174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 BadHttpRequestException.Throw(requestRejectionReason, context.Method);
             }
 
+            context.OnTrailersComplete(); // No trailers for these.
             return keepAlive ? MessageBody.ZeroContentLengthKeepAlive : MessageBody.ZeroContentLengthClose;
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
@@ -8,17 +8,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     internal readonly struct Http1ParsingHandler : IHttpRequestLineHandler, IHttpHeadersHandler
     {
         public readonly Http1Connection Connection;
+        public readonly bool Trailers;
 
         public Http1ParsingHandler(Http1Connection connection)
         {
             Connection = connection;
+            Trailers = false;
+        }
+
+        public Http1ParsingHandler(Http1Connection connection, bool trailers)
+        {
+            Connection = connection;
+            Trailers = trailers;
         }
 
         public void OnHeader(Span<byte> name, Span<byte> value)
-            => Connection.OnHeader(name, value);
+        {
+            if (Trailers)
+            {
+                Connection.OnTrailer(name, value);
+            }
+            else
+            {
+                Connection.OnHeader(name, value);
+            }
+        }
 
         public void OnHeadersComplete()
-            => Connection.OnHeadersComplete();
+        {
+            if (Trailers)
+            {
+                Connection.OnTrailersComplete();
+            }
+            else
+            {
+                Connection.OnHeadersComplete();
+            }
+        }
 
         public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
             => Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                           IHttpConnectionFeature,
                                           IHttpRequestLifetimeFeature,
                                           IHttpRequestIdentifierFeature,
+                                          IHttpRequestTrailersFeature,
                                           IHttpBodyControlFeature,
                                           IHttpMaxRequestBodySizeFeature,
                                           IHttpResponseStartFeature,
@@ -130,6 +131,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 RequestBodyPipeReader = value;
                 RequestBody = new ReadOnlyPipeStream(RequestBodyPipeReader);
+            }
+        }
+
+        IHeaderDictionary IHttpRequestTrailersFeature.Trailers
+        {
+            get
+            {
+                return RequestTrailers;
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -134,10 +134,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
+        bool IHttpRequestTrailersFeature.Available => RequestTrailersAvailable;
+
         IHeaderDictionary IHttpRequestTrailersFeature.Trailers
         {
             get
             {
+                if (!RequestTrailersAvailable)
+                {
+                    throw new InvalidOperationException(CoreStrings.RequestTrailersNotAvailable);
+                }
                 return RequestTrailers;
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -298,6 +298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             _currentIHttp2StreamIdFeature = this;
             _currentIHttpResponseTrailersFeature = this;
+            _currentIHttpRequestTrailersFeature = this;
         }
 
         void IHttpResponseFeature.OnStarting(Func<object, Task> callback, object state)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -298,7 +298,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             _currentIHttp2StreamIdFeature = this;
             _currentIHttpResponseTrailersFeature = this;
-            _currentIHttpRequestTrailersFeature = this;
         }
 
         void IHttpResponseFeature.OnStarting(Func<object, Task> callback, object state)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -84,6 +84,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIHttpUpgradeFeature = this;
             _currentIHttpRequestIdentifierFeature = this;
             _currentIHttpRequestLifetimeFeature = this;
+            _currentIHttpRequestTrailersFeature = this;
             _currentIHttpConnectionFeature = this;
             _currentIHttpMaxRequestBodySizeFeature = this;
             _currentIHttpMinRequestBodyDataRateFeature = this;
@@ -94,7 +95,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             _currentIServiceProvidersFeature = null;
             _currentIHttpAuthenticationFeature = null;
-            _currentIHttpRequestTrailersFeature = null;
             _currentIQueryFeature = null;
             _currentIFormFeature = null;
             _currentIHttp2StreamIdFeature = null;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private static readonly Type IRouteValuesFeatureType = typeof(IRouteValuesFeature);
         private static readonly Type IEndpointFeatureType = typeof(IEndpointFeature);
         private static readonly Type IHttpAuthenticationFeatureType = typeof(IHttpAuthenticationFeature);
+        private static readonly Type IHttpRequestTrailersFeatureType = typeof(IHttpRequestTrailersFeature);
         private static readonly Type IQueryFeatureType = typeof(IQueryFeature);
         private static readonly Type IFormFeatureType = typeof(IFormFeature);
         private static readonly Type IHttpUpgradeFeatureType = typeof(IHttpUpgradeFeature);
@@ -52,6 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private object _currentIRouteValuesFeature;
         private object _currentIEndpointFeature;
         private object _currentIHttpAuthenticationFeature;
+        private object _currentIHttpRequestTrailersFeature;
         private object _currentIQueryFeature;
         private object _currentIFormFeature;
         private object _currentIHttpUpgradeFeature;
@@ -92,6 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             _currentIServiceProvidersFeature = null;
             _currentIHttpAuthenticationFeature = null;
+            _currentIHttpRequestTrailersFeature = null;
             _currentIQueryFeature = null;
             _currentIFormFeature = null;
             _currentIHttp2StreamIdFeature = null;
@@ -200,6 +203,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == IHttpAuthenticationFeatureType)
                 {
                     feature = _currentIHttpAuthenticationFeature;
+                }
+                else if (key == IHttpRequestTrailersFeatureType)
+                {
+                    feature = _currentIHttpRequestTrailersFeature;
                 }
                 else if (key == IQueryFeatureType)
                 {
@@ -321,6 +328,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIHttpAuthenticationFeature = value;
                 }
+                else if (key == IHttpRequestTrailersFeatureType)
+                {
+                    _currentIHttpRequestTrailersFeature = value;
+                }
                 else if (key == IQueryFeatureType)
                 {
                     _currentIQueryFeature = value;
@@ -438,6 +449,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
                 feature = (TFeature)_currentIHttpAuthenticationFeature;
+            }
+            else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
+            {
+                feature = (TFeature)_currentIHttpRequestTrailersFeature;
             }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
@@ -563,6 +578,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttpAuthenticationFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
+            {
+                _currentIHttpRequestTrailersFeature = feature;
+            }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
                 _currentIQueryFeature = feature;
@@ -678,6 +697,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttpAuthenticationFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IHttpAuthenticationFeatureType, _currentIHttpAuthenticationFeature);
+            }
+            if (_currentIHttpRequestTrailersFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IHttpRequestTrailersFeatureType, _currentIHttpRequestTrailersFeature);
             }
             if (_currentIQueryFeature != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -552,11 +552,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             RequestTrailersAvailable = true;
         }
 
-        public void EnableRequestTrailersFeature()
-        {
-            _currentIHttpRequestTrailersFeature = this;
-        }
-
         public async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)
         {
             try

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -103,16 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         [MethodImpl(MethodImplOptions.NoInlining)]
         private unsafe void AppendUnknownHeaders(Span<byte> name, string valueString)
         {
-            string key = new string('\0', name.Length);
-            fixed (byte* pKeyBytes = name)
-            fixed (char* keyBuffer = key)
-            {
-                if (!StringUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, name.Length))
-                {
-                    BadHttpRequestException.Throw(RequestRejectionReason.InvalidCharactersInHeaderName);
-                }
-            }
-
+            string key = name.GetHeaderName();
             Unknown.TryGetValue(key, out var existing);
             Unknown[key] = AppendValue(existing, valueString);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -575,9 +575,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _currentHeadersStream.Reset();
                 _headerFlags = _incomingFrame.HeadersFlags;
 
-                // All HTTP/2 requests support request trailers.
-                _currentHeadersStream.EnableRequestTrailersFeature();
-
                 var headersPayload = payload.Slice(0, _incomingFrame.HeadersPayloadLength); // Minus padding
                 return DecodeHeadersAsync(_incomingFrame.HeadersEndHeaders, headersPayload);
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -403,6 +403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 }
             }
 
+            OnTrailersComplete();
             RequestBodyPipe.Writer.Complete();
 
             _inputFlowControl.StopWindowUpdates();

--- a/src/Servers/Kestrel/Core/src/Properties/CoreStrings.Designer.cs
+++ b/src/Servers/Kestrel/Core/src/Properties/CoreStrings.Designer.cs
@@ -2268,6 +2268,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatHttp2MinDataRateNotSupported()
             => GetString("Http2MinDataRateNotSupported");
 
+        /// <summary>
+        /// The request trailers are not available yet. They may not be available until the full request body is read.
+        /// </summary>
+        internal static string RequestTrailersNotAvailable
+        {
+            get => GetString("RequestTrailersNotAvailable");
+        }
+
+        /// <summary>
+        /// The request trailers are not available yet. They may not be available until the full request body is read.
+        /// </summary>
+        internal static string FormatRequestTrailersNotAvailable()
+            => GetString("RequestTrailersNotAvailable");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.UTF8.GetBytes("\r\n\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            _http1Connection.TakeMessageHeaders(readableBuffer, out _consumed, out _examined);
+            _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(headerValue, _http1Connection.RequestHeaders[headerName]);
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(extendedAsciiEncoding.GetBytes("\r\n\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var exception = Assert.Throws<InvalidOperationException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
+            var exception = Assert.Throws<InvalidOperationException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLine}\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
+            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(CoreStrings.BadRequest_HeadersExceedMaxTotalSize, exception.Message);
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLines}\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
+            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(CoreStrings.BadRequest_TooManyHeaders, exception.Message);
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLine1}\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var takeMessageHeaders = _http1Connection.TakeMessageHeaders(readableBuffer, out _consumed, out _examined);
+            var takeMessageHeaders = _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(takeMessageHeaders);
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLine2}\r\n"));
             readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            takeMessageHeaders = _http1Connection.TakeMessageHeaders(readableBuffer, out _consumed, out _examined);
+            takeMessageHeaders = _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(takeMessageHeaders);

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -121,6 +121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _collection[typeof(IRequestBodyPipeFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpRequestIdentifierFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpRequestLifetimeFeature)] = CreateHttp1Connection();
+            _collection[typeof(IHttpRequestTrailersFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpConnectionFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpMaxRequestBodySizeFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpMinRequestBodyDataRateFeature)] = CreateHttp1Connection();
@@ -144,6 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _collection.Set<IRequestBodyPipeFeature>(CreateHttp1Connection());
             _collection.Set<IHttpRequestIdentifierFeature>(CreateHttp1Connection());
             _collection.Set<IHttpRequestLifetimeFeature>(CreateHttp1Connection());
+            _collection.Set<IHttpRequestTrailersFeature>(CreateHttp1Connection());
             _collection.Set<IHttpConnectionFeature>(CreateHttp1Connection());
             _collection.Set<IHttpMaxRequestBodySizeFeature>(CreateHttp1Connection());
             _collection.Set<IHttpMinRequestBodyDataRateFeature>(CreateHttp1Connection());

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionParsingOverheadBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionParsingOverheadBenchmark.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 ErrorUtilities.ThrowInvalidRequestLine();
             }
 
-            if (!_http1Connection.TakeMessageHeaders(_buffer, out consumed, out examined))
+            if (!_http1Connection.TakeMessageHeaders(_buffer, trailers: false, out consumed, out examined))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             _http1Connection.Reset();
 
-            if (!_http1Connection.TakeMessageHeaders(_buffer, out var consumed, out var examined))
+            if (!_http1Connection.TakeMessageHeaders(_buffer, trailers: false, out var consumed, out var examined))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/RequestParsingBenchmark.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
                 readableBuffer = readableBuffer.Slice(consumed);
 
-                if (!Http1Connection.TakeMessageHeaders(readableBuffer, out consumed, out examined))
+                if (!Http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out consumed, out examined))
                 {
                     ErrorUtilities.ThrowInvalidRequestHeaders();
                 }
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 result = Pipe.Reader.ReadAsync().GetAwaiter().GetResult();
                 readableBuffer = result.Buffer;
 
-                if (!Http1Connection.TakeMessageHeaders(readableBuffer, out consumed, out examined))
+                if (!Http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out consumed, out examined))
                 {
                     ErrorUtilities.ThrowInvalidRequestHeaders();
                 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -232,14 +232,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 var buffer = new byte[200];
 
-                Assert.True(request.SupportsTrailers(), "SupportsTrailers");
-                Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable"); // Not yet
-                Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));  // Not yet
-
-                // The last request is content-length with no trailers.
-                if (requestsReceived < requestCount)
+                // The first request is chunked with no trailers.
+                if (requestsReceived == 0)
                 {
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable"); // Not yet
+                    Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));  // Not yet
+                }
+                // The middle requests are chunked with trailers.
+                else if (requestsReceived < requestCount)
+                {
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable"); // Not yet
+                    Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));  // Not yet
                     Assert.Equal("X-Trailer-Header", request.GetDeclaredTrailers().ToString());
+                }
+                // The last request is content-length with no trailers.
+                else
+                {
+                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
                 }
 
                 while (await request.Body.ReadAsync(buffer, 0, buffer.Length) != 0)
@@ -247,18 +260,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     ;// read to end
                 }
 
-                Assert.True(request.SupportsTrailers(), "SupportsTrailers");
-                Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                Assert.False(request.Headers.ContainsKey("X-Trailer-Header"));
 
-                if (requestsReceived < requestCount)
+                // The first request is chunked with no trailers.
+                if (requestsReceived == 0)
                 {
-                    Assert.False(request.Headers.ContainsKey("X-Trailer-Header"));
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Equal(string.Empty, request.GetDeclaredTrailers().ToString());
+                    Assert.Equal(string.Empty, request.GetTrailer("X-Trailer-Header").ToString());
+                }
+                // The middle requests are chunked with trailers.
+                else if (requestsReceived < requestCount)
+                {
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Equal("X-Trailer-Header", request.GetDeclaredTrailers().ToString());
                     Assert.Equal(new string('a', requestsReceived), request.GetTrailer("X-Trailer-Header").ToString());
                 }
+                // The last request is content-length with no trailers.
                 else
                 {
-                    Assert.False(request.Headers.ContainsKey("X-Trailer-Header"));
-                    Assert.True(string.IsNullOrEmpty(request.GetTrailer("X-Trailer-Header")));
+                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Equal(string.Empty, request.GetDeclaredTrailers().ToString());
+                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
                 }
 
                 requestsReceived++;
@@ -331,14 +357,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 var response = httpContext.Response;
                 var request = httpContext.Request;
 
-                Assert.True(request.SupportsTrailers(), "SupportsTrailers");
-                Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable"); // Not yet
-                Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));  // Not yet
-
-                // The last request is content-length with no trailers.
-                if (requestsReceived < requestCount)
+                // The first request is chunked with no trailers.
+                if (requestsReceived == 0)
                 {
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable"); // Not yet
+                    Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));  // Not yet
+                }
+                // The middle requests are chunked with trailers.
+                else if (requestsReceived < requestCount)
+                {
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable"); // Not yet
+                    Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));  // Not yet
                     Assert.Equal("X-Trailer-Header", request.GetDeclaredTrailers().ToString());
+                }
+                // The last request is content-length with no trailers.
+                else
+                {
+                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
                 }
 
                 while (true)
@@ -351,18 +390,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     }
                 }
 
-                Assert.True(request.SupportsTrailers(), "SupportsTrailers");
-                Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                Assert.False(request.Headers.ContainsKey("X-Trailer-Header"));
 
-                if (requestsReceived < requestCount)
+                // The first request is chunked with no trailers.
+                if (requestsReceived == 0)
                 {
-                    Assert.False(request.Headers.ContainsKey("X-Trailer-Header"));
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Equal(string.Empty, request.GetDeclaredTrailers().ToString());
+                    Assert.Equal(string.Empty, request.GetTrailer("X-Trailer-Header").ToString());
+                }
+                // The middle requests are chunked with trailers.
+                else if (requestsReceived < requestCount)
+                {
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Equal("X-Trailer-Header", request.GetDeclaredTrailers().ToString());
                     Assert.Equal(new string('a', requestsReceived), request.GetTrailer("X-Trailer-Header").ToString());
                 }
+                // The last request is content-length with no trailers.
                 else
                 {
-                    Assert.False(request.Headers.ContainsKey("X-Trailer-Header"));
-                    Assert.True(string.IsNullOrEmpty(request.GetTrailer("X-Trailer-Header")));
+                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.Equal(string.Empty, request.GetDeclaredTrailers().ToString());
+                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
                 }
 
                 requestsReceived++;
@@ -527,13 +579,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     ;// read to end
                 }
 
+                Assert.True(string.IsNullOrEmpty(request.Headers["X-Trailer-Header"]));
+
                 if (requestsReceived < requestCount)
                 {
-                    Assert.Equal(new string('a', requestsReceived), request.Headers["X-Trailer-Header"].ToString());
-                }
-                else
-                {
-                    Assert.True(string.IsNullOrEmpty(request.Headers["X-Trailer-Header"]));
+                    Assert.Equal(new string('a', requestsReceived), request.GetTrailer("X-Trailer-Header").ToString());
                 }
 
                 requestsReceived++;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -250,9 +250,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 // The last request is content-length with no trailers.
                 else
                 {
-                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
                     Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
-                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
+                    Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));
                 }
 
                 while (await request.Body.ReadAsync(buffer, 0, buffer.Length) != 0)
@@ -281,10 +281,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 // The last request is content-length with no trailers.
                 else
                 {
-                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
-                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
                     Assert.Equal(string.Empty, request.GetDeclaredTrailers().ToString());
-                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
+                    Assert.Equal(string.Empty, request.GetTrailer("X-Trailer-Header").ToString());
                 }
 
                 requestsReceived++;
@@ -375,9 +375,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 // The last request is content-length with no trailers.
                 else
                 {
-                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
                     Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
-                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
+                    Assert.Throws<InvalidOperationException>(() => request.GetTrailer("X-Trailer-Header"));
                 }
 
                 while (true)
@@ -411,10 +411,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 // The last request is content-length with no trailers.
                 else
                 {
-                    Assert.False(request.SupportsTrailers(), "SupportsTrailers");
-                    Assert.False(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
+                    Assert.True(request.SupportsTrailers(), "SupportsTrailers");
+                    Assert.True(request.CheckTrailersAvailable(), "CheckTrailersAvailable");
                     Assert.Equal(string.Empty, request.GetDeclaredTrailers().ToString());
-                    Assert.Throws<NotSupportedException>(() => request.GetTrailer("X-Trailer-Header"));
+                    Assert.Equal(string.Empty, request.GetTrailer("X-Trailer-Header").ToString());
                 }
 
                 requestsReceived++;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task HEADERS_Received_WithTrailers_Discarded(bool sendData)
+        public async Task HEADERS_Received_WithTrailers_Available(bool sendData)
         {
             await InitializeConnectionAsync(_readTrailersApplication);
 
@@ -1206,10 +1206,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             VerifyDecodedRequestHeaders(_browserRequestHeaders);
 
-            // Make sure the trailers are missing. https://github.com/aspnet/KestrelHttpServer/issues/2630
+            // Make sure the trailers are in the trailers collection.
             foreach (var header in _requestTrailers)
             {
                 Assert.False(_receivedHeaders.ContainsKey(header.Key));
+                Assert.True(_receivedTrailers.ContainsKey(header.Key));
+                Assert.Equal(header.Value, _receivedTrailers[header.Key]);
             }
 
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
@@ -3288,7 +3290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CONTINUATION_Received_WithTrailers_Discarded(bool sendData)
+        public async Task CONTINUATION_Received_WithTrailers_Available(bool sendData)
         {
             await InitializeConnectionAsync(_readTrailersApplication);
 
@@ -3331,9 +3333,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             VerifyDecodedRequestHeaders(_browserRequestHeaders);
 
-            // Make sure the trailers are missing. https://github.com/aspnet/KestrelHttpServer/issues/2630
+            // Make sure the trailers are in the trailers collection.
             Assert.False(_receivedHeaders.ContainsKey("trailer-1"));
             Assert.False(_receivedHeaders.ContainsKey("trailer-2"));
+            Assert.True(_receivedTrailers.ContainsKey("trailer-1"));
+            Assert.True(_receivedTrailers.ContainsKey("trailer-2"));
+            Assert.Equal("1", _receivedTrailers["trailer-1"]);
+            Assert.Equal("2", _receivedTrailers["trailer-2"]);
 
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
@@ -360,7 +361,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 } while (count != 0);
 
                 Assert.Equal("Hello World", Encoding.ASCII.GetString(buffer));
-                Assert.Equal("trailing-value", context.Request.Headers["Trailing-Header"].ToString());
+                Assert.Equal("trailing-value", context.Request.GetTrailer("Trailing-Header").ToString());
             },
             new TestServiceContext(LoggerFactory) { ServerOptions = { Limits = { MaxRequestBodySize = globalMaxRequestBodySize } } }))
             {

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -26,6 +26,7 @@ namespace CodeGenerator
             var commonFeatures = new[]
             {
                 "IHttpAuthenticationFeature",
+                "IHttpRequestTrailersFeature",
                 "IQueryFeature",
                 "IFormFeature",
             };

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -70,6 +70,7 @@ namespace CodeGenerator
                 "IHttpUpgradeFeature",
                 "IHttpRequestIdentifierFeature",
                 "IHttpRequestLifetimeFeature",
+                "IHttpRequestTrailersFeature",
                 "IHttpConnectionFeature",
                 "IHttpMaxRequestBodySizeFeature",
                 "IHttpMinRequestBodyDataRateFeature",


### PR DESCRIPTION
 #4771 Having request headers and trailers in the same collection creates some ambiguity and potential spoofing concerns (e.g. headers changing after validation). In the HTTP/2 scenario there are also concurrency issues where all headers and trailers are processed on the connection thread, not the request thread. This PR adds a new feature and collection for trailers to keep them isolated. 

I ended up using a bool Available to track state rather than returning a null connection because it let me use the main collection property to store incomplete trailers without worrying if anyone would access them (e.g. HTTP/2 concurrency issues). It also simplified re-using the collection across requests, it can just be cleared out.

The most interesting detail is that Http/2 trailers aren't processed as part of the request body like HTTP/1.1. The connection loop reads them as soon as they arrive. That means you may not have to read all the way to the end of the request body before they're available, only far enough that the remainder fit in the buffer and the client's window size unblocked the sending of trailers. Consistency with HTTP/1.1 is maintained by ensuring that the trailers are always available if you have read to the end of the request body.