### PR TITLE
Update links and disable warnings related to tests that don't work in Helix

### DIFF
--- a/docs/Helix.md
+++ b/docs/Helix.md
@@ -61,6 +61,6 @@ Most tests that don't just work on helix automatically are ones that depend on t
 ## How to skip tests on helix
 There are two main ways to opt out of helix
 - Skipping the entire test project via `<BuildHelixPayload>false</BuildHelixPayload>` in csproj (the default value for this is IsTestProject).
-- Skipping an individual test via `[SkipOnHelix]` which might require including a compile reference to: `<Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />`
+- Skipping an individual test via `[SkipOnHelix("url to github issue")]` which might require including a compile reference to: `<Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />`
 
 Make sure to file an issue for any skipped tests and include that in a comment next to either of these

--- a/src/Analyzers/Analyzers/test/AnalyzerTestBase.cs
+++ b/src/Analyzers/Analyzers/test/AnalyzerTestBase.cs
@@ -51,7 +51,11 @@ namespace Microsoft.AspNetCore.Analyzers
                 return AppContext.BaseDirectory;
             }
 
+// This test code needs to be updated to support distributed testing.
+// See https://github.com/aspnet/AspNetCore/issues/10422
+#pragma warning disable 0618
             var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Analyzers");
+#pragma warning restore 0618
             var projectDirectory = Path.Combine(solutionDirectory, "Analyzers", "test");
             return projectDirectory;
         }

--- a/src/Analyzers/Analyzers/test/Microsoft.AspNetCore.Analyzers.Test.csproj
+++ b/src/Analyzers/Analyzers/test/Microsoft.AspNetCore.Analyzers.Test.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.AspNetCore.Analyzers</RootNamespace>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/10422 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <BaseOutputPath />
     <OutputPath />

--- a/src/Components/Blazor/Build/test/RuntimeDependenciesResolverTest.cs
+++ b/src/Components/Blazor/Build/test/RuntimeDependenciesResolverTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
         }
 
         [ConditionalFact]
