### PR TITLE
Implement Http/2 CompleteAsync

### DIFF
--- a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
+++ b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.netstandard2.0.cs
@@ -200,6 +200,10 @@ namespace Microsoft.AspNetCore.Http.Features
         bool Available { get; }
         Microsoft.AspNetCore.Http.IHeaderDictionary Trailers { get; }
     }
+    public partial interface IHttpResponseCompletionFeature
+    {
+        System.Threading.Tasks.Task CompleteAsync();
+    }
     public partial interface IHttpResponseFeature
     {
         System.IO.Stream Body { get; set; }

--- a/src/Http/Http.Features/src/IHttpResponseCompletionFeature.cs
+++ b/src/Http/Http.Features/src/IHttpResponseCompletionFeature.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    /// <summary>
+    /// A feature to gracefully end a response.
+    /// </summary>
+    public interface IHttpResponseCompletionFeature
+    {
+        /// <summary>
+        /// Flush any remaining response headers, data, or trailers.
+        /// This may throw if the response is in an invalid state such as a Content-Length mismatch.
+        /// </summary>
+        /// <returns></returns>
+        Task CompleteAsync();
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -277,6 +277,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected void ResetHttp2Features()
         {
             _currentIHttp2StreamIdFeature = this;
+            _currentIHttpResponseCompletionFeature = this;
             _currentIHttpResponseTrailersFeature = this;
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private static readonly Type IFormFeatureType = typeof(IFormFeature);
         private static readonly Type IHttpUpgradeFeatureType = typeof(IHttpUpgradeFeature);
         private static readonly Type IHttp2StreamIdFeatureType = typeof(IHttp2StreamIdFeature);
+        private static readonly Type IHttpResponseCompletionFeatureType = typeof(IHttpResponseCompletionFeature);
         private static readonly Type IHttpResponseTrailersFeatureType = typeof(IHttpResponseTrailersFeature);
         private static readonly Type IResponseCookiesFeatureType = typeof(IResponseCookiesFeature);
         private static readonly Type IItemsFeatureType = typeof(IItemsFeature);
@@ -58,6 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private object _currentIFormFeature;
         private object _currentIHttpUpgradeFeature;
         private object _currentIHttp2StreamIdFeature;
+        private object _currentIHttpResponseCompletionFeature;
         private object _currentIHttpResponseTrailersFeature;
         private object _currentIResponseCookiesFeature;
         private object _currentIItemsFeature;
@@ -98,6 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIQueryFeature = null;
             _currentIFormFeature = null;
             _currentIHttp2StreamIdFeature = null;
+            _currentIHttpResponseCompletionFeature = null;
             _currentIHttpResponseTrailersFeature = null;
             _currentIResponseCookiesFeature = null;
             _currentIItemsFeature = null;
@@ -224,6 +227,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     feature = _currentIHttp2StreamIdFeature;
                 }
+                else if (key == IHttpResponseCompletionFeatureType)
+                {
+                    feature = _currentIHttpResponseCompletionFeature;
+                }
                 else if (key == IHttpResponseTrailersFeatureType)
                 {
                     feature = _currentIHttpResponseTrailersFeature;
@@ -348,6 +355,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIHttp2StreamIdFeature = value;
                 }
+                else if (key == IHttpResponseCompletionFeatureType)
+                {
+                    _currentIHttpResponseCompletionFeature = value;
+                }
                 else if (key == IHttpResponseTrailersFeatureType)
                 {
                     _currentIHttpResponseTrailersFeature = value;
@@ -469,6 +480,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
                 feature = (TFeature)_currentIHttp2StreamIdFeature;
+            }
+            else if (typeof(TFeature) == typeof(IHttpResponseCompletionFeature))
+            {
+                feature = (TFeature)_currentIHttpResponseCompletionFeature;
             }
             else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
             {
@@ -598,6 +613,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttp2StreamIdFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(IHttpResponseCompletionFeature))
+            {
+                _currentIHttpResponseCompletionFeature = feature;
+            }
             else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
             {
                 _currentIHttpResponseTrailersFeature = feature;
@@ -717,6 +736,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttp2StreamIdFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IHttp2StreamIdFeatureType, _currentIHttp2StreamIdFeature);
+            }
+            if (_currentIHttpResponseCompletionFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IHttpResponseCompletionFeatureType, _currentIHttpResponseCompletionFeature);
             }
             if (_currentIHttpResponseTrailersFeature != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/RequestProcessingStatus.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/RequestProcessingStatus.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         ParsingHeaders,
         AppStarted,
         HeadersCommitted,
-        HeadersFlushed
+        HeadersFlushed,
+        ResponseCompleted
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
@@ -59,12 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // Finalize headers
             if (!HasResponseStarted)
             {
-                if (!VerifyResponseContentLength(out var lengthException))
-                {
-                    throw lengthException;
-                }
-
-                await InitializeResponseAsync(0, appCompleted: true);
+                await FireOnStarting();
             }
 
             // Flush headers, body, trailers...
@@ -75,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     throw lengthException;
                 }
 
