### PR TITLE
fix #7548 by updating to v142 toolset (again)

### DIFF
--- a/eng/Workarounds.props
+++ b/eng/Workarounds.props
@@ -12,9 +12,4 @@
     <_ProjectExtensionsWereImported>true</_ProjectExtensionsWereImported>
     <WixTargetsPath>$(WixInstallPath)\wix2010.targets</WixTargetsPath>
   </PropertyGroup>
-
-  <!-- Workaround https://developercommunity.visualstudio.com/content/problem/434385/vs2019-preview-2-targetframeworkversion-or-platfor.html -->
-  <PropertyGroup>
-    <VCToolsVersion Condition = "'$(VCToolsVersion)' == ''" >14.16.27023</VCToolsVersion>
-  </PropertyGroup>
 </Project>

--- a/eng/scripts/vs.buildtools.json
+++ b/eng/scripts/vs.buildtools.json
@@ -17,8 +17,6 @@
         "Microsoft.VisualStudio.Component.NuGet.BuildTools",
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-        "Microsoft.VisualStudio.Component.VC.v141.ATL",
-        "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
         "Microsoft.VisualStudio.Component.Windows10SDK.17134",
         "Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools",
         "Microsoft.VisualStudio.Workload.MSBuildTools",

--- a/eng/scripts/vs.json
+++ b/eng/scripts/vs.json
@@ -15,8 +15,6 @@
         "Microsoft.VisualStudio.Component.Azure.Storage.Emulator",
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-        "Microsoft.VisualStudio.Component.VC.v141.ATL",
-        "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
         "Microsoft.VisualStudio.Component.Windows10SDK.17134",
         "Microsoft.VisualStudio.Workload.ManagedDesktop",
         "Microsoft.VisualStudio.Workload.NativeDesktop",

--- a/korebuild.json
+++ b/korebuild.json
@@ -16,8 +16,6 @@
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-        "Microsoft.VisualStudio.Component.VC.v141.ATL",
-        "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
         "Microsoft.VisualStudio.Component.Windows10SDK.17134"
       ]
     }

--- a/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
@@ -42,7 +42,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/IIS-Common/lib/IISSetup.CommonLib.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/IIS-Common/lib/IISSetup.CommonLib.vcxproj
@@ -31,7 +31,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <WholeProgramOptimization>false</WholeProgramOptimization>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/IIS-Common/reftrace/reftrace.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/IIS-Common/reftrace/reftrace.vcxproj
@@ -47,7 +47,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/iisca.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/iisca.vcxproj
@@ -74,7 +74,7 @@
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup Label="Configuration">

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/CommonLib.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/CommonLib.vcxproj
@@ -245,7 +245,6 @@
     <ClCompile Include="file_utility.cpp" />
     <ClCompile Include="fx_ver.cpp" />
     <ClCompile Include="GlobalVersionUtility.cpp" />
-    <ClCompile Include="HandleWrapper.cpp" />
     <ClCompile Include="HostFxr.cpp" />
     <ClCompile Include="HostFxrResolver.cpp" />
     <ClCompile Include="HostFxrResolutionResult.cpp" />

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HandleWrapper.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HandleWrapper.cpp
@@ -4,5 +4,6 @@
 #include "HandleWrapper.h"
 
 // Workaround for VC++ bug https://developercommunity.visualstudio.com/content/problem/33928/constexpr-failing-on-nullptr-v141-compiler-regress.html
+// REVIEW: This is fixed maybe? We could try removing it now that we're on v142. Is there test coverage?
 const HANDLE InvalidHandleTraits::DefaultHandle = INVALID_HANDLE_VALUE;
 const HANDLE FindFileHandleTraits::DefaultHandle = INVALID_HANDLE_VALUE;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HandleWrapper.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HandleWrapper.cpp
@@ -1,9 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-#include "HandleWrapper.h"
-
-// Workaround for VC++ bug https://developercommunity.visualstudio.com/content/problem/33928/constexpr-failing-on-nullptr-v141-compiler-regress.html
-// REVIEW: This is fixed maybe? We could try removing it now that we're on v142. Is there test coverage?
-const HANDLE InvalidHandleTraits::DefaultHandle = INVALID_HANDLE_VALUE;
-const HANDLE FindFileHandleTraits::DefaultHandle = INVALID_HANDLE_VALUE;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HandleWrapper.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HandleWrapper.h
@@ -9,7 +9,7 @@
 struct InvalidHandleTraits
 {
     using HandleType = HANDLE;
-    static const HANDLE DefaultHandle;
+    static constexpr HANDLE DefaultHandle = nullptr;
     static void Close(HANDLE handle) noexcept { CloseHandle(handle); }
 };
 
@@ -23,7 +23,7 @@ struct NullHandleTraits
 struct FindFileHandleTraits
 {
     using HandleType = HANDLE;
-    static const HANDLE DefaultHandle;
+    static constexpr HANDLE DefaultHandle = nullptr;
     static void Close(HANDLE handle) noexcept { FindClose(handle); }
 };
 
@@ -35,16 +35,16 @@ struct ModuleHandleTraits
 };
 
 // Code analysis doesn't like nullptr usages via traits
-#pragma warning( push )
-#pragma warning ( disable : 26477 ) // disable  Use 'nullptr' rather than 0 or NULL (es.47).
+#pragma warning(push)
+#pragma warning(disable : 26477) // disable  Use 'nullptr' rather than 0 or NULL (es.47).
 
-template<typename traits>
+template <typename traits>
 class HandleWrapper
 {
 public:
     using HandleType = typename traits::HandleType;
 
-    HandleWrapper(HandleType handle = traits::DefaultHandle) noexcept : m_handle(handle) { }
+    HandleWrapper(HandleType handle = traits::DefaultHandle) noexcept : m_handle(handle) {}
     ~HandleWrapper()
     {
         if (m_handle != traits::DefaultHandle)
@@ -54,14 +54,14 @@ public:
     }
 
     operator HandleType() noexcept { return m_handle; }
-    HandleWrapper& operator =(HandleType value) noexcept
+    HandleWrapper &operator=(HandleType value) noexcept
     {
         DBG_ASSERT(m_handle == traits::DefaultHandle);
         m_handle = value;
         return *this;
     }
 
-    HandleType* operator&() noexcept { return &m_handle; }
+    HandleType *operator&() noexcept { return &m_handle; }
 
     HandleType release() noexcept
     {
@@ -74,4 +74,4 @@ private:
     HandleType m_handle;
 };
 
-#pragma warning( pop )
+#pragma warning(pop)


### PR DESCRIPTION
This time, it's personal.

Trying again to update to v142. We'll see how this goes ;).

We can probably also remove the v141 toolset from the vs.json files as a result of this, but I'd like to wait until we know this works to do that :). If we get a green check, we can do a second pass to clean-up (in this PR, but just after we know it works)

Before merge checklist:
* [x] Remove v141 toolset install from `korebuild.json`, `eng\scripts\vs.buildtools.json` and `eng\scripts\vs.json` files