### PR TITLE
 Don't remove auth header when stopping HubConnection

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -57,7 +57,6 @@ public class HubConnection {
     private Map<String, Observable> streamMap = new ConcurrentHashMap<>();
     private TransportEnum transportEnum = TransportEnum.ALL;
     private String connectionId;
-    private boolean tokenSetByNegotiate;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
 
     /**
@@ -275,7 +274,6 @@ public class HubConnection {
                 this.redirectAccessTokenProvider = Single.just(negotiateResponse.getAccessToken());
                 // We know the Single is non blocking in this case
                 // It's fine to call blockingGet() on it.
-                this.tokenSetByNegotiate = true;
                 String token = this.redirectAccessTokenProvider.blockingGet();
                 this.localHeaders.put("Authorization", "Bearer " + token);
             }
@@ -336,7 +334,7 @@ public class HubConnection {
                         transport = new LongPollingTransport(localHeaders, httpClient, tokenProvider);
                         break;
                     default:
-                        transport = new WebSocketTransport(localHeaders, httpClient, tokenProvider);
+                        transport = new WebSocketTransport(localHeaders, httpClient);
                 }
             }
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -41,7 +41,7 @@ public class HubConnection {
     private final boolean skipNegotiate;
     private Single<String> accessTokenProvider;
     private Single<String> redirectAccessTokenProvider;
-    private Map<String, String> headers;
+    private final Map<String, String> headers;
     private final Map<String, String> localHeaders = new HashMap<>();
     private ConnectionState connectionState = null;
     private HttpClient httpClient;
@@ -148,10 +148,7 @@ public class HubConnection {
             this.handshakeResponseTimeout = handshakeResponseTimeout;
         }
 
-        if (headers != null) {
-            this.headers = headers;
-        }
-
+        this.headers = headers;
         this.skipNegotiate = skipNegotiate;
 
         this.callback = (payload) -> {
@@ -304,7 +301,7 @@ public class HubConnection {
         handshakeResponseSubject = CompletableSubject.create();
         handshakeReceived = false;
         CompletableSubject tokenCompletable = CompletableSubject.create();
-        if(headers != null) {
+        if (headers != null) {
             this.localHeaders.putAll(headers);
         }
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -56,6 +56,7 @@ public class HubConnection {
     private Map<String, Observable> streamMap = new ConcurrentHashMap<>();
     private TransportEnum transportEnum = TransportEnum.ALL;
     private String connectionId;
+    private boolean tokenSetByNegotiate;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
 
     /**
@@ -273,6 +274,7 @@ public class HubConnection {
                 this.redirectAccessTokenProvider = Single.just(negotiateResponse.getAccessToken());
                 // We know the Single is non blocking in this case
                 // It's fine to call blockingGet() on it.
+                this.tokenSetByNegotiate = true;
                 String token = this.redirectAccessTokenProvider.blockingGet();
                 this.headers.put("Authorization", "Bearer " + token);
             }
@@ -493,7 +495,9 @@ public class HubConnection {
             redirectAccessTokenProvider = null;
             connectionId = null;
             transportEnum = TransportEnum.ALL;
-            this.headers.remove("Authorization");
+            if (tokenSetByNegotiate) {
+                this.headers.remove("Authorization");
+            }
         } finally {
             hubConnectionStateLock.unlock();
         }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -331,7 +331,7 @@ public class HubConnection {
                         transport = new LongPollingTransport(headers, httpClient, tokenProvider);
                         break;
                     default:
-                        transport = new WebSocketTransport(headers, httpClient);
+                        transport = new WebSocketTransport(headers, httpClient, tokenProvider);
                 }
             }
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
@@ -19,8 +19,6 @@ class WebSocketTransport implements Transport {
     private String url;
     private HttpClient client;
     private Map<String, String> headers;
-    private Single<String> accessTokenProvider;
-
     private final Logger logger = LoggerFactory.getLogger(WebSocketTransport.class);
 
     private static final String HTTP = "http";
@@ -29,13 +27,8 @@ class WebSocketTransport implements Transport {
     private static final String WSS = "wss";
 
     public WebSocketTransport(Map<String, String> headers, HttpClient client) {
-        this(headers, client, Single.just(""));
-    }
-
-    public WebSocketTransport(Map<String, String> headers, HttpClient client, Single<String> accessTokenProvider) {
         this.client = client;
         this.headers = headers;
-        this.accessTokenProvider = accessTokenProvider;
     }
 
     String getUrl() {
@@ -52,32 +45,19 @@ class WebSocketTransport implements Transport {
         return url;
     }
 
-    private Single updateHeaderToken() {
-        return this.accessTokenProvider.flatMap((token) -> {
-            if (!token.isEmpty()) {
-                this.headers.put("Authorization", "Bearer " + token);
-            }
-            return Single.just("");
-        });
-    }
-
     @Override
     public Completable start(String url) {
         this.url = formatUrl(url);
-        CompletableSubject start = CompletableSubject.create();
         logger.debug("Starting Websocket connection.");
-        return this.updateHeaderToken().flatMapCompletable((r) -> {
-            this.webSocketClient = client.createWebSocket(this.url, this.headers);
-            this.webSocketClient.setOnReceive((message) -> onReceive(message));
-            this.webSocketClient.setOnClose((code, reason) -> {
-                if (onClose != null) {
-                    onClose(code, reason);
-                }
-            });
+        this.webSocketClient = client.createWebSocket(this.url, this.headers);
+        this.webSocketClient.setOnReceive((message) -> onReceive(message));
+        this.webSocketClient.setOnClose((code, reason) -> {
+            if (onClose != null) {
+                onClose(code, reason);
+            }
+        });
 
-            return webSocketClient.start().doOnComplete(() -> logger.info("WebSocket transport connected to: {}.", this.url));
-        }).subscribeWith(start);
-
+        return webSocketClient.start().doOnComplete(() -> logger.info("WebSocket transport connected to: {}.", this.url));
     }
 
     @Override

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
@@ -5,8 +5,6 @@ package com.microsoft.signalr;
 
 import java.util.Map;
 
-import io.reactivex.Single;
-import io.reactivex.subjects.CompletableSubject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1965,7 +1965,6 @@ class HubConnectionTest {
         AtomicReference<String> afterRedirectHeader = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-
                 .on("POST", "http://example.com/negotiate",
                         (req) -> {
                             beforeRedirectHeader.set(req.getHeaders().get("Authorization"));

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1727,7 +1727,7 @@ class HubConnectionTest {
         beforeRedirectToken.set("");
         token.set("");
 
-        // Restart the connection to make sure that the orignal accessTokenProvider that we registered is still registered before the redirect.
+        // Restart the connection to make sure that the original accessTokenProvider that we registered is still registered before the redirect.
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
@@ -1818,12 +1818,58 @@ class HubConnectionTest {
         beforeRedirectToken.set("");
         token.set("");
 
-        // Restart the connection to make sure that the orignal accessTokenProvider that we registered is still registered before the redirect.
+        // Restart the connection to make sure that the original accessTokenProvider that we registered is still registered before the redirect.
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertNull(beforeRedirectToken.get());
         assertEquals("Bearer newToken", token.get());
+    }
+
+    @Test
+    public void authorizationHeaderFromNegotiateGetsSetToNewValue() {
+        AtomicReference<String> token = new AtomicReference<>();
+        AtomicReference<String> redirectToken = new AtomicReference<>();
+        AtomicInteger redirectCount = new AtomicInteger();
+
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate", (req) -> {
+                    if(redirectCount.get() == 0){
+                        redirectCount.incrementAndGet();
+                        redirectToken.set(req.getHeaders().get("Authorization"));
+                        return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"firstRedirectToken\"}"));
+                    } else {
+                        redirectToken.set(req.getHeaders().get("Authorization"));
+                        return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"secondRedirectToken\"}"));
+                    }
+                })
+                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                    token.set(req.getHeaders().get("Authorization"));
+                    return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                            + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                });
+
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .build();
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals("Bearer firstRedirectToken", token.get());
+
+        // Clear the tokens to see if they get reset to the proper values
+        redirectToken.set("");
+        token.set("");
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop();
+        assertNull(redirectToken.get());
+        assertEquals("Bearer secondRedirectToken", token.get());
     }
 
     @Test
@@ -1882,6 +1928,34 @@ class HubConnectionTest {
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
+        assertEquals("ExampleValue", header.get());
+    }
+
+    @Test
+    public void headersAreNotClearedWhenConnectionIsRestarted() {
+        AtomicReference<String> header = new AtomicReference<>();
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate",
+                        (req) -> {
+                            header.set(req.getHeaders().get("Authorization"));
+                            return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                    + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                        });
+
+        MockTransport transport = new MockTransport();
+        HubConnection hubConnection = HubConnectionBuilder.create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .withHeader("Authorization", "ExampleValue")
+                .build();
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        hubConnection.stop();
+        assertEquals("ExampleValue", header.get());
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("ExampleValue", header.get());
     }
 

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
@@ -18,14 +18,14 @@ import io.reactivex.Single;
 class WebSocketTransportTest {
     // @Test Skipping until we add functional test support
     public void WebSocketThrowsIfItCantConnect() {
-        Transport transport = new WebSocketTransport(new HashMap<>(), new DefaultHttpClient(), Single.just(""));
+        Transport transport = new WebSocketTransport(new HashMap<>(), new DefaultHttpClient());
         RuntimeException exception = assertThrows(RuntimeException.class, () -> transport.start("http://url.fake.example").blockingAwait(1, TimeUnit.SECONDS));
         assertEquals("There was an error starting the WebSocket transport.", exception.getMessage());
     }
 
     @Test
     public void CanPassNullExitCodeToOnClosed() {
-        WebSocketTransport transport = new WebSocketTransport(new HashMap<>(), new WebSocketTestHttpClient(), Single.just(""));
+        WebSocketTransport transport = new WebSocketTransport(new HashMap<>(), new WebSocketTestHttpClient());
         AtomicBoolean closed = new AtomicBoolean();
         transport.setOnClose(reason -> {
             closed.set(true);

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
@@ -18,14 +18,14 @@ import io.reactivex.Single;
 class WebSocketTransportTest {
     // @Test Skipping until we add functional test support
     public void WebSocketThrowsIfItCantConnect() {
-        Transport transport = new WebSocketTransport(new HashMap<>(), new DefaultHttpClient());
+        Transport transport = new WebSocketTransport(new HashMap<>(), new DefaultHttpClient(), Single.just(""));
         RuntimeException exception = assertThrows(RuntimeException.class, () -> transport.start("http://url.fake.example").blockingAwait(1, TimeUnit.SECONDS));
         assertEquals("There was an error starting the WebSocket transport.", exception.getMessage());
     }
 
     @Test
     public void CanPassNullExitCodeToOnClosed() {
-        WebSocketTransport transport = new WebSocketTransport(new HashMap<>(), new WebSocketTestHttpClient());
+        WebSocketTransport transport = new WebSocketTransport(new HashMap<>(), new WebSocketTestHttpClient(), Single.just(""));
         AtomicBoolean closed = new AtomicBoolean();
         transport.setOnClose(reason -> {
             closed.set(true);

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
@@ -25,7 +25,7 @@ class WebSocketTransportUrlFormatTest {
     @ParameterizedTest
     @MethodSource("protocols")
     public void checkWebsocketUrlProtocol(String url, String expectedUrl) {
-        WebSocketTransport webSocketTransport = new WebSocketTransport(new HashMap<>(), new TestHttpClient(), Single.just(""));
+        WebSocketTransport webSocketTransport = new WebSocketTransport(new HashMap<>(), new TestHttpClient());
         try {
             webSocketTransport.start(url);
         } catch (Exception e) {}

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
+import io.reactivex.Single;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -24,7 +25,7 @@ class WebSocketTransportUrlFormatTest {
     @ParameterizedTest
     @MethodSource("protocols")
     public void checkWebsocketUrlProtocol(String url, String expectedUrl) {
-        WebSocketTransport webSocketTransport = new WebSocketTransport(new HashMap<>(), new TestHttpClient());
+        WebSocketTransport webSocketTransport = new WebSocketTransport(new HashMap<>(), new TestHttpClient(), Single.just(""));
         try {
             webSocketTransport.start(url);
         } catch (Exception e) {}


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/10575

We were removing the Authorization header after the connection was stopped. This causes issues when users don't set the header via the `AccessTokenProvider`. 
An alternative for the linked issue would be to have an option that would allow the user to specify something other than bearer auth with the `AccessTokenProvider`. 

