### PR TITLE
Prefer File.Move for DataProtection key creation + Fallback

### DIFF
--- a/src/DataProtection/DataProtection/src/Repositories/FileSystemXmlRepository.cs
+++ b/src/DataProtection/DataProtection/src/Repositories/FileSystemXmlRepository.cs
@@ -143,8 +143,16 @@ namespace Microsoft.AspNetCore.DataProtection.Repositories
                 // Renames are atomic operations on the file systems we support.
                 _logger.WritingDataToFile(finalFilename);
 
-                // Use File.Copy because File.Move on NFS shares has issues in .NET Core 2.0
-                File.Copy(tempFilename, finalFilename);
+                try
+                {
+                    // Prefer the atomic move operation to avoid multi-process startup issues
+                    File.Move(tempFilename, finalFilename);
+                }
+                catch (IOException)
+                {
+                    // Use File.Copy because File.Move on NFS shares has issues in .NET Core 2.0
+                    File.Copy(tempFilename, finalFilename);
+                }
             }
             finally
             {

--- a/src/DataProtection/DataProtection/src/Repositories/FileSystemXmlRepository.cs
+++ b/src/DataProtection/DataProtection/src/Repositories/FileSystemXmlRepository.cs
@@ -151,6 +151,7 @@ namespace Microsoft.AspNetCore.DataProtection.Repositories
                 catch (IOException)
                 {
                     // Use File.Copy because File.Move on NFS shares has issues in .NET Core 2.0
+                    // See https://github.com/aspnet/AspNetCore/issues/2941 for more context
                     File.Copy(tempFilename, finalFilename);
                 }
             }

--- a/src/Security/Authentication/test/SecureDataFormatTests.cs
+++ b/src/Security/Authentication/test/SecureDataFormatTests.cs
@@ -48,8 +48,7 @@ namespace Microsoft.AspNetCore.Authentication.DataHandler
             Assert.Equal(input, result);
         }
 
-        [ConditionalFact]
-        [SkipOnHelix("https://github.com/aspnet/AspNetCore-Internal/issues/1974")]
+        [Fact]
         public void UnprotectWithDifferentPurposeFails()
         {
             var provider = ServiceProvider.GetRequiredService<IDataProtectionProvider>();


### PR DESCRIPTION
We changed from `File.Move` (which is atomic) to `File.Copy` because `File.Move` has issues when using NFS.
You can read the original here: https://github.com/aspnet/AspNetCore/issues/2941

The proposed change is to keep the preferred atomic operation and fallback to `Copy` when `Move` doesn't work.

This does mean there can still be issues on NFS because we are using `Copy` but the only solution (I know of) to that would be to write our own Pinvoke code to use rename on Unix systems instead of link/unlink (which is what `File.Move` does).