### PR TITLE
Clarify documentation of RefreshSignInAsync

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -161,10 +161,10 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Regenerates the user's application cookie, whilst preserving the existing
-        /// AuthenticationProperties like rememberMe, as an asynchronous operation.
+        /// Signs in the specified <paramref name="user"/>, whilst preserving the existing
+        /// AuthenticationProperties of the current signed-in user like rememberMe, as an asynchronous operation.
         /// </summary>
-        /// <param name="user">The user whose sign-in cookie should be refreshed.</param>
+        /// <param name="user">The user to sign-in.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         public virtual async Task RefreshSignInAsync(TUser user)
         {


### PR DESCRIPTION
Clarify that the method does not somehow regenerate, refresh, or invalidate the sign-in cookie of any user other than the currently signed-in user.

In particular, the param doc for `user`, "The user whose sign-in cookie should be refreshed", was the most misleading part, as it implied for example that if the current authenticated user for the request is Alice, and a `TUser` representing Bob was passed in, that Bob would receive a new/refreshed cookie the next time he accessed the site.

What actually happens is that Alice will just become signed in as Bob.

Addresses issues of confusion raised in https://github.com/aspnet/Identity/issues/1900 and https://github.com/aspnet/AspNetCore/issues/5844

