### PR TITLE
Initial counter implementations

### DIFF
--- a/src/Hosting/Hosting/ref/Microsoft.AspNetCore.Hosting.netcoreapp3.0.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.AspNetCore.Hosting.netcoreapp3.0.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
     }
     public partial class HostingApplication : Microsoft.AspNetCore.Hosting.Server.IHttpApplication<Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context>
     {
-        public HostingApplication(Microsoft.AspNetCore.Http.RequestDelegate application, Microsoft.Extensions.Logging.ILogger logger, System.Diagnostics.DiagnosticListener diagnosticSource, Microsoft.AspNetCore.Http.IHttpContextFactory httpContextFactory) { }
+        public HostingApplication(Microsoft.AspNetCore.Http.RequestDelegate application, Microsoft.Extensions.Logging.ILogger logger, System.Diagnostics.DiagnosticListener diagnosticSource, Microsoft.AspNetCore.Http.IHttpContextFactory httpContextFactory, Microsoft.AspNetCore.Http.IHttpCounters counters = null, Microsoft.AspNetCore.Hosting.Internal.HostingEventSource hostingEventSource = null) { }
         public Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context CreateContext(Microsoft.AspNetCore.Http.Features.IFeatureCollection contextFeatures) { throw null; }
         public void DisposeContext(Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context context, System.Exception exception) { }
         public System.Threading.Tasks.Task ProcessRequestAsync(Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context context) { throw null; }
@@ -145,15 +145,14 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public static void Initialize(this Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnvironment, string contentRootPath, Microsoft.AspNetCore.Hosting.Internal.WebHostOptions options) { }
         public static void Initialize(this Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnvironment, string contentRootPath, Microsoft.AspNetCore.Hosting.Internal.WebHostOptions options) { }
     }
-    [System.Diagnostics.Tracing.EventSourceAttribute(Name="Microsoft-AspNetCore-Hosting")]
     public sealed partial class HostingEventSource : System.Diagnostics.Tracing.EventSource
     {
-        internal HostingEventSource() { }
-        public static readonly Microsoft.AspNetCore.Hosting.Internal.HostingEventSource Log;
+        public HostingEventSource(Microsoft.AspNetCore.Http.IHttpCounters counters) { }
         [System.Diagnostics.Tracing.EventAttribute(1, Level=System.Diagnostics.Tracing.EventLevel.Informational)]
         public void HostStart() { }
         [System.Diagnostics.Tracing.EventAttribute(2, Level=System.Diagnostics.Tracing.EventLevel.Informational)]
         public void HostStop() { }
+        protected override void OnEventCommand(System.Diagnostics.Tracing.EventCommandEventArgs command) { }
         [System.Diagnostics.Tracing.EventAttribute(3, Level=System.Diagnostics.Tracing.EventLevel.Informational)]
         public void RequestStart(string method, string path) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)][System.Diagnostics.Tracing.EventAttribute(4, Level=System.Diagnostics.Tracing.EventLevel.Informational)]

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -86,6 +86,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 services.TryAddSingleton<IHttpContextFactory, DefaultHttpContextFactory>();
                 services.TryAddScoped<IMiddlewareFactory, MiddlewareFactory>();
                 services.TryAddSingleton<IApplicationBuilderFactory, ApplicationBuilderFactory>();
+                services.TryAddSingleton<HostingEventSource>();
+                services.TryAddSingleton<IHttpCounters, DefaultHttpCounters>();
 
                 // IMPORTANT: This needs to run *before* direct calls on the builder (like UseStartup)
                 _hostingStartupWebHostBuilder?.ConfigureServices(webhostContext, services);

--- a/src/Hosting/Hosting/src/Internal/DefaultHttpCounters.cs
+++ b/src/Hosting/Hosting/src/Internal/DefaultHttpCounters.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    internal class DefaultHttpCounters : IHttpCounters
+    {
+        private long _totalRequests;
+        private long _currentRequests;
+        private long _failedRequests;
+
+        public long TotalRequests => _totalRequests;
+
+        public long CurrentRequests => _currentRequests;
+
+        public long FailedRequests => _failedRequests;
+
+        public void RequestException()
+        {
+            Interlocked.Increment(ref _failedRequests);
+        }
+
+        public void RequestStart()
+        {
+            Interlocked.Increment(ref _totalRequests);
+            Interlocked.Increment(ref _currentRequests);
+        }
+
+        public void RequestStop()
+        {
+            Interlocked.Decrement(ref _currentRequests);
+        }
+    }
+}

