### PR TITLE
Hoist activity fields to the logging scope

### DIFF
--- a/src/Hosting/Hosting/src/Internal/ActivityExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/ActivityExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 ActivityIdFormat.Hierarchical => activity.Id,
                 ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
                 _ => null,
-            };
+            } ?? string.Empty;
         }
 
         public static string GetTraceId(this Activity activity)
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 ActivityIdFormat.Hierarchical => activity.RootId,
                 ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
                 _ => null,
-            };
+            } ?? string.Empty;
         }
 
         public static string GetParentId(this Activity activity)
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 ActivityIdFormat.Hierarchical => activity.ParentId,
                 ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
                 _ => null,
-            };
+            } ?? string.Empty;
         }
     }
 }

--- a/src/Hosting/Hosting/src/Internal/ActivityExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/ActivityExtensions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    /// <summary>
+    /// Helpers for getting the right values from Activity no matter the format (w3c or hierarchical)
+    /// </summary>
+    internal static class ActivityExtensions
+    {
+        public static string GetSpanId(this Activity activity)
+        {
+            return activity.IdFormat switch
+            {
+                ActivityIdFormat.Hierarchical => activity.Id,
+                ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
+                _ => null,
+            };
+        }
+
+        public static string GetTraceId(this Activity activity)
+        {
+            return activity.IdFormat switch
+            {
+                ActivityIdFormat.Hierarchical => activity.RootId,
+                ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
+                _ => null,
+            };
+        }
+
+        public static string GetParentId(this Activity activity)
+        {
+            return activity.IdFormat switch
+            {
+                ActivityIdFormat.Hierarchical => activity.ParentId,
+                ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 // Scope may be relevant for a different level of logging, so we always create it
                 // see: https://github.com/aspnet/Hosting/pull/944
                 // Scope can be null if logging is not on.
-                context.Scope = _logger.RequestScope(httpContext, context.Activity.Id);
+                context.Scope = _logger.RequestScope(httpContext, context.Activity);
 
                 if (_logger.IsEnabled(LogLevel.Information))
                 {

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 {
                     _traceId = activity.TraceId.ToHexString();
                     _spanId = activity.SpanId.ToHexString();
-                    _parentId = activity.ParentId;
+                    _parentId = activity.ParentSpanId.ToHexString();
                 }
                 else
                 {

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -123,15 +123,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
-                        return new KeyValuePair<string, object>("SpanId", _activity.GetSpanId() ?? string.Empty);
+                        return new KeyValuePair<string, object>("SpanId", _activity.GetSpanId());
                     }
                     else if (index == 3)
                     {
-                        return new KeyValuePair<string, object>("TraceId", _activity.GetTraceId() ?? string.Empty);
+                        return new KeyValuePair<string, object>("TraceId", _activity.GetTraceId());
                     }
                     else if (index == 4)
                     {
-                        return new KeyValuePair<string, object>("ParentId", _activity.GetParentId() ?? string.Empty);
+                        return new KeyValuePair<string, object>("ParentId", _activity.GetParentId());
                     }
 
                     throw new ArgumentOutOfRangeException(nameof(index));

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -13,9 +14,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class HostingLoggerExtensions
     {
-        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string activityId)
+        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, Activity activity)
         {
-            return logger.BeginScope(new HostingLogScope(httpContext, activityId));
+            return logger.BeginScope(new HostingLogScope(httpContext, activity));
         }
 
         public static void ApplicationError(this ILogger logger, Exception exception)
@@ -96,7 +97,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             private readonly string _path;
             private readonly string _traceIdentifier;
-            private readonly string _activityId;
+            private readonly string _traceId;
+            private readonly string _parentId;
+            private readonly string _spanId;
 
             private string _cachedToString;
 
@@ -104,7 +107,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 get
                 {
-                    return 3;
+                    return 5;
                 }
             }
 
@@ -122,20 +125,40 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
-                        return new KeyValuePair<string, object>("ActivityId", _activityId);
+                        return new KeyValuePair<string, object>("SpanId", _spanId);
+                    }
+                    else if (index == 3)
+                    {
+                        return new KeyValuePair<string, object>("TraceId", _traceId);
+                    }
+                    else if (index == 4)
+                    {
+                        return new KeyValuePair<string, object>("ParentId", _parentId);
                     }
 
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
 
-            public HostingLogScope(HttpContext httpContext, string activityId)
+            public HostingLogScope(HttpContext httpContext, Activity activity)
             {
                 _traceIdentifier = httpContext.TraceIdentifier;
                 _path = (httpContext.Request.PathBase.HasValue 
                          ? httpContext.Request.PathBase + httpContext.Request.Path 
                          : httpContext.Request.Path).ToString();
-                _activityId = activityId;
+
+                if (activity.IdFormat == ActivityIdFormat.W3C)
+                {
+                    _traceId = activity.TraceId.ToHexString();
+                    _spanId = activity.SpanId.ToHexString();
+                    _parentId = activity.ParentId;
+                }
+                else
+                {
+                    _traceId = activity.RootId;
+                    _spanId = activity.Id;
+                    _parentId = activity.ParentId;
+                }
             }
 
             public override string ToString()
@@ -144,10 +167,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 {
                     _cachedToString = string.Format(
                         CultureInfo.InvariantCulture,
-                        "RequestPath:{0} RequestId:{1}, ActivityId:{2}",
+                        "RequestPath:{0} RequestId:{1}, SpanId:{2}, TraceId:{3}, ParentId:{4}",
                         _path,
                         _traceIdentifier,
-                        _activityId);
+                        _spanId,
+                        _traceId,
+                        _parentId);
                 }
 
                 return _cachedToString;

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -97,9 +97,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             private readonly string _path;
             private readonly string _traceIdentifier;
