### PR TITLE
Disable site extensions builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -82,14 +82,15 @@ jobs:
       displayName: Build x86
 
     # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
-    - script: ./build.cmd
-            -ci
-            -sign
-            -forceCoreMsbuild
-            /p:DisableCodeSigning=true
-            -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
-            $(_BuildArgs)
-      displayName: Build SiteExtension
+    # TODO: This step is producing errors which may cause build hangs.
+    # - script: ./build.cmd
+    #         -ci
+    #         -sign
+    #         -forceCoreMsbuild
+    #         /p:DisableCodeSigning=true
+    #         -projects ./src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+    #         $(_BuildArgs)
+    #   displayName: Build SiteExtension
 
     # Remove all task build output
     - script: rmdir /s /q build\tasks\bin


### PR DESCRIPTION
Our builds are hanging because the SiteExtension builds are producing errors like:
```
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3027: Could not copy "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Exceeded retry count of 10. Failed.  [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
F:\workspace\_work\1\s\.dotnet\sdk\3.0.100-preview5-011568\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ComposeStore.targets(347,5): error MSB3021: Unable to copy file "F:\workspace\_work\1\s\.nuget\packages\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" to "F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll". Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs\win-x64\x64\netcoreapp3.0\microsoft.extensions.configuration.environmentvariables\3.0.0-preview7.19312.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll'. [F:\workspace\_work\1\s\artifacts\obj\LoggingBranch\Release\net461\win-x64\se\rs.csproj]
```

This is due to flakiness in `dotnet store` and the errors can usually be ignored. However, it seems like any errors will cause the build to hang in AzDO. Since we need to disable Site Extension builds once we convert to Arcade, I think we can mitigate build hangs by disabling this step right now. It's hopefully temporary.