### PR TITLE
Add PlatformManifest to runtime package

### DIFF
--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <ManifestsPackagePath>data/</ManifestsPackagePath>
     <!-- Shared between targeting pack and runtime build. -->
     <PlatformManifestFileName>PlatformManifest.txt</PlatformManifestFileName>
     <PlatformManifestOutputPath>$(ArtifactsObjDir)$(PlatformManifestFileName)</PlatformManifestOutputPath>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -33,7 +33,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
 
     <PackageConflictManifestFileName>PackageOverrides.txt</PackageConflictManifestFileName>
-    <ManifestsPackagePath>data/</ManifestsPackagePath>
 
     <!-- Reference implementation assemblies in addition to ref assemblies to get xml docs -->
     <ReferenceImplementationAssemblies>true</ReferenceImplementationAssemblies>

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -265,8 +265,18 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           BeforeTargets="_GetPackageFiles;GenerateNuspec"
           DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <!-- Native files are included in _PackageFile instead because they belong in a separate package folder.r -->
+      <!-- Native files are included in _PackageFile instead because they belong in a separate package folder. -->
       <Content Include="@(ReferenceCopyLocalPaths)" PackagePath="$(NativeAssetsPackagePath)" Condition=" '%(ReferenceCopyLocalPaths.IsNativeImage)' == 'true' AND '%(ReferenceCopyLocalPaths.Extension)' != '.pdb' " />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ResolveRuntimePackContent"
+          BeforeTargets="_GetPackageFiles"
+          DependsOnTargets="GenerateSharedFxDepsFile">
+    <ItemGroup>
+      <RuntimePackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
+
+      <_PackageFiles Include="@(RuntimePackContent)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Addresses https://github.com/aspnet/AspNetCore/issues/10474

I verified on a local build that data/PlatformManifest.txt is now included in Microsoft.AspNetCore.App.Runtime.*.nupkg. I see a PackageOverrides.txt, is that required for the runtime pack as well or is it just a ref pack thing?