-            private readonly string _traceId;
-            private readonly string _parentId;
-            private readonly string _spanId;
+            private readonly Activity _activity;
 
             private string _cachedToString;
 
@@ -125,15 +123,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
-                        return new KeyValuePair<string, object>("SpanId", _spanId);
+                        return new KeyValuePair<string, object>("SpanId", _activity.GetSpanId());
                     }
                     else if (index == 3)
                     {
-                        return new KeyValuePair<string, object>("TraceId", _traceId);
+                        return new KeyValuePair<string, object>("TraceId", _activity.GetTraceId());
                     }
                     else if (index == 4)
                     {
-                        return new KeyValuePair<string, object>("ParentId", _parentId);
+                        return new KeyValuePair<string, object>("ParentId", _activity.GetParentId());
                     }
 
                     throw new ArgumentOutOfRangeException(nameof(index));
@@ -147,18 +145,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                          ? httpContext.Request.PathBase + httpContext.Request.Path 
                          : httpContext.Request.Path).ToString();
 
-                if (activity.IdFormat == ActivityIdFormat.W3C)
-                {
-                    _traceId = activity.TraceId.ToHexString();
-                    _spanId = activity.SpanId.ToHexString();
-                    _parentId = activity.ParentSpanId.ToHexString();
-                }
-                else
-                {
-                    _traceId = activity.RootId;
-                    _spanId = activity.Id;
-                    _parentId = activity.ParentId;
-                }
+                _activity = activity;
             }
 
             public override string ToString()
@@ -170,9 +157,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                         "RequestPath:{0} RequestId:{1}, SpanId:{2}, TraceId:{3}, ParentId:{4}",
                         _path,
                         _traceIdentifier,
-                        _spanId,
-                        _traceId,
-                        _parentId);
+                        _activity.GetSpanId(),
+                        _activity.GetTraceId(),
+                        _activity.GetParentId());
                 }
 
                 return _cachedToString;

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -123,15 +123,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
-                        return new KeyValuePair<string, object>("SpanId", _activity.GetSpanId());
+                        return new KeyValuePair<string, object>("SpanId", _activity.GetSpanId() ?? string.Empty);
                     }
                     else if (index == 3)
                     {
-                        return new KeyValuePair<string, object>("TraceId", _activity.GetTraceId());
+                        return new KeyValuePair<string, object>("TraceId", _activity.GetTraceId() ?? string.Empty);
                     }
                     else if (index == 4)
                     {
-                        return new KeyValuePair<string, object>("ParentId", _activity.GetParentId());
+                        return new KeyValuePair<string, object>("ParentId", _activity.GetParentId() ?? string.Empty);
                     }
 
                     throw new ArgumentOutOfRangeException(nameof(index));

