### PR TITLE
Correct EnableEndpointRouting spelling

### DIFF
--- a/src/Mvc/Mvc.Analyzers/src/Startup/StartupAnalyzer.Diagnostics.cs
+++ b/src/Mvc/Mvc.Analyzers/src/Startup/StartupAnalyzer.Diagnostics.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Analyzers
         internal readonly static DiagnosticDescriptor UnsupportedUseMvcWithEndpointRouting = new DiagnosticDescriptor(
             "MVC1005", 
             "Cannot use UseMvc with Endpoint Routing.", 
-            "Using '{0}' to configure MVC is not supported while using Endpoint Routing. To continue using '{0}', please set 'MvcOptions.EnableEndpointRounting = false' inside '{1}'.",
+            "Using '{0}' to configure MVC is not supported while using Endpoint Routing. To continue using '{0}', please set 'MvcOptions.EnableEndpointRouting = false' inside '{1}'.",
             "Usage", 
             DiagnosticSeverity.Warning, 
             isEnabledByDefault: true,


### PR DESCRIPTION
Fixed spelling of EnableEndpointRouting that could show up on the intellisense for app.UseMvc
