### PR TITLE
Add file manifest for runtime and targeting pack

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,6 +70,10 @@
     <SharedFxName>Microsoft.AspNetCore.App</SharedFxName>
     <SharedFxDescription>Shared Framework for hosting of Microsoft ASP.NET Core applications. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub ($(RepositoryUrl)). We happily accept issues and PRs.</SharedFxDescription>
 
+    <NETCoreAppFrameworkIdentifier>.NETCoreApp</NETCoreAppFrameworkIdentifier>
+    <NETCoreAppFramework>netcoreapp$(AspNetCoreMajorMinorVersion)</NETCoreAppFramework>
+    <AspNetCoreAppFrameworkBrandName>ASP.NET Core $(AspNetCoreMajorMinorVersion)</AspNetCoreAppFrameworkBrandName>
+
     <TargetingPackName>Microsoft.AspNetCore.App.Ref</TargetingPackName>
     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -1,15 +1,14 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace RepoTasks
 {
@@ -26,7 +25,7 @@ namespace RepoTasks
 
         /// <summary>
         /// Extra attributes to place on the root node.
-        /// 
+        ///
         /// %(Identity): Attribute name.
         /// %(Value): Attribute value.
         /// </summary>

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -53,7 +53,6 @@ namespace RepoTasks
                     IsNative = item.GetMetadata("IsNativeImage") == "true",
                     IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true"
                 })
-                .Where(a => a.Filename.Contains("aspnetcorev2"))
                 .Where(f =>
                     !f.IsSymbolFile &&
                     (f.Filename.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || f.IsNative))

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -34,10 +34,6 @@ namespace RepoTasks
 
         public override bool Execute()
         {
-            //while (!Debugger.IsAttached)
-            //{
-
-            //}
             XAttribute[] rootAttributes = RootAttributes
                 ?.Select(item => new XAttribute(item.ItemSpec, item.GetMetadata("Value")))
                 .ToArray();
@@ -54,9 +50,10 @@ namespace RepoTasks
                     TargetPath = item.GetMetadata("TargetPath"),
                     AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
                     FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
-                    IsNative = item.GetMetadata("IsNative") == "true",
+                    IsNative = item.GetMetadata("IsNativeImage") == "true",
                     IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true"
                 })
