### PR TITLE
Fix RendererSyncContext.Post()

### DIFF
--- a/src/Components/Components/src/Rendering/RendererSynchronizationContext.cs
+++ b/src/Components/Components/src/Rendering/RendererSynchronizationContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public Task Invoke(Action action)
         {
             var completion = new TaskCompletionSource<object>();
-            Post(_ =>
+            ExecuteSynchronouslyIfPossible(_ =>
             {
                 try
                 {
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public Task InvokeAsync(Func<Task> asyncAction)
         {
             var completion = new TaskCompletionSource<object>();
-            Post(async (_) =>
+            ExecuteSynchronouslyIfPossible(async (_) =>
             {
                 try
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public Task<TResult> Invoke<TResult>(Func<TResult> function)
         {
             var completion = new TaskCompletionSource<TResult>();
-            Post(_ =>
+            ExecuteSynchronouslyIfPossible(_ =>
             {
                 try
                 {
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> asyncFunction)
         {
             var completion = new TaskCompletionSource<TResult>();
-            Post(async (_) =>
+            ExecuteSynchronouslyIfPossible(async (_) =>
             {
                 try
                 {
@@ -130,24 +130,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
         }
 
         // asynchronously runs the callback
+        //
+        // NOTE: this must always run async. It's not legal here to execute the work item synchronously.
         public override void Post(SendOrPostCallback d, object state)
         {
-            TaskCompletionSource<object> completion;
             lock (_state.Lock)
             {
-                if (!_state.Task.IsCompleted)
-                {
-                    _state.Task = Enqueue(_state.Task, d, state);
-                    return;
-                }
-
-                // We can execute this synchronously because nothing is currently running
-                // or queued.
-                completion = new TaskCompletionSource<object>();
-                _state.Task = completion.Task;
+                _state.Task = Enqueue(_state.Task, d, state, forceAsync: true);
             }
-
-            ExecuteSynchronously(completion, d, state);
         }
 
         // synchronously runs the callback
@@ -177,10 +167,33 @@ namespace Microsoft.AspNetCore.Components.Rendering
             return new RendererSynchronizationContext(_state);
         }
 
-        private Task Enqueue(Task antecedant, SendOrPostCallback d, object state)
+        // Similar to Post, but it can runs the work item synchronously if the context is not busy.
+        //
+        // This is the main code path used by components, we want to be able to run async work but only dispatch
+        // if necessary.
+        private void ExecuteSynchronouslyIfPossible(SendOrPostCallback d, object state)
         {
-            // If we get here is means that a callback is being queued while something is currently executing
-            // in this context. Let's instead add it to the queue and yield.
+            TaskCompletionSource<object> completion;
+            lock (_state.Lock)
+            {
+                if (!_state.Task.IsCompleted)
+                {
+                    _state.Task = Enqueue(_state.Task, d, state);
+                    return;
+                }
+
+                // We can execute this synchronously because nothing is currently running
+                // or queued.
+                completion = new TaskCompletionSource<object>();
+                _state.Task = completion.Task;
+            }
+
+            ExecuteSynchronously(completion, d, state);
+        }
+
+        private Task Enqueue(Task antecedant, SendOrPostCallback d, object state, bool forceAsync = false)
+        {
+            // If we get here is means that a callback is being explicitly queued. Let's instead add it to the queue and yield.
             //
             // We use our own queue here to maintain the execution order of the callbacks scheduled here. Also
             // we need a queue rather than just scheduling an item in the thread pool - those items would immediately
@@ -194,13 +207,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 executionContext = ExecutionContext.Capture();
             }
 
+            var flags = forceAsync ? TaskContinuationOptions.RunContinuationsAsynchronously : TaskContinuationOptions.None;
             return antecedant.ContinueWith(BackgroundWorkThunk, new WorkItem()
             {
                 SynchronizationContext = this,
                 ExecutionContext = executionContext,
                 Callback = d,
                 State = state,
-            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current);
+            }, CancellationToken.None, flags, TaskScheduler.Current);
         }
 
         private void ExecuteSynchronously(

--- a/src/Components/Components/test/Rendering/RendererSynchronizationContextTest.cs
+++ b/src/Components/Components/test/Rendering/RendererSynchronizationContextTest.cs
@@ -591,7 +591,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             Thread capturedThread = null;
 
             // Act
-            var task = context.Invoke(() =>
+            var task = context.InvokeAsync(() =>
             {
                 capturedThread = Thread.CurrentThread;
                 return Task.CompletedTask;

--- a/src/Components/Shared/test/TestRenderer.cs
+++ b/src/Components/Shared/test/TestRenderer.cs
@@ -25,7 +25,11 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
         {
         }
 
+        public Action OnExceptionHandled { get; set; }
+
         public Action<RenderBatch> OnUpdateDisplay { get; set; }
+
+        public Action OnUpdateDisplayComplete { get; set; }
 
         public List<CapturedBatch> Batches { get; }
             = new List<CapturedBatch>();
@@ -81,6 +85,7 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
             }
 
             HandledExceptions.Add(exception);
+            OnExceptionHandled?.Invoke();
         }
 
         protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
@@ -102,6 +107,8 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
 
             // This renderer updates the UI synchronously, like the WebAssembly one.
             // To test async UI updates, subclass TestRenderer and override UpdateDisplayAsync.
+
+            OnUpdateDisplayComplete?.Invoke();
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Fixes: #9683 - SignalR connection breaks on large DOM

The root cause here is a misbehaving sync context. It's not legal for a
Post() implementation to run a callback synchronously. We want that
behavior for most of the functionality Blazor calls directly, but Post()
should always go async or else various threading primitives are broken.

-------------

/cc @stephentoub @BrennanConroy @halter73 

-----

This won't pass the CI yet because we have a number (8 or so) of Blazor **tests** that were based on this flawed behavior. All of these tests follow the pattern of:

```
var tcs = new TaskCompletionSource<object>();

// Do a bunch of stuff

tcs.SetResult(null);

// Verify a bunch of stuff
```

The flaw is that we're not awaiting anything after setting the result - and baking in the assumption that the continuations of the non-completed task will run synchronously. This relies on the bug we're fixing, and so these tests need to be improved to await for something.

I'm not aware of another underlying product bug in this area yet, and my attempts to investigate these tests have been stymied by debugger issues.  
