### PR TITLE
Reduce allocations when Activity is enabled

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
         }
 
-        // These are versions of DiagnosticSource.Star/StopActivity that don't allocate strings per call (see https://github.com/dotnet/corefx/issues/37055)
+        // These are versions of DiagnosticSource.Start/StopActivity that don't allocate strings per call (see https://github.com/dotnet/corefx/issues/37055)
         private Activity StartActivity(Activity activity, HttpContext httpContext)
         {
             activity.Start();

--- a/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
+++ b/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
@@ -24,6 +24,8 @@ namespace Microsoft.AspNetCore.Http
         public override Microsoft.AspNetCore.Http.ConnectionInfo Connection { get { throw null; } }
         public override Microsoft.AspNetCore.Http.Features.IFeatureCollection Features { get { throw null; } }
         public Microsoft.AspNetCore.Http.Features.FormOptions FormOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public Microsoft.AspNetCore.Http.HttpContext HttpContext { get { throw null; } }
         public override System.Collections.Generic.IDictionary<object, object> Items { get { throw null; } set { } }
         public override Microsoft.AspNetCore.Http.HttpRequest Request { get { throw null; } }
         public override System.Threading.CancellationToken RequestAborted { get { throw null; } set { } }

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -157,6 +157,11 @@ namespace Microsoft.AspNetCore.Http
             }
         }
 
+        // This property exists because of backwards compatibility.
+        // We send an anonymous object with an HttpContext property
+        // via DiagnosticSource in various events throughout the pipeline. Instead
+        // we just send the HttpContext to avoid extra allocations
+        public HttpContext HttpContext => this;
 
         public override void Abort()
         {

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Security.Claims;
 using System.Threading;
 using Microsoft.AspNetCore.Http.Features;
@@ -161,6 +162,7 @@ namespace Microsoft.AspNetCore.Http
         // We send an anonymous object with an HttpContext property
         // via DiagnosticSource in various events throughout the pipeline. Instead
         // we just send the HttpContext to avoid extra allocations
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public HttpContext HttpContext => this;
 
         public override void Abort()


### PR DESCRIPTION
- Remove string allocations caused by DiagnosticSource.Stop/StartActivity
- Pass the HttpContext directly as the object for StartActivity and StopActivity to avoid the anonymous object allocation.
- Though it's a bit ugly, added an HttpContext property to DefaultHttpContext to avoid breaking back-compat (which had to do reflection to get the HttpContext property anyways)

Contributes to #9594

Before:
![image](https://user-images.githubusercontent.com/95136/59157417-e8df0680-8a5e-11e9-850e-d879e3bf14f7.png)

After:
![image](https://user-images.githubusercontent.com/95136/59157432-22b00d00-8a5f-11e9-8be7-973a62bc783a.png)