+                .Where(a => a.Filename.Contains("aspnetcorev2"))
                 .Where(f =>
                     !f.IsSymbolFile &&
                     (f.Filename.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || f.IsNative))

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace RepoTasks
+{
+    public class CreateFrameworkListFile : Task
+    {
+        /// <summary>
+        /// Files to extract basic information from and include in the list.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        /// <summary>
+        /// A list of assembly names with Profile classifications. A Profile="%(Profile)" attribute
+        /// is set in the framework list for the matching Files item if %(Profile) contains text.
+        ///
+        /// If *any* FileProfiles are passed:
+        ///
+        ///   *Every* file that ends up listed in the framework list must have a matching
+        ///   FileProfile, even if %(Profile) is not set.
+        ///
+        ///   Additionally, every FileProfile must find exactly one File.
+        ///
+        /// This task fails if the conditions aren't met. This ensures the classification doesn't
+        /// become out of date when the list of files changes.
+        ///
+        /// %(Identity): Assembly name (including ".dll").
+        /// %(Profile): List of profiles that apply, semicolon-delimited.
+        /// </summary>
+        public ITaskItem[] FileProfiles { get; set; }
+
+        [Required]
+        public string TargetFile { get; set; }
+
+        public string[] TargetFilePrefixes { get; set; }
+
+        /// <summary>
+        /// Extra attributes to place on the root node.
+        ///
+        /// %(Identity): Attribute name.
+        /// %(Value): Attribute value.
+        /// </summary>
+        public ITaskItem[] RootAttributes { get; set; }
+
+        public override bool Execute()
+        {
+            // while (!Debugger.IsAttached)
+            // {
+
+            // }
+            XAttribute[] rootAttributes = RootAttributes
+                ?.Select(item => new XAttribute(item.ItemSpec, item.GetMetadata("Value")))
+                .ToArray();
+
+            var frameworkManifest = new XElement("FileList", rootAttributes);
+
+            Dictionary<string, string> fileProfileLookup = FileProfiles
+                ?.ToDictionary(
+                    item => item.ItemSpec,
+                    item => item.GetMetadata("Profile"),
+                    StringComparer.OrdinalIgnoreCase);
+
+            var usedFileProfiles = new HashSet<string>();
+
+            foreach (var f in Files
+                .Where(IsTargetPathIncluded)
+                .Select(item => new
+                {
+                    Item = item,
+                    Filename = Path.GetFileName(item.ItemSpec),
+                    TargetPath = item.GetMetadata("TargetPath"),
+                    AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
+                    FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
+                    IsNative = item.GetMetadata("IsNative") == "true",
+                    IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true"
+                })
+                .Where(f =>
+                    !f.IsSymbolFile &&
+                    (f.Filename.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || f.IsNative))
+                .OrderBy(f => f.TargetPath, StringComparer.Ordinal)
+                .ThenBy(f => f.Filename, StringComparer.Ordinal))
+            {
+                var element = new XElement(
+                    "File",
+                    new XAttribute("Type", f.IsNative ? "Native" : "Managed"),
+                    new XAttribute(
+                        "Path",
+                        Path.Combine(f.TargetPath, f.Filename).Replace('\\', '/')));
+
+                if (f.AssemblyName != null)
+                {
+                    byte[] publicKeyToken = f.AssemblyName.GetPublicKeyToken();
+                    string publicKeyTokenHex;
+
+                    if (publicKeyToken != null)
+                    {
+                        publicKeyTokenHex = BitConverter.ToString(publicKeyToken)
+                            .ToLowerInvariant()
+                            .Replace("-", "");
+                    }
+                    else
+                    {
+                        Log.LogError($"No public key token found for assembly {f.Item.ItemSpec}");
+                        publicKeyTokenHex = "";
+                    }
+
+                    element.Add(
+                        new XAttribute("AssemblyName", f.AssemblyName.Name),
+                        new XAttribute("PublicKeyToken", publicKeyTokenHex),
+                        new XAttribute("AssemblyVersion", f.AssemblyName.Version));
+                }
+                else if (!f.IsNative)
+                {
+                    // This file isn't managed and isn't native. Leave it off the list.
+                    continue;
+                }
+
+                element.Add(new XAttribute("FileVersion", f.FileVersion));
+
+                if (fileProfileLookup != null)
+                {
+                    if (fileProfileLookup.TryGetValue(f.Filename, out string profile))
+                    {
+                        if (!string.IsNullOrEmpty(profile))
+                        {
+                            element.Add(new XAttribute("Profile", profile));
+                        }
+
+                        usedFileProfiles.Add(f.Filename);
+                    }
+                    else
+                    {
+                        Log.LogError($"File matches no profile classification: {f.Filename}");
+                    }
+                }
+
+                frameworkManifest.Add(element);
+            }
+
+            foreach (var unused in fileProfileLookup
+                ?.Keys.Except(usedFileProfiles).OrderBy(p => p)
+                ?? Enumerable.Empty<string>())
+            {
+                Log.LogError($"Profile classification matches no files: {unused}");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(TargetFile));
+            File.WriteAllText(TargetFile, frameworkManifest.ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private bool IsTargetPathIncluded(ITaskItem item)
+        {
+            return TargetFilePrefixes
+                ?.Any(prefix => item.GetMetadata("TargetPath")?.StartsWith(prefix) == true) ?? true;
+        }
+    }
+}

--- a/eng/tools/RepoTasks/FileUtilities.cs
+++ b/eng/tools/RepoTasks/FileUtilities.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/eng/tools/RepoTasks/FileUtilities.cs
+++ b/eng/tools/RepoTasks/FileUtilities.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -7,39 +8,40 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 
-namespace Microsoft.DotNet.Build.Tasks
+namespace RepoTasks
 {
-    internal static class FileUtilities
+    internal static partial class FileUtilities
     {
+        private static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(
+            new[] { ".dll", ".exe", ".winmd" },
+            StringComparer.OrdinalIgnoreCase);
+
         public static Version GetFileVersion(string sourcePath)
         {
             var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
 
-            return fvi != null
-                ? new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart)
-                : null;
+            if (fvi != null)
+            {
+                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+            }
+
+            return null;
         }
 
-        private static readonly HashSet<string> _assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
-
-        public static Version TryGetAssemblyVersion(string sourcePath)
+        public static AssemblyName GetAssemblyName(string path)
         {
-            var extension = Path.GetExtension(sourcePath);
+            if (!s_assemblyExtensions.Contains(Path.GetExtension(path)))
+            {
+                return null;
+            }
 
-            return _assemblyExtensions.Contains(extension)
-                ? GetAssemblyVersion(sourcePath)
-                : null;
-        }
-
-        private static Version GetAssemblyVersion(string sourcePath)
-        {
             try
             {
-                return AssemblyName.GetAssemblyName(sourcePath)?.Version;
+                return AssemblyName.GetAssemblyName(path);
             }
             catch (BadImageFormatException)
             {
-                // If an .dll file cannot be read, it may be a native .dll which would not have an assembly version.
+                // Not a valid assembly.
                 return null;
             }
         }

--- a/eng/tools/RepoTasks/GenerateSharedFrameworkDepsFile.cs
+++ b/eng/tools/RepoTasks/GenerateSharedFrameworkDepsFile.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Microsoft.DotNet.Build.Tasks;
 using Microsoft.Extensions.DependencyModel;
 
 namespace RepoTasks
@@ -61,7 +60,7 @@ namespace RepoTasks
                 var filePath = reference.ItemSpec;
                 var fileName = Path.GetFileName(filePath);
                 var fileVersion = FileUtilities.GetFileVersion(filePath)?.ToString() ?? string.Empty;
-                var assemblyVersion = FileUtilities.TryGetAssemblyVersion(filePath);
+                var assemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version;
                 if (assemblyVersion == null)
                 {
                     var nativeFile = new RuntimeFile(fileName, null, fileVersion);

--- a/eng/tools/RepoTasks/RepoTasks.tasks
+++ b/eng/tools/RepoTasks/RepoTasks.tasks
@@ -8,5 +8,6 @@
   <UsingTask TaskName="RepoTasks.GenerateGuid" AssemblyFile="$(_RepoTaskAssembly)" Condition="'$(MSBuildRuntimeType)' != 'core'" />
   <UsingTask TaskName="RepoTasks.GetMsiProperty" AssemblyFile="$(_RepoTaskAssembly)" Condition="'$(MSBuildRuntimeType)' != 'core'" />
   <UsingTask TaskName="RepoTasks.GenerateSharedFrameworkDepsFile" AssemblyFile="$(_RepoTaskAssembly)" />
+  <UsingTask TaskName="RepoTasks.CreateFrameworkListFile" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.RemoveSharedFrameworkDependencies" AssemblyFile="$(_RepoTaskAssembly)" />
 </Project>

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -5,9 +5,7 @@
     <ManifestsPackagePath>data/</ManifestsPackagePath>
     <!-- Shared between targeting pack and runtime build. -->
     <PlatformManifestFileName>PlatformManifest.txt</PlatformManifestFileName>
-    <FrameworkListFileName>FrameworkList.xml</FrameworkListFileName>
     <PlatformManifestOutputPath>$(ArtifactsObjDir)$(PlatformManifestFileName)</PlatformManifestOutputPath>
-    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -5,7 +5,16 @@
     <ManifestsPackagePath>data/</ManifestsPackagePath>
     <!-- Shared between targeting pack and runtime build. -->
     <PlatformManifestFileName>PlatformManifest.txt</PlatformManifestFileName>
+    <FrameworkListFileName>FrameworkList.xml</FrameworkListFileName>
     <PlatformManifestOutputPath>$(ArtifactsObjDir)$(PlatformManifestFileName)</PlatformManifestOutputPath>
+    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkListRootAttributes Include="Name" Value="$(AspNetCoreAppFrameworkBrandName)" />
+    <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NETCoreAppFrameworkIdentifier)" />
+    <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="$(AspNetCoreMajorMinorVersion)" />
+    <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFxName)" />
+  </ItemGroup>
 
 </Project>

--- a/src/Framework/build.cmd
+++ b/src/Framework/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET RepoRoot=%~dp0..\..
+%RepoRoot%\build.cmd -projects %~dp0**\*.*proj %*

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -178,6 +178,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="IncludeFrameworkListFile"
+          DependsOnTargets="_ResolveTargetingPackContent"
+          BeforeTargets="_GetPackageFiles"
           Condition="'$(PackageTargetRuntime)' == '' AND '$(ManifestsPackagePath)' != ''">
     <RepoTasks.CreateFrameworkListFile
       Files="@(RefPackContent)"
@@ -185,8 +187,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>
-      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)">
-      </RefPackContent>
+      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
       <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
   </Target>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -38,7 +38,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <ReferenceImplementationAssemblies>true</ReferenceImplementationAssemblies>
 
     <!-- Platform manifest data -->
-    <!-- <PlatformManifestTargetPath>$(ManifestsPackagePath)FrameworkList.txt</PlatformManifestTargetPath> -->
+    <FrameworkListFileName>FrameworkList.xml</FrameworkListFileName>
+    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -187,8 +187,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>
-      <RefPackContent Include="$(FrameworkListOutputPath)">
-        <PackagePath>$(ManifestsPackagePath)</PackagePath>
+      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)">
       </RefPackContent>
     </ItemGroup>
   </Target>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -38,7 +38,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <ReferenceImplementationAssemblies>true</ReferenceImplementationAssemblies>
 
     <!-- Platform manifest data -->
