### PR TITLE
Use the defaults that existed in Kestrel before

### DIFF
--- a/src/Servers/Kestrel/Transport.Libuv/src/LibuvTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/LibuvTransportOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
 {
@@ -28,9 +27,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
         /// </remarks>
         public bool NoDelay { get; set; } = true;
 
-        public long? MaxReadBufferSize { get; set; } = PipeOptions.Default.PauseWriterThreshold;
+        public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-        public long? MaxWriteBufferSize { get; set; } = PipeOptions.Default.PauseWriterThreshold;
+        public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.MemoryPoolFactory.Create;
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
@@ -25,9 +24,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// </remarks>
         public bool NoDelay { get; set; } = true;
 
-        public long? MaxReadBufferSize { get; set; } = PipeOptions.Default.PauseWriterThreshold;
+        public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-        public long? MaxWriteBufferSize { get; set; } = PipeOptions.Default.PauseWriterThreshold;
+        public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.MemoryPoolFactory.Create;
     }


### PR DESCRIPTION
Preserving the existing settings but now at the transport level.

