### PR TITLE
Set official build ID

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -20,7 +20,15 @@ pr:
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
-
+- name: _TeamName
+  value:  AspNetCore
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _BuildArgs
+    value: /p:TeamName=$(_TeamName)
+           /p:OfficialBuildId=$(Build.BuildNumber)
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _BuildArgs
+    value: ''
 jobs:
 - template: jobs/default-build.yml
   parameters:
@@ -50,18 +58,36 @@ jobs:
     # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
     # The sign settings have been configured to
 
-    - script: ./eng/scripts/cibuild.cmd -BuildNative -arch x64 /p:DisableCodeSigning=true /bl:artifacts/log/build.x64.binlog
+    - script: ./eng/scripts/cibuild.cmd
+          -arch x64
+          -BuildNative
+          /p:DisableCodeSigning=true
+          /bl:artifacts/log/build.x64.binlog
+          $(_BuildArgs)
       displayName: Build x64
     # TODO: make it possible to build for one Windows architecture at a time
     # This is going to actually build x86 native assets. See https://github.com/aspnet/AspNetCore/issues/7196
 
     # Build the x86 shared framework
     # Set DisableSignCheck because we'll run sign check in an explicit step after installers build
-    - script: ./eng/scripts/cibuild.cmd -arch x86 -NoRestore -BuildNative /t:BuildSharedFx /p:DisableCodeSigning=true /bl:artifacts/log/build.x86.binlog
+    - script: ./eng/scripts/cibuild.cmd
+            -arch x86
+            -NoRestore
+            -BuildNative
+            /t:BuildSharedFx
+            /p:DisableCodeSigning=true
+            /bl:artifacts/log/build.x86.binlog
+            $(_BuildArgs)
       displayName: Build x86
 
     # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
-    - script: ./build.cmd -ci -sign -forceCoreMsbuild /p:DisableCodeSigning=true -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+    - script: ./build.cmd
+            -ci
+            -sign
+            -forceCoreMsbuild
+            /p:DisableCodeSigning=true
+            -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+            $(_BuildArgs)
       displayName: Build SiteExtension
 
     # Remove all task build output
@@ -71,15 +97,33 @@ jobs:
     # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
     # consider running code-signing inline with the other previous steps.
     # Sign check is disabled because it is run in a separate step below, after installers are built.
-    - script: ./build.cmd -ci -sign -NoRestore /t:CodeSign /p:SignType=$(_SignType) /p:DisableSignCheck=true /bl:artifacts/log/build.codesign.binlog
+    - script: ./build.cmd
+              -ci
+              -sign
+              -NoRestore
+              /t:CodeSign
+              /p:SignType=$(_SignType)
+              /p:DisableSignCheck=true
+              /bl:artifacts/log/build.codesign.binlog
+              $(_BuildArgs)
       displayName: Code sign packages
 
     # Windows installers bundle both x86 and x64 assets
-    - powershell: ./src/Installers/Windows/build.ps1 -ci /p:SignType=$(_SignType)
+    - powershell: ./src/Installers/Windows/build.ps1
+        -ci
+        /p:SignType=$(_SignType)
+         $(_BuildArgs)
       displayName: Build Installers
 
     # Run sign check to verify everything was code signed.
-    - script: ./build.cmd -ci -sign -NoRestore /t:SignCheck /p:SignType=$(_SignType) /bl:artifacts/log/build.signcheck.binlog
+    - script: ./build.cmd
+        -ci
+        -sign
+        -NoRestore
+        /t:SignCheck
+        /p:SignType=$(_SignType)
+        /bl:artifacts/log/build.signcheck.binlog
+         $(_BuildArgs)
       displayName: Run sign check
       condition: eq(variables['_SignType'], 'real')
 
@@ -104,7 +148,12 @@ jobs:
     jobDisplayName: "Build: Windows ARM"
     agentOs: Windows
     buildScript: ./eng/scripts/cibuild.cmd
-    buildArgs: -arch arm -NoBuildNodeJS -NoBuildJava /p:SignType=$(_SignType) /bl:artifacts/log/build.win-arm.binlog
+    buildArgs: -arch arm
+      -NoBuildNodeJS
+      -NoBuildJava
+      /p:SignType=$(_SignType)
+      /bl:artifacts/log/build.win-arm.binlog
+      $(_BuildArgs)
     installNodeJs: false
     installJdk: false
     afterBuild:
@@ -129,7 +178,10 @@ jobs:
     jobDisplayName: "Build: macOS"
     agentOs: macOs
     buildScript: ./eng/scripts/cibuild.sh
-    buildArgs: --no-build-nodejs --no-build-java /bl:artifacts/log/build.macos.binlog
+    buildArgs: --no-build-nodejs
+      --no-build-java
+      /bl:artifacts/log/build.macos.binlog
+      $(_BuildArgs)
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -158,7 +210,12 @@ jobs:
     agentOs: Linux
     installNodeJs: false
     steps:
