### PR TITLE
Clear ShutdownTestRun flaky state

### DIFF
--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Windows)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/1687", FlakyOn.AzP.Linux)]
         public async Task ShutdownTestRun()
         {
             await ExecuteShutdownTest(nameof(ShutdownTestRun), "Run");


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/1687

The original issue was fixed. It's not clear why there was flakyness for several weeks after, but there hasn't been any in 2 months now.