-    <PlatformManifestTargetPath>$(ManifestsPackagePath)FrameworkList.txt</PlatformManifestTargetPath>
+    <!-- <PlatformManifestTargetPath>$(ManifestsPackagePath)FrameworkList.txt</PlatformManifestTargetPath> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -70,6 +70,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       $(BuildDependsOn);
       GeneratePackageConflictManifest;
       _ResolveTargetingPackContent;
+      IncludeFrameworkListFile;
       _BatchCopyToLayoutTargetDir;
       _InstallTargetingPackIntoLocalDotNet;
       _CreateTargetingPackArchive;
@@ -178,19 +179,17 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(TarArchiveOutputPath)" />
   </Target>
 
-   <Target Name="IncludeFrameworkListFile"
-          BeforeTargets="_BatchCopyToLayoutTargetDir"
+  <Target Name="IncludeFrameworkListFile"
           Condition="'$(PackageTargetRuntime)' == '' AND '$(ManifestsPackagePath)' != ''">
     <RepoTasks.CreateFrameworkListFile
-      Files="@(File)"
+      Files="@(RefPackContent)"
       TargetFile="$(FrameworkListOutputPath)"
-      TargetFilePrefixes="ref/;runtimes/"
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>
-      <File Include="$(FrameworkListFile)">
+      <RefPackContent Include="$(FrameworkListOutputPath)">
         <TargetPath>$(ManifestsPackagePath)</TargetPath>
