### PR TITLE
Update gRPC package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -180,9 +180,9 @@
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
-    <GoogleProtobufPackageVersion>3.7.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCoreServerPackageVersion>0.1.21-dev201905010701</GrpcAspNetCoreServerPackageVersion>
-    <GrpcToolsPackageVersion>1.20.0-pre3</GrpcToolsPackageVersion>
+    <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
+    <GrpcAspNetCoreServerPackageVersion>0.1.21-dev201906020701</GrpcAspNetCoreServerPackageVersion>
+    <GrpcToolsPackageVersion>1.21.0</GrpcToolsPackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0-preview3.4</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0-preview3.4</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0-preview3.4</IdentityServer4PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -181,7 +181,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCoreServerPackageVersion>0.1.21-dev201906020701</GrpcAspNetCoreServerPackageVersion>
+    <GrpcAspNetCoreServerPackageVersion>0.1.21-pre1</GrpcAspNetCoreServerPackageVersion>
     <GrpcToolsPackageVersion>1.21.0</GrpcToolsPackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0-preview3.4</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0-preview3.4</IdentityServer4EntityFrameworkPackageVersion>


### PR DESCRIPTION
Update the versions of gRPC packages that we consume, which will be used in the templates. We should also push for a 0.1.21 version of Grpc.AspNetCore.Server to be built and pushed to NuGet.