### PR TITLE
Reduce logging branch path size.

### DIFF
--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -9,7 +9,7 @@
     <FxProjectToBuild Condition=" '$(TargetRuntimeIdentifier)' == 'linux-x64' AND '$(LinuxInstallerType)' == 'rpm' " Include="$(RepoRoot)src\Installers\Rpm\**\*.*proj" />
 
     <FxProjectToBuild Condition=" '$(BuildSiteExtensions)' == 'true' " Include="$(RepoRoot)src\SiteExtensions\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj" />
-    <FxProjectToBuild Condition=" '$(BuildSiteExtensions)' == 'true' " Include="$(RepoRoot)src\SiteExtensions\LoggingBranch\LoggingBranch.csproj" />
+    <FxProjectToBuild Condition=" '$(BuildSiteExtensions)' == 'true' " Include="$(RepoRoot)src\SiteExtensions\LoggingBranch\LB.csproj" />
 
     <FxProjectToBuild Condition=" '$(TargetRuntimeIdentifier)' == 'win-x86' " Include="$(RepoRoot)src\Framework\src\Microsoft.AspNetCore.App.Runtime.csproj" />
     <FxProjectToBuild Condition=" '$(TargetRuntimeIdentifier)' == 'win-x86' " Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\Symbols\Microsoft.AspNetCore.ANCMSymbols.csproj" />

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -8,6 +8,7 @@
     <PackageTags>aspnet;logging;aspnetcore;AzureSiteExtension;keyvault;configuration;dataprotection</PackageTags>
     <ContentTargetFolders>content</ContentTargetFolders>
     <PackageId>Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).$(TargetArchitecture)</PackageId>
+    <RuntimeIdentifier>$(TargetRuntimeIdentifier)</RuntimeIdentifier>
     <HostingStartupRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRuntimeVersion)</HostingStartupRuntimeFrameworkVersion>
 
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -8,7 +8,6 @@
     <PackageTags>aspnet;logging;aspnetcore;AzureSiteExtension;keyvault;configuration;dataprotection</PackageTags>
     <ContentTargetFolders>content</ContentTargetFolders>
     <PackageId>Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).$(TargetArchitecture)</PackageId>
-    <RuntimeIdentifier>$(TargetRuntimeIdentifier)</RuntimeIdentifier>
     <HostingStartupRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRuntimeVersion)</HostingStartupRuntimeFrameworkVersion>
 
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/SiteExtensions/LoggingBranch/LoggingBranch.csproj
+++ b/src/SiteExtensions/LoggingBranch/LoggingBranch.csproj
@@ -11,7 +11,6 @@
     <RuntimeIdentifier>$(TargetRuntimeIdentifier)</RuntimeIdentifier>
     <HostingStartupRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRuntimeVersion)</HostingStartupRuntimeFrameworkVersion>
 
-    <TargetFramework>net461</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageType>AzureSiteExtension</PackageType>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
We were hitting max path issues.

There were also two target frameworks, so removing one as cleanup.

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2665