### PR TITLE
Add versioning to dotnet-dev-certs

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -126,10 +126,13 @@ namespace Microsoft.AspNetCore.Certificates.Generation
 
             bool MatchesVersion(X509Certificate2 c)
             {
-                var byteArray = c.Extensions.OfType<X509Extension>().Where(e => string.Equals(AspNetHttpsOid, e.Oid.Value, StringComparison.Ordinal)).Single().RawData;
+                var byteArray = c.Extensions.OfType<X509Extension>()
+                                    .Where(e => string.Equals(AspNetHttpsOid, e.Oid.Value, StringComparison.Ordinal))
+                                    .Single()
+                                    .RawData;
                 if (byteArray.Length == AspNetHttpsOidFriendlyNameLength)
                 {
-                    // No Version set, default to null/0
+                    // No Version set, default to 0
                     return 0 >= AspNetHttpsCertificateVersion;
                 }
                 else

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Certificates.Generation
     {
         public const string AspNetHttpsOid = "1.3.6.1.4.1.311.84.1.1";
         public const string AspNetHttpsOidFriendlyName = "ASP.NET Core HTTPS development certificate";
-        private const int AspNetHttpsOidFriendlyNameLength = 42;
 
         private const string ServerAuthenticationEnhancedKeyUsageOid = "1.3.6.1.5.5.7.3.1";
         private const string ServerAuthenticationEnhancedKeyUsageOidFriendlyName = "Server Authentication";
@@ -131,7 +130,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                     .Single()
                     .RawData;
 
-                if (byteArray.Length == AspNetHttpsOidFriendlyNameLength)
+                if (byteArray.Length == AspNetHttpsOidFriendlyName.Length || byteArray.Length == 0)
                 {
                     // No Version set, default to 0
                     return 0 >= AspNetHttpsCertificateVersion;
@@ -139,7 +138,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 else
                 {
                     // Version is in the last byte of the byte array.
-                    return byteArray[AspNetHttpsOidFriendlyNameLength] >= AspNetHttpsCertificateVersion;
+                    return byteArray[0] >= AspNetHttpsCertificateVersion;
                 }
             }
 #if !XPLAT
@@ -200,9 +199,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation
 
             if (AspNetHttpsCertificateVersion != 0)
             {
-                bytePayload = new byte[AspNetHttpsOidFriendlyNameLength + 1];
-                Encoding.ASCII.GetBytes(AspNetHttpsOidFriendlyName, bytePayload);
-                bytePayload[AspNetHttpsOidFriendlyNameLength] = (byte)AspNetHttpsCertificateVersion;
+                bytePayload = new byte[1];
+                bytePayload[0] = (byte)AspNetHttpsCertificateVersion;
             }
             else
             {

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -127,9 +127,10 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             bool MatchesVersion(X509Certificate2 c)
             {
                 var byteArray = c.Extensions.OfType<X509Extension>()
-                                    .Where(e => string.Equals(AspNetHttpsOid, e.Oid.Value, StringComparison.Ordinal))
-                                    .Single()
-                                    .RawData;
+                    .Where(e => string.Equals(AspNetHttpsOid, e.Oid.Value, StringComparison.Ordinal))
+                    .Single()
+                    .RawData;
+
                 if (byteArray.Length == AspNetHttpsOidFriendlyNameLength)
                 {
                     // No Version set, default to 0

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                     .Single()
                     .RawData;
 
-                if (byteArray.Length == AspNetHttpsOidFriendlyName.Length || byteArray.Length == 0)
+                if ((byteArray.Length == AspNetHttpsOidFriendlyName.Length && byteArray[0] == (byte)'A') || byteArray.Length == 0)
                 {
                     // No Version set, default to 0
                     return 0 >= AspNetHttpsCertificateVersion;

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 }
                 else
                 {
-                    // Version is in the last byte of the byte array.
+                    // Version is in the only byte of the byte array.
                     return byteArray[0] >= AspNetHttpsCertificateVersion;
                 }
             }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
 
         public ITestOutputHelper Output { get; }
 
-        [Fact(Skip = "true")]
+        [Fact(Skip = "Modifies global machine state")]
         public void EnsureCreateHttpsCertificate_CreatesACertificate_WhenThereAreNoHttpsCertificates()
         {
             try
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
                     httpsCertificate.Extensions.OfType<X509Extension>(),
                     e => e.Critical == false &&
                         e.Oid.Value == "1.3.6.1.4.1.311.84.1.1" &&
-                        Encoding.ASCII.GetString(e.RawData).StartsWith("ASP.NET Core HTTPS development certificate"));
+                        e.RawData[0] == manager.AspNetHttpsCertificateVersion);
 
                 Assert.Equal(httpsCertificate.GetCertHashString(), exportedCertificate.GetCertHashString());
 
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             }
         }
 
-        [Fact(Skip = "true")]
+        [Fact(Skip = "Modifies global machine state")]
         public void EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates()
         {
             // Arrange
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Equal(httpsCertificate.GetCertHashString(), exportedCertificate.GetCertHashString());
         }
 
-        [Fact(Skip = "true")]
+        [Fact(Skip = "Modifies global machine state")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateIfVersionIsIncorrect()
         {
             var manager = new CertificateManager();
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact(Skip = "true")]
+        [Fact(Skip = "Modifies global machine state")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateForEmptyVersionField()
         {
             var manager = new CertificateManager();
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact(Skip = "true")]
+        [Fact(Skip = "Modifies global machine state")]
         public void EnsureCreateHttpsCertificate_ReturnsValidIfVersionIsZero()
         {
             var manager = new CertificateManager();
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.NotEmpty(httpsCertificateList);
         }
 
-        [Fact(Skip = "true")]
+        [Fact(Skip = "Modifies global machine state")]
         public void EnsureCreateHttpsCertificate_ReturnValidIfCertIsNewer()
         {
             var manager = new CertificateManager();

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
 
         public ITestOutputHelper Output { get; }
 
-        [Fact]
+        [Fact(Skip = "true")]
         public void EnsureCreateHttpsCertificate_CreatesACertificate_WhenThereAreNoHttpsCertificates()
         {
             try
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Equal(httpsCertificate.GetCertHashString(), exportedCertificate.GetCertHashString());
         }
 
-        [Fact]
+        [Fact(Skip = "true")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateIfVersionIsIncorrect()
         {
             var manager = new CertificateManager();
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact]
+        [Fact(Skip = "true")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateForEmptyVersionField()
         {
             var manager = new CertificateManager();
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact]
+        [Fact(Skip = "true")]
         public void EnsureCreateHttpsCertificate_ReturnsValidIfVersionIsZero()
         {
             var manager = new CertificateManager();
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.NotEmpty(httpsCertificateList);
         }
 
-        [Fact]
+        [Fact(Skip = "true")]
         public void EnsureCreateHttpsCertificate_ReturnValidIfCertIsNewer()
         {
             var manager = new CertificateManager();
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             now = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, 0, now.Offset);
             var trustFailed = manager.EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1), path: null, trust: true, subject: TestCertificateSubject);
 
-            Assert.Equal(EnsureCertificateResult.UserCancelledTrustStep, trustFailed);
+            Assert.Equal(EnsureCertificateResult.UserCancelledTrustStep, trustFailed.ResultCode);
         }
 
         [Fact(Skip = "Requires user interaction")]

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
 
         public ITestOutputHelper Output { get; }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_CreatesACertificate_WhenThereAreNoHttpsCertificates()
         {
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates()
         {
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Equal(httpsCertificate.GetCertHashString(), exportedCertificate.GetCertHashString());
         }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateIfVersionIsIncorrect()
         {
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateForEmptyVersionField()
         {
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnsValidIfVersionIsZero()
         {
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.NotEmpty(httpsCertificateList);
         }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnValidIfCertIsNewer()
         {

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,7 +25,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
 
         public ITestOutputHelper Output { get; }
 
-        [Fact(Skip = "Modifies global machine state")]
+        [Fact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_CreatesACertificate_WhenThereAreNoHttpsCertificates()
         {
             try
@@ -123,7 +125,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             }
         }
 
-        [Fact(Skip = "Modifies global machine state")]
+        [Fact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates()
         {
             // Arrange
@@ -159,7 +162,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Equal(httpsCertificate.GetCertHashString(), exportedCertificate.GetCertHashString());
         }
 
-        [Fact(Skip = "Modifies global machine state")]
+        [Fact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateIfVersionIsIncorrect()
         {
             var manager = new CertificateManager();
@@ -180,7 +184,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact(Skip = "Modifies global machine state")]
+        [Fact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateForEmptyVersionField()
         {
             var manager = new CertificateManager();
@@ -202,7 +207,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Empty(httpsCertificateList);
         }
 
-        [Fact(Skip = "Modifies global machine state")]
+        [Fact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnsValidIfVersionIsZero()
         {
             var manager = new CertificateManager();
@@ -222,7 +228,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.NotEmpty(httpsCertificateList);
         }
 
-        [Fact(Skip = "Modifies global machine state")]
+        [Fact]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/6721")]
         public void EnsureCreateHttpsCertificate_ReturnValidIfCertIsNewer()
         {
             var manager = new CertificateManager();

--- a/src/Tools/README.md
+++ b/src/Tools/README.md
@@ -30,3 +30,6 @@ Add `--help` to see more details. For example,
 ```
 dotnet watch --help
 ```
+
+To test any of these projects, do the following:
+

--- a/src/Tools/README.md
+++ b/src/Tools/README.md
@@ -30,6 +30,3 @@ Add `--help` to see more details. For example,
 ```
 dotnet watch --help
 ```
-
-To test any of these projects, do the following:
-

--- a/src/Tools/Tools.sln
+++ b/src/Tools/Tools.sln
@@ -7,6 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-watch", "dotnet-watc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-watch.Tests", "dotnet-watch\test\dotnet-watch.Tests.csproj", "{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-dev-certs", "dotnet-dev-certs\src\dotnet-dev-certs.csproj", "{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.DeveloperCertificates.XPlat", "FirstRunCertGenerator\src\Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj", "{7BBDBDA2-299F-4C36-8338-23C525901DE0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.DeveloperCertificates.XPlat.Tests", "FirstRunCertGenerator\test\Microsoft.AspNetCore.DeveloperCertificates.XPlat.Tests.csproj", "{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +27,18 @@ Global
 		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63F7E822-D1E2-4C41-8ABF-60B9E3A9C54C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D6D5693-7E0C-4FE8-B4AA-21207B2650AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BBDBDA2-299F-4C36-8338-23C525901DE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EC6FA27-40A5-433F-8CA1-636E7ED8863E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                             (check.HasValue() && (exportPath.HasValue() || password.HasValue() || clean.HasValue())))
                         {
                             reporter.Error(@"Incompatible set of flags. Sample usages
+'dotnet dev-certs https'
 'dotnet dev-certs https --clean'
 'dotnet dev-certs https --check --trust'
 'dotnet dev-certs https -ep ./certificate.pfx -p password --trust'");
@@ -133,7 +134,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 }
 
                 manager.CleanupHttpsCertificates();
-                reporter.Verbose("HTTPS development certificates successfully removed from the machine.");
+                reporter.Output("HTTPS development certificates successfully removed from the machine.");
                 return Success;
             }
             catch(Exception e)
@@ -152,12 +153,12 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
             var certificates = certificateManager.ListCertificates(CertificatePurpose.HTTPS, StoreName.My, StoreLocation.CurrentUser, isValid: true);
             if (certificates.Count == 0)
             {
-                reporter.Verbose("No valid certificate found.");
+                reporter.Output("No valid certificate found.");
                 return ErrorNoValidCertificateFound;
             }
             else
             {
-                reporter.Verbose("A valid certificate was found.");
+                reporter.Output("A valid certificate was found.");
             }
 
             if (trust != null && trust.HasValue())
@@ -166,13 +167,13 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 var trustedCertificates = certificateManager.ListCertificates(CertificatePurpose.HTTPS, store, StoreLocation.CurrentUser, isValid: true);
                 if (!certificates.Any(c => certificateManager.IsTrusted(c)))
                 {
-                    reporter.Verbose($@"The following certificates were found, but none of them is trusted:
+                    reporter.Output($@"The following certificates were found, but none of them is trusted:
 {string.Join(Environment.NewLine, certificates.Select(c => $"{c.Subject} - {c.Thumbprint}"))}");
                     return ErrorCertificateNotTrusted;
                 }
                 else
                 {
-                    reporter.Verbose("A trusted certificate was found.");
+                    reporter.Output("A trusted certificate was found.");
                 }
             }
 
@@ -207,7 +208,9 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 password.HasValue(),
                 password.Value());
 
-            switch (result)
+            reporter.Verbose(string.Join(Environment.NewLine, result.Diagnostics.Messages));
+
+            switch (result.ResultCode)
             {
                 case EnsureCertificateResult.Succeeded:
                     reporter.Output("The HTTPS developer certificate was generated successfully.");


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/9810

Also does a few cleanup items:
- Uses EnsureValidCertificateExists that returns diagnostic info.
- Increases log level on dotnet dev-certs https --check to info rather than verbose.