### PR TITLE
Spanified Webencoders.Base64UrlEncode

### DIFF
--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp3.0.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp3.0.cs
@@ -230,6 +230,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         public static byte[] Base64UrlDecode(string input) { throw null; }
         public static byte[] Base64UrlDecode(string input, int offset, char[] buffer, int bufferOffset, int count) { throw null; }
         public static byte[] Base64UrlDecode(string input, int offset, int count) { throw null; }
+        public static string Base64UrlEncode(System.ReadOnlySpan<byte> input) { throw null; }
         public static string Base64UrlEncode(byte[] input) { throw null; }
         public static int Base64UrlEncode(byte[] input, int offset, char[] output, int outputOffset, int count) { throw null; }
         public static string Base64UrlEncode(byte[] input, int offset, int count) { throw null; }

--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp3.0.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp3.0.cs
@@ -230,10 +230,10 @@ namespace Microsoft.AspNetCore.WebUtilities
         public static byte[] Base64UrlDecode(string input) { throw null; }
         public static byte[] Base64UrlDecode(string input, int offset, char[] buffer, int bufferOffset, int count) { throw null; }
         public static byte[] Base64UrlDecode(string input, int offset, int count) { throw null; }
-        public static string Base64UrlEncode(System.ReadOnlySpan<byte> input) { throw null; }
         public static string Base64UrlEncode(byte[] input) { throw null; }
         public static int Base64UrlEncode(byte[] input, int offset, char[] output, int outputOffset, int count) { throw null; }
         public static string Base64UrlEncode(byte[] input, int offset, int count) { throw null; }
+        public static string Base64UrlEncode(System.ReadOnlySpan<byte> input) { throw null; }
         public static int GetArraySizeRequiredToDecode(int count) { throw null; }
         public static int GetArraySizeRequiredToEncode(int count) { throw null; }
     }

--- a/src/Shared/WebEncoders/WebEncoders.cs
+++ b/src/Shared/WebEncoders/WebEncoders.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Extensions.WebEncoders.Sources;
@@ -194,6 +195,36 @@ namespace Microsoft.Extensions.Internal
         /// </summary>
         /// <param name="input">The binary input to encode.</param>
         /// <returns>The base64url-encoded form of <paramref name="input"/>.</returns>
+        public static string Base64UrlEncode(ReadOnlySpan<byte> input)
+        {
+            if (input.IsEmpty)
+            {
+                return string.Empty;
+            }
+
+            int bufferSize = GetArraySizeRequiredToEncode(input.Length);
+
+            char[] bufferToReturnToPool = null;
+            Span<char> buffer = bufferSize <= 128
+                ? stackalloc char[bufferSize]
+                : bufferToReturnToPool = ArrayPool<char>.Shared.Rent(bufferSize);
+
+            var numBase64Chars = Base64UrlEncode(input, buffer);
+            var base64Url = new string(buffer.Slice(0, numBase64Chars));
+
+            if (bufferToReturnToPool != null)
+            {
+                ArrayPool<char>.Shared.Return(bufferToReturnToPool);
+            }
+
+            return base64Url;
+        }
+
+        /// <summary>
+        /// Encodes <paramref name="input"/> using base64url encoding.
+        /// </summary>
+        /// <param name="input">The binary input to encode.</param>
+        /// <returns>The base64url-encoded form of <paramref name="input"/>.</returns>
         public static string Base64UrlEncode(byte[] input)
         {
             if (input == null)
@@ -220,16 +251,7 @@ namespace Microsoft.Extensions.Internal
 
             ValidateParameters(input.Length, nameof(input), offset, count);
 
-            // Special-case empty input
-            if (count == 0)
-            {
-                return string.Empty;
-            }
-
-            var buffer = new char[GetArraySizeRequiredToEncode(count)];
-            var numBase64Chars = Base64UrlEncode(input, offset, buffer, outputOffset: 0, count: count);
-
-            return new String(buffer, startIndex: 0, length: numBase64Chars);
+            return Base64UrlEncode(input.AsSpan(offset, count));
         }
 
         /// <summary>
@@ -280,37 +302,7 @@ namespace Microsoft.Extensions.Internal
                     nameof(count));
             }
 