-    - script: ./eng/scripts/cibuild.sh --arch x64 --no-build-nodejs --no-build-java /bl:artifacts/log/build.lin-x64.binlog
+    - script: ./eng/scripts/cibuild.sh
+          --arch x64
+          --no-build-nodejs
+          --no-build-java
+          /bl:artifacts/log/build.linux-x64.binlog
+          $(_BuildArgs)
       displayName: Run cibuild.sh
     - script: |
         rm -rf .dotnet/
@@ -172,7 +229,8 @@ jobs:
           /t:BuildSharedFx  \
           /p:BuildRuntimeArchive=false \
           /p:LinuxInstallerType=deb \
-          /bl:artifacts/log/build.deb.binlog
+          /bl:artifacts/log/build.deb.binlog \
+          $(_BuildArgs)
       displayName: Build Debian installers
     - script: |
         rm -rf .dotnet/
@@ -186,7 +244,8 @@ jobs:
           /t:BuildSharedFx  \
           /p:BuildRuntimeArchive=false \
           /p:LinuxInstallerType=rpm \
-          /bl:artifacts/log/build.rpm.binlog
+          /bl:artifacts/log/build.rpm.binlog \
+          $(_BuildArgs)
       displayName: Build RPM installers
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -214,7 +273,11 @@ jobs:
     jobDisplayName: "Build: Linux ARM"
     agentOs: Linux
     buildScript: ./eng/scripts/cibuild.sh
-    buildArgs: --arch arm --no-build-nodejs --no-build-java /bl:artifacts/log/build.lin-arm.binlog
+    buildArgs: --arch arm
+      --no-build-nodejs
+      --no-build-java
+      /bl:artifacts/log/build.linux-arm.binlog
+      $(_BuildArgs)
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -242,7 +305,11 @@ jobs:
     jobDisplayName: "Build: Linux ARM64"
     agentOs: Linux
     buildScript: ./eng/scripts/cibuild.sh
-    buildArgs: --arch arm64 --no-build-nodejs --no-build-java /bl:artifacts/log/build.arm64.binlog
+    buildArgs: --arch arm64
+      --no-build-nodejs
+      --no-build-java
+      /bl:artifacts/log/build.arm64.binlog
+      $(_BuildArgs)
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -270,7 +337,16 @@ jobs:
     jobDisplayName: "Build: Linux Musl x64"
     agentOs: Linux
     buildScript: ./dockerbuild.sh alpine
-    buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch x64 --os-name linux-musl --no-build-nodejs --no-build-java /bl:artifacts/log/build.musl.binlog
+    buildArgs: --ci
+      --pack
+      --all
+      -e KOREBUILD_SKIP_INSTALL_NETFX=0
+      --arch x64
+      --os-name linux-musl
+      --no-build-nodejs
+      --no-build-java
+      /bl:artifacts/log/build.musl.binlog
+      $(_BuildArgs)
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.
@@ -298,7 +374,16 @@ jobs:
     jobDisplayName: "Build: Linux Musl ARM64"
     agentOs: Linux
     buildScript: ./dockerbuild.sh ubuntu-alpine37
-    buildArgs: --ci --pack --all -e KOREBUILD_SKIP_INSTALL_NETFX=0 --arch arm64 --os-name linux-musl --no-build-nodejs --no-build-java /bl:artifacts/log/build.musl.binlog
+    buildArgs: --ci
+      --pack
+      --all
+      -e KOREBUILD_SKIP_INSTALL_NETFX=0
+      --arch arm64
+      --os-name linux-musl
+      --no-build-nodejs
+      --no-build-java
+      /bl:artifacts/log/build.musl.binlog
+      $(_BuildArgs)
     installNodeJs: false
     afterBuild:
     # Remove packages that are not rid-specific.

--- a/build/CodeSign.targets
+++ b/build/CodeSign.targets
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <!-- Configures signcheck to inspect well-known folders for signed content. -->
-    <SignCheckDirectory Include="$(ArtifactsPackagesDir)" />
-    <SignCheckDirectory Include="$(InstallersOutputPath)" />
-    <SignCheckDirectory Include="$(VisualStudioSetupOutputPath)" />
+    <SignCheckDirectory Include="$(ArtifactsPackagesDir.TrimEnd('\'))" />
+    <SignCheckDirectory Include="$(InstallersOutputPath.TrimEnd('\'))" />
+    <SignCheckDirectory Include="$(VisualStudioSetupOutputPath.TrimEnd('\'))" />
     <!-- KoreBuild by default scans everything in artifacts/, but this causes problems because we put unsigned content in artifacts/obj/ and bin/ which can be ignored. -->
     <SignCheckDirectory Remove="$(ArtifactsDir)" />
   </ItemGroup>


### PR DESCRIPTION
Fix regression caused by #10674. Before this, CI picked up BUILD_BUILDNUMBER automatically from CI.

Arcade, on the other hand, requires that you explicitly set `/p:OfficialBuildId=$(Build.BuildNumber)` in order to get builds like `3.0.0-preview7.build.number`