### PR TITLE
Check for Java in local SignalR build

### DIFF
--- a/src/SignalR/build.cmd
+++ b/src/SignalR/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..\
-%RepoRoot%build.cmd -projects %~dp0**\*.*proj %*
+%RepoRoot%build.cmd -buildJava -projects %~dp0**\*.*proj %*


### PR DESCRIPTION
This will run the java check (and install a local jdk if you're missing it) when running build from SignalR sub-folder.
@natemcmaster 