### PR TITLE
fix #11114 by setting WebHostService to 'Code' designer category

### DIFF
--- a/src/Hosting/WindowsServices/src/WebHostService.cs
+++ b/src/Hosting/WindowsServices/src/WebHostService.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Hosting.WindowsServices
     /// <summary>
     ///     Provides an implementation of a Windows service that hosts ASP.NET Core.
     /// </summary>
+    [DesignerCategory("Code")]
     public class WebHostService : ServiceBase
     {
         private readonly IWebHost _host;


### PR DESCRIPTION
Verified that this fixes the icon in VS and makes it load in the code editor instead of the component designer. I also verified that it works transitively for derived classes (which is how users actually hit this issue).

Addresses #11114 in 3.0.