### PR TITLE
Remove dependency on pipe events in HttpConnection

### DIFF
--- a/src/Servers/Kestrel/Core/src/Adapter/Internal/RawStream.cs
+++ b/src/Servers/Kestrel/Core/src/Adapter/Internal/RawStream.cs
@@ -14,11 +14,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
     {
         private readonly PipeReader _input;
         private readonly PipeWriter _output;
+        private readonly bool _throwOnCancelled;
 
-        public RawStream(PipeReader input, PipeWriter output)
+        public RawStream(PipeReader input, PipeWriter output, bool throwOnCancelled = false)
         {
             _input = input;
             _output = output;
+            _throwOnCancelled = throwOnCancelled;
         }
 
         public override bool CanRead => true;
@@ -113,6 +115,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
                 var readableBuffer = result.Buffer;
                 try
                 {
+                    if (_throwOnCancelled && result.IsCanceled)
+                    {
+                        throw new OperationCanceledException();
+                    }
+
                     if (!readableBuffer.IsEmpty)
                     {
                         // buffer.Count is int

--- a/src/Servers/Kestrel/Core/src/Adapter/Internal/RawStream.cs
+++ b/src/Servers/Kestrel/Core/src/Adapter/Internal/RawStream.cs
@@ -61,17 +61,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
         {
             // ValueTask uses .GetAwaiter().GetResult() if necessary
             // https://github.com/dotnet/corefx/blob/f9da3b4af08214764a51b2331f3595ffaf162abe/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs#L156
-            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count)).Result;
+            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), default).Result;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
         {
-            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count)).AsTask();
+            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
         {
-            return ReadAsyncInternal(destination);
+            return ReadAsyncInternal(destination, cancellationToken);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -105,11 +105,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
             return WriteAsync(null, 0, 0, cancellationToken);
         }
 
