### PR TITLE
Update Microsoft.AspNetCore.Blazor.Mono to 0.10.0-preview6.19273.9 and automatically flow updates

### DIFF
--- a/build/sources.props
+++ b/build/sources.props
@@ -10,6 +10,7 @@
 
     <RestoreSources Condition=" '$(DotNetBuildOffline)' != 'true' ">
       $(RestoreSources);
+      https://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json;
@@ -27,11 +28,6 @@
     <RestoreSources>
       $(RestoreSources);
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-    </RestoreSources>
-    <!-- TODO remove this once we move Microsoft.AspNetCore.Blazor.Mono to a non-myget feed -->
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
     </RestoreSources>
 
     <!-- In an orchestrated build, this may be overriden to other Azure feeds. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,6 +9,10 @@
 -->
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.AspNetCore.Blazor.Mono" Version="0.10.0-preview6.19273.9">
+      <Uri>https://github.com/aspnet/Blazor</Uri>
+      <Sha>c879c3a911b4c2d6cccd4d6ff2de86a6949cda88</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="3.0.0-preview6.19272.2">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>5bcd00877984c63293665f75bad20f522132638a</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,7 +47,7 @@
     <SystemThreadingChannelsPackageVersion>4.6.0-preview6.19270.12</SystemThreadingChannelsPackageVersion>
     <!-- Only listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19270.12</MicrosoftNETCorePlatformsPackageVersion>
-    <!-- Dependencies from aspnet/Blazor -->
+    <!-- Packages from aspnet/Blazor -->
     <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.10.0-preview6.19273.9</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from aspnet/Extensions -->
     <InternalAspNetCoreAnalyzersPackageVersion>3.0.0-preview6.19271.2</InternalAspNetCoreAnalyzersPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,6 +47,8 @@
     <SystemThreadingChannelsPackageVersion>4.6.0-preview6.19270.12</SystemThreadingChannelsPackageVersion>
     <!-- Only listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19270.12</MicrosoftNETCorePlatformsPackageVersion>
+    <!-- Dependencies from aspnet/Blazor -->
+    <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.10.0-preview6.19273.9</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from aspnet/Extensions -->
     <InternalAspNetCoreAnalyzersPackageVersion>3.0.0-preview6.19271.2</InternalAspNetCoreAnalyzersPackageVersion>
     <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>3.0.0-preview6.19271.2</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
@@ -168,8 +170,6 @@
     <MicrosoftWebAdministrationPackageVersion>11.1.0</MicrosoftWebAdministrationPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <SystemIdentityModelTokensJwtPackageVersion>5.3.0</SystemIdentityModelTokensJwtPackageVersion>
-    <!-- Dependencies for Blazor. -->
-    <MicrosoftAspNetCoreBlazorMonoPackageVersion>0.10.0-preview-20190523.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from 2.1/2.2 branches used for site extension build -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore-Internal/issues/2360

The only changes in this are the result of infrastructure changes. The updated package uses Arcade build numbers now and has 'preview6' in it. 