### PR TITLE
Ext Auth Dev Msg Remove

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V3/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V3/Account/Login.cshtml
@@ -7,7 +7,14 @@
 
 <h2>@ViewData["Title"]</h2>
 <div class="row">
-    <div class="col-md-4">
+    @{
+        string colspan = "col-md-4";
+        if ((Model.ExternalLogins?.Count ?? 0) == 0)
+        {
+            colspan = "col-md-6";
+        }
+    }
+    <div class="@colspan">
         <section>
             <form id="account" method="post">
                 <h4>Use a local account to log in.</h4>
@@ -48,36 +55,27 @@
             </form>
         </section>
     </div>
-    <div class="col-md-6 col-md-offset-2">
-        <section>
-            <h4>Use another service to log in.</h4>
-            <hr />
-            @{
-                if ((Model.ExternalLogins?.Count ?? 0) == 0)
-                {
-                    <div>
-                        <p>
-                            There are no external authentication services configured. See <a href="https://go.microsoft.com/fwlink/?LinkID=532715">this article</a>
-                            for details on setting up this ASP.NET application to support logging in via external services.
-                        </p>
-                    </div>
-                }
-                else
-                {
-                    <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
-                        <div>
-                            <p>
-                                @foreach (var provider in Model.ExternalLogins)
-                                {
-                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                                }
-                            </p>
-                        </div>
-                    </form>
-                }
-            }
-        </section>
-    </div>
+	 @{
+        if ((Model.ExternalLogins?.Count ?? 0) > 0)
+        {
+			<div class="col-md-6 col-md-offset-2">
+				<section>
+					<h4>Use another service to log in.</h4>
+					<hr />
+					<form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
+						<div>
+							<p>
+								@foreach (var provider in Model.ExternalLogins)
+								{
+									<button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
+								}
+							</p>
+						</div>
+					</form>
+				</section>
+			</div>
+		}
+	}
 </div>
 
 @section Scripts {

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml
@@ -45,36 +45,27 @@
             </form>
         </section>
     </div>
-    <div class="col-md-6 col-md-offset-2">
-        <section>
-            <h4>Use another service to log in.</h4>
-            <hr />
-            @{
-                if ((Model.ExternalLogins?.Count ?? 0) == 0)
-                {
-                    <div>
-                        <p>
-                            There are no external authentication services configured. See <a href="https://go.microsoft.com/fwlink/?LinkID=532715">this article</a>
-                            for details on setting up this ASP.NET application to support logging in via external services.
-                        </p>
-                    </div>
-                }
-                else
-                {
-                    <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
-                        <div>
-                            <p>
-                                @foreach (var provider in Model.ExternalLogins)
-                                {
-                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                                }
-                            </p>
-                        </div>
-                    </form>
-                }
-            }
-        </section>
-    </div>
+	@{
+		if ((Model.ExternalLogins?.Count ?? 0) == 0)
+		{
+		<div class="col-md-6 col-md-offset-2">
+			<section>
+				<h4>Use another service to log in.</h4>
+				<hr />
+				<form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
+					<div>
+						<p>
+							@foreach (var provider in Model.ExternalLogins)
+							{
+								<button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
+							}
+						</p>
+					</div>
+				</form>
+			</section>
+		</div>
+		}
+	}
 </div>
 
 @section Scripts {


### PR DESCRIPTION
Remove developer message: "There are no external authentication services configured."

Summary of the changes (Less than 80 chars)
 - Removing from v3 and v4 identity page templates, the dev message when there are no External auth providers
 - Pointless to have to scaffold and override Login.cshtml when only supplying local auth to customer.

Addresses #5769
