### PR TITLE
HeaderProgation middleware: logger scope

### DIFF
--- a/src/Middleware/HeaderPropagation/ref/Microsoft.AspNetCore.HeaderPropagation.netcoreapp3.0.cs
+++ b/src/Middleware/HeaderPropagation/ref/Microsoft.AspNetCore.HeaderPropagation.netcoreapp3.0.cs
@@ -6,6 +6,7 @@ namespace Microsoft.AspNetCore.Builder
     public static partial class HeaderPropagationApplicationBuilderExtensions
     {
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseHeaderPropagation(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) { throw null; }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseHeaderPropagation(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, bool includeInLoggerScope) { throw null; }
     }
 }
 namespace Microsoft.AspNetCore.HeaderPropagation
@@ -33,6 +34,11 @@ namespace Microsoft.AspNetCore.HeaderPropagation
         public void Add(string headerName, System.Func<Microsoft.AspNetCore.HeaderPropagation.HeaderPropagationContext, Microsoft.Extensions.Primitives.StringValues> valueFilter) { }
         public void Add(string inboundHeaderName, string outboundHeaderName) { }
         public void Add(string inboundHeaderName, string outboundHeaderName, System.Func<Microsoft.AspNetCore.HeaderPropagation.HeaderPropagationContext, Microsoft.Extensions.Primitives.StringValues> valueFilter) { }
+    }
+    public partial class HeaderPropagationLoggerScopeMiddleware
+    {
+        public HeaderPropagationLoggerScopeMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILogger<Microsoft.AspNetCore.HeaderPropagation.HeaderPropagationLoggerScopeMiddleware> logger, Microsoft.AspNetCore.HeaderPropagation.IHeaderPropagationLoggerScopeBuilder loggerScopeBuilder) { }
+        public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
     }
     public partial class HeaderPropagationMessageHandler : System.Net.Http.DelegatingHandler
     {
@@ -69,7 +75,9 @@ namespace Microsoft.AspNetCore.HeaderPropagation
     public partial class HeaderPropagationValues
     {
         public HeaderPropagationValues() { }
-        public System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> Headers { get { throw null; } set { } }
+    }
+    public partial interface IHeaderPropagationLoggerScopeBuilder
+    {
     }
 }
 namespace Microsoft.Extensions.DependencyInjection

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/HeaderPropagationSample.csproj
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/HeaderPropagationSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -11,5 +11,6 @@
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 </Project>

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Program.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace HeaderPropagationSample
 {
@@ -16,6 +17,8 @@ namespace HeaderPropagationSample
                 {
                     webBuilder.UseKestrel();
                     webBuilder.UseStartup<Startup>();
-                });
+                })
+                .ConfigureLogging((hostingContext, logging) =>
+                    logging.AddConsole(options => options.IncludeScopes = true));
     }
 }

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
@@ -58,7 +58,9 @@ namespace HeaderPropagationSample
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseHeaderPropagation();
+            // Add the propagated headers Middleware
+            // and configure it to include the propagated headers to the logger scope.
+            app.UseHeaderPropagation(includeInLoggerScope: true);
 
             app.UseRouting();
 

--- a/src/Middleware/HeaderPropagation/src/DependencyInjection/HeaderPropagationApplicationBuilderExtensions.cs
+++ b/src/Middleware/HeaderPropagation/src/DependencyInjection/HeaderPropagationApplicationBuilderExtensions.cs
@@ -34,5 +34,23 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.UseMiddleware<HeaderPropagationMiddleware>();
         }
+
+        /// <summary>
+        /// Adds a middleware that collect headers to be propagated to a <see cref="HttpClient"/>.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+        /// <param name="includeInLoggerScope">Includes the captured headers in the logger scope.</param>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
+        public static IApplicationBuilder UseHeaderPropagation(this IApplicationBuilder app, bool includeInLoggerScope)
+        {
+            app.UseHeaderPropagation();
+
+            if (includeInLoggerScope)
+            {
+                app.UseMiddleware<HeaderPropagationLoggerScopeMiddleware>();
+            }
+
+            return app;
+        }
     }
 }