-      </File>
+      </RefPackContent>
     </ItemGroup>
   </Target>
 

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -118,8 +118,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(ManifestsPackagePath)" />
       <RefPackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
-
-      <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
   </Target>
 
@@ -189,6 +187,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <ItemGroup>
       <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)">
       </RefPackContent>
+      <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
   </Target>
 

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -36,6 +36,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <!-- Reference implementation assemblies in addition to ref assemblies to get xml docs -->
     <ReferenceImplementationAssemblies>true</ReferenceImplementationAssemblies>
+
+    <!-- Platform manifest data -->
+    <PlatformManifestTargetPath>$(ManifestsPackagePath)FrameworkList.txt</PlatformManifestTargetPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -113,6 +116,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(ManifestsPackagePath)" />
       <RefPackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
+      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
 
       <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
@@ -172,6 +176,22 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       Command="tar -czf $(TarArchiveOutputPath) ."
       WorkingDirectory="$(TargetingPackLayoutRoot)" />
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(TarArchiveOutputPath)" />
+  </Target>
+
+   <Target Name="IncludeFrameworkListFile"
+          BeforeTargets="_BatchCopyToLayoutTargetDir"
+          Condition="'$(PackageTargetRuntime)' == '' AND '$(ManifestsPackagePath)' != ''">
+    <RepoTasks.CreateFrameworkListFile
+      Files="@(File)"
+      TargetFile="$(FrameworkListOutputPath)"
+      TargetFilePrefixes="ref/;runtimes/"
+      RootAttributes="@(FrameworkListRootAttributes)" />
+
+    <ItemGroup>
+      <File Include="$(FrameworkListFile)">
+        <TargetPath>$(ManifestsPackagePath)</TargetPath>
+      </File>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -117,7 +117,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(ManifestsPackagePath)" />
       <RefPackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
-      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
 
       <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
@@ -188,7 +187,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <ItemGroup>
       <RefPackContent Include="$(FrameworkListOutputPath)">
-        <TargetPath>$(ManifestsPackagePath)</TargetPath>
+        <PackagePath>$(ManifestsPackagePath)</PackagePath>
       </RefPackContent>
     </ItemGroup>
   </Target>

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -462,6 +462,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <ItemGroup>
       <RuntimePackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)">
       </RuntimePackContent>
+      <_PackageFiles Include="@(RuntimePackContent)" />
     </ItemGroup>
   </Target>
 

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -154,6 +154,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       GenerateSharedFxVersionsFiles;
       Crossgen;
       _ResolveSharedFrameworkContent;
