### PR TITLE
Undo MVC breaking change

### DIFF
--- a/src/Identity/test/Identity.FunctionalTests/Infrastructure/ServerFactory.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Infrastructure/ServerFactory.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,9 +42,16 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
             });
         }
 
-        public override void EnsureDatabaseCreated()
+        protected override TestServer CreateServer(IWebHostBuilder builder)
         {
-            using (var scope = Services.CreateScope())
+            var result = base.CreateServer(builder);
+            EnsureDatabaseCreated(result);
+            return result;
+        }
+
+        public void EnsureDatabaseCreated(TestServer server)
+        {
+            using (var scope = server.Host.Services.CreateScope())
             {
                 scope.ServiceProvider.GetService<TContext>().Database.EnsureCreated();
             }

--- a/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -289,8 +289,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
 
             var server = ServerFactory.WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
 
-            ServerFactory.EnsureDatabaseCreated();
-
             var client = server.CreateClient();
             var newClient = server.CreateClient();
 
@@ -312,8 +310,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
                 .SetupTestEmailSender(emailSender);
 
             var server = ServerFactory.WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
-
-            ServerFactory.EnsureDatabaseCreated();
 
             var client = server.CreateClient();
             var resetPasswordClient = server.CreateClient();

--- a/src/Identity/test/Identity.FunctionalTests/ManagementTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/ManagementTests.cs
@@ -289,8 +289,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
                 .WithWebHostBuilder(whb => whb.ConfigureTestServices(ConfigureTestServices))
                 .CreateClient();
 
-            ServerFactory.EnsureDatabaseCreated();
-
             var userName = $"{Guid.NewGuid()}@example.com";
             var guid = Guid.NewGuid();
             var email = userName;

--- a/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
@@ -31,8 +31,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
                     .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
                     .CreateClient();
 
-            ServerFactory.EnsureDatabaseCreated();
-
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = $"!Test.Password1$";
 
@@ -50,8 +48,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
                     .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
             var client = server.CreateClient();
             var client2 = server.CreateClient();
-
-            ServerFactory.EnsureDatabaseCreated();
 
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = $"!Test.Password1$";
@@ -85,8 +81,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
             var client = server.CreateClient();
             var client2 = server.CreateClient();
 
-            ServerFactory.EnsureDatabaseCreated();
-
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = $"!Test.Password1$";
 
@@ -108,8 +102,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
                     .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
                     .CreateClient();
 
-            ServerFactory.EnsureDatabaseCreated();
-
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = $"!Test.Password1$";
 
@@ -128,8 +120,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
             var client = ServerFactory
                 .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
                 .CreateClient();
-
-            ServerFactory.EnsureDatabaseCreated();
 
             var guid = Guid.NewGuid();
             var userName = $"{guid}";
@@ -151,8 +141,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
                 .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
                 .CreateClient();
 
-            ServerFactory.EnsureDatabaseCreated();
-
             var guid = Guid.NewGuid();
             var userName = $"{guid}";
             var email = $"{guid}@example.com";
@@ -173,8 +161,6 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
             var client = ServerFactory
                 .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
                 .CreateClient();
-
-            ServerFactory.EnsureDatabaseCreated();
 
             var guid = Guid.NewGuid();
             var userName = $"{guid}";

--- a/src/Mvc/Mvc.Testing/ref/Microsoft.AspNetCore.Mvc.Testing.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Testing/ref/Microsoft.AspNetCore.Mvc.Testing.netcoreapp3.0.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         protected virtual Microsoft.AspNetCore.Hosting.IWebHostBuilder CreateWebHostBuilder() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public virtual void EnsureDatabaseCreated() { }
         ~WebApplicationFactory() { }
         protected virtual System.Collections.Generic.IEnumerable<System.Reflection.Assembly> GetTestAssemblies() { throw null; }
         public Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint> WithWebHostBuilder(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder> configuration) { throw null; }

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -162,12 +162,6 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             SetContentRoot(builder);
             _configuration(builder);
             _server = CreateServer(builder);
-
-            EnsureDatabaseCreated();
-        }
-
-        public virtual void EnsureDatabaseCreated()
-        {
         }
 
         private void SetContentRoot(IWebHostBuilder builder)


### PR DESCRIPTION
I ran into this the other day. Microsoft.AspNetCore.Mvc.Testing is part of the product and should not have any knowledge about the database.

I removed the breaking change and updated the code in Identity UI to achieve the same thing in a non-breaking way.
