### PR TITLE
TestServer sends remaining content in pipe writer on complete

### DIFF
--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -127,6 +127,9 @@ namespace Microsoft.AspNetCore.TestHost
 
         internal async Task CompleteResponseAsync()
         {
+            // Flush any pending content in writer
+            await _httpContext.Response.BodyWriter.FlushAsync();
+
             _pipelineFinished = true;
             await ReturnResponseMessageAsync();
             _responseStream.CompleteWrites();

--- a/src/Hosting/WindowsServices/src/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/src/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
@@ -16,9 +16,7 @@
     <Reference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="WebHostService.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Update="WebHostService.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Change TestServer to match Kestrel's behavior by sending unflushed content in pipe writer when completing request.