### PR TITLE
Increase stack size for IIS Inprocess

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
@@ -29,6 +29,7 @@
 #define CS_ASPNETCORE_DISABLE_START_UP_ERROR_PAGE        L"disableStartUpErrorPage"
 #define CS_ENABLED                                       L"enabled"
 #define CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK          L"callStartupHook"
+#define CS_ASPNETCORE_HANDLER_STACK_SIZE                 L"stackSize"
 
 class ConfigurationSection: NonCopyable
 {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.cpp
@@ -59,6 +59,7 @@ InProcessOptions::InProcessOptions(const ConfigurationSource &configurationSourc
     const auto handlerSettings = aspNetCoreSection->GetKeyValuePairs(CS_ASPNETCORE_HANDLER_SETTINGS);
     m_fSetCurrentDirectory = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_HANDLER_SET_CURRENT_DIRECTORY).value_or(L"true"), L"true");
     m_fCallStartupHook = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK).value_or(L"true"), L"true");
+    m_strStackSize = find_element(handlerSettings, CS_ASPNETCORE_HANDLER_STACK_SIZE).value_or(L"1048576");
 
     m_dwStartupTimeLimitInMS = aspNetCoreSection->GetRequiredLong(CS_ASPNETCORE_PROCESS_STARTUP_TIME_LIMIT) * 1000;
     m_dwShutdownTimeLimitInMS = aspNetCoreSection->GetRequiredLong(CS_ASPNETCORE_PROCESS_SHUTDOWN_TIME_LIMIT) * 1000;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
@@ -112,6 +112,12 @@ public:
         return m_bindingInformation;
     }
 
+    std::wstring
+    QueryStackSize() const
+    {
+        return m_strStackSize;
+    }
+
     InProcessOptions(const ConfigurationSource &configurationSource, IHttpSite* pSite);
 
     static
@@ -125,6 +131,7 @@ private:
     std::wstring                   m_strArguments;
     std::wstring                   m_strProcessPath;
     std::wstring                   m_struStdoutLogFile;
+    std::wstring                   m_strStackSize;
     bool                           m_fStdoutLogEnabled;
     bool                           m_fDisableStartUpErrorPage;
     bool                           m_fSetCurrentDirectory;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -253,8 +253,7 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
 
         // Used to make .NET Runtime always log to event log when there is an unhandled exception.
         LOG_LAST_ERROR_IF(!SetEnvironmentVariable(L"COMPlus_UseEntryPointFilter", L"1"));
-        // make this configurable.
-        //LOG_LAST_ERROR_IF(!SetEnvironmentVariable(L"COMPlus_DefaultStackSize ", L"1048576"));
+        LOG_LAST_ERROR_IF(!SetEnvironmentVariable(L"COMPlus_DefaultStackSize", m_pConfig->QueryStackSize().c_str()));
 
         bool clrThreadExited;
         {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -253,6 +253,8 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
 
         // Used to make .NET Runtime always log to event log when there is an unhandled exception.
         LOG_LAST_ERROR_IF(!SetEnvironmentVariable(L"COMPlus_UseEntryPointFilter", L"1"));
+        // make this configurable.
+        //LOG_LAST_ERROR_IF(!SetEnvironmentVariable(L"COMPlus_DefaultStackSize ", L"1048576"));
 
         bool clrThreadExited;
         {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -673,15 +673,25 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             VerifyDotnetRuntimeEventLog(deploymentResult);
         }
 
-
         [ConditionalFact]
         [RequiresNewHandler]
         public async Task StackOverflowIsAvoidedBySettingLargerStack()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-
             var deploymentResult = await DeployAsync(deploymentParameters);
             var result = await deploymentResult.HttpClient.GetAsync("/StackSize");
+            Assert.True(result.IsSuccessStatusCode);
+        }
+
+        [ConditionalFact]
+        [RequiresNewHandler]
+        public async Task StackOverflowCanBeSetBySettingLargerStackViaHandlerSetting()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+            deploymentParameters.HandlerSettings["stackSize"] = "10000000";
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+            var result = await deploymentResult.HttpClient.GetAsync("/StackSizeLarge");
             Assert.True(result.IsSuccessStatusCode);
         }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -673,6 +673,18 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             VerifyDotnetRuntimeEventLog(deploymentResult);
         }
 
+
+        [ConditionalFact]
+        [RequiresNewHandler]
+        public async Task StackOverflowIsAvoidedBySettingLargerStack()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+            var result = await deploymentResult.HttpClient.GetAsync("/StackSize");
+            Assert.True(result.IsSuccessStatusCode);
+        }
+
         private static void VerifyDotnetRuntimeEventLog(IISDeploymentResult deploymentResult)
         {
             var entries = GetEventLogsFromDotnetRuntime(deploymentResult);

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -698,7 +698,15 @@ namespace TestSite
 
         private async Task StackSize(HttpContext ctx)
         {
-            RecursiveFunction(100000);
+            // This would normally stackoverflow if we didn't increase the stack size per thread.
+            RecursiveFunction(10000);
+            await ctx.Response.WriteAsync("Hello World");
+        }
+
+        private async Task StackSizeLarge(HttpContext ctx)
+        {
+            // This would normally stackoverflow if we didn't increase the stack size per thread.
+            RecursiveFunction(30000);
             await ctx.Response.WriteAsync("Hello World");
         }
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -696,6 +696,21 @@ namespace TestSite
             await server.StopAsync(cts.Token);
         }
 
+        private async Task StackSize(HttpContext ctx)
+        {
+            RecursiveFunction(100000);
+            await ctx.Response.WriteAsync("Hello World");
+        }
+
+        private void RecursiveFunction(int i)
+        {
+            if (i == 0)
+            {
+                return;
+            }
+            RecursiveFunction(i - 1);
+        }
+
         private async Task GetServerVariableStress(HttpContext ctx)
         {
             // This test simulates the scenario where native Flush call is being


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/9394. Adds a handler setting to override it.

The only thing I'd consider changing is making it so we preserve the CS_* environment variables if they are already set.
