### PR TITLE
Disable bundle localization for Preview 6

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -8,7 +8,6 @@
                                                     SuppressOptionsUI="yes"
                                                     ThemeFile="thm.xml"
                                                     LocalizationFile="thm.wxl"/>
-            <PayloadGroupRef Id="PG_Resources"/>
         </BootstrapperApplicationRef>
 
         <!-- Ensure upgrades from 3.0.0 preview 1, 2, and 3. Conditioned for the 3.0.0 family. -->
@@ -23,12 +22,6 @@
         <RelatedBundle Action="Upgrade" Id="{FDCA5106-C69E-34BB-A3B8-A24ADD0B4769}"/>
         <?endif?>
         <?endif?>
-
-        <PayloadGroup Id="PG_Resources">
-            <?foreach lcid in 2052;1028;1029;1031;3082;1036;1040;1041;1042;1045;1046;1049;1055?>
-            <Payload Id="PL_thm_$(var.lcid)" SourceFile="$(var.lcid)\thm.wxl" Name="$(var.lcid)\thm.wxl" Compressed="yes"/>
-            <?endforeach?>
-        </PayloadGroup>
 
         <!-- Customizations of the default BA -->
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -9,7 +9,6 @@
                                                     SuppressOptionsUI="yes"
                                                     ThemeFile="thm.xml"
                                                     LocalizationFile="thm.wxl"/>
-            <PayloadGroupRef Id="PG_Resources"/>
         </BootstrapperApplicationRef>
 
         <!-- Ensure upgrades from 3.0.0 preview 1 and 2 (Preview 3 was not shipped). Conditioned for the 3.0.0 family. Hosting bundle simships x86/x64 so there's
@@ -18,13 +17,6 @@
         <RelatedBundle Action="Upgrade" Id="{D8BFC3A1-72B1-36C1-9E5A-49FE36A5563B}"/>
         <RelatedBundle Action="Upgrade" Id="{EA47395A-BC9B-3ECC-8229-229BC9528DF6}"/>
         <?endif?>
-
-        <PayloadGroup Id="PG_Resources">
-          <?foreach lcid in 2052;1028;1029;1031;3082;1036;1040;1041;1042;1045;1046;1049;1055?>
-            <Payload Id="PL_thm_$(var.lcid)" SourceFile="$(var.lcid)\thm.wxl" Name="$(var.lcid)\thm.wxl" Compressed="yes"/>
-            <Payload Id="PL_Strings_$(var.lcid)" SourceFile="$(var.lcid)\Strings.wxl" Name="$(var.lcid)\Strings.wxl" Compressed="yes"/> 
-          <?endforeach?>
-        </PayloadGroup>
 
         <!-- Customizations of the default BA -->
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />


### PR DESCRIPTION
Too little time to test the update localization full. Turning it off for Preview 6