+      IncludeFrameworkListFile;
       _DownloadAndExtractDotNetRuntime;
       _BatchCopyToSharedFrameworkLayout;
       _BatchCopyToRedistLayout;
@@ -380,6 +381,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <SharedFxContent Include="$(ProjectRuntimeConfigFilePath)" />
       <SharedFxContent Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
       <SharedFxContent Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" />
+      <SharedFxContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>
   </Target>
 
@@ -446,6 +448,20 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       Command="tar -czf $(RedistArchiveOutputPath) ."
       WorkingDirectory="$(RedistSharedFrameworkLayoutRoot)"
       Condition="'$(ArchiveExtension)' == '.tar.gz'" />
+  </Target>
+  
+  <Target Name="IncludeFrameworkListFile"
+          Condition="'$(ManifestsPackagePath)' != ''">
+    <RepoTasks.CreateFrameworkListFile
+      Files="@(SharedFxContent)"
+      TargetFile="$(FrameworkListOutputPath)"
+      RootAttributes="@(FrameworkListRootAttributes)" />
+
+    <ItemGroup>
+      <SharedFxContent Include="$(FrameworkListOutputPath)">
+        <TargetPath>$(ManifestsPackagePath)</TargetPath>
+      </SharedFxContent>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -451,6 +451,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="IncludeFrameworkListFile"
+          DependsOnTargets="_ResolveSharedFrameworkContent"
           BeforeTargets="_GetPackageFiles"
           Condition="'$(ManifestsPackagePath)' != ''">
     <RepoTasks.CreateFrameworkListFile

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -100,6 +100,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <RuntimePackageRoot>$([MSBuild]::EnsureTrailingSlash('$(RuntimePackageRoot)'))</RuntimePackageRoot>
     <CrossgenToolPath>$([System.IO.Path]::Combine('$(RuntimePackageRoot)', 'tools', '$(CrossgenToolPackagePath)'))</CrossgenToolPath>
     <AssetTargetFallback>$(AssetTargetFallback);native,Version=0.0</AssetTargetFallback>
+
+    <FrameworkListFileName>RuntimeList.xml</FrameworkListFileName>
+    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -448,7 +451,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       WorkingDirectory="$(RedistSharedFrameworkLayoutRoot)"
       Condition="'$(ArchiveExtension)' == '.tar.gz'" />
   </Target>
-  
+
   <Target Name="IncludeFrameworkListFile"
           Condition="'$(ManifestsPackagePath)' != ''">
     <RepoTasks.CreateFrameworkListFile

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -279,8 +279,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           DependsOnTargets="GenerateSharedFxDepsFile">
     <ItemGroup>
       <RuntimePackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
-
-      <_PackageFiles Include="@(RuntimePackContent)" />
     </ItemGroup>
   </Target>
 
@@ -453,6 +451,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="IncludeFrameworkListFile"
+          BeforeTargets="_GetPackageFiles"
           Condition="'$(ManifestsPackagePath)' != ''">
     <RepoTasks.CreateFrameworkListFile
       Files="@(SharedFxContent)"
@@ -460,8 +459,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>
-      <RuntimePackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)">
-      </RuntimePackContent>
+      <RuntimePackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
       <_PackageFiles Include="@(RuntimePackContent)" />
     </ItemGroup>
   </Target>

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -381,7 +381,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <SharedFxContent Include="$(ProjectRuntimeConfigFilePath)" />
       <SharedFxContent Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
       <SharedFxContent Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" />
-      <SharedFxContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>
   </Target>
 
@@ -459,7 +458,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <ItemGroup>
       <SharedFxContent Include="$(FrameworkListOutputPath)">
-        <TargetPath>$(ManifestsPackagePath)</TargetPath>
+        <PackagePath>$(ManifestsPackagePath)</PackagePath>
       </SharedFxContent>
     </ItemGroup>
   </Target>

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -460,9 +460,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>
-      <SharedFxContent Include="$(FrameworkListOutputPath)">
-        <PackagePath>$(ManifestsPackagePath)</PackagePath>
-      </SharedFxContent>
+      <RuntimePackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)">
+      </RuntimePackContent>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/10215 and https://github.com/aspnet/AspNetCore/issues/10216

This seems to be working locally for win-x64. I want to confirm things look good on CI before I do some finalization.

Few open questions that I'm working on solving:
- For the runtime pack manifest, make sure manifests are in the right location and have the right names (may need clarification here as it wasn't clear in the issues)
- Determine which dlls should be in which manifest (should native dlls be in the targeting pack?)

I'd also like to add a few automated tests once I confirm things are correct.