### PR TITLE
Remove arch from filename for RPM for targeting pack

### DIFF
--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <RpmPackageInstallRoot>/usr/share/dotnet/</RpmPackageInstallRoot>
-    <TargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)-x64.rpm</TargetFileName>
+    <TargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion).rpm</TargetFileName>
 
     <PackageContentRoot>$(TargetingPackLayoutRoot)</PackageContentRoot>
 


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/8835

Targeting packs are not CPU- or RID- specific. This updates the RPM to be consistent with .deb/.zip/.tar.gz, etc.