### PR TITLE
Small fixes for DatabaseErrorPageMiddleware

### DIFF
--- a/src/Middleware/Diagnostics.EntityFrameworkCore/src/DatabaseErrorPageMiddleware.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/src/DatabaseErrorPageMiddleware.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
                                 if (databaseExists)
                                 {
                                     // Also check if the database is completely empty - see https://github.com/aspnet/EntityFrameworkCore/issues/15997
-                                    databaseExists = (bool)typeof(RelationalDatabaseCreator).GetMethod("HasTables", BindingFlags.Instance | BindingFlags.NonPublic).Invoke(relationalDatabaseCreator, null);
+                                    databaseExists = (bool)typeof(RelationalDatabaseCreator).GetMethod("HasTables", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).Invoke(relationalDatabaseCreator, null);
                                 }
 
                                 var migrationsAssembly = context.GetService<IMigrationsAssembly>();

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/TestModels/BloggingContextWithMigrations.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/TestModels/BloggingContextWithMigrations.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
             {
                 builder.Entity("Blogging.Models.Blog", b =>
                 {
-                    b.Property<int>("BlogId");
+                    b.Property<int>("BlogId").ValueGeneratedOnAdd();
                     b.Property<string>("Name");
                     b.HasKey("BlogId");
                 });


### PR DESCRIPTION
The main change here is to also allow public `HasTables` to be found. This will be removed once we get the new EF merged.

The change to the migration makes it align with what we would generate, but I don't think has any functional impact on the tests.

See also https://github.com/aspnet/EntityFrameworkCore/pull/16024 which (I really hope!) fixes the other failures once it makes it here.
