### PR TITLE
Blazor template fixes

### DIFF
--- a/src/Components/Blazor/Templates/src/SetPackageProperties.targets
+++ b/src/Components/Blazor/Templates/src/SetPackageProperties.targets
@@ -11,15 +11,11 @@
 
   <Target Name="SetTemplateJsonSymbolReplacements">
     <PropertyGroup>
-      <IncludeCustomRestoreSourcesValue>true</IncludeCustomRestoreSourcesValue>
-      <IncludeCustomRestoreSourcesValue Condition=" '$(IsFinalBuild)' == 'true' AND ('$(PreReleaseLabel)' == 'servicing' OR '$(PreReleaseLabel)' == 'rtm')">false</IncludeCustomRestoreSourcesValue>
-
       <!--
         Properties here will be injected into the template config *.json files
         during the build, replacing tokens of the form ${PropertyName}
       -->
       <GeneratedContentProperties>
-        IncludeCustomRestoreSources=$(IncludeCustomRestoreSourcesValue);
         TemplateBlazorVersion=$(PackageVersion);
         TemplateComponentsVersion=$(ComponentsPackageVersion);
         RepositoryCommit=$(SourceRevisionId);

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/.template.config.src/template.json
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/.template.config.src/template.json
@@ -71,12 +71,6 @@
       "type": "bind",
       "binding": "HostIdentifier"
     },
-    "IncludeCustomRestoreSourcesSymbol": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "If set, includes restore sources for the Blazor MyGet feed.",
-      "defaultValue": "${IncludeCustomRestoreSources}"
-    },
     "TemplateBlazorVersionSymbol": {
       "type": "parameter",
       "datatype": "string",

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/App.razor
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/App.razor
@@ -1,1 +1,5 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" />
+﻿<Router AppAssembly="typeof(Program).Assembly">
+    <NotFoundContent>
+        <p>Sorry, there's nothing at this address.</p>
+    </NotFoundContent>
+</Router>

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
@@ -3,10 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
@@ -2,10 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/Startup.cs
@@ -33,7 +33,7 @@ namespace BlazorHosted_CSharp.Server
                 app.UseBlazorDebugging();
             }
 
-            app.UseBlazorClientSideFiles<Client.Startup>();
+            app.UseClientSideBlazorFiles<Client.Startup>();
 
             app.UseRouting();
 

--- a/src/Components/Blazor/Templates/src/content/BlazorLibrary-CSharp/.template.config.src/template.json
+++ b/src/Components/Blazor/Templates/src/content/BlazorLibrary-CSharp/.template.config.src/template.json
@@ -43,12 +43,6 @@
       "type": "bind",
       "binding": "HostIdentifier"
     },
-    "IncludeCustomRestoreSourcesSymbol": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "If set, includes restore sources for the Blazor MyGet feed.",
-      "defaultValue": "${IncludeCustomRestoreSources}"
-    },
     "TemplateBlazorVersionSymbol": {
       "type": "parameter",
       "datatype": "string",

--- a/src/Components/Blazor/Templates/src/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
@@ -3,10 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/.template.config.src/template.json
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/.template.config.src/template.json
@@ -44,12 +44,6 @@
       "type": "bind",
       "binding": "HostIdentifier"
     },
-    "IncludeCustomRestoreSourcesSymbol": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "If set, includes restore sources for the Blazor MyGet feed.",
-      "defaultValue": "${IncludeCustomRestoreSources}"
-    },
     "TemplateBlazorVersionSymbol": {
       "type": "parameter",
       "datatype": "string",

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/App.razor
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/App.razor
@@ -1,1 +1,5 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" />
+﻿<Router AppAssembly="typeof(Program).Assembly">
+    <NotFoundContent>
+        <p>Sorry, there's nothing at this address.</p>
+    </NotFoundContent>
+</Router>

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
@@ -2,10 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>

--- a/src/Components/Blazor/Templates/src/content/Directory.Build.props
+++ b/src/Components/Blazor/Templates/src/content/Directory.Build.props
@@ -2,8 +2,4 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\build\dependencies.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\build\sources.props" />
-
-  <PropertyGroup>
-    <IncludeCustomRestoreSourcesSymbol>true</IncludeCustomRestoreSourcesSymbol>
-  </PropertyGroup>
 </Project>

--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorComponentsWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorComponentsWeb-CSharp.csproj.in
@@ -10,7 +10,7 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">RazorComponentsWeb_CSharp</RootNamespace>
   </PropertyGroup>
 
-  <!--#if (IndividualLocalAuth && UseLocalDB) -->
+  <!--#if (IndividualLocalAuth && !UseLocalDB) -->
   <ItemGroup>
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/.template.config/template.json
@@ -70,6 +70,24 @@
           "exclude": [
             "Shared/LoginDisplay.razor"
           ]
+        },
+        {
+          "condition": "(NoAuth)",
+          "rename": {
+            "Shared/MainLayout.NoAuth.razor": "Shared/MainLayout.razor"
+          },
+          "exclude": [
+            "Shared/MainLayout.Auth.razor"
+          ]
+        },
+        {
+          "condition": "(!NoAuth)",
+          "rename": {
+            "Shared/MainLayout.Auth.razor": "Shared/MainLayout.razor"
+          },
+          "exclude": [
+            "Shared/MainLayout.NoAuth.razor"
+          ]
         }
       ]
     }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/.template.config/template.json