-        private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination)
+        private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
         {
             while (true)
             {
-                var result = await _input.ReadAsync();
+                var result = await _input.ReadAsync(cancellationToken);
                 var readableBuffer = result.Buffer;
                 try
                 {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -68,8 +68,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected override void OnRequestProcessingEnded()
         {
-            Input.Complete();
-
             TimeoutControl.StartDrainTimeout(MinResponseDataRate, ServerOptions.Limits.MaxResponseBufferSize);
 
             // Prevent RequestAborted from firing. Free up unneeded feature references.

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -402,7 +402,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 _log.ConnectionDisconnect(_connectionId);
                 _pipeWriterCompleted = true;
                 _completed = true;
-                _pipeWriter.Complete();
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -86,6 +86,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _memoryPool = memoryPool;
         }
 
+        // For tests
+        internal PipeWriter PipeWriter => _pipeWriter;
+
         public Task WriteDataAsync(ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -281,7 +281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         private async Task<Stream> ApplyConnectionAdaptersAsync()
         {
             var connectionAdapters = _context.ConnectionAdapters;
-            var stream = new RawStream(_context.Transport.Input, _context.Transport.Output);
+            var stream = new RawStream(_context.Transport.Input, _context.Transport.Output, throwOnCancelled: true);
             var adapterContext = new ConnectionAdapterContext(_context.ConnectionContext, stream);
             _adaptedConnections = new List<IAdaptedConnection>(connectionAdapters.Count);
 

--- a/src/Servers/Kestrel/Core/test/OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/OutputProducerTests.cs
@@ -47,9 +47,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 await socketOutput.WriteDataAsync(new byte[] { 1, 2, 3, 4 }, default);
 
-                Assert.True(socketOutput.Pipe.Reader.TryRead(out var result));
-                Assert.True(result.IsCompleted);
-                Assert.True(result.Buffer.IsEmpty);
+                Assert.False(socketOutput.Pipe.Reader.TryRead(out var result));
+
+                socketOutput.Pipe.Writer.Complete();
+                socketOutput.Pipe.Reader.Complete();
             }
         }
 

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
@@ -31,6 +31,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         private MemoryHandle _bufferHandle;
         private Task _processingTask;
+        private readonly TaskCompletionSource<object> _waitForConnectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _connectionClosed;
 
         public LibuvConnection(UvStreamHandle socket,
                                ILibuvTrace log,
@@ -135,21 +137,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                     // We're done with the socket now
                     _socket.Dispose();
 
-                    // Fire the connection closed token and wait for it to complete
-                    var waitForConnectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    // Ensure this always fires
+                    FireConnectionClosed();
 
-                    ThreadPool.UnsafeQueueUserWorkItem(state =>
-                    {
-                        (var connection, var tcs) = state;
-
-                        connection.CancelConnectionClosedToken();
-
-                        tcs.TrySetResult(null);
-                    },
-                    (this, waitForConnectionClosedTcs),
-                    preferLocal: false);
-
-                    await waitForConnectionClosedTcs.Task;
+                    await _waitForConnectionClosedTcs.Task;
                 }
             }
             catch (Exception e)
@@ -234,6 +225,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 if (status == LibuvConstants.EOF)
                 {
                     Log.ConnectionReadFin(ConnectionId);
+
+                    FireConnectionClosed();
                 }
                 else
                 {
@@ -244,6 +237,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 // Complete after aborting the connection
                 Input.Complete(error);
             }
+        }
+
+        private void FireConnectionClosed()
+        {
+            // Guard against scheduling this multiple times
+            if (_connectionClosed)
+            {
+                return;
+            }
+
+            _connectionClosed = true;
+
+            ThreadPool.UnsafeQueueUserWorkItem(state =>
+            {
+                state.CancelConnectionClosedToken();
+
+                state._waitForConnectionClosedTcs.TrySetResult(null);
+            },
+            this,
+            preferLocal: false);
         }
 
         private async Task ApplyBackpressureAsync(ValueTask<FlushResult> flushTask)

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
@@ -225,14 +225,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 if (status == LibuvConstants.EOF)
                 {
                     Log.ConnectionReadFin(ConnectionId);
-
-                    FireConnectionClosed();
                 }
                 else
                 {
                     handle.Libuv.Check(status, out var uvError);
                     error = LogAndWrapReadError(uvError);
                 }
+
+                FireConnectionClosed();
 
                 // Complete after aborting the connection
                 Input.Complete(error);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionAdapterTests.cs
@@ -407,7 +407,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                var actual = await _innerStream.ReadAsync(buffer, offset, count);
+                var actual = await _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
 
                 BytesRead += actual;
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -840,10 +840,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "This test is racy and requires a product change.")]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes()
         {
-            var testContext = new TestServiceContext(LoggerFactory);
+            var testContext = new TestServiceContext(LoggerFactory)
+            {
+                Scheduler = PipeScheduler.Inline
+            };
 
             await using (var server = new TestServer(TestApp.EchoAppChunked, testContext))
             {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -843,11 +843,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes()
         {
-            var testContext = new TestServiceContext(LoggerFactory)
-            {
-                // FIN callbacks are scheduled so run inline to make this test more reliable
-                Scheduler = PipeScheduler.Inline
-            };
+            var testContext = new TestServiceContext(LoggerFactory);
 
             await using (var server = new TestServer(TestApp.EchoAppChunked, testContext))
             {
@@ -856,6 +852,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     await connection.Send(
                         "POST / HTTP/1.1");
                     connection.ShutdownSend();
+                    await connection.TransportConnection.WaitForCloseTask;
                     await connection.ReceiveEnd();
                 }
 
@@ -866,6 +863,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "Content-Length: 7");
                     connection.ShutdownSend();
+                    await connection.TransportConnection.WaitForCloseTask;
                     await connection.ReceiveEnd();
                 }
             }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
@@ -54,6 +54,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
 
             Input.Complete(abortReason);
 
+            OnClosed();
+
             AbortReason = abortReason;
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
@@ -48,6 +48,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
 
         public ConnectionAbortedException AbortReason { get; private set; }
 
+        public Task WaitForCloseTask => _waitForCloseTcs.Task;
+
         public override void Abort(ConnectionAbortedException abortReason)
         {
             _logger.LogDebug(@"Connection id ""{ConnectionId}"" closing because: ""{Message}""", ConnectionId, abortReason?.Message);


### PR DESCRIPTION
- Refactored the HttpConnection to not depend on OnReaderCompleted and OnWriterCompleted. Instead we use ConnectionClosed to detect the FIN that we propagate via ConnectedAborted.
- Fire ConnectionClosed when a FIN is received from both transports.
- Remove pipe completion from Http1Connection and Http1OutputProducer. Instead just return from request processing.
- Flow the CancellaitonToken property in RawStream
