### PR TITLE
fix #11114 by setting DesignerCategory for WebHostService

### DIFF
--- a/src/Hosting/WindowsServices/src/WebHostService.cs
+++ b/src/Hosting/WindowsServices/src/WebHostService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.ServiceProcess;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,6 +11,7 @@ namespace Microsoft.AspNetCore.Hosting.WindowsServices
     /// <summary>
     ///     Provides an implementation of a Windows service that hosts ASP.NET Core.
     /// </summary>
+    [DesignerCategory("Code")]
     public class WebHostService : ServiceBase
     {
         private IWebHost _host;


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore/pull/11117 but this time on 2.1.

Will submit to shiproom. It's trivial and low risk but with high value.

This fixes #11114 (and the corresponding VS Feedback item https://dev.azure.com/devdiv/DevDiv/_workitems/edit/899142?src=WorkItemMention&src-action=artifact_link). It's a pretty bad experience. Basically, if you follow one of our docs (https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/windows-service?view=aspnetcore-2.2&tabs=visual-studio) it encourages you to create a class deriving from `WebHostService`. However, because this derives from `ServiceBase` it shows as a Component and tries to open the designer. That would be OK except we also have a constructor with parameters which breaks the designer.

Since this is never intended to use the designer, this change applies an attribute to "undo" this behavior and cause this class (and derived classes) to be considered as plain code files that open in the code editor in VS.

**Risk:** Very low, no runtime impact at all. Worst case scenario is that it doesn't fix the issue.