### PR TITLE
Add SignInWithClaims overload and set amr claim appropriately

### DIFF
--- a/src/Identity/Core/ref/Microsoft.AspNetCore.Identity.netcoreapp3.0.cs
+++ b/src/Identity/Core/ref/Microsoft.AspNetCore.Identity.netcoreapp3.0.cs
@@ -148,11 +148,13 @@ namespace Microsoft.AspNetCore.Identity
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task RememberTwoFactorClientAsync(TUser user) { throw null; }
         protected virtual System.Threading.Tasks.Task ResetLockout(TUser user) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task SignInAsync(TUser user, Microsoft.AspNetCore.Authentication.AuthenticationProperties authenticationProperties, string authenticationMethod = null) { throw null; }
         public virtual System.Threading.Tasks.Task SignInAsync(TUser user, bool isPersistent, string authenticationMethod = null) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         protected virtual System.Threading.Tasks.Task<Microsoft.AspNetCore.Identity.SignInResult> SignInOrTwoFactorAsync(TUser user, bool isPersistent, string loginProvider = null, bool bypassTwoFactor = false) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public virtual System.Threading.Tasks.Task SignInWithClaimsAsync(TUser user, Microsoft.AspNetCore.Authentication.AuthenticationProperties authenticationProperties, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> additionalClaims) { throw null; }
+        public virtual System.Threading.Tasks.Task SignInWithClaimsAsync(TUser user, bool isPersistent, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> additionalClaims) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task SignOutAsync() { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/5783

New SignInWithClaimsAsync overload that adds arbitrary claims to the cookie
Also amr: pwd and mfa claims are added for PasswordSignIn vs TwoFactorSignIn