-            // Special-case empty input.
-            if (count == 0)
-            {
-                return 0;
-            }
-
-            // Use base64url encoding with no padding characters. See RFC 4648, Sec. 5.
-
-            // Start with default Base64 encoding.
-            var numBase64Chars = Convert.ToBase64CharArray(input, offset, count, output, outputOffset);
-
-            // Fix up '+' -> '-' and '/' -> '_'. Drop padding characters.
-            for (var i = outputOffset; i - outputOffset < numBase64Chars; i++)
-            {
-                var ch = output[i];
-                if (ch == '+')
-                {
-                    output[i] = '-';
-                }
-                else if (ch == '/')
-                {
-                    output[i] = '_';
-                }
-                else if (ch == '=')
-                {
-                    // We've reached a padding character; truncate the remainder.
-                    return i - outputOffset;
-                }
-            }
-
-            return numBase64Chars;
+            return Base64UrlEncode(input.AsSpan(offset, count), output.AsSpan(outputOffset));
         }
 
         /// <summary>
@@ -325,6 +317,41 @@ namespace Microsoft.Extensions.Internal
         {
             var numWholeOrPartialInputBlocks = checked(count + 2) / 3;
             return checked(numWholeOrPartialInputBlocks * 4);
+        }
+
+        private static int Base64UrlEncode(ReadOnlySpan<byte> input, Span<char> output)
+        {
+            Debug.Assert(output.Length >= GetArraySizeRequiredToEncode(input.Length));
+
+            if (input.IsEmpty)
+            {
+                return 0;
+            }
+
+            // Use base64url encoding with no padding characters. See RFC 4648, Sec. 5.
+
+            Convert.TryToBase64Chars(input, output, out int charsWritten);
+
+            // Fix up '+' -> '-' and '/' -> '_'. Drop padding characters.
+            for (var i = 0; i < charsWritten; i++)
+            {
+                var ch = output[i];
+                if (ch == '+')
+                {
+                    output[i] = '-';
+                }
+                else if (ch == '/')
+                {
+                    output[i] = '_';
+                }
+                else if (ch == '=')
+                {
+                    // We've reached a padding character; truncate the remainder.
+                    return i;
+                }
+            }
+
+            return charsWritten;
         }
 
         private static int GetNumBase64PaddingCharsInString(string str)

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -105,11 +105,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         private static string MakeNewConnectionId()
         {
-            // TODO: Use Span when WebEncoders implements Span methods https://github.com/aspnet/Home/issues/2966
             // 128 bit buffer / 8 bits per byte = 16 bytes
-            var buffer = new byte[16];
-            _keyGenerator.GetBytes(buffer);
+            Span<byte> buffer = stackalloc byte[16];
             // Generate the id with RNGCrypto because we want a cryptographically random id, which GUID is not
+            _keyGenerator.GetBytes(buffer);
             return WebEncoders.Base64UrlEncode(buffer);
         }
 


### PR DESCRIPTION
Added `string Base64UrlEncode(ReadOnlySpan<byte> input)` to WebEncoders, and
redirected the other `string Base64UrlEncode(...)`-methods to use the spanified version.

Used this new method in SignalR's `HttpConnectionManager.MakeNewConnectionId`.

So in total it safes two allocations. One in `MakeNewConnectionId`, as the buffer is stackalloced, the other one in the base64 encoding, as the buffer is stackalloced or rented from the `ArrayPool`.

Addresses https://github.com/aspnet/Extensions/issues/456

Note: 
This fix just safes the allocations. In this PR no attempt was made to do base64Url 
encoding directly -- i.e. as O(n) operation instead a O(2n) as used here, where in the 
base64 encoded results `+` and `/` are substituted (see https://github.com/aspnet/Extensions/pull/338 for a (declined) PR that does this directly). 
Further no attempt was made to vectorize the encoding (similar to https://github.com/dotnet/corefx/pull/34529, or as used in https://github.com/gfoidl/Base64).
Perf-improvments will come for free once https://github.com/dotnet/coreclr/pull/21833 is merged.

/CC: @BrennanConroy 
