### PR TITLE
Propagate cancellation token IAsyncEnumerators

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1944,7 +1944,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             public async Task<ConnectionState> WaitForActiveConnectionAsync(string methodName, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = 0)
             {
-                await WaitConnectionLockAsync();
+                await WaitConnectionLockAsync(methodName);
 
                 if (CurrentConnectionStateUnsynchronized == null || CurrentConnectionStateUnsynchronized.Stopping)
                 {

--- a/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
+++ b/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
             public IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             {
-                var enumerator = _asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+                var enumerator = _asyncEnumerable.GetAsyncEnumerator(_cts.Token);
                 if (cancellationToken.CanBeCanceled)
                 {
                     var registration = cancellationToken.Register((ctsState) =>

--- a/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
+++ b/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
             public IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             {
-                var enumerator = _asyncEnumerable.GetAsyncEnumerator();
+                var enumerator = _asyncEnumerable.GetAsyncEnumerator(cancellationToken);
                 if (cancellationToken.CanBeCanceled)
                 {
                     var registration = cancellationToken.Register((ctsState) =>
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                         ((CancellationTokenSource)ctsState).Cancel();
                     }, _cts);
 
-                    return new CancelableEnumerator<TResult>(_asyncEnumerable.GetAsyncEnumerator(), registration);
+                    return new CancelableEnumerator<TResult>(enumerator, registration);
                 }
 
                 return enumerator;


### PR DESCRIPTION
Will hopefully fix: https://github.com/aspnet/AspNetCore-Internal/issues/2572
We weren't passing through a cancellation token passed into upload stream methods.