-                await WriteSuffix();
+                await ProduceEnd();
             }
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -1840,6 +1840,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task ResponseTrailers_WithExeption500_Cleared()
+        {
+            await InitializeConnectionAsync(context =>
+            {
+                context.Response.AppendTrailer("CustomName", "Custom Value");
+                throw new NotImplementedException("Test Exception");
+            });
+
+            await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 55,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_STREAM | Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("500", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
+        }
+
+        [Fact]
         public async Task ResponseTrailers_WithData_Sent()
         {
             await InitializeConnectionAsync(async context =>
@@ -3306,6 +3332,699 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.Contains(TestSink.Writes, w => w.EventId.Id == 13 && w.LogLevel == LogLevel.Error
                        && w.Exception is ConnectionAbortedException && w.Exception.InnerException == expectedException);
+        }
+
+        [Fact]
+        public async Task CompleteAsync_BeforeBodyStarted_SendsHeadersWithEndStream()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 55,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders["content-length"]);
+        }
+
+        [Fact]
+        public async Task CompleteAsync_BeforeBodyStarted_WithTrailers_SendsHeadersAndTrailersWithEndStream()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+                    await completionFeature.CompleteAsync().DefaultTimeout(); // Can be called twice, no-ops
+
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 55,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var trailersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 25,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders["content-length"]);
+
+            _decodedHeaders.Clear();
+
+            _hpackDecoder.Decode(trailersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Single(_decodedHeaders);
+            Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
+        }
+
+        [Fact]
+        public async Task CompleteAsync_BeforeBodyStarted_WithTrailers_TruncatedContentLength_ThrowsAnd500()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    context.Response.ContentLength = 25;
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => completionFeature.CompleteAsync().DefaultTimeout());
+                    Assert.Equal(CoreStrings.FormatTooFewBytesWritten(0, 25), ex.Message);
+
+                    Assert.False(startingTcs.Task.IsCompleted); // OnStarting did not get called.
+                    Assert.False(context.Response.Headers.IsReadOnly);
+                    Assert.False(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 55,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("500", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
+        }
+
+        [Fact]
+        public async Task CompleteAsync_AfterBodyStarted_SendsBodyWithEndStream()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await context.Response.WriteAsync("Hello World");
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+                    await completionFeature.CompleteAsync().DefaultTimeout(); // Can be called twice, no-ops
+
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+        }
+
+        [Fact]
+        public async Task CompleteAsync_WriteAfterComplete_Throws()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.WriteAsync("2 Hello World").DefaultTimeout());
+                    Assert.Equal("Writing is not allowed after writer was completed.", ex.Message);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 55,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
+        }
+
+        [Fact]
+        public async Task CompleteAsync_WriteAgainAfterComplete_Throws()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await context.Response.WriteAsync("Hello World").DefaultTimeout();
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.WriteAsync("2 Hello World").DefaultTimeout());
+                    Assert.Equal("Writing is not allowed after writer was completed.", ex.Message);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+        }
+
+        [Fact]
+        public async Task CompleteAsync_AfterBodyStarted_WithTrailers_SendsBodyAndTrailersWithEndStream()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await context.Response.WriteAsync("Hello World");
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            var trailersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 25,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+
+            _decodedHeaders.Clear();
+
+            _hpackDecoder.Decode(trailersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Single(_decodedHeaders);
+            Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
+        }
+
+        [Fact]
+        public async Task CompleteAsync_AfterBodyStarted_WithTrailers_TruncatedContentLength_ThrowsAndReset()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    context.Response.ContentLength = 25;
+                    await context.Response.WriteAsync("Hello World");
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => completionFeature.CompleteAsync().DefaultTimeout());
+                    Assert.Equal(CoreStrings.FormatTooFewBytesWritten(11, 25), ex.Message);
+
+                    Assert.False(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 56,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR,
+                expectedErrorMessage: CoreStrings.FormatTooFewBytesWritten(11, 25));
+
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("25", _decodedHeaders[HeaderNames.ContentLength]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+        }
+
+        [Fact]
+        public async Task AbortAfterCompleteAsync_GETWithResponseBodyAndTrailers_ResetsAfterResponse()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await context.Response.WriteAsync("Hello World");
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // RequestAborted will no longer fire after CompleteAsync.
+                    Assert.False(context.RequestAborted.CanBeCanceled);
+                    context.Abort();
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            var trailersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 25,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, expectedErrorMessage: null);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+
+            _decodedHeaders.Clear();
+
+            _hpackDecoder.Decode(trailersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Single(_decodedHeaders);
+            Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
+        }
+
+        [Fact]
+        public async Task AbortAfterCompleteAsync_POSTWithResponseBodyAndTrailers_RequestBodyThrows()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "POST"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    var requestBodyTask = context.Request.BodyReader.ReadAsync();
+
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    await context.Response.WriteAsync("Hello World");
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // RequestAborted will no longer fire after CompleteAsync.
+                    Assert.False(context.RequestAborted.CanBeCanceled);
+                    context.Abort();
+
+                    await Assert.ThrowsAsync<TaskCanceledException>(async () => await requestBodyTask);
+                    await Assert.ThrowsAsync<ConnectionAbortedException>(async () => await context.Request.BodyReader.ReadAsync());
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: false);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            var trailersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 25,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, expectedErrorMessage: null);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+
+            _decodedHeaders.Clear();
+
+            _hpackDecoder.Decode(trailersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Single(_decodedHeaders);
+            Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -3484,7 +3484,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => completionFeature.CompleteAsync().DefaultTimeout());
                     Assert.Equal(CoreStrings.FormatTooFewBytesWritten(0, 25), ex.Message);
 
