### PR TITLE
Use Ubuntu 18.04 LTS instead of 18.10

### DIFF
--- a/docs/Helix.md
+++ b/docs/Helix.md
@@ -3,7 +3,7 @@ Helix testing in ASP.NET Core
 
 Helix is the distributed test platform that we use to run tests.  We build a helix payload that contains the publish directory of every test project that we want to test
 send a job with with this payload to a set of queues for the various combinations of OS that we want to test
-for example: `Windows.10.Amd64.ClientRS4.VS2017.Open`, `OSX.1012.Amd64.Open`, `Ubuntu.1810.Amd64.Open`. Helix takes care of unzipping, running the job, and reporting results.
+for example: `Windows.10.Amd64.ClientRS4.VS2017.Open`, `OSX.1012.Amd64.Open`, `Ubuntu.1804.Amd64.Open`. Helix takes care of unzipping, running the job, and reporting results.
 
 For more info about helix see: [SDK](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/Readme.md), [JobSender](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/Readme.md)
 

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -16,8 +16,8 @@
     <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" Platform="Windows" EnableByDefault="false" />
     <HelixAvailableTargetQueue Include="OSX.1013.Amd64.Open" Platform="OSX" />
-    <HelixAvailableTargetQueue Include="Ubuntu.1810.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.1604.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Centos.7.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Debian.8.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />


### PR DESCRIPTION
18.10 is going out of support next month. I'm assuming we want to test on 18.04 LTS as we probably want some coverage on the latest LTS instead of removing the queue completely. 