### PR TITLE
Complete and make ignitor more extensible

### DIFF
--- a/src/Components/test/testassets/Ignitor/ComponentNode.cs
+++ b/src/Components/test/testassets/Ignitor/ComponentNode.cs
@@ -3,7 +3,7 @@
 
 namespace Ignitor
 {
-    internal class ComponentNode : ContainerNode
+    public class ComponentNode : ContainerNode
     {
         private readonly int _componentId;
 

--- a/src/Components/test/testassets/Ignitor/ContainerNode.cs
+++ b/src/Components/test/testassets/Ignitor/ContainerNode.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Ignitor
 {
-    internal abstract class ContainerNode : Node
+    public abstract class ContainerNode : Node
     {
         private readonly List<Node> _children;
 

--- a/src/Components/test/testassets/Ignitor/ElementHive.cs
+++ b/src/Components/test/testassets/Ignitor/ElementHive.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components.RenderTree;
 
 namespace Ignitor
 {
-    internal class ElementHive
+    public class ElementHive
     {
         private const string SelectValuePropname = "_blazorSelectValue";
 

--- a/src/Components/test/testassets/Ignitor/ElementNode.cs
+++ b/src/Components/test/testassets/Ignitor/ElementNode.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 
 namespace Ignitor
 {
-    internal class ElementNode : ContainerNode
+    public class ElementNode : ContainerNode
     {
         private readonly Dictionary<string, object> _attributes;
         private readonly Dictionary<string, object> _properties;
@@ -79,9 +79,9 @@ namespace Ignitor
         {
             if (!Events.TryGetValue("click", out var clickEventDescriptor))
             {
-                Console.WriteLine("Button does not have a click event. Exiting");
-                return;
+                throw new InvalidOperationException("Element does not have a click event.");
             }
+
             var mouseEventArgs = new UIMouseEventArgs()
             {
                 Type = clickEventDescriptor.EventName,

--- a/src/Components/test/testassets/Ignitor/Error.cs
+++ b/src/Components/test/testassets/Ignitor/Error.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Ignitor
+{
+    internal class Error
+        {
+            public string Stack { get; set; }
+        }
+}

--- a/src/Components/test/testassets/Ignitor/Error.cs
+++ b/src/Components/test/testassets/Ignitor/Error.cs
@@ -4,7 +4,7 @@
 namespace Ignitor
 {
     internal class Error
-        {
-            public string Stack { get; set; }
-        }
+    {
+        public string Stack { get; set; }
+    }
 }

--- a/src/Components/test/testassets/Ignitor/MarkupNode.cs
+++ b/src/Components/test/testassets/Ignitor/MarkupNode.cs
@@ -3,7 +3,7 @@
 
 namespace Ignitor
 {
-    internal class MarkupNode : Node
+    public class MarkupNode : Node
     {
         public MarkupNode(string markupContent)
         {

--- a/src/Components/test/testassets/Ignitor/Node.cs
+++ b/src/Components/test/testassets/Ignitor/Node.cs
@@ -3,7 +3,7 @@
 
 namespace Ignitor
 {
-    internal abstract class Node
+    public abstract class Node
     {
         public virtual ContainerNode Parent { get; set; }
     }

--- a/src/Components/test/testassets/Ignitor/TextNode.cs
+++ b/src/Components/test/testassets/Ignitor/TextNode.cs
@@ -3,7 +3,7 @@
 
 namespace Ignitor
 {
-    internal class TextNode : Node
+    public class TextNode : Node
     {
         public TextNode(string text)
         {


### PR DESCRIPTION
I added a bunch stuff that I'm gonna be needing and I've moved the bootstrap code into a separate class library so that it can be reused. I would like the flow of this to be something like:
* I can create a regular functional test (like the ones we have)
* I new up an instance of `BlazorClient` (ignitor).
* I start issuing commands and perform my test.

Here are the things that I've added:

* Add support for sending dotnet calls from "JS"
* Add support for acknowledging render batches.
* Extract logic into a separate `BlazorClient` class so that it can be reused.
* Support non prerendered pages.
* Allow reacting to incoming JSInterop calls.
* Allow reacting to incoming RenderBatch.