### PR TITLE
Adding HTTP header with empty string value yields confusing error #11032

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -385,8 +385,12 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                             var headerNameBytes = Encoding.UTF8.GetBytes(headerPair.Key);
                             fixed (byte* pHeaderName = headerNameBytes)
                             {
-                                NativeMethods.HttpResponseSetUnknownHeader(_pInProcessHandler, pHeaderName, pHeaderValue, (ushort)headerValueBytes.Length, fReplace: isFirst);
-                            }
+								if(headerValueBytes.Length == 0){
+									throw new ArgumentException("Header value cannot be an empty string");
+								}else{
+									NativeMethods.HttpResponseSetUnknownHeader(_pInProcessHandler, pHeaderName, pHeaderValue, (ushort)headerValueBytes.Length, fReplace: isFirst);
+								}
+							}
                         }
                         else
                         {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Pre-Check **headerValueBytes** length 
 - if header value is empty than throw exception with custom message

Addresses #11032 
