### PR TITLE
Turn SETLOCAL on so that we don't accumulate in the PATH

### DIFF
--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,4 +1,5 @@
 @ECHO OFF
+SETLOCAL
 
 :: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Constraint the environment change to stay inside the script by adding [SETLOCAL](https://ss64.com/nt/setlocal.html) in the `startvs.cmd` 
 - I tested, the normal workflow using `startvs.cmd` still works, and the shell environment no longer contains duplicated paths.

Addresses #10501  (in this specific format)
