### PR TITLE
Don't inject ANCM managed exception page into the static page

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/file_utility.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/file_utility.cpp
@@ -168,9 +168,9 @@ Finished:
     return hr;
 }
 
-std::string FILE_UTILITY::GetHtml(HMODULE module, int page, USHORT statusCode, USHORT subStatusCode, const std::string& speicificReasonPhrase, const std::string& solution)
+std::string FILE_UTILITY::GetHtml(HMODULE module, int page, USHORT statusCode, USHORT subStatusCode, const std::string& specificReasonPhrase, const std::string& solution)
 {
-    return GetHtml(module, page, statusCode, subStatusCode, speicificReasonPhrase, solution, std::string());
+    return GetHtml(module, page, statusCode, subStatusCode, specificReasonPhrase, solution, std::string());
 }
 
 std::string

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/dllmain.cpp
@@ -134,17 +134,21 @@ CreateApplication(
             std::unique_ptr<InProcessOptions> options;
             THROW_IF_FAILED(InProcessOptions::Create(*pServer, pSite, *pHttpApplication, options));
             // Set the currently running application to a fake application that returns startup exceptions.
-            auto pErrorApplication = std::make_unique<StartupExceptionApplication>(*pServer,
-                *pHttpApplication,
-                options->QueryDisableStartUpErrorPage(),
-                hr,
+            auto content = !g_errorPageContent.empty() ?
+                g_errorPageContent :
                 FILE_UTILITY::GetHtml(g_hServerModule,
                     IN_PROCESS_RH_STATIC_HTML,
                     500i16,
                     30i16,
                     "ANCM In-Process Start Failure",
                     "<ul><li>The application failed to start</li><li>The application started but then stopped</li><li>The application started but threw an exception during startup</li></ul>",
-                    g_errorPageContent),
+                    "");
+
+            auto pErrorApplication = std::make_unique<StartupExceptionApplication>(*pServer,
+                *pHttpApplication,
+                options->QueryDisableStartUpErrorPage(),
+                hr,
+                content,
                 500i16,
                 30i16,
                 "Internal Server Error");

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -696,6 +696,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Assert.Contains("InvalidOperationException", content);
             Assert.Contains("TestSite.Program.Main", content);
             Assert.Contains("From Configure", content);
+            Assert.DoesNotContain("ANCM In-Process Start Failure", content);
 
             StopServer();
 


### PR DESCRIPTION
Another thing noticed by verification. I actually added the ANCM startup page into the static page.