--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -21,10 +21,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             RequestDelegate application,
             ILogger logger,
             DiagnosticListener diagnosticSource,
-            IHttpContextFactory httpContextFactory)
+            IHttpContextFactory httpContextFactory,
+            IHttpCounters counters = null,
+            HostingEventSource hostingEventSource = null)
         {
             _application = application;
-            _diagnostics = new HostingApplicationDiagnostics(logger, diagnosticSource);
+            _diagnostics = new HostingApplicationDiagnostics(logger, diagnosticSource, counters, hostingEventSource);
             _httpContextFactory = httpContextFactory;
         }
 

--- a/src/Hosting/Hosting/src/WebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilder.cs
@@ -281,6 +281,8 @@ namespace Microsoft.AspNetCore.Hosting
             services.AddSingleton<DiagnosticListener>(listener);
             services.AddSingleton<DiagnosticSource>(listener);
 
+            services.AddSingleton<HostingEventSource>();
+            services.AddSingleton<IHttpCounters, DefaultHttpCounters>();
             services.AddTransient<IApplicationBuilderFactory, ApplicationBuilderFactory>();
             services.AddTransient<IHttpContextFactory, DefaultHttpContextFactory>();
             services.AddScoped<IMiddlewareFactory, MiddlewareFactory>();

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Collections.Generic
+{
+    internal static class AsyncEnumerableExtensions
+    {
+        public static async Task<T> FirstOrDefault<T>(this IAsyncEnumerator<T> values, Func<T, bool> filter)
+        {
+            while (await values.MoveNextAsync())
+            {
+                if (filter(values.Current))
+                {
+                    return values.Current;
+                }
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/Hosting/Hosting/test/Microsoft.AspNetCore.Hosting.Tests.csproj
+++ b/src/Hosting/Hosting/test/Microsoft.AspNetCore.Hosting.Tests.csproj
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="System.Threading.Channels" />
   </ItemGroup>
 
 </Project>

--- a/src/Http/Http.Abstractions/ref/Microsoft.AspNetCore.Http.Abstractions.netcoreapp3.0.cs
+++ b/src/Http/Http.Abstractions/ref/Microsoft.AspNetCore.Http.Abstractions.netcoreapp3.0.cs
@@ -306,6 +306,15 @@ namespace Microsoft.AspNetCore.Http
         Microsoft.AspNetCore.Http.HttpContext Create(Microsoft.AspNetCore.Http.Features.IFeatureCollection featureCollection);
         void Dispose(Microsoft.AspNetCore.Http.HttpContext httpContext);
     }
+    public partial interface IHttpCounters
+    {
+        long CurrentRequests { get; }
+        long FailedRequests { get; }
+        long TotalRequests { get; }
+        void RequestException();
+        void RequestStart();
+        void RequestStop();
+    }
     public partial interface IMiddleware
     {
         System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next);

--- a/src/Http/Http.Abstractions/src/IHttpCounters.cs
+++ b/src/Http/Http.Abstractions/src/IHttpCounters.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public interface IHttpCounters
+    {
+        long TotalRequests { get; }
+        long CurrentRequests { get; }
+        long FailedRequests { get; }
+
+        void RequestStart();
+
+        void RequestStop();
+
+        void RequestException();
+    }
+}

--- a/src/Middleware/Diagnostics/ref/Microsoft.AspNetCore.Diagnostics.netcoreapp3.0.cs
+++ b/src/Middleware/Diagnostics/ref/Microsoft.AspNetCore.Diagnostics.netcoreapp3.0.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 {
     public partial class DeveloperExceptionPageMiddleware
     {
-        public DeveloperExceptionPageMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.DeveloperExceptionPageOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnvironment, System.Diagnostics.DiagnosticSource diagnosticSource, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter> filters) { }
+        public DeveloperExceptionPageMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.DeveloperExceptionPageOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnvironment, System.Diagnostics.DiagnosticSource diagnosticSource, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter> filters, Microsoft.AspNetCore.Http.IHttpCounters counters) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
     }
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Diagnostics
     }
     public partial class ExceptionHandlerMiddleware
     {
-        public ExceptionHandlerMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.ExceptionHandlerOptions> options, System.Diagnostics.DiagnosticListener diagnosticListener) { }
+        public ExceptionHandlerMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.ExceptionHandlerOptions> options, System.Diagnostics.DiagnosticListener diagnosticListener, Microsoft.AspNetCore.Http.IHttpCounters counters) { }
         public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
     }
     public partial class StatusCodeContext

