### PR TITLE
Set ReferenceAssemblyAttribute in reference assemblies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -98,6 +98,10 @@
     <BuildHelixPayload Condition="'$(BuildHelixPayload)' == '' AND '$(IsTestProject)' == 'true'">true</BuildHelixPayload>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(Language)' == 'C#' AND '$(IsReferenceAssemblyProject)' == 'true'">
+    <Compile Include="$(SharedSourceRoot)ReferenceAssemblyInfo.cs" LinkBase="Properties" />
+  </ItemGroup>
+
   <ItemGroup>
     <KnownFrameworkReference Update="Microsoft.NETCore.App">
       <!-- Always update the 'latest version', whether the repo is servicing or not. -->

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -5,6 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,6 +26,36 @@ namespace Microsoft.AspNetCore
             _output = output;
             _expectedRid = TestData.GetSharedFxRuntimeIdentifier();
             _targetingPackRoot = Path.Combine(TestData.GetTestDataValue("TargetingPackLayoutRoot"), "packs", "Microsoft.AspNetCore.App.Ref", TestData.GetTestDataValue("TargetingPackVersion"));
+        }
+
+        [Fact]
+        public void AssembliesAreReferenceAssemblies()
+        {
+            IEnumerable<string> dlls = Directory.GetFiles(_targetingPackRoot, "*.dll", SearchOption.AllDirectories);
+            Assert.NotEmpty(dlls);
+
+            // Workaround https://github.com/aspnet/AspNetCore/issues/11206
+            dlls = dlls.Where(d => !d.Contains("System.IO.Pipelines"));
+
+            Assert.All(dlls, path =>
+            {
+                var assemblyName = AssemblyName.GetAssemblyName(path);
+                using var fileStream = File.OpenRead(path);
+                using var peReader = new PEReader(fileStream, PEStreamOptions.Default);
+                var reader = peReader.GetMetadataReader(MetadataReaderOptions.Default);
+                var assemblyDefinition = reader.GetAssemblyDefinition();
+                var hasRefAssemblyAttribute = assemblyDefinition.GetCustomAttributes().Any(attr =>
+                {
+                    var attribute = reader.GetCustomAttribute(attr);
+                    var attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                    var attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
+                    return reader.StringComparer.Equals(attributeType.Namespace, typeof(ReferenceAssemblyAttribute).Namespace)
+                        && reader.StringComparer.Equals(attributeType.Name, nameof(ReferenceAssemblyAttribute));
+                });
+
+                Assert.True(hasRefAssemblyAttribute, $"{path} should have {nameof(ReferenceAssemblyAttribute)}");
+                Assert.Equal(ProcessorArchitecture.None, assemblyName.ProcessorArchitecture);
+            });
         }
 
         [Fact]

--- a/src/Mvc/Mvc.Analyzers/test/Mvc.Analyzers.Test.csproj
+++ b/src/Mvc/Mvc.Analyzers/test/Mvc.Analyzers.Test.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Mvc.Analyzers\src\Microsoft.AspNetCore.Mvc.Analyzers.csproj" />
-    <ProjectReference Include="..\..\Mvc\ref\Microsoft.AspNetCore.Mvc.csproj" />
+    <ProjectReference Include="..\..\Mvc\src\Microsoft.AspNetCore.Mvc.csproj" />
     <Reference Include="Microsoft.AspNetCore.Analyzer.Testing" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>

--- a/src/Mvc/Mvc.Api.Analyzers/test/Mvc.Api.Analyzers.Test.csproj
+++ b/src/Mvc/Mvc.Api.Analyzers/test/Mvc.Api.Analyzers.Test.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Mvc.Api.Analyzers\src\Microsoft.AspNetCore.Mvc.Api.Analyzers.csproj" />
-    <ProjectReference Include="..\..\Mvc\ref\Microsoft.AspNetCore.Mvc.csproj" />
+    <ProjectReference Include="..\..\Mvc\src\Microsoft.AspNetCore.Mvc.csproj" />
     <Reference Include="Microsoft.AspNetCore.Analyzer.Testing" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>

--- a/src/Shared/ReferenceAssemblyInfo.cs
+++ b/src/Shared/ReferenceAssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// All reference assemblies should have the 0x70 flag which prevents them from loading
+// and the ReferenceAssemblyAttribute.
+[assembly:System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly:System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]

--- a/src/Shared/ReferenceAssemblyInfo.cs
+++ b/src/Shared/ReferenceAssemblyInfo.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-// All reference assemblies should have the 0x70 flag which prevents them from loading
-// and the ReferenceAssemblyAttribute.
+// Reference assemblies should have the ReferenceAssemblyAttribute. 
 [assembly:System.Runtime.CompilerServices.ReferenceAssembly]
+
+// Reference assemblies should have the 0x70 flag which prevents them from loading.
+// This flag sets AssemblyName.ProcessorArchitecture to None. There is no public API for this.
+// Cref https://github.com/dotnet/coreclr/blob/64ca544ecf55490675e72b853e98ebc8cc75a4fe/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs#L74
 [assembly:System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]


### PR DESCRIPTION
Depends on https://github.com/aspnet/Extensions/pull/1845 to get a passing test. 

Reference assemblies in .NET are supposed to have these two attributes, which prevent the runtime from loading and executing them.

For other examples of this, see https://github.com/dotnet/corefx/blob/41489a93acf3f36abcaaaea2003a8fdbb577cf35/eng/ReferenceAssemblies.props#L23-L28
and https://github.com/dotnet/standard/blob/14b6385e8640328e33883a919eca11594e22f21c/eng/versioning.targets#L48-L53