### PR TITLE
Application restarts on changes to Razor files

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/build/netcoreapp3.0/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/build/netcoreapp3.0/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
@@ -8,5 +8,7 @@
 
     <!-- Prevent VS from restarting the application when cshtml files change since this package handles it -->
     <RazorUpToDateReloadFileTypes>$(RazorUpToDateReloadFileTypes.Replace('.cshtml', ''))</RazorUpToDateReloadFileTypes>
+
+    <AddCshtmlFilesToDotNetWatchList>false</AddCshtmlFilesToDotNetWatchList>
   </PropertyGroup>
 </Project>

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/build/netcoreapp3.0/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/build/netcoreapp3.0/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
@@ -5,5 +5,8 @@
 
     <!-- Generate hosting attributes during build time compilation to support runtime compilation -->
     <GenerateRazorHostingAssemblyInfo Condition="'$(GenerateRazorHostingAssemblyInfo)'==''">true</GenerateRazorHostingAssemblyInfo>
+
+    <!-- Prevent VS from restarting the application when cshtml files change since this package handles it -->
+    <RazorUpToDateReloadFileTypes>$(RazorUpToDateReloadFileTypes.Replace('.cshtml', ''))</RazorUpToDateReloadFileTypes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* .cshtml and .razor files cause dotnet-watch to reload by default
* .cshtml files do not cause VS or dotnet-watch to reload when using RuntimeCompilation

Fixes https://github.com/aspnet/AspNetCore/issues/9644

