### PR TITLE
Install Visual Studio: add support for preview

### DIFF
--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -9,6 +9,10 @@
         Community
         Professional
         Enterprise (the default)
+.PARAMETER Channel
+    Selects which channel of Visual Studio to install. Must be one of these values:
+        Release (the default)
+        Preview
 .PARAMETER InstallPath
     The location on disk where Visual Studio should be installed or updated. Default path is location of latest
     existing installation of the specified edition, if any. If that VS edition is not currently installed, default
@@ -28,6 +32,8 @@
 param(
     [ValidateSet('BuildTools','Community', 'Professional', 'Enterprise')]
     [string]$Edition = 'Enterprise',
+    [ValidateSet('Release', 'Preview')]
+    [string]$Channel = 'Release',
     [string]$InstallPath,
     [switch]$Passive,
     [switch]$Quiet
@@ -52,14 +58,23 @@ mkdir $intermedateDir -ErrorAction Ignore | Out-Null
 
 $bootstrapper = "$intermedateDir\vsinstaller.exe"
 $ProgressPreference = 'SilentlyContinue' # Workaround PowerShell/PowerShell#2138
-Invoke-WebRequest -Uri "https://aka.ms/vs/16/release/vs_$($Edition.ToLowerInvariant()).exe" -OutFile $bootstrapper
 
-$responseFile = "$PSScriptRoot\vs.json"
+$channelUri = "https://aka.ms/vs/16/release"
+$responseFileName = "vs"
 if ("$Edition" -eq "BuildTools") {
-    $responseFile = "$PSScriptRoot\vs.buildtools.json"
+    $responseFileName += ".buildtools"
+}
+if ("$Channel" -eq "Preview") {
+    $responseFileName += ".preview"
+    $channelUri = "https://aka.ms/vs/16/pre"
 }
 
+$responseFile = "$PSScriptRoot\$responseFileName.json"
 $channelId = (Get-Content $responseFile | ConvertFrom-Json).channelId
+
+$bootstrapperUri = "$channelUri/vs_$($Edition.ToLowerInvariant()).exe"
+Write-Host "Downloading Visual Studio 2019 $Edition ($Channel) bootstrapper from $bootstrapperUri"
+Invoke-WebRequest -Uri $bootstrapperUri -OutFile $bootstrapper
 
 $productId = "Microsoft.VisualStudio.Product.$Edition"
 if (-not $InstallPath) {
@@ -78,7 +93,11 @@ if (-not $InstallPath) {
 }
 
 if (-not $InstallPath) {
-    $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\$Edition"
+    if ("$Channel" -eq "Preview") {
+        $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Preview"
+    } else {
+        $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\$Edition"
+    }
 }
 
 # no backslashes - this breaks the installer
@@ -103,7 +122,7 @@ if ($Quiet) {
 }
 
 Write-Host
-Write-Host "Installing Visual Studio 2019 $Edition" -f Magenta
+Write-Host "Installing Visual Studio 2019 $Edition ($Channel)" -f Magenta
 Write-Host
 Write-Host "Running '$bootstrapper $arguments'"
 

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -94,7 +94,7 @@ if (-not $InstallPath) {
 
 if (-not $InstallPath) {
     if ("$Channel" -eq "Preview") {
-        $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Preview"
+        $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\${Edition}_Pre"
     } else {
         $InstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\$Edition"
     }

--- a/eng/scripts/vs.buildtools.preview.json
+++ b/eng/scripts/vs.buildtools.preview.json
@@ -1,0 +1,28 @@
+{
+    "channelUri": "https://aka.ms/vs/16/pre/channel",
+    "channelId": "VisualStudio.16.Preview",
+    "includeRecommended": false,
+    "addProductLang": [
+        "en-US"
+    ],
+    "add": [
+        "Microsoft.Net.Component.4.6.1.TargetingPack",
+        "Microsoft.Net.Component.4.6.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.1.TargetingPack",
+        "Microsoft.Net.Component.4.7.2.SDK",
+        "Microsoft.Net.Component.4.7.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.TargetingPack",
+        "Microsoft.VisualStudio.Component.FSharp.MSBuild",
+        "Microsoft.VisualStudio.Component.NuGet",
+        "Microsoft.VisualStudio.Component.NuGet.BuildTools",
+        "Microsoft.VisualStudio.Component.VC.ATL",
+        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+        "Microsoft.VisualStudio.Component.Windows10SDK.17134",
+        "Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools",
+        "Microsoft.VisualStudio.Workload.MSBuildTools",
+        "Microsoft.VisualStudio.Workload.NetCoreBuildTools",
+        "Microsoft.VisualStudio.Workload.VCTools",
+        "Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools",
+        "Microsoft.VisualStudio.Workload.WebBuildTools"
+    ]
+}

--- a/eng/scripts/vs.preview.json
+++ b/eng/scripts/vs.preview.json
@@ -1,0 +1,25 @@
+{
+    "channelUri": "https://aka.ms/vs/16/pre/channel",
+    "channelId": "VisualStudio.16.Preview",
+    "includeRecommended": false,
+    "addProductLang": [
+        "en-US"
+    ],
+    "add": [
+        "Microsoft.Net.Component.4.6.1.TargetingPack",
+        "Microsoft.Net.Component.4.6.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.1.TargetingPack",
+        "Microsoft.Net.Component.4.7.2.SDK",
+        "Microsoft.Net.Component.4.7.2.TargetingPack",
+        "Microsoft.Net.Component.4.7.TargetingPack",
+        "Microsoft.VisualStudio.Component.Azure.Storage.Emulator",
+        "Microsoft.VisualStudio.Component.VC.ATL",
+        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+        "Microsoft.VisualStudio.Component.Windows10SDK.17134",
+        "Microsoft.VisualStudio.Workload.ManagedDesktop",
+        "Microsoft.VisualStudio.Workload.NativeDesktop",
+        "Microsoft.VisualStudio.Workload.NetCoreTools",
+        "Microsoft.VisualStudio.Workload.NetWeb",
+        "Microsoft.VisualStudio.Workload.VisualStudioExtension"
+    ]
+}


### PR DESCRIPTION
Currently the `eng/scripts/InstallVisualStudio.ps1` script, if only the preview version is installed, will install a release version instead of updating the preview one.
This add the ability to target the preview version.
It also allow to decide which channel to target if both are installed (I should be able to test it tomorrow on a different machine) or allow to install a different channel in addition to it.
(Note: I doesn't support installing from scratch an additional preview 'Edition', as the automatic path selection will point to the existing Preview, however I am not sure if it is a supported scenario, I had issue in the past with the VS installer when attempting it).

@natemcmaster let me know if I should take a different approach.
Also the download url has been guessed by trial and error, so although it works I am not sure it is the supported one.

Thank you,
 Alessio