### PR TITLE
If libuv doesn't unwind gracefully log a warning

### DIFF
--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvThread.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvThread.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 Post(t => t.AllowStop());
                 if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                 {
-                    _log.LogCritical($"{nameof(LibuvThread)}.{nameof(StopAsync)} failed to terminate libuv thread, {nameof(AllowStop)}");
+                    _log.LogWarning($"{nameof(LibuvThread)}.{nameof(StopAsync)} failed to terminate libuv thread, {nameof(AllowStop)}");
 
                     Post(t => t.OnStopRude());
                     if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))


### PR DESCRIPTION
- We added 3 critical logs to see if there was a resource leak happeing during the loop thread shutdown, turns out that during testing its very common for the thread to not end immediately because of the latency of thread pool dispatching (the latency between queuing and execution of the work item). As a result, we log a warning instead of an error.

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2606
