### PR TITLE
Handle Content Length header greater than 2GB on uploads

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.h
@@ -211,7 +211,7 @@ private:
     //
     volatile  LONG                      m_dwHandlers;
     DWORD                               m_cchHeaders;
-    DWORD                               m_BytesToReceive;
+    ULONGLONG                           m_BytesToReceive;
     DWORD                               m_BytesToSend;
     DWORD                               m_cchLastSend;
     DWORD                               m_cEntityBuffers;


### PR DESCRIPTION
Summary of the changes
 - Use atoll instead of atol when converting the string content length to the value (solves 2GB limit)
 - If content length > 4 GB call WinHttpSendRequest with 0 (WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH) for the content length to indicate that the content length is greater than 4 GB. See https://docs.microsoft.com/en-us/windows/desktop/api/winhttp/nf-winhttp-winhttpsendrequest

Addresses #2711
