### PR TITLE
Collect dumps for tests that seem to be flaky

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging.Testing;
 using Moq;
 using Xunit;
 
@@ -42,6 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
             };
         }
 
+        [CollectDump]
         [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/9985", Queues = "Fedora.28.Amd64.Open")] // https://github.com/aspnet/AspNetCore/issues/9985
         [Flaky("https://github.com/aspnet/AspNetCore/issues/9985", FlakyOn.All)]

--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -811,6 +811,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Fact]
         [Flaky("https://github.com/dotnet/corefx/issues/30691", FlakyOn.AzP.Windows)]
+        [CollectDump]
         public async Task ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseHeaders()
         {
             var headerSize = 1024 * 1024; // 1 MB for each header value

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
@@ -26,6 +27,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
 #endif
         [ConditionalFact]
+        [CollectDump]
         public async Task TestUnixDomainSocket()
         {
             var path = Path.GetTempFileName();


### PR DESCRIPTION
Lets see if we can find any blocking going on when these tests fail with timeouts.