### PR TITLE
Ensure CircuitRegistry evicts CircuitHost entries after configured

### DIFF
--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             var registry = CreateRegistry(circuitIdFactory);
             var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
-            registry.DisconnectedCircuits.Set(circuitHost.CircuitId, circuitHost, new MemoryCacheEntryOptions { Size = 1 });
+            registry.RegisterDisconnectedCircuit(circuitHost);
 
             var newClient = Mock.Of<IClientProxy>();
             var newConnectionId = "new-id";
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var registry = CreateRegistry(circuitIdFactory);
             var handler = new Mock<CircuitHandler> { CallBase = true };
             var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId(), handlers: new[] { handler.Object });
-            registry.DisconnectedCircuits.Set(circuitHost.CircuitId, circuitHost, new MemoryCacheEntryOptions { Size = 1 });
+            registry.RegisterDisconnectedCircuit(circuitHost);
 
             var newClient = Mock.Of<IClientProxy>();
             var newConnectionId = "new-id";


### PR DESCRIPTION
duration

* Use an active expiration token to trigger expiration
* Add logging during host state transitions

Fixes https://github.com/aspnet/AspNetCore/issues/9893


