### PR TITLE
Produce Microsoft.AspNetCore.Authorization as a package

### DIFF
--- a/eng/SharedFramework.Local.props
+++ b/eng/SharedFramework.Local.props
@@ -8,11 +8,9 @@
 <Project>
   <ItemGroup>
     <!-- These assemblies are available as both a NuGet package and in the shared framework -->
-    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Authorization" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Features" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Connections.Common" />
-    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Metadata" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Components.Browser" />
@@ -35,6 +33,7 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Extensions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http" />
+    <AspNetCoreAppReference Include="Microsoft.AspNetCore.Metadata" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.WebUtilities" />
@@ -52,6 +51,7 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.OAuth" />
+    <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authorization" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authorization.Policy" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.CookiePolicy" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Cors" />

--- a/eng/SharedFramework.Local.props
+++ b/eng/SharedFramework.Local.props
@@ -9,7 +9,9 @@
   <ItemGroup>
     <!-- These assemblies are available as both a NuGet package and in the shared framework -->
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Features" />
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Metadata" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Authorization" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Connections.Common" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
@@ -33,7 +35,6 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Extensions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http" />
-    <AspNetCoreAppReference Include="Microsoft.AspNetCore.Metadata" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.WebUtilities" />
@@ -51,7 +52,6 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.OAuth" />
-    <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authorization" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authorization.Policy" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.CookiePolicy" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Cors" />

--- a/eng/SharedFramework.Local.props
+++ b/eng/SharedFramework.Local.props
@@ -8,9 +8,11 @@
 <Project>
   <ItemGroup>
     <!-- These assemblies are available as both a NuGet package and in the shared framework -->
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Authorization" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Features" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Connections.Common" />
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Metadata" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Components.Browser" />
@@ -33,7 +35,6 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Extensions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http" />
-    <AspNetCoreAppReference Include="Microsoft.AspNetCore.Metadata" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.WebUtilities" />
@@ -51,7 +52,6 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.OAuth" />
-    <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authorization" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authorization.Policy" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.CookiePolicy" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Cors" />

--- a/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
+++ b/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
@@ -4,6 +4,7 @@
     <Description>ASP.NET Core metadata.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
+    <IsShippingPackage>true</IsShippingPackage>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
+++ b/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
@@ -7,6 +7,7 @@ Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute
 Microsoft.AspNetCore.Authorization.AuthorizeAttribute</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
+    <IsShippingPackage>true</IsShippingPackage>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authorization</PackageTags>


### PR DESCRIPTION
This is required for client-side blazor, as Microsoft.AspNetCore.Components references is a package in the Blazor client-side case.