--- a/src/Middleware/HeaderPropagation/src/DependencyInjection/HeaderPropagationServiceCollectionExtensions.cs
+++ b/src/Middleware/HeaderPropagation/src/DependencyInjection/HeaderPropagationServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.TryAddSingleton<HeaderPropagationValues>();
+            services.TryAddSingleton<IHeaderPropagationLoggerScopeBuilder, HeaderPropagationLoggerScopeBuilder>();
 
             return services;
         }

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationLoggerScope.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationLoggerScope.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.HeaderPropagation
+{
+    internal class HeaderPropagationLoggerScope : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        private readonly List<string> _headerNames;
+        private readonly IDictionary<string, StringValues> _headerValues;
+        private string _cachedToString;
+
+        public HeaderPropagationLoggerScope(List<string> headerNames, IDictionary<string, StringValues> headerValues)
+        {
+            _headerNames = headerNames ?? throw new ArgumentNullException(nameof(headerNames));
+            _headerValues = headerValues ?? throw new ArgumentNullException(nameof(headerValues));
+        }
+
+        public int Count => _headerNames.Count;
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                var headerName = _headerNames[index];
+                _headerValues.TryGetValue(headerName, out var value);
+                return new KeyValuePair<string, object>(headerName, value);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            if (_cachedToString == null)
+            {
+                var sb = new StringBuilder();
+
+                for (int i = 0; i < Count; i++)
+                {
+                    if (i > 0) sb.Append(' ');
+
+                    var headerName = _headerNames[i];
+                    _headerValues.TryGetValue(headerName, out var value);
+
+                    sb.Append(string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0}:{1}",
+                        headerName, value.ToString()));
+                }
+
+                _cachedToString = sb.ToString();
+            }
+
+            return _cachedToString;
+        }
+    }
+}

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationLoggerScopeBuilder.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationLoggerScopeBuilder.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.HeaderPropagation
+{
+
+    /// <summary>
+    /// A builder to build the <see cref="HeaderPropagationLoggerScope"/> for the <see cref="HeaderPropagationMiddleware"/>.
+    /// </summary>
+    internal class HeaderPropagationLoggerScopeBuilder : IHeaderPropagationLoggerScopeBuilder
+    {
+        private readonly List<string> _headerNames = new List<string>();
+        private readonly HeaderPropagationValues _values;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="HeaderPropagationLoggerScopeBuilder"/>.
+        /// </summary>
+        /// <param name="options">The options that define which headers are propagated.</param>
+        /// <param name="values">The values of the headers to be propagated populated by the
+        /// <see cref="HeaderPropagationMiddleware"/>.</param>
+        public HeaderPropagationLoggerScopeBuilder(IOptions<HeaderPropagationOptions> options, HeaderPropagationValues values)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            var headers = options.Value.Headers;
+
+            _values = values ?? throw new ArgumentNullException(nameof(values));
+
+            var uniqueHeaderNames = new HashSet<string>();
+
+            // Perf: not using directly the HashSet so we can iterate without allocating an enumerator
+            // and avoiding foreach since we don't define a struct-enumerator.
+            for (var i = 0; i < headers.Count; i++)
+            {
+                var headerName = headers[i].CapturedHeaderName;
+                if (uniqueHeaderNames.Add(headerName))
+                {
+                    _headerNames.Add(headerName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Build the <see cref="HeaderPropagationLoggerScope"/> for the current async context.
+        /// </summary>
+        HeaderPropagationLoggerScope IHeaderPropagationLoggerScopeBuilder.Build() =>
+            new HeaderPropagationLoggerScope(_headerNames, _values.Headers);
+    }
+}

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationLoggerScopeMiddleware.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationLoggerScopeMiddleware.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.HeaderPropagation
+{
+    public class HeaderPropagationLoggerScopeMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<HeaderPropagationLoggerScopeMiddleware> _logger;
+        private readonly IHeaderPropagationLoggerScopeBuilder _loggerScopeBuilder;
+
+        public HeaderPropagationLoggerScopeMiddleware(RequestDelegate next, ILogger<HeaderPropagationLoggerScopeMiddleware> logger, IHeaderPropagationLoggerScopeBuilder loggerScopeBuilder)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _loggerScopeBuilder = loggerScopeBuilder ?? throw new ArgumentNullException(nameof(loggerScopeBuilder));
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            using (_logger.BeginScope(_loggerScopeBuilder.Build()))
+            {
+                return _next.Invoke(context);
+            }
+        }
+    }
+}

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationValues.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationValues.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.HeaderPropagation
@@ -23,7 +21,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
         /// <remarks>
         /// The keys of <see cref="Headers"/> correspond to <see cref="HeaderPropagationEntry.CapturedHeaderName"/>.
         /// </remarks>
-        public IDictionary<string, StringValues> Headers
+        internal IDictionary<string, StringValues> Headers
         {
             get
             {

--- a/src/Middleware/HeaderPropagation/src/IHeaderPropagationLoggerScopeBuilder.cs
+++ b/src/Middleware/HeaderPropagation/src/IHeaderPropagationLoggerScopeBuilder.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.HeaderPropagation
+{
+    /// <summary>
+    /// A builder to build the <see cref="HeaderPropagationLoggerScope"/> for the <see cref="HeaderPropagationMiddleware"/>.
+    /// </summary>
+    public interface IHeaderPropagationLoggerScopeBuilder
+    {
+        /// <summary>
+        /// Build the <see cref="HeaderPropagationLoggerScope"/> for the current async context.
+        /// </summary>
+        internal HeaderPropagationLoggerScope Build();
+    }
+}

--- a/src/Middleware/HeaderPropagation/src/Microsoft.AspNetCore.HeaderPropagation.csproj
+++ b/src/Middleware/HeaderPropagation/src/Microsoft.AspNetCore.HeaderPropagation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ASP.NET Core middleware to propagate HTTP headers from the incoming request to the outgoing HTTP Client requests</Description>
@@ -8,10 +8,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;httpclient</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.AspNetCore.HeaderPropagation.Tests" />
-  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http" />

--- a/src/Middleware/HeaderPropagation/src/Properties/AssemblyInfo.cs
+++ b/src/Middleware/HeaderPropagation/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.AspNetCore.HeaderPropagation.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Middleware/HeaderPropagation/test/HeaderPropagationLoggerScopeBuilderTest.cs
+++ b/src/Middleware/HeaderPropagation/test/HeaderPropagationLoggerScopeBuilderTest.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.HeaderPropagation.Tests
+{
+    public class HeaderPropagationLoggerScopeBuilderTest
+    {
+        public HeaderPropagationLoggerScopeBuilderTest()
+        {
+            Options = new HeaderPropagationOptions();
+            Values = new HeaderPropagationValues()
+            {
+                Headers = new Dictionary<string, StringValues>()
+            };
+        }
+
+        public HeaderPropagationOptions Options { get; set; }
+        public HeaderPropagationValues Values { get; set; }
+
+        [Fact]
+        public void NoPropagatedHeaders_EmptyScope()
+        {
+            // Arrange
+            IHeaderPropagationLoggerScopeBuilder builder = CreateBuilder();
+
+            // Act
+            var scope = builder.Build();
+
+            // Assert
+            Assert.Empty(scope);
+            Assert.Empty(scope.ToString());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void PropagatedHeaderHasValue_AddValueInScope_WithoutDuplicates(int times)
+        {
+            // Arrange
+            for (var i = 0; i < times; i++)
+            {
+                Options.Headers.Add("foo");
+            }
+            Values.Headers.Add("foo", "bar");
+            IHeaderPropagationLoggerScopeBuilder builder = new HeaderPropagationLoggerScopeBuilder(
+                new OptionsWrapper<HeaderPropagationOptions>(Options),
+                Values);
+
+            // Act
+            var scope = builder.Build();
+
+            // Assert
+            Assert.Single(scope);
+            var entry = scope[0];
+            Assert.Equal("foo", entry.Key);
+            Assert.IsType<StringValues>(entry.Value);
+            Assert.Equal("bar", (StringValues)entry.Value);
+            Assert.Equal("foo:bar", scope.ToString());
+        }
+
+        private IHeaderPropagationLoggerScopeBuilder CreateBuilder() =>
+            new HeaderPropagationLoggerScopeBuilder(new OptionsWrapper<HeaderPropagationOptions>(Options), Values);
+
+    }
+}

--- a/src/Middleware/HeaderPropagation/test/HeaderPropagationLoggerScopeMiddlewareTest.cs
+++ b/src/Middleware/HeaderPropagation/test/HeaderPropagationLoggerScopeMiddlewareTest.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.HeaderPropagation.Tests
+{
+    public class HeaderPropagationLoggerScopeMiddlewareTest
+    {
+        public HeaderPropagationLoggerScopeMiddlewareTest()
+        {
+            Context = new DefaultHttpContext();
+            Next = ctx => Task.CompletedTask;
+            Logger = new TestLogger<HeaderPropagationLoggerScopeMiddleware>();
+            Builder = new TestHeaderPropagationLoggerScopeBuilder();
+
+            Middleware = new HeaderPropagationLoggerScopeMiddleware(Next, Logger, Builder);
+        }
+
+        public DefaultHttpContext Context { get; set; }
+        public RequestDelegate Next { get; set; }
+        public TestLogger<HeaderPropagationLoggerScopeMiddleware> Logger { get; set; }
+        public TestHeaderPropagationLoggerScopeBuilder Builder { get; set; }
+        public HeaderPropagationLoggerScopeMiddleware Middleware { get; set; }
+
+        [Fact]
+        public async Task GetsScopeFromBuilderAndAddsItToLogger()
+        {
+            // Act
+            await Middleware.Invoke(Context);
+
+            // Assert
+            Assert.NotNull(Logger.Scope);
+            Assert.Same(Builder.Scope, Logger.Scope);
+        }
+    }
+
+    public class TestHeaderPropagationLoggerScopeBuilder : IHeaderPropagationLoggerScopeBuilder
+    {
+        internal HeaderPropagationLoggerScope Scope { get; set; } =
+            new HeaderPropagationLoggerScope(new List<string>(), new Dictionary<string, StringValues>());
+
+        HeaderPropagationLoggerScope IHeaderPropagationLoggerScopeBuilder.Build() => Scope;
+    }
+
+    public class TestLogger<T> : ILogger<T>
+    {
+        public object Scope { get; private set; }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            Scope = state;
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+        }
+    }
+}

--- a/src/Middleware/HeaderPropagation/test/HeaderPropagationLoggerScopeTest.cs
+++ b/src/Middleware/HeaderPropagation/test/HeaderPropagationLoggerScopeTest.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.HeaderPropagation.Tests
+{
+    public class HeaderPropagationLoggerScopeTest
+    {
+        [Fact]
+        public void NoPropagatedHeaders_EmptyScope()
+        {
+            // Arrange
+            var headerNames = new List<string>();
+            var headerValues = new Dictionary<string, StringValues>();
+
+            // Act
+            var scope = new HeaderPropagationLoggerScope(headerNames, headerValues);
+
+            // Assert
+            Assert.Empty(scope);
+            Assert.Empty(scope.ToString());
+        }
+
+        [Fact]
+        public void PropagatedHeaderHasValue_AddsValueInScope()
+        {
+            // Arrange
+            var headerNames = new List<string> { "foo" };
+            var headerValues = new Dictionary<string, StringValues> { ["foo"] = "bar" };
+
+            // Act
+            var scope = new HeaderPropagationLoggerScope(headerNames, headerValues);
+
+            // Assert
+            Assert.Single(scope);
+            var entry = scope[0];
+            Assert.Equal("foo", entry.Key);
+            Assert.IsType<StringValues>(entry.Value);
+            Assert.Equal("bar", (StringValues)entry.Value);
+            Assert.Equal("foo:bar", scope.ToString());
+        }
+
+        [Fact]
+        public void PropagatedHeaderHasNoValue_AddsValueInScopeWithoutValue()
+        {
+            // Arrange
+            var headerNames = new List<string> { "foo" };
+            var headerValues = new Dictionary<string, StringValues>();
+
+            // Act
+            var scope = new HeaderPropagationLoggerScope(headerNames, headerValues);
+
+            // Assert
+            Assert.Single(scope);
+            var entry = scope[0];
+            Assert.Equal("foo", entry.Key);
+            Assert.IsType<StringValues>(entry.Value);
+            Assert.Empty((StringValues)entry.Value);
+            Assert.Equal("foo:", scope.ToString());
+        }
+
+        [Fact]
+        public void MultiplePropagatedHeadersHaveValue_AddsAllInScopeInOrder()
+        {
+            // Arrange
+            var headerNames = new List<string> { "foo", "answer" };
+            var headerValues = new Dictionary<string, StringValues> {
+                ["foo"] = "bar",
+                ["answer"] = "42"
+            };
+
+            // Act
+            var scope = new HeaderPropagationLoggerScope(headerNames, headerValues);
+
+            // Assert
+            Assert.Equal(2, scope.Count);
+            var entry = scope[0];
+            Assert.Equal("foo", entry.Key);
+            Assert.IsType<StringValues>(entry.Value);
+            Assert.Equal("bar", (StringValues)entry.Value);
+            entry = scope[1];
+            Assert.Equal("answer", entry.Key);
+            Assert.IsType<StringValues>(entry.Value);
+            Assert.Equal("42", (StringValues)entry.Value);
+            Assert.Equal("foo:bar answer:42", scope.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This add the headers captured by the `HeaderProgation` middleware into the logger scope.

I understand that it is not current practice to have official Middlewares add information to the logger scope, however I believe it's a reasonable requirement to tag the log entries with the propagated header values.
Currently it could be achieved anyway, but, when relying on the valuefactory to determine the values, it requires to access the captured headers (but how they are stored should be an internal implementation details) and a bit of code.

Features
 - Opt-in behaviour
 - Headers are added to the scope using the `PropagatedName`
 - When formatted as string, the scope uses `space` as separator:
   - it looks like there is no specific convention as I found used either `space` or `comma` as separator, even inside the same scope. Am I missing something?
   - In this context `space` makes sense as comma is already used to separate multiple values (behaviour of `StringValues`)
 - No cost per request when not enabled
 - No startup cost when not enabled
 - Changed `HeaderPropagationValues.Headers` to be internal as I believe logging was the only reason to keep it exposed and it feels a bit risky to expose it given it is not thread safe.

Please let me know how you feel about including this functionality.

If this can be considered as PR, I can provide details on the implementation choices if it can help the code review.

Thank you,
 Alessio

cc: @rynowak 
