### PR TITLE
Use web.config environment variables to read if in Development

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
@@ -48,12 +48,12 @@ ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
     // Indexing into environment variable map will add a default entry if none is present
     // This is okay here as we throw away the map shortly after.
     // Process set environment variables are prioritized over web config variables.
-    const auto detailedErrors = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_DETAILEDERRORS")
-        .value_or(environmentVariables[L"ASPNETCORE_DETAILEDERRORS"]);
-    const auto aspnetCoreEnvironment = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_ENVIRONMENT")
-        .value_or(environmentVariables[L"ASPNETCORE_ENVIRONMENT"]);
-    const auto dotnetEnvironment = Environment::GetEnvironmentVariableValue(L"DOTNET_ENVIRONMENT")
-        .value_or(environmentVariables[L"DOTNET_ENVIRONMENT"]);
+    const auto detailedErrors = Environment::GetEnvironmentVariableValue(CS_ASPNETCORE_DETAILEDERRORS)
+        .value_or(environmentVariables[CS_ASPNETCORE_DETAILEDERRORS]);
+    const auto aspnetCoreEnvironment = Environment::GetEnvironmentVariableValue(CS_ASPNETCORE_ENVIRONMENT)
+        .value_or(environmentVariables[CS_ASPNETCORE_ENVIRONMENT]);
+    const auto dotnetEnvironment = Environment::GetEnvironmentVariableValue(CS_DOTNET_ENVIRONMENT)
+        .value_or(environmentVariables[CS_DOTNET_ENVIRONMENT]);
 
     auto detailedErrorsEnabled = equals_ignore_case(L"1", detailedErrors) || equals_ignore_case(L"true", detailedErrors);
     auto aspnetCoreEnvironmentEnabled = equals_ignore_case(L"Development", aspnetCoreEnvironment);

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
@@ -43,26 +43,21 @@ ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
     m_struStdoutLogFile = section->GetRequiredString(CS_ASPNETCORE_STDOUT_LOG_FILE);
     m_fDisableStartupPage = section->GetRequiredBool(CS_ASPNETCORE_DISABLE_START_UP_ERROR_PAGE);
 
-    const auto detailedErrors = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_DETAILEDERRORS").value_or(L"");
-    const auto aspnetCoreEnvironment = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_ENVIRONMENT").value_or(L"");
-    const auto dotnetEnvironment = Environment::GetEnvironmentVariableValue(L"DOTNET_ENVIRONMENT").value_or(L"");
+    auto environmentVariables = section->GetMap(CS_ASPNETCORE_ENVIRONMENT_VARIABLES);
+
+    // Indexing into environment variable map will add a default entry if none is present
+    // This is okay here as we throw away the map shortly after.
+    // Process set environment variables are prioritized over web config variables.
+    const auto detailedErrors = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_DETAILEDERRORS")
+        .value_or(environmentVariables[L"ASPNETCORE_DETAILEDERRORS"]);
+    const auto aspnetCoreEnvironment = Environment::GetEnvironmentVariableValue(L"ASPNETCORE_ENVIRONMENT")
+        .value_or(environmentVariables[L"ASPNETCORE_ENVIRONMENT"]);
+    const auto dotnetEnvironment = Environment::GetEnvironmentVariableValue(L"DOTNET_ENVIRONMENT")
+        .value_or(environmentVariables[L"DOTNET_ENVIRONMENT"]);
 
     auto detailedErrorsEnabled = equals_ignore_case(L"1", detailedErrors) || equals_ignore_case(L"true", detailedErrors);
     auto aspnetCoreEnvironmentEnabled = equals_ignore_case(L"Development", aspnetCoreEnvironment);
     auto dotnetEnvironmentEnabled = equals_ignore_case(L"Development", dotnetEnvironment);
-
-    // Need to read web.config environment variables to check if aspnetcore environment is set too.
-    auto environmentVariables = section->GetMap(CS_ASPNETCORE_ENVIRONMENT_VARIABLES);
-
-    // Technically this will add an entry to the map here, but we aren't keeping the m
-    const auto detailedErrorsFromWebConfig = environmentVariables[L"ASPNETCORE_DETAILEDERRORS"];
-    const auto aspnetCoreEnvironmentFromWebConfig = environmentVariables[L"ASPNETCORE_ENVIRONMENT"];
-    const auto dotnetEnvironmentFromWebConfig = environmentVariables[L"DOTNET_ENVIRONMENT"];
-
-    // TODO make some helpers for this
-    detailedErrorsEnabled |= equals_ignore_case(L"1", detailedErrorsFromWebConfig) || equals_ignore_case(L"true", detailedErrorsFromWebConfig);
-    aspnetCoreEnvironmentEnabled |= equals_ignore_case(L"Development", aspnetCoreEnvironmentFromWebConfig);
-    dotnetEnvironmentEnabled |= equals_ignore_case(L"Development", dotnetEnvironmentFromWebConfig);
 
     m_fShowDetailedErrors = detailedErrorsEnabled || aspnetCoreEnvironmentEnabled || dotnetEnvironmentEnabled;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
