### PR TITLE
Added more logs to unix domain sockets test

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -118,6 +118,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                     // A call was made to UnbindAsync/DisposeAsync just return null which signals we're done
                     return null;
                 }
+                catch (SocketException e) when (e.SocketErrorCode == SocketError.OperationAborted)
+                {
+                    // A call was made to UnbindAsync/DisposeAsync just return null which signals we're done
+                    return null;
+                }
                 catch (SocketException)
                 {
                     // The connection got reset while it was in the backlog, so we try again.

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -49,6 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                             if (result.IsCompleted)
                             {
+                                Logger.LogDebug("Application receive loop ending for connection {connectionId}.", connection.ConnectionId);
                                 break;
                             }
 
@@ -59,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     }
                     catch (OperationCanceledException)
                     {
-
+                        Logger.LogDebug("Graceful shutdown triggered for {connectionId}.", connection.ConnectionId);
                     }
                 }
 


### PR DESCRIPTION
- The current theory is that the tests are experiencing starvation so add more logs to see if if anything in the application is running between the FIN being received on the server side and application code receiving the notification that the pipe was completed.
- Detect OperationAborted to avoid the connection reset log.

More data for https://github.com/aspnet/AspNetCore-Internal/issues/2614