### PR TITLE
HeaderPropagation middleware: small cleanup

### DIFF
--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Program.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Program.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;

--- a/src/Middleware/HeaderPropagation/src/DependencyInjection/HeaderPropagationServiceCollectionExtensions.cs
+++ b/src/Middleware/HeaderPropagation/src/DependencyInjection/HeaderPropagationServiceCollectionExtensions.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.TryAddSingleton<HeaderPropagationValues>();
-            services.TryAddTransient<HeaderPropagationMessageHandler>();
 
             return services;
         }

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationEntryCollection.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationEntryCollection.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
         /// <param name="headerName">The header name to be propagated.</param>
         /// <param name="valueFilter">
         /// A filter delegate that can be used to transform the header value.
-        /// <see cref="HeaderPropagationEntry.ValueFilter"/>.
+        /// See <see cref="HeaderPropagationEntry.ValueFilter"/>.
         /// </param>
         public void Add(string headerName, Func<HeaderPropagationContext, StringValues> valueFilter)
         {
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
         /// </param>
         /// <param name="valueFilter">
         /// A filter delegate that can be used to transform the header value.
-        /// <see cref="HeaderPropagationEntry.ValueFilter"/>.
+        /// See <see cref="HeaderPropagationEntry.ValueFilter"/>.
         /// </param>
         public void Add(
             string inboundHeaderName,


### PR DESCRIPTION
- Removed `MessageHandler` DI registration as not needed.
- Fixed two parameters XML descriptions.
- Cleaned up `using`s in the example.

/cc @rynowak 