### PR TITLE
Noop on the request body stream in TestServer

### DIFF
--- a/src/Hosting/TestHost/src/AsyncStreamWrapper.cs
+++ b/src/Hosting/TestHost/src/AsyncStreamWrapper.cs
@@ -116,17 +116,18 @@ namespace Microsoft.AspNetCore.TestHost
 
         public override void Close()
         {
-            _inner.Close();
+            // Don't dispose the inner stream, we don't want to impact the client stream
         }
 
         protected override void Dispose(bool disposing)
         {
-            _inner.Dispose();
+            // Don't dispose the inner stream, we don't want to impact the client stream
         }
 
         public override ValueTask DisposeAsync()
         {
-            return _inner.DisposeAsync();
+            // Don't dispose the inner stream, we don't want to impact the client stream
+            return default;
         }
     }
 }

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -216,29 +216,6 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
-        public async Task DispoingTheResponseBodyDoesNotDisposeClientStreams()
-        {
-            var builder = new WebHostBuilder().Configure(app =>
-            {
-                app.Run(async context =>
-                {
-                    await using (var sr = new StreamWriter(context.Response.Body))
-                    {
-                        sr.Write("Hello World");
-                    }
-                });
-            });
-
-            var server = new TestServer(builder);
-
-            var stream = new ThrowOnDisposeStream();
-            stream.Write(Encoding.ASCII.GetBytes("Hello World"));
-            var response = await server.CreateClient().PostAsync("/", new StreamContent(stream));
-            Assert.True(response.IsSuccessStatusCode);
-            Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
-        }
-
         public class CustomContainerStartup
         {
             public IServiceProvider Services;


### PR DESCRIPTION
- Disposable should not be observable on the client side if the server disposes the body. This is similar to how Kestrel noops on dispose to avoid common usages like StreamReader disposing the underlying stream.

Fixes #10737