### PR TITLE
Fix helix test

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -378,8 +378,9 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
 
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-                Assert.Contains("HTTP Error 500.31 - ANCM Failed to Find Native Dependencies", await response.Content.ReadAsStringAsync());
-                Assert.Contains("The specified framework 'Microsoft.NETCore.App', version '2.9.9'", await response.Content.ReadAsStringAsync());
+                var responseContent = await response.Content.ReadAsStringAsync();
+                Assert.Contains("HTTP Error 500.31 - ANCM Failed to Find Native Dependencies", responseContent);
+                Assert.Contains("The specified framework 'Microsoft.NETCore.App', version '2.9.9'", responseContent);
             }
             else
             {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -375,9 +375,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ANCM Failed to Find Native Dependencies");
-                var responseString = await deploymentResult.HttpClient.GetStringAsync("/HelloWorld");
-                Assert.Contains("The specified framework 'Microsoft.NETCore.App', version '2.9.9'", responseString);
+                var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+                Assert.Contains("HTTP Error 500.31 - ANCM Failed to Find Native Dependencies", await response.Content.ReadAsStringAsync());
+                Assert.Contains("The specified framework 'Microsoft.NETCore.App', version '2.9.9'", await response.Content.ReadAsStringAsync());
             }
             else
             {


### PR DESCRIPTION
Currently helix is failing on the test TargedDifferenceSharedFramework_FailedToFindNativeDependenciesErrorInResponse. 

The build that contained my changes on helix was https://mc.dot.net/#/user/aspnetcore/pr~2Faspnet~2Faspnetcore/ci/20190530.15. This seemed to pass with my changes just fine, and it passed locally. However, this test was incredibly flaky (I called shutdown on the server and then sent an HttpRequest to the server after shutdown). 

The thing that confuses me the most is that the test is failing hard on other builds: https://dev.azure.com/dnceng/public/_build/results?buildId=206419&view=ms.vss-test-web.build-test-results-tab. Like after 3 runs the test is failing consistently. 

I'm going to investigate if the build that contained my changes _actually_ contained my changes.