-                    Assert.False(startingTcs.Task.IsCompleted); // OnStarting did not get called.
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully);
                     Assert.False(context.Response.Headers.IsReadOnly);
                     Assert.False(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -3713,6 +3713,87 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task CompleteAsync_AfterPipeWrite_WithTrailers_SendsBodyAndTrailersWithEndStream()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                    var completionFeature = context.Features.Get<IHttpResponseCompletionFeature>();
+                    Assert.NotNull(completionFeature);
+
+                    var buffer = context.Response.BodyWriter.GetMemory();
+                    var length = Encoding.UTF8.GetBytes("Hello World", buffer.Span);
+                    context.Response.BodyWriter.Advance(length);
+
+                    Assert.False(startingTcs.Task.IsCompletedSuccessfully); // OnStarting did not get called.
+                    Assert.False(context.Response.Headers.IsReadOnly);
+
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    await completionFeature.CompleteAsync().DefaultTimeout();
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    Assert.True(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            var trailersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 25,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+
+            _decodedHeaders.Clear();
+
+            _hpackDecoder.Decode(trailersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Single(_decodedHeaders);
+            Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
+        }
+
+        [Fact]
         public async Task CompleteAsync_AfterBodyStarted_WithTrailers_SendsBodyAndTrailersWithEndStream()
         {
             var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -35,6 +35,7 @@ namespace CodeGenerator
             {
                 "IHttpUpgradeFeature",
                 "IHttp2StreamIdFeature",
+                "IHttpResponseCompletionFeature",
                 "IHttpResponseTrailersFeature",
                 "IResponseCookiesFeature",
                 "IItemsFeature",


### PR DESCRIPTION
 #10886 Adding IHttpResponseCompletionFeature.CompleteAsync for HTTP/2 only.

- Allows for the graceful completion of a response message (from the client's perspective) without waiting for the request delegate to unwind.
- It makes sure all remaining response headers, data, and trailers are sent before it returns.
- It may throw if the response is in an invalid state such as a Content-Length mismatch.
- RequestAborted will not fire after this completes. Abort can still be used though.

Retrofitting this for HTTP/1.1 shouldn't be hard but I wanted to unblock the gRPC scenarios first.

While testing this I fixed a bug in response trailers where they were not getting cleared if the app threw an exception and the server converted it to a 500 response. You'd end up with a 500 + trailers.