--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         [Fact]
-        public void CreateContextWithEnabledLoggerCreatesActivityAndSetsActivityIdInScope()
+        public void CreateContextWithEnabledLoggerCreatesActivityAndSetsActivityInScope()
         {
             // Arrange
             var logger = new LoggerWithScopes(isEnabled: true);
@@ -53,7 +53,36 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             Assert.Single(logger.Scopes);
             var pairs = ((IReadOnlyList<KeyValuePair<string, object>>)logger.Scopes[0]).ToDictionary(p => p.Key, p => p.Value);
-            Assert.Equal(Activity.Current.Id, pairs["ActivityId"].ToString());
+            Assert.Equal(Activity.Current.Id, pairs["SpanId"].ToString());
+            Assert.Equal(Activity.Current.RootId, pairs["TraceId"].ToString());
+            Assert.Null(pairs["ParentId"]?.ToString());
+        }
+
+        [Fact]
+        public void CreateContextWithEnabledLoggerAndRequestIdCreatesActivityAndSetsActivityInScope()
+        {
+            // Arrange
+
+            // Generate an id we can use for the request id header (in the correct format)
+            var activity = new Activity("IncomingRequest");
+            activity.Start();
+            var id = activity.Id;
+            activity.Stop();
+
+            var logger = new LoggerWithScopes(isEnabled: true);
+            var hostingApplication = CreateApplication(out var features, logger: logger, configure: context =>
+            {
+                context.Request.Headers["Request-Id"] = id;
+            });
+
+            // Act
+            var context = hostingApplication.CreateContext(features);
+
+            Assert.Single(logger.Scopes);
+            var pairs = ((IReadOnlyList<KeyValuePair<string, object>>)logger.Scopes[0]).ToDictionary(p => p.Key, p => p.Value);
+            Assert.Equal(Activity.Current.Id, pairs["SpanId"].ToString());
+            Assert.Equal(Activity.Current.RootId, pairs["TraceId"].ToString());
+            Assert.Equal(id, pairs["ParentId"].ToString());
         }
 
         [Fact]
@@ -89,10 +118,6 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             // Act
             var context = hostingApplication.CreateContext(features);
-
-            Assert.Single(logger.Scopes);
-            var pairs = ((IReadOnlyList<KeyValuePair<string, object>>)logger.Scopes[0]).ToDictionary(p => p.Key, p => p.Value);
-            Assert.Equal(Activity.Current.Id, pairs["ActivityId"].ToString());
 
             hostingApplication.DisposeContext(context, exception: null);
 
@@ -398,13 +423,15 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         private static HostingApplication CreateApplication(out FeatureCollection features,
-            DiagnosticListener diagnosticSource = null, ILogger logger = null)
+            DiagnosticListener diagnosticSource = null, ILogger logger = null, Action<DefaultHttpContext> configure = null)
         {
             var httpContextFactory = new Mock<IHttpContextFactory>();
 
             features = new FeatureCollection();
             features.Set<IHttpRequestFeature>(new HttpRequestFeature());
-            httpContextFactory.Setup(s => s.Create(It.IsAny<IFeatureCollection>())).Returns(new DefaultHttpContext(features));
+            var context = new DefaultHttpContext(features);
+            configure?.Invoke(context);
+            httpContextFactory.Setup(s => s.Create(It.IsAny<IFeatureCollection>())).Returns(context);
             httpContextFactory.Setup(s => s.Dispose(It.IsAny<HttpContext>()));
 
             var hostingApplication = new HostingApplication(
@@ -453,7 +480,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             {
-                
+
             }
 
             private class Scope : IDisposable

--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var pairs = ((IReadOnlyList<KeyValuePair<string, object>>)logger.Scopes[0]).ToDictionary(p => p.Key, p => p.Value);
             Assert.Equal(Activity.Current.Id, pairs["SpanId"].ToString());
             Assert.Equal(Activity.Current.RootId, pairs["TraceId"].ToString());
-            Assert.Null(pairs["ParentId"]?.ToString());
+            Assert.Equal(string.Empty, pairs["ParentId"]?.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
- Expose SpanId, TraceId and ParentId to logging scope properties
- Added tests to verify the Hierarchical ID format

Fixes #9491

PS: I need to spend some time looking at allocations before I merge this.

cc @benaadams 

cc @lmolkova @SergeyKanzhelev for review