### PR TITLE
HttpMethodAttribute: fix documentation and parameter check

### DIFF
--- a/src/Mvc/Mvc.Core/src/Routing/HttpMethodAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/HttpMethodAttribute.cs
@@ -17,23 +17,19 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         /// <summary>
         /// Creates a new <see cref="HttpMethodAttribute"/> with the given
         /// set of HTTP methods.
-        /// <param name="httpMethods">The set of supported HTTP methods.</param>
+        /// <param name="httpMethods">The set of supported HTTP methods. May not be null.</param>
         /// </summary>
         public HttpMethodAttribute(IEnumerable<string> httpMethods)
             : this(httpMethods, null)
         {
-            if (httpMethods == null)
-            {
-                throw new ArgumentNullException(nameof(httpMethods));
-            }
         }
 
         /// <summary>
         /// Creates a new <see cref="HttpMethodAttribute"/> with the given
         /// set of HTTP methods an the given route template.
         /// </summary>
-        /// <param name="httpMethods">The set of supported methods.</param>
-        /// <param name="template">The route template. May not be null.</param>
+        /// <param name="httpMethods">The set of supported methods. May not be null.</param>
+        /// <param name="template">The route template.</param>
         public HttpMethodAttribute(IEnumerable<string> httpMethods, string template)
         {
             if (httpMethods == null)


### PR DESCRIPTION
The second constructor of the `HttpMethodAttribute` class claims that the `template` parameter may not be `null`, and no such claim is present about the `httpMethods` parameter. However, when `httpMethods` is `null`, an exception is thrown, while `template` *is* allowed to be null (as can be seen in the `HttpMethodAttribute(IEnumerable<string>)` constructor, which passes `null`.

In addition, the `HttpMethodAttribute(IEnumerable<string>)` constructor contains a `null`-check for the `httpMethods` parameter, but since this check is *also* in the `HttpMethodAttribute(IEnumerable<string>, string)` constructor this check is dead code.