@@ -67,16 +67,11 @@
         },
         {
           "condition": "(NoAuth)",
-          "exclude": [
-            "Shared/LoginDisplay.razor"
-          ]
-        },
-        {
-          "condition": "(NoAuth)",
           "rename": {
             "Shared/MainLayout.NoAuth.razor": "Shared/MainLayout.razor"
           },
           "exclude": [
+            "Shared/LoginDisplay.*.razor",
             "Shared/MainLayout.Auth.razor"
           ]
         },
@@ -87,6 +82,50 @@
           },
           "exclude": [
             "Shared/MainLayout.NoAuth.razor"
+          ]
+        },
+        {
+          "condition": "(IndividualLocalAuth)",
+          "rename": {
+            "Shared/LoginDisplay.IndividualLocalAuth.razor": "Shared/LoginDisplay.razor"
+          },
+          "exclude": [
+            "Shared/LoginDisplay.IndividualB2CAuth.razor",
+            "Shared/LoginDisplay.OrganizationalAuth.razor",
+            "Shared/LoginDisplay.WindowsAuth.razor"
+          ]
+        },
+        {
+          "condition": "(IndividualB2CAuth)",
+          "rename": {
+            "Shared/LoginDisplay.IndividualB2CAuth.razor": "Shared/LoginDisplay.razor"
+          },
+          "exclude": [
+            "Shared/LoginDisplay.IndividualLocalAuth.razor",
+            "Shared/LoginDisplay.OrganizationalAuth.razor",
+            "Shared/LoginDisplay.WindowsAuth.razor"
+          ]
+        },
+        {
+          "condition": "(OrganizationalAuth)",
+          "rename": {
+            "Shared/LoginDisplay.OrganizationalAuth.razor": "Shared/LoginDisplay.razor"
+          },
+          "exclude": [
+            "Shared/LoginDisplay.IndividualLocalAuth.razor",
+            "Shared/LoginDisplay.IndividualB2CAuth.razor",
+            "Shared/LoginDisplay.WindowsAuth.razor"
+          ]
+        },
+        {
+          "condition": "(WindowsAuth)",
+          "rename": {
+            "Shared/LoginDisplay.WindowsAuth.razor": "Shared/LoginDisplay.razor"
+          },
+          "exclude": [
+            "Shared/LoginDisplay.IndividualLocalAuth.razor",
+            "Shared/LoginDisplay.IndividualB2CAuth.razor",
+            "Shared/LoginDisplay.OrganizationalAuth.razor"
           ]
         }
       ]

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/App.razor
@@ -1,7 +1,6 @@
 ﻿<CascadingAuthenticationState>
     <Router AppAssembly="typeof(Startup).Assembly">
         <NotFoundContent>
-            <h3>Page not found</h3>
             <p>Sorry, there's nothing at this address.</p>
         </NotFoundContent>
     </Router>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Properties/launchSettings.json
