### PR TITLE
On RenderTreeBuilder, add SetUpdatesAttributeName

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -786,6 +786,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         public void OpenComponent<TComponent>(int sequence) where TComponent : Microsoft.AspNetCore.Components.IComponent { }
         public void OpenElement(int sequence, string elementName) { }
         public void SetKey(object value) { }
+        public void SetUpdatesAttributeName(string updatesAttributeName) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct RenderTreeDiff

--- a/src/Components/Components/src/RenderTree/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeBuilder.cs
@@ -517,6 +517,24 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         }
 
         /// <summary>
+        /// <para>
+        /// Indicates that the preceding attribute represents an event handler
+        /// whose execution updates the attribute with name <paramref name="updatesAttributeName"/>.
+        /// </para>
+        /// <para>
+        /// This information is used by the rendering system to determine whether
+        /// to accept a value update for the other attribute when receiving a
+        /// call to the event handler.
+        /// </para>
+        /// </summary>
+        /// <param name="updatesAttributeName">The name of another attribute whose value can be updated when the event handler is executed.</param>
+        public void SetUpdatesAttributeName(string updatesAttributeName)
+        {
+            // TODO: This will be implemented in a later PR, once aspnetcore-tooling
+            // is updated to call this method.
+        }
+
+        /// <summary>
         /// Appends a frame representing a child component.
         /// </summary>
         /// <typeparam name="TComponent">The type of the child component.</typeparam>


### PR DESCRIPTION
This is part of #8204

Because aspnetcore-tooling is a separate repo, we need a three-phase commit:

 1. First we add `SetUpdatesAttributeName` in this repo
 2. Then we can merge the PR in aspnetcore-tooling that generates calls to `SetUpdatesAttributeName`. If we didn't do (1) first, then we'd start getting build errors when the aspnetcore-tooling changes were received here.
 3. Then we can implement the behavior for `SetUpdatesAttributeName` and it will actually be used.
