### PR TITLE
Always include ANCM in build output

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,6 +11,7 @@
     <!-- Always include framework metapackages in patch updates. -->
     <IsPackageInThisPatch Condition="'$(IsFrameworkMetapackage)' == 'true' OR '$(IsSharedSourcePackage)' == 'true' ">true</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="'$(IsPackageInThisPatch)' == ''">$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackageInThisPatch>
+    <IsPackageInThisPatch Condition="'$(IsANCMPackage)' == 'true'">true</IsPackageInThisPatch>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsPackable)' != 'false' AND '$(IsServicingBuild)' == 'true' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,6 +11,8 @@
     <!-- Always include framework metapackages in patch updates. -->
     <IsPackageInThisPatch Condition="'$(IsFrameworkMetapackage)' == 'true' OR '$(IsSharedSourcePackage)' == 'true' ">true</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="'$(IsPackageInThisPatch)' == ''">$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackageInThisPatch>
+    
+    <!-- ANCM always builds every patch as we don't push temporary nuget packages anymore and that ANCM itself is a global singleton -->
     <IsPackageInThisPatch Condition="'$(IsANCMPackage)' == 'true'">true</IsPackageInThisPatch>
   </PropertyGroup>
 

--- a/src/Servers/IIS/AspNetCoreModuleV1/Microsoft.AspNetCore.AspNetCoreModuleV1/Microsoft.AspNetCore.AspNetCoreModuleV1.pkgproj
+++ b/src/Servers/IIS/AspNetCoreModuleV1/Microsoft.AspNetCore.AspNetCoreModuleV1/Microsoft.AspNetCore.AspNetCoreModuleV1.pkgproj
@@ -10,6 +10,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageDescription>ASP.NET Core Module</PackageDescription>
+    <IsANCMPackage>true</IsANCMPackage>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
Note, this is purely a build only change. I'm currently working on verifying this works with separate branches on aspnetci.

Same change as https://github.com/aspnet/AspNetCore/pull/11198, except just for 2.1.