### PR TITLE
Add inproc handler to shared framework

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     # Build the x86 shared framework
     # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
-    - script: ./eng/scripts/cibuild.cmd -arch x86 -NoRestore /t:BuildSharedFx /p:DisableCodeSigning=true /bl:artifacts/log/build.x86.binlog
+    - script: ./eng/scripts/cibuild.cmd -arch x86 -NoRestore -BuildNative /t:BuildSharedFx /p:DisableCodeSigning=true /bl:artifacts/log/build.x86.binlog
       displayName: Build x86
 
     # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -50,7 +50,7 @@ jobs:
     # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
     # The sign settings have been configured to
 
-    - script: ./eng/scripts/cibuild.cmd -arch x64 /p:DisableCodeSigning=true /bl:artifacts/log/build.x64.binlog
+    - script: ./eng/scripts/cibuild.cmd -BuildNative -arch x64 /p:DisableCodeSigning=true /bl:artifacts/log/build.x64.binlog
       displayName: Build x64
     # TODO: make it possible to build for one Windows architecture at a time
     # This is going to actually build x86 native assets. See https://github.com/aspnet/AspNetCore/issues/7196

--- a/build/repo.props
+++ b/build/repo.props
@@ -3,6 +3,13 @@
     <TargetRuntimeIdentifier Condition="'$(TargetRuntimeIdentifier)' == ''">$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(BuildAllProjects)' == 'true' ">
+    <BuildNative>true</BuildNative>
+    <BuildManaged>true</BuildManaged>
+    <BuildNodeJS>true</BuildNodeJS>
+    <BuildJava>true</BuildJava>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- This repo does not have solutions to build -->
     <DisableDefaultTargets>true</DisableDefaultTargets>
@@ -27,13 +34,6 @@
     <DisableSignCheckStrongName>true</DisableSignCheckStrongName>
 
     <SharedSourcesFolder>$(RepoRoot)src\Shared\</SharedSourcesFolder>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(BuildAllProjects)' == 'true' ">
-    <BuildNative>true</BuildNative>
-    <BuildManaged>true</BuildManaged>
-    <BuildNodeJS>true</BuildNodeJS>
-    <BuildJava>true</BuildJava>
     <BuildIisNativeProjects Condition="'$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64')">true</BuildIisNativeProjects>
   </PropertyGroup>
 

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -202,12 +202,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -BuildNative -BuildManaged` to build both C# and C++." />
   </Target>
 
-    <Target Name="_ErrorAboutUnbuiltNativeDependenciesOnCI"
-          BeforeTargets="Build"
-          Condition=" '$(BuildIisNativeProjects)' != 'true' AND '$(CI)' == 'true' AND '$(TargetOsName)' == 'win' ">
-    <Error Text="IIS native assets are not being built on CI. Native assets must be included in the shared framework." />
-  </Target>
-
   <Target Name="_ResolveCopyLocalNativeReference" DependsOnTargets="ResolveProjectReferences">
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(_ResolvedNativeProjectReferencePaths)" />

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -202,6 +202,12 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -BuildNative -BuildManaged` to build both C# and C++." />
   </Target>
 
+    <Target Name="_ErrorAboutUnbuiltNativeDependenciesOnCI"
+          BeforeTargets="Build"
+          Condition=" '$(BuildIisNativeProjects)' != 'true' AND $(CI) == 'true' AND '$(TargetOsName)' == 'win' ">
+    <Error Text="IIS native assets are not being built on CI. Native assets must be included in the shared framework." />
+  </Target>
+
   <Target Name="_ResolveCopyLocalNativeReference" DependsOnTargets="ResolveProjectReferences">
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(_ResolvedNativeProjectReferencePaths)" />

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -204,7 +204,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <Target Name="_ErrorAboutUnbuiltNativeDependenciesOnCI"
           BeforeTargets="Build"
-          Condition=" '$(BuildIisNativeProjects)' != 'true' AND $(CI) == 'true' AND '$(TargetOsName)' == 'win' ">
+          Condition=" '$(BuildIisNativeProjects)' != 'true' AND '$(CI)' == 'true' AND '$(TargetOsName)' == 'win' ">
     <Error Text="IIS native assets are not being built on CI. Native assets must be included in the shared framework." />
   </Target>
 


### PR DESCRIPTION
The inproc handler wasn't being included in the shared framework. I _believe_ this will fix it, but will verify for sure.

Reported by CTI. Adding a check to make sure that CI always includes the native assets.