@@ -30,6 +30,9 @@
 #define CS_ENABLED                                       L"enabled"
 #define CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK          L"callStartupHook"
 #define CS_ASPNETCORE_HANDLER_STACK_SIZE                 L"stackSize"
+#define CS_ASPNETCORE_DETAILEDERRORS                     L"ASPNETCORE_DETAILEDERRORS"
+#define CS_ASPNETCORE_ENVIRONMENT                        L"ASPNETCORE_ENVIRONMENT"
+#define CS_DOTNET_ENVIRONMENT                            L"DOTNET_ENVIRONMENT"
 
 class ConfigurationSection: NonCopyable
 {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
@@ -47,10 +47,10 @@ Environment::GetEnvironmentVariableValue(const std::wstring & str)
     }
     else if (requestedSize == 1)
     {
-        // String just contains a nullcharacter, return empty string
+        // String just contains a nullcharacter, return nothing
         // GetEnvironmentVariableW has inconsistent behavior when returning size for an empty
         // environment variable.
-        return L"";
+        return std::nullopt;
     }
 
     std::wstring expandedStr;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -366,6 +366,26 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         }
 
         [ConditionalFact]
+        public async Task TargedDifferenceSharedFramework_FailedToFindNativeDependenciesErrorInResponse()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
+            deploymentParameters.WebConfigBasedEnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "TRUE";
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ANCM Failed to Find Native Dependencies");
+                var responseString = await deploymentResult.HttpClient.GetStringAsync("/HelloWorld");
+                Assert.Contains("The specified framework 'Microsoft.NETCore.App', version '2.9.9'", responseString);
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+            }
+        }
+
+        [ConditionalFact]
         public async Task RemoveInProcessReference_FailedToFindRequestHandler()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
@@ -662,7 +682,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             deploymentParameters.TransformArguments((a, _) => $"{a} Throw");
 
             // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
-            deploymentParameters.EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "";
+            deploymentParameters.EnvironmentVariables.Remove("ASPNETCORE_DETAILEDERRORS");
             deploymentParameters.EnvironmentVariables[environmentVariable] = value;
 
             var deploymentResult = await DeployAsync(deploymentParameters);
@@ -678,20 +698,16 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             VerifyDotnetRuntimeEventLog(deploymentResult);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [RequiresNewHandler]
-        [InlineData("ASPNETCORE_ENVIRONMENT", "Development")]
-        [InlineData("DOTNET_ENVIRONMENT", "deVelopment")]
-        [InlineData("ASPNETCORE_DETAILEDERRORS", "1")]
-        [InlineData("ASPNETCORE_DETAILEDERRORS", "TRUE")]
-        public async Task ExceptionIsLoggedToEventLogAndPutInResponseWhenDeveloperExceptionPageIsEnabledViaWebConfig(string environmentVariable, string value)
+        public async Task ExceptionIsLoggedToEventLogAndPutInResponseWhenDeveloperExceptionPageIsEnabledViaWebConfig()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters();
             deploymentParameters.TransformArguments((a, _) => $"{a} Throw");
 
             // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
-            deploymentParameters.EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "";
-            deploymentParameters.WebConfigBasedEnvironmentVariables[environmentVariable] = value;
+            deploymentParameters.EnvironmentVariables.Remove("ASPNETCORE_DETAILEDERRORS");
+            deploymentParameters.WebConfigBasedEnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "TRUE";
 
             var deploymentResult = await DeployAsync(deploymentParameters);
             var result = await deploymentResult.HttpClient.GetAsync("/");
@@ -705,7 +721,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             VerifyDotnetRuntimeEventLog(deploymentResult);
         }
-
 
         [ConditionalTheory]
         [RequiresIIS(IISCapability.PoolEnvironmentVariables)]


### PR DESCRIPTION
Caught this during verification. By default, the ASPNETCORE_ENVIRONMENT is set in the web.config rather than on the iisexpress process, which I thought to be the case. 