### PR TITLE
Add <frameworkReferences> metadata to nuspec of packages that depend on the shared framework

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -137,7 +137,8 @@
 
     <RepoTasks.RemoveSharedFrameworkDependencies Condition="@(_BuildOutput->Count()) != 0"
       Files="@(_BuildOutput)"
-      FrameworkOnlyPackages="@(AspNetCoreAppReference)" />
+      FrameworkOnlyPackages="@(AspNetCoreAppReference)"
+      SharedFrameworkTargetFramework="netcoreapp$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)" />
   </Target>
 
   <Target Name="GenerateBuildAssetManifest">


### PR DESCRIPTION
Workaround for https://github.com/aspnet/AspNetCore/issues/4257. This hacks the `<frameworkReference>` metadata into packages which depend on a framework-only assembly because we can't update our build to use `<FrameworkReference>` in .csproj just yet.

This is part of resolving https://github.com/dotnet/cli/issues/10666.

Expected output: any package which depends on Microsoft.AspNetCore.App should have this in its nuspec:
```xml
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <!-- ... -->

    <frameworkReferences>
      <group targetFramework=".NETCoreApp3.0">
        <frameworkReference name="Microsoft.AspNetCore.App" />
      </group>
    </frameworkReferences>
  </metadata>
</package>
```