@@ -1,7 +1,12 @@
 {
   "iisSettings": {
+    //#if (WindowsAuth)
+    "windowsAuthentication": true,
+    "anonymousAuthentication": false,
+    //#else
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
+    //#endif
     "iisExpress": {
       "applicationUrl": "http://localhost:8080",
       //#if(RequiresHttps)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.IndividualB2CAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.IndividualB2CAuth.razor
@@ -1,15 +1,3 @@
-@*#if (IndividualLocalAuth)
-<AuthorizeView>
-    <Authorized>
-        <a href="Identity/Account/Manage">Hello, @context.User.Identity.Name!</a>
-        <a href="Identity/Account/LogOut">Log out</a>
-    </Authorized>
-    <NotAuthorized>
-        <a href="Identity/Account/Register">Register</a>
-        <a href="Identity/Account/Login">Log in</a>
-    </NotAuthorized>
-</AuthorizeView>
-#elseif (IndividualB2CAuth)
 @using Microsoft.AspNetCore.Authentication.AzureADB2C.UI
 @using Microsoft.Extensions.Options
 @inject IOptionsMonitor<AzureADB2COptions> AzureADB2COptions
@@ -40,18 +28,3 @@
         canEditProfile = !string.IsNullOrEmpty(options.EditProfilePolicyId);
     }
 }
-#elseif (OrganizationalAuth)
-<AuthorizeView>
-    <Authorized>
-        Hello, @context.User.Identity.Name!
-        <a href="AzureAD/Account/SignOut">Log out</a>
-    </Authorized>
-    <NotAuthorized>
-        <a href="AzureAD/Account/SignIn">Log in</a>
-    </NotAuthorized>
-</AuthorizeView>
-#elseif (WindowsAuth)
-<AuthorizeView>
-    Hello, @context.User.Identity.Name!
-</AuthorizeView>
-#endif*@

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.IndividualLocalAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.IndividualLocalAuth.razor
@@ -1,0 +1,10 @@
+<AuthorizeView>
+    <Authorized>
+        <a href="Identity/Account/Manage">Hello, @context.User.Identity.Name!</a>
+        <a href="Identity/Account/LogOut">Log out</a>
+    </Authorized>
+    <NotAuthorized>
+        <a href="Identity/Account/Register">Register</a>
+        <a href="Identity/Account/Login">Log in</a>
+    </NotAuthorized>
+</AuthorizeView>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.OrganizationalAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.OrganizationalAuth.razor
@@ -1,0 +1,9 @@
+<AuthorizeView>
+    <Authorized>
+        Hello, @context.User.Identity.Name!
+        <a href="AzureAD/Account/SignOut">Log out</a>
+    </Authorized>
+    <NotAuthorized>
+        <a href="AzureAD/Account/SignIn">Log in</a>
+    </NotAuthorized>
+</AuthorizeView>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.WindowsAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/LoginDisplay.WindowsAuth.razor
@@ -1,0 +1,3 @@
+<AuthorizeView>
+    Hello, @context.User.Identity.Name!
+</AuthorizeView>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/MainLayout.Auth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/MainLayout.Auth.razor
@@ -6,9 +6,7 @@
 
 <div class="main">
     <div class="top-row px-4">
-@*#if (!NoAuth)
         <LogInDisplay />
-#endif*@
         <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
     </div>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/MainLayout.NoAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Shared/MainLayout.NoAuth.razor
@@ -1,0 +1,15 @@
+﻿@inherits LayoutComponentBase
+
+<div class="sidebar">
+    <NavMenu />
+</div>
+
+<div class="main">
+    <div class="top-row px-4">
+        <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
+    </div>
+
+    <div class="content px-4">
+        @Body
+    </div>
+</div>


### PR DESCRIPTION
Issues found during initial verification for preview 6:

* In the server-side .csproj, `<None Update="app.db" CopyToOutputDirectory="PreserveNewest" />` appears if you're using LocalDB, but not if you aren't. This condition is the opposite to what it should be.
* None of the conditionals in any of the `.razor` files are applied when the template is executed from VS, although they do work correctly on the command line. This means the app does nothing useful, as all the conditionally-included code is just left commented out.
* In the client-side Blazor templates,
  * There's a compilation error: it tries to call `UseBlazorClientSideFiles`; should be `UseClientSideBlazorFiles`.
  * If you visit a "not found" URL (e.g., any made-up URL), instead of displaying "not found", it does an infinite redirect loop
  * The csproj still adds references to MyGet feeds which are no longer updated

This PR includes fixes to all the above. Notes:

 * For the "conditionals are not applied in `.razor` files", who knows who to follow up with about this? Why does VS differ from the command line for this? My workaround in this PR is kind of awkward - it would be good if we could revert it and go back to using conditionals.
 * For the redirect-loop in client-side Blazor, my workaround is to add some `NotFoundContent`, because the logic in `Router` is to do a redirect if there is no `NotFoundContent`. But why do we have this logic? I know it was [added recently here](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/Routing/Router.cs#L118) but it doesn't cover this scenario. cc @pranavkm for thoughts on this, as he worked on that PR.

### Other issues

In verification I also found the following, which I don't think we can address for preview 6:

 * The client-side Blazor app has expanded back to 2.3MB (same as before the linker improvements) because we now reference a load more assemblies from `Microsoft.Extensions` (e.g., `Primitives`, `Options`, `Logging.Abstractions`) as well as `Microsoft.AspNetCore.Authorization` even if you aren't using it.
   * This is problematic because people will keep adding stuff to those `Microsoft.Extensions` packages without being aware of the consequences for client-side Blazor app size.
   * We should look at either having the linker treat `Microsoft.AspNetCore.*` as part of the BCL (i.e., subject to linking out), or try to find ways to break the dependency chains
* In my version of VS, the `@attribute` directive still doesn't show up. Not sure what version of VS I should be using.