--- a/src/Middleware/Middleware.sln
+++ b/src/Middleware/Middleware.sln
@@ -289,6 +289,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Reques
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.RequestThrottling.Tests", "RequestThrottling\test\Microsoft.AspNetCore.RequestThrottling.Tests.csproj", "{353AA2B0-1013-486C-B5BD-9379385CA403}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Metadata", "..\Http\Metadata\src\Microsoft.AspNetCore.Metadata.csproj", "{A902B1B0-D407-42DA-9099-7FDDC46FB222}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Authorization", "..\Security\Authorization\Core\src\Microsoft.AspNetCore.Authorization.csproj", "{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1571,6 +1575,30 @@ Global
 		{353AA2B0-1013-486C-B5BD-9379385CA403}.Release|x64.Build.0 = Release|Any CPU
 		{353AA2B0-1013-486C-B5BD-9379385CA403}.Release|x86.ActiveCfg = Release|Any CPU
 		{353AA2B0-1013-486C-B5BD-9379385CA403}.Release|x86.Build.0 = Release|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Debug|x64.Build.0 = Debug|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Debug|x86.Build.0 = Debug|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Release|x64.ActiveCfg = Release|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Release|x64.Build.0 = Release|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Release|x86.ActiveCfg = Release|Any CPU
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222}.Release|x86.Build.0 = Release|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Debug|x64.Build.0 = Debug|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Debug|x86.Build.0 = Debug|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Release|x64.ActiveCfg = Release|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Release|x64.Build.0 = Release|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Release|x86.ActiveCfg = Release|Any CPU
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1695,6 +1723,8 @@ Global
 		{6720919C-0DEA-49E1-90DC-F1883F7919CD} = {8C9AA8A2-9D1F-4450-9F8D-56BAB6F3D343}
 		{4CE2384D-6B88-4824-ADD1-4183D180FEFF} = {8C9AA8A2-9D1F-4450-9F8D-56BAB6F3D343}
 		{353AA2B0-1013-486C-B5BD-9379385CA403} = {8C9AA8A2-9D1F-4450-9F8D-56BAB6F3D343}
+		{A902B1B0-D407-42DA-9099-7FDDC46FB222} = {ACA6DDB9-7592-47CE-A740-D15BF307E9E0}
+		{4CDC107D-BAF1-4B72-BAB8-3C7EDE3668E5} = {ACA6DDB9-7592-47CE-A740-D15BF307E9E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {83786312-A93B-4BB4-AB06-7C6913A59AFA}


### PR DESCRIPTION
- Added RPS counter - Requests per second, Total Requests, Current Requests and Failed Requests.
- Added EventSource tests that can run in parallel.
- Added IHttpCounters so that the diagnostic middleware can increment the failed request count without a direct reference to the hosting event source and without their own event source.

Here's how it looks:

![image](https://user-images.githubusercontent.com/95136/58933238-7cd96700-871b-11e9-8eb2-0fd0577389a4.png)


Notes:
- I'm not in love with `IHttpCounters`, it feels kinda smelly as it needs to be a read/write interface so outside consumers can increment it (like the diagnostic middleware).
- The event source needs to be in the container now so that we can get the right instance of `IHttpCounters`
- In speaking to various people, we're going with the approach that each subsystem has its own set of counters. This means you'll need to explicitly enable them to see all of the ASP.NET counters. We won't have as much as logging categories though so it might scale just fine.

PS: If we can live without the diagnostic middleware incrementing the main failed request counter, it would be much simpler 😄. 

cc @shirhatti @DamianEdwards 