### PR TITLE
Change SkipStatusCodePagesAttribute to inherit from IAlwaysRunResultFilter

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.netcoreapp3.0.cs
@@ -130,11 +130,11 @@ namespace Microsoft.AspNetCore.Mvc
         public override bool IsValid(object value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
-    public partial class SkipStatusCodePagesAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.Filters.IFilterMetadata, Microsoft.AspNetCore.Mvc.Filters.IResourceFilter
+    public partial class SkipStatusCodePagesAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.Filters.IAlwaysRunResultFilter, Microsoft.AspNetCore.Mvc.Filters.IFilterMetadata, Microsoft.AspNetCore.Mvc.Filters.IResultFilter
     {
         public SkipStatusCodePagesAttribute() { }
-        public void OnResourceExecuted(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext context) { }
-        public void OnResourceExecuting(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutingContext context) { }
+        public void OnResultExecuted(Microsoft.AspNetCore.Mvc.Filters.ResultExecutedContext context) { }
+        public void OnResultExecuting(Microsoft.AspNetCore.Mvc.Filters.ResultExecutingContext context) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Property, Inherited=true, AllowMultiple=false)]
     public sealed partial class TempDataAttribute : System.Attribute

--- a/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.netcoreapp3.0.cs
@@ -130,9 +130,10 @@ namespace Microsoft.AspNetCore.Mvc
         public override bool IsValid(object value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
-    public partial class SkipStatusCodePagesAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.Filters.IAlwaysRunResultFilter, Microsoft.AspNetCore.Mvc.Filters.IFilterMetadata, Microsoft.AspNetCore.Mvc.Filters.IResultFilter
+    public partial class SkipStatusCodePagesAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.Filters.IAlwaysRunResultFilter, Microsoft.AspNetCore.Mvc.Filters.IFilterMetadata, Microsoft.AspNetCore.Mvc.Filters.IOrderedFilter, Microsoft.AspNetCore.Mvc.Filters.IResultFilter
     {
         public SkipStatusCodePagesAttribute() { }
+        public int Order { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void OnResultExecuted(Microsoft.AspNetCore.Mvc.Filters.ResultExecutedContext context) { }
         public void OnResultExecuting(Microsoft.AspNetCore.Mvc.Filters.ResultExecutingContext context) { }
     }

--- a/src/Mvc/Mvc.ViewFeatures/src/SkipStatusCodePagesAttribute.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/SkipStatusCodePagesAttribute.cs
@@ -11,8 +11,15 @@ namespace Microsoft.AspNetCore.Mvc
     /// A filter that prevents execution of the StatusCodePages middleware.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-    public class SkipStatusCodePagesAttribute : Attribute, IAlwaysRunResultFilter
+    public class SkipStatusCodePagesAttribute : Attribute, IAlwaysRunResultFilter, IOrderedFilter
     {
+        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the order value for determining the order of execution of filters. Filters execute in
+        /// ascending numeric value of the <see cref="Order" /> property.
+        /// </summary>
+        public int Order { get; set; } = -1000;
+
         /// <inheritdoc />
         public void OnResultExecuted(ResultExecutedContext context)
         {

--- a/src/Mvc/Mvc.ViewFeatures/src/SkipStatusCodePagesAttribute.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/SkipStatusCodePagesAttribute.cs
@@ -11,15 +11,16 @@ namespace Microsoft.AspNetCore.Mvc
     /// A filter that prevents execution of the StatusCodePages middleware.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-    public class SkipStatusCodePagesAttribute : Attribute, IResourceFilter
+    public class SkipStatusCodePagesAttribute : Attribute, IAlwaysRunResultFilter
     {
         /// <inheritdoc />
-        public void OnResourceExecuted(ResourceExecutedContext context)
+        public void OnResultExecuted(ResultExecutedContext context)
         {
+            // Intentionally empty.
         }
 
         /// <inheritdoc />
-        public void OnResourceExecuting(ResourceExecutingContext context)
+        public void OnResultExecuting(ResultExecutingContext context)
         {
             if (context == null)
             {

--- a/src/Mvc/Mvc.ViewFeatures/test/SkipStatusCodePagesAttributeTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/SkipStatusCodePagesAttributeTest.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Xunit;
 
@@ -19,12 +17,12 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         {
             // Arrange
             var skipStatusCodeAttribute = new SkipStatusCodePagesAttribute();
-            var resourceExecutingContext = CreateResourceExecutingContext(new IFilterMetadata[] { skipStatusCodeAttribute });
+            var resultExecutingContext = CreateResultExecutingContext(new IFilterMetadata[] { skipStatusCodeAttribute });
             var statusCodePagesFeature = new TestStatusCodeFeature();
-            resourceExecutingContext.HttpContext.Features.Set<IStatusCodePagesFeature>(statusCodePagesFeature);
+            resultExecutingContext.HttpContext.Features.Set<IStatusCodePagesFeature>(statusCodePagesFeature);
 
             // Act
-            skipStatusCodeAttribute.OnResourceExecuting(resourceExecutingContext);
+            skipStatusCodeAttribute.OnResultExecuting(resultExecutingContext);
 
             // Assert
             Assert.False(statusCodePagesFeature.Enabled);
@@ -35,18 +33,19 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         {
             // Arrange
             var skipStatusCodeAttribute = new SkipStatusCodePagesAttribute();
-            var resourceExecutingContext = CreateResourceExecutingContext(new IFilterMetadata[] { skipStatusCodeAttribute });
+            var resultExecutingContext = CreateResultExecutingContext(new IFilterMetadata[] { skipStatusCodeAttribute });
 
             // Act
-            skipStatusCodeAttribute.OnResourceExecuting(resourceExecutingContext);
+            skipStatusCodeAttribute.OnResultExecuting(resultExecutingContext);
         }
 
-        private static ResourceExecutingContext CreateResourceExecutingContext(IFilterMetadata[] filters)
+        private static ResultExecutingContext CreateResultExecutingContext(IFilterMetadata[] filters)
         {
-            return new ResourceExecutingContext(
+            return new ResultExecutingContext(
                 CreateActionContext(),
                 filters,
-                new List<IValueProviderFactory>());
+                null,
+                new object());
         }
 
         private static ActionContext CreateActionContext()


### PR DESCRIPTION
Summary of the changes
 - Change SkipStatusCodePagesAttribute to inherit from IAlwaysRunResultFilter instead of IResourceFilter
-  Add IOrderedFilter to SkipStatusCodePagesAttribute so that callers can ensure it executes first

Addresses #10317
