### PR TITLE
Always include ANCM in build output

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,6 +11,7 @@
     <!-- Always include framework metapackages in patch updates. -->
     <IsPackageInThisPatch Condition="'$(IsFrameworkMetapackage)' == 'true' OR '$(IsSharedSourcePackage)' == 'true' ">true</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="'$(IsPackageInThisPatch)' == ''">$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackageInThisPatch>
+    <IsPackageInThisPatch Condition="'$(IsANCMPackage)' == 'true'">true</IsPackageInThisPatch>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsPackable)' != 'false' AND '$(IsServicingBuild)' == 'true' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,6 +11,8 @@
     <!-- Always include framework metapackages in patch updates. -->
     <IsPackageInThisPatch Condition="'$(IsFrameworkMetapackage)' == 'true' OR '$(IsSharedSourcePackage)' == 'true' ">true</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="'$(IsPackageInThisPatch)' == ''">$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackageInThisPatch>
+    
+    <!-- ANCM always builds every patch as we don't push temporary nuget packages anymore and that ANCM itself is a global singleton -->
     <IsPackageInThisPatch Condition="'$(IsANCMPackage)' == 'true'">true</IsPackageInThisPatch>
   </PropertyGroup>
 

--- a/src/Servers/IIS/AspNetCoreModuleV1/Microsoft.AspNetCore.AspNetCoreModule/Microsoft.AspNetCore.AspNetCoreModule.pkgproj
+++ b/src/Servers/IIS/AspNetCoreModuleV1/Microsoft.AspNetCore.AspNetCoreModule/Microsoft.AspNetCore.AspNetCoreModule.pkgproj
@@ -11,6 +11,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageDescription>ASP.NET Core Module</PackageDescription>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
+    <IsANCMPackage>true</IsANCMPackage>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/src/Servers/IIS/AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2.pkgproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2/Microsoft.AspNetCore.AspNetCoreModuleV2.pkgproj
@@ -11,6 +11,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageDescription>ASP.NET Core Module</PackageDescription>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
+    <IsANCMPackage>true</IsANCMPackage>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
Note, this is purely a build only change. I'm currently working on verifying this works with separate branches on aspnetci.

## Impact
After we stopped pushing to MyGet, ANCM transfer packages have stopped being uploaded. Builds are now failing with an error saying ANCM could not be found as an artifact dependency as well as the latest version of ANCM being 2.2.2 on myget. This change makes it so ANCM always builds, regardless of if there was a change to ANCM or not.

The reason this is fine is:
- ANCM is shipped globally and isn't put in a package.
- We are already doing this in 3.0.

## Risk
Very low risk. We are rebuilding ANCM every patch version, which will update dll/msi versions. However, the source code being used is the same.