-        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6549")]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/10426")]
         public void FindsReferenceAssemblyGraph_ForStandaloneApp()
         {
             // Arrange

--- a/src/Components/Blazor/Build/test/RuntimeDependenciesResolverTest.cs
+++ b/src/Components/Blazor/Build/test/RuntimeDependenciesResolverTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6549
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6549")]
         public void FindsReferenceAssemblyGraph_ForStandaloneApp()
         {
             // Arrange

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -2577,7 +2577,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7487
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/7487")]
         public async Task CanTriggerEventHandlerDisposedInEarlierPendingBatchAsync()
         {
             // This represents the scenario where the same event handler is being triggered

--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.DataProtection
         [ConditionalFact]
         [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2177", FlakyOn.AzP.Windows)]
         [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public void System_UsesProvidedDirectoryAndCertificate()
         {
             var filePath = Path.Combine(GetTestFilesPath(), "TestCert.pfx");
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.DataProtection
 
         [ConditionalFact]
         [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public void System_UsesProvidedCertificateNotFromStore()
         {
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/Microsoft.AspNetCore.FunctionalTests.csproj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/Microsoft.AspNetCore.FunctionalTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/10424 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <BaseOutputPath />
     <OutputPath />

--- a/src/Hosting/Hosting/test/WebHostTests.cs
+++ b/src/Hosting/Hosting/test/WebHostTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7291
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/7291")]
         public async Task WebHostStopAsyncUsesDefaultTimeoutIfGivenTokenDoesNotFire()
         {
             var data = new Dictionary<string, string>
@@ -315,7 +315,7 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7291
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/7291")]
         public void WebHostApplicationLifetimeEventsOrderedCorrectlyDuringShutdown()
         {
             using (var host = CreateBuilder()

--- a/src/Hosting/test/FunctionalTests/Microsoft.AspNetCore.Hosting.FunctionalTests.csproj
+++ b/src/Hosting/test/FunctionalTests/Microsoft.AspNetCore.Hosting.FunctionalTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/8247 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <BaseOutputPath />
     <OutputPath />

--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -49,8 +49,11 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
             {
                 var logger = loggerFactory.CreateLogger(testName);
 
+// https://github.com/aspnet/AspNetCore/issues/8247
+#pragma warning disable 0618
                 var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "testassets",
                     "Microsoft.AspNetCore.Hosting.TestSites");
+#pragma warning restore 0618
 
                 var deploymentParameters = new DeploymentParameters(
                     applicationPath,

--- a/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
+++ b/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
@@ -28,7 +28,10 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
             {
                 var logger = loggerFactory.CreateLogger(nameof(InjectedStartup_DefaultApplicationNameIsEntryAssembly));
 
+// https://github.com/aspnet/AspNetCore/issues/8247
+#pragma warning disable 0618
                 var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "testassets", "IStartupInjectionAssemblyName");
+#pragma warning restore 0618
 
                 var deploymentParameters = new DeploymentParameters(variant)
                 {

--- a/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/ConfigureSigningCredentialsTests.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/ConfigureSigningCredentialsTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
             UnsafeEphemeralKeySet : (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? X509KeyStorageFlags.PersistKeySet :
             X509KeyStorageFlags.DefaultKeySet);
 
-        [ConditionalFact] 
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [ConditionalFact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         [FrameworkSkipCondition(RuntimeFrameworks.CLR)]
         public void Configure_AddsDevelopmentKeyFromConfiguration()
         {
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public void Configure_LoadsPfxCertificateCredentialFromConfiguration()
         {
             // Arrange
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public void Configure_LoadsCertificateStoreCertificateCredentialFromConfiguration()
         {
             try

--- a/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/SigningKeysLoaderTests.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/SigningKeysLoaderTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
         [Fact]
         public void LoadFromFile_ThrowsIfFileDoesNotExist()
         {
-            // Arrange, Act & Assert           
+            // Arrange, Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() => SigningKeysLoader.LoadFromFile("./nonexisting.pfx", "", DefaultFlags));
             Assert.Equal($"There was an error loading the certificate. The file './nonexisting.pfx' was not found.", exception.Message);
         }
@@ -58,8 +58,8 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
             Assert.Equal("Couldn't find a valid certificate with subject 'Invalid' on the 'CurrentUser\\My'", exception.Message);
         }
 
-        [ConditionalFact] 
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [ConditionalFact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public static void LoadFromStoreCert_SkipsCertificatesNotYetValid()
         {
             try
@@ -81,8 +81,8 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
             }
         }
 
-        [ConditionalFact] 
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [ConditionalFact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public static void LoadFromStoreCert_PrefersCertificatesCloserToExpirationDate()
         {
             try
@@ -104,8 +104,8 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
             }
         }
 
-        [ConditionalFact] 
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6720
+        [ConditionalFact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6720")]
         public static void LoadFromStoreCert_SkipsExpiredCertificates()
         {
             try

--- a/src/Middleware/CORS/test/FunctionalTests/CORS.FunctionalTests.csproj
+++ b/src/Middleware/CORS/test/FunctionalTests/CORS.FunctionalTests.csproj
@@ -6,7 +6,7 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);node_modules\**\*</DefaultItemExcludes>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/7990 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <BaseOutputPath />
     <OutputPath />

--- a/src/Middleware/CORS/test/FunctionalTests/CorsMiddlewareFunctionalTest.cs
+++ b/src/Middleware/CORS/test/FunctionalTests/CorsMiddlewareFunctionalTest.cs
@@ -68,7 +68,10 @@ namespace FunctionalTests
 
         private static async Task<SamplesDeploymentResult> CreateDeployments(ILoggerFactory loggerFactory, string startup)
         {
+            // https://github.com/aspnet/AspNetCore/issues/7990
+#pragma warning disable 0618
             var solutionPath = TestPathUtilities.GetSolutionRootDirectory("Middleware");
+#pragma warning restore 0618
 
             var configuration =
 #if RELEASE

--- a/src/MusicStore/test/MusicStore.E2ETests/Common/Helpers.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Common/Helpers.cs
@@ -9,7 +9,10 @@ namespace E2ETests
     {
         public static string GetApplicationPath()
         {
+            // https://github.com/aspnet/AspNetCore/issues/8343
+#pragma warning disable 0618
             var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("MusicStore");
+#pragma warning restore 0618
             return Path.GetFullPath(Path.Combine(solutionDirectory, "samples", "MusicStore"));
         }
 

--- a/src/MusicStore/test/MusicStore.E2ETests/MusicStore.E2ETests.csproj
+++ b/src/MusicStore/test/MusicStore.E2ETests/MusicStore.E2ETests.csproj
@@ -9,7 +9,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
     <!-- Temporarily suppress warnings about Microsoft.AspNetCore.Server.IntegrationTesting -->
     <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/8343 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <IsTestProject>false</IsTestProject>
     <IsReferenceAssemblyProject>false</IsReferenceAssemblyProject>

--- a/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -27,13 +27,16 @@ namespace Microsoft.AspNetCore.Mvc
 
         private static string GetProjectDirectory()
         {
-            // On helix we use the published test files 
+            // On helix we use the published test files
             if (SkipOnHelixAttribute.OnHelix())
             {
                 return AppContext.BaseDirectory;
             }
 
+// https://github.com/aspnet/AspNetCore/issues/9431
+#pragma warning disable 0618
             var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Mvc");
+#pragma warning restore 0618
             var projectDirectory = Path.Combine(solutionDirectory, "Mvc.Analyzers", "test");
             return projectDirectory;
         }

--- a/src/Mvc/Mvc.Analyzers/test/Mvc.Analyzers.Test.csproj
+++ b/src/Mvc/Mvc.Analyzers/test/Mvc.Analyzers.Test.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.AspNetCore.Mvc.Analyzers</RootNamespace>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/9431 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <BaseOutputPath />
     <OutputPath />

--- a/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -27,13 +27,16 @@ namespace Microsoft.AspNetCore.Mvc
 
         private static string GetProjectDirectory()
         {
-            // On helix we use the published test files 
+            // On helix we use the published test files
             if (SkipOnHelixAttribute.OnHelix())
             {
                 return AppContext.BaseDirectory;
             }
 
+// https://github.com/aspnet/AspNetCore/issues/9431
+#pragma warning disable 0618
             var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Mvc");
+#pragma warning restore 0618
             var projectDirectory = Path.Combine(solutionDirectory, "Mvc.Api.Analyzers", "test");
             return projectDirectory;
         }

--- a/src/Mvc/Mvc.Api.Analyzers/test/Mvc.Api.Analyzers.Test.csproj
+++ b/src/Mvc/Mvc.Api.Analyzers/test/Mvc.Api.Analyzers.Test.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Microsoft.AspNetCore.Mvc.Api.Analyzers</RootNamespace>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/9431 -->
     <BuildHelixPayload>false</BuildHelixPayload>
     <BaseOutputPath />
     <OutputPath />

--- a/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/ResourceFile.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/ResourceFile.cs
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.Mvc
                 // The build system compiles every file under the resources folder as a resource available at runtime
                 // with the same name as the file name. Need to update this file on disc.
 
-                https://github.com/aspnet/AspNetCore/issues/10423
+// https://github.com/aspnet/AspNetCore/issues/10423
 #pragma warning disable 0618
                 var solutionPath = TestPathUtilities.GetSolutionRootDirectory("Mvc");
 #pragma warning restore 0618

--- a/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/ResourceFile.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/ResourceFile.cs
@@ -191,7 +191,11 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 // The build system compiles every file under the resources folder as a resource available at runtime
                 // with the same name as the file name. Need to update this file on disc.
+
+                https://github.com/aspnet/AspNetCore/issues/10423
+#pragma warning disable 0618
                 var solutionPath = TestPathUtilities.GetSolutionRootDirectory("Mvc");
+#pragma warning restore 0618
                 var projectPath = Path.Combine(solutionPath, "test", assembly.GetName().Name);
                 var fullPath = Path.Combine(projectPath, resourceName);
                 WriteFile(fullPath, content);

--- a/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
@@ -9,7 +9,7 @@
     <TestGroupName>Mvc.FunctionalTests</TestGroupName>
     <!-- The test asset projects this depends on are not strong-named. -->
     <SignAssembly>false</SignAssembly>
-    <!-- https://github.com/aspnet/AspNetCore/issues/6549 -->
+    <!-- https://github.com/aspnet/AspNetCore/issues/10423 -->
     <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 

--- a/src/Security/Authentication/test/SecureDataFormatTests.cs
+++ b/src/Security/Authentication/test/SecureDataFormatTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Authentication.DataHandler
         }
 
         [ConditionalFact]
-        [SkipOnHelix]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore-Internal/issues/1974")]
         public void UnprotectWithDifferentPurposeFails()
         {
             var provider = ServiceProvider.GetRequiredService<IDataProtectionProvider>();

--- a/src/Servers/IIS/IIS/benchmarks/IIS.Performance/StartupTimeBenchmark.cs
+++ b/src/Servers/IIS/IIS/benchmarks/IIS.Performance/StartupTimeBenchmark.cs
@@ -20,11 +20,15 @@ namespace Microsoft.AspNetCore.Server.IIS.Performance
         [IterationSetup]
         public void Setup()
         {
+// Deployers do not work in distributed environments
+// see https://github.com/aspnet/AspNetCore/issues/10268 and https://github.com/aspnet/Extensions/issues/1697
+#pragma warning disable 0618
             var deploymentParameters = new DeploymentParameters(Path.Combine(TestPathUtilities.GetSolutionRootDirectory("IISIntegration"), "test/testassets/InProcessWebSite"),
                 ServerType.IISExpress,
                 RuntimeFlavor.CoreClr,
                 RuntimeArchitecture.x64)
             {
+#pragma warning restore 0618
                 ServerConfigTemplateContent = File.ReadAllText("IISExpress.config"),
                 SiteName = "HttpTestSite",
                 TargetFramework = "netcoreapp2.1",

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -113,8 +113,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         [SkipIfNotAdmin]
         [RequiresNewShim]
         [RequiresIIS(IISCapability.PoolEnvironmentVariables)]
-        [SkipOnHelix]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2221", FlakyOn.Helix.All)]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore-Internal/issues/2221")]
         public async Task StartsWithDotnetInstallLocation(RuntimeArchitecture runtimeArchitecture)
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters();

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/PublishedApplicationPublisher.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/PublishedApplicationPublisher.cs
@@ -42,7 +42,11 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
         private string GetProjectReferencePublishLocation(DeploymentParameters deploymentParameters)
         {
+// Deployers do not work in distributed environments
+// see https://github.com/aspnet/AspNetCore/issues/10268 and https://github.com/aspnet/Extensions/issues/1697
+#pragma warning disable 0618
             var testAssetsBasePath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("IISIntegration"), "IIS", "test", "testassets", _applicationName);
+#pragma warning restore 0618
             var configuration = this.GetType().GetTypeInfo().Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>().Configuration;
             var path = Path.Combine(testAssetsBasePath, "bin", configuration, deploymentParameters.TargetFramework, "publish", GetProfileName(deploymentParameters));
             return path;

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/MofFileTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/MofFileTests.cs
@@ -19,7 +19,11 @@ namespace IIS.FunctionalTests
         [SkipOnHelix]
         public void CheckMofFile()
         {
+// This test code needs to be updated to support distributed testing.
+// See https://github.com/aspnet/AspNetCore-Internal/issues/2222
+#pragma warning disable 0618
             var path = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("IISIntegration"), "aspnetcoremodulev2", "aspnetcore", "ancm.mof");
+#pragma warning restore 0618
             var process = Process.Start("mofcomp.exe", path);
             process.WaitForExit();
             Assert.Equal(0, process.ExitCode);

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/MofFileTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/MofFileTests.cs
@@ -15,8 +15,7 @@ namespace IIS.FunctionalTests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         [RequiresIIS(IISCapability.TracingModule)]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2222", FlakyOn.Helix.All)]
-        [SkipOnHelix]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore-Internal/issues/2222")]
         public void CheckMofFile()
         {
 // This test code needs to be updated to support distributed testing.

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [HostNameIsReachable]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7267
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/7267")]
         public async Task RegisterAddresses_HostName_Success()
         {
             var hostName = Dns.GetHostName();
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [HostNameIsReachable]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7267
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/7267")]
         public async Task ListenAnyIP_HostName_Success()
         {
             var hostName = Dns.GetHostName();

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
 {
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/corefx/issues/30492")]
-    [SkipOnHelix(Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
+    [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/10428", Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10)]
     public class HandshakeTests : LoggedTest
     {

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
 {
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/corefx/issues/30492")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10)]
-    [SkipOnHelix(Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
+    [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/10428", Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
     public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
     {
         private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
         }
 
         [ConditionalFact]
-        [SkipOnHelix(Queues = "Fedora.28.Amd64.Open")] // https://github.com/aspnet/AspNetCore/issues/9985
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/9985", Queues = "Fedora.28.Amd64.Open")] // https://github.com/aspnet/AspNetCore/issues/9985
         [Flaky("https://github.com/aspnet/AspNetCore/issues/9985", FlakyOn.All)]
         public async Task GracefulShutdownWaitsForRequestsToFinish()
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/TlsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/TlsTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.Http2
         private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/7000        
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/7000        ")]
         public async Task TlsHandshakeRejectsTlsLessThan12()
         {
             using (var server = new TestServer(context =>

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -21,7 +21,7 @@ namespace Interop.FunctionalTests
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/corefx/issues/30492")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win81,
         SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support")]
-    [SkipOnHelix(Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
+    [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/10428", Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
     public class H2SpecTests : LoggedTest
     {
         [ConditionalTheory]

--- a/src/Shared/test/SkipOnHelixAttribute.cs
+++ b/src/Shared/test/SkipOnHelixAttribute.cs
@@ -12,6 +12,17 @@ namespace Microsoft.AspNetCore.Testing.xunit
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
     public class SkipOnHelixAttribute : Attribute, ITestCondition
     {
+        public SkipOnHelixAttribute(string issueUrl)
+        {
+            if (string.IsNullOrEmpty(issueUrl))
+            {
+                throw new ArgumentException();
+            }
+            IssueUrl = issueUrl;
+        }
+
+        public string IssueUrl { get; }
+
         public bool IsMet
         {
             get
@@ -33,7 +44,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
         }
 
         public static bool OnHelix() => !string.IsNullOrEmpty(GetTargetHelixQueue());
-        
+
         public static string GetTargetHelixQueue() => Environment.GetEnvironmentVariable("helix");
     }
 }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/6721
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate2_CreatesACertificate_WhenThereAreNoHttpsCertificates()
         {
             try

--- a/src/Tools/dotnet-watch/test/DotNetWatcherTests.cs
+++ b/src/Tools/dotnet-watch/test/DotNetWatcherTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/8267
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/8267")]
         public async Task RunsWithDotnetWatchEnvVariable()
         {
             Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_WATCH")), "DOTNET_WATCH cannot be set already when this test is running");

--- a/src/Tools/dotnet-watch/test/GlobbingAppTests.cs
+++ b/src/Tools/dotnet-watch/test/GlobbingAppTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/8267
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/8267")]
         public async Task ChangeExcludedFile()
         {
             await _app.StartWatcherAsync();
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/8267
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/8267")]
         public async Task ListsFiles()
         {
             await _app.PrepareAsync();

--- a/src/Tools/dotnet-watch/test/NoDepsAppTests.cs
+++ b/src/Tools/dotnet-watch/test/NoDepsAppTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
-        [SkipOnHelix] // https://github.com/aspnet/AspNetCore/issues/8267
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/8267")]
         public async Task RestartProcessThatTerminatesAfterFileChange()
         {
             await _app.StartWatcherAsync();


### PR DESCRIPTION
* Reacting to https://github.com/aspnet/Extensions/pull/1698
* Updated a bunch of tests that link to a closed issue (#6549)
* Require `SkipOnHelix` to include a path to a GitHub issue url

Cref tracking issues to enable tests in helix

- https://github.com/aspnet/AspNetCore/issues/7990
- https://github.com/aspnet/AspNetCore/issues/8247
- https://github.com/aspnet/AspNetCore/issues/8343
- https://github.com/aspnet/AspNetCore/issues/9431
- https://github.com/aspnet/AspNetCore/issues/10268
- https://github.com/aspnet/AspNetCore/issues/10422
- https://github.com/aspnet/AspNetCore/issues/10423
- https://github.com/aspnet/AspNetCore-Internal/issues/2222
- https://github.com/aspnet/AspNetCore/issues/10428