### PR TITLE
Allow sending a Single null arg in Java client

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -577,20 +577,22 @@ public class HubConnection {
     }
 
     Object[] checkUploadStream(Object[] args, List<String> streamIds) {
-        if (args != null) {
-            List<Object> params = new ArrayList<>(Arrays.asList(args));
-            for (Object arg: args) {
-                if (arg instanceof Observable) {
-                    params.remove(arg);
-                    Observable stream = (Observable)arg;
-                    String streamId = connectionState.getNextInvocationId();
-                    streamIds.add(streamId);
-                    this.streamMap.put(streamId, stream);
-                }
-            }
-            return params.toArray();
+        if (args == null) {
+            return new Object[] { null };
         }
-        return new Object[] { null };
+
+        List<Object> params = new ArrayList<>(Arrays.asList(args));
+        for (Object arg: args) {
+            if (arg instanceof Observable) {
+                params.remove(arg);
+                Observable stream = (Observable)arg;
+                String streamId = connectionState.getNextInvocationId();
+                streamIds.add(streamId);
+                this.streamMap.put(streamId, stream);
+            }
+        }
+        
+        return params.toArray();
     }
 
     /**

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -577,18 +577,20 @@ public class HubConnection {
     }
 
     Object[] checkUploadStream(Object[] args, List<String> streamIds) {
-        List<Object> params = new ArrayList<>(Arrays.asList(args));
-        for (Object arg: args) {
-            if (arg instanceof Observable) {
-                params.remove(arg);
-                Observable stream = (Observable)arg;
-                String streamId = connectionState.getNextInvocationId();
-                streamIds.add(streamId);
-                this.streamMap.put(streamId, stream);
+        if (args != null) {
+            List<Object> params = new ArrayList<>(Arrays.asList(args));
+            for (Object arg: args) {
+                if (arg instanceof Observable) {
+                    params.remove(arg);
+                    Observable stream = (Observable)arg;
+                    String streamId = connectionState.getNextInvocationId();
+                    streamIds.add(streamId);
+                    this.streamMap.put(streamId, stream);
+                }
             }
+            return params.toArray();
         }
-
-        return params.toArray();
+        return new Object[] { null };
     }
 
     /**

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -954,8 +954,7 @@ class HubConnectionTest {
 
         assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
     }
-
-
+    
     @Test
     public void canSendNullArgInInvocation() {
         MockTransport mockTransport = new MockTransport();

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -955,6 +955,43 @@ class HubConnectionTest {
         assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
     }
 
+
+    @Test
+    public void canSendNullArgInInvocation() {
+        MockTransport mockTransport = new MockTransport();
+        HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+
+        AtomicBoolean done = new AtomicBoolean();
+        Single<String> result = hubConnection.invoke(String.class, "fixedMessage", null);
+        result.doOnSuccess(value -> done.set(true));
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"fixedMessage\",\"arguments\":[null]}" + RECORD_SEPARATOR, mockTransport.getSentMessages()[1]);
+        assertFalse(done.get());
+
+        mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"Hello World\"}" + RECORD_SEPARATOR);
+
+        assertEquals("Hello World", result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+    }
+
+    @Test
+    public void canSendMultipleNullArgsInInvocation() {
+        MockTransport mockTransport = new MockTransport();
+        HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
+
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+
+        AtomicBoolean done = new AtomicBoolean();
+        Single<String> result = hubConnection.invoke(String.class, "fixedMessage", null, null);
+        result.doOnSuccess(value -> done.set(true));
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"fixedMessage\",\"arguments\":[null,null]}"+ RECORD_SEPARATOR, mockTransport.getSentMessages()[1]);
+        assertFalse(done.get());
+
+        mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"Hello World\"}" + RECORD_SEPARATOR);
+
+        assertEquals("Hello World", result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+    }
+
     @Test
     public void multipleInvokesWaitForOwnCompletionMessage() {
         MockTransport mockTransport = new MockTransport();


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/11239

When passing in a single null value to a method accepting var args, is there is only one value, the parameter get serialized not as an array with a null value, but just null. This adds support for sending just a single null value, and also tests sending multiple nulls. 

``` invoke(String.class "echo", null) ``` -> args becomes `null`

``` invoke(String.class "echo", null, null) ``` -> args becomes `[null, null]`

I found this as a part of https://github.com/aspnet/AspNetCore/issues/11239#issuecomment-502520410 