### PR TITLE
Fix _LoginPartial.OrgAuth.cshtml referencing non-existent CSS classes

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Shared/_LoginPartial.OrgAuth.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Shared/_LoginPartial.OrgAuth.cshtml
@@ -17,14 +17,14 @@
         {
             <li class="nav-item">
                 <a class="nav-link text-dark" asp-area="AzureADB2C" asp-controller="Account" asp-action="EditProfile">
-                    <span class="nav-text text-dark">Hello @User.Identity.Name!</span>
+                    <span class="text-dark">Hello @User.Identity.Name!</span>
                 </a>
             </li>
         }
         else
         {
             <li class="nav-item">
-                <span class="nav-text text-dark">Hello @User.Identity.Name!</span>
+                <span class="navbar-text text-dark">Hello @User.Identity.Name!</span>
             </li>
         }
         <li class="nav-item">
@@ -41,7 +41,7 @@ else
 @if (User.Identity.IsAuthenticated)
 {
         <li class="nav-item">
-            <span class="nav-text text-dark">Hello @User.Identity.Name!</span>
+            <span class="navbar-text text-dark">Hello @User.Identity.Name!</span>
         </li>
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="AzureAD" asp-controller="Account" asp-action="SignOut">Sign out</a>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/_LoginPartial.OrgAuth.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/_LoginPartial.OrgAuth.cshtml
@@ -18,14 +18,14 @@
         {
             <li class="nav-item">
                 <a class="nav-link text-dark" asp-area="AzureADB2C" asp-controller="Account" asp-action="EditProfile">
-                    <span class="nav-text text-dark">Hello @User.Identity.Name!</span>
+                    <span class="text-dark">Hello @User.Identity.Name!</span>
                 </a>
             </li>
         }
         else
         {
             <li class="nav-item">
-                <span class="nav-text text-dark">Hello @User.Identity.Name!</span>
+                <span class="navbar-text text-dark">Hello @User.Identity.Name!</span>
             </li>
         }
         <li class="nav-item">
@@ -42,7 +42,7 @@ else
 @if (User.Identity.IsAuthenticated)
 {
         <li class="nav-item">
-            <span class="nav-text text-dark">Hello @User.Identity.Name!</span>
+            <span class="navbar-text text-dark">Hello @User.Identity.Name!</span>
         </li>
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="AzureAD" asp-controller="Account" asp-action="SignOut">Sign out</a>


### PR DESCRIPTION
Summary of the changes
 - Eliminate one reference to non-existent `nav-text` CSS class that was already being covered by `nav-link` class.
 - Replaces other two references to non-existent `nav-text` CSS class with `navbar-text`.

Before:
![Repro Edge](https://user-images.githubusercontent.com/922096/58823803-67ffb500-85ef-11e9-9806-66fa74cd1d7d.png)

After:
![Fixed Edge](https://user-images.githubusercontent.com/922096/58823812-6d5cff80-85ef-11e9-9854-9ac3bad137b8.png)

Addresses #10779
