### PR TITLE
Pass options to HubConnectionContext

### DIFF
--- a/src/SignalR/common/testassets/Tests.Utils/HubConnectionContextUtils.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/HubConnectionContextUtils.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 KeepAliveInterval = TimeSpan.FromSeconds(15),
             };
 
-            return new HubConnectionContext(connection, NullLoggerFactory.Instance, options)
+            return new HubConnectionContext(connection, options, NullLoggerFactory.Instance)
             {
                 Protocol = protocol ?? new JsonHubProtocol(),
                 UserIdentifier = userIdentifier,
@@ -40,13 +40,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 ClientTimeoutInterval = TimeSpan.FromSeconds(15),
                 StreamBufferCapacity = 10,
             };
-            return new MockHubConnectionContext(connection, NullLoggerFactory.Instance, options);
+            return new MockHubConnectionContext(connection, options, NullLoggerFactory.Instance);
         }
 
         public class MockHubConnectionContext : HubConnectionContext
         {
-            public MockHubConnectionContext(ConnectionContext connectionContext, ILoggerFactory loggerFactory, HubOptions options)
-                : base(connectionContext, loggerFactory, options)
+            public MockHubConnectionContext(ConnectionContext connectionContext, HubOptions options, ILoggerFactory loggerFactory)
+                : base(connectionContext, options, loggerFactory)
             {
             }
 

--- a/src/SignalR/common/testassets/Tests.Utils/HubConnectionContextUtils.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/HubConnectionContextUtils.cs
@@ -20,12 +20,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public static HubConnectionContext Create(ConnectionContext connection, IHubProtocol protocol = null, string userIdentifier = null)
         {
-            var options = new HubOptions()
+            var contextOptions = new HubConnectionContextOptions()
             {
                 KeepAliveInterval = TimeSpan.FromSeconds(15),
             };
 
-            return new HubConnectionContext(connection, options, NullLoggerFactory.Instance)
+            return new HubConnectionContext(connection, contextOptions, NullLoggerFactory.Instance)
             {
                 Protocol = protocol ?? new JsonHubProtocol(),
                 UserIdentifier = userIdentifier,
@@ -34,19 +34,19 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public static MockHubConnectionContext CreateMock(ConnectionContext connection)
         {
-            var options = new HubOptions()
+            var contextOptions = new HubConnectionContextOptions()
             {
                 KeepAliveInterval = TimeSpan.FromSeconds(15),
                 ClientTimeoutInterval = TimeSpan.FromSeconds(15),
                 StreamBufferCapacity = 10,
             };
-            return new MockHubConnectionContext(connection, options, NullLoggerFactory.Instance);
+            return new MockHubConnectionContext(connection, contextOptions, NullLoggerFactory.Instance);
         }
 
         public class MockHubConnectionContext : HubConnectionContext
         {
-            public MockHubConnectionContext(ConnectionContext connectionContext, HubOptions options, ILoggerFactory loggerFactory)
-                : base(connectionContext, options, loggerFactory)
+            public MockHubConnectionContext(ConnectionContext connectionContext, HubConnectionContextOptions contextOptions, ILoggerFactory loggerFactory)
+                : base(connectionContext, contextOptions, loggerFactory)
             {
             }
 

--- a/src/SignalR/common/testassets/Tests.Utils/HubConnectionContextUtils.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/HubConnectionContextUtils.cs
@@ -20,7 +20,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public static HubConnectionContext Create(ConnectionContext connection, IHubProtocol protocol = null, string userIdentifier = null)
         {
-            return new HubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance)
+            var options = new HubOptions()
+            {
+                KeepAliveInterval = TimeSpan.FromSeconds(15),
+            };
+
+            return new HubConnectionContext(connection, NullLoggerFactory.Instance, options)
             {
                 Protocol = protocol ?? new JsonHubProtocol(),
                 UserIdentifier = userIdentifier,
@@ -29,15 +34,20 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public static MockHubConnectionContext CreateMock(ConnectionContext connection)
         {
-            return new MockHubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance, TimeSpan.FromSeconds(15), streamBufferCapacity: 10);
+            var options = new HubOptions()
+            {
+                KeepAliveInterval = TimeSpan.FromSeconds(15),
+                ClientTimeoutInterval = TimeSpan.FromSeconds(15),
+                StreamBufferCapacity = 10,
+            };
+            return new MockHubConnectionContext(connection, NullLoggerFactory.Instance, options);
         }
 
         public class MockHubConnectionContext : HubConnectionContext
         {
-            public MockHubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory, TimeSpan clientTimeoutInterval, int streamBufferCapacity)
-                : base(connectionContext, keepAliveInterval, loggerFactory, clientTimeoutInterval, streamBufferCapacity)
+            public MockHubConnectionContext(ConnectionContext connectionContext, ILoggerFactory loggerFactory, HubOptions options)
+                : base(connectionContext, loggerFactory, options)
             {
-
             }
 
             public override ValueTask WriteAsync(HubMessage message, CancellationToken cancellationToken = default)

--- a/src/SignalR/perf/Microbenchmarks/BroadcastBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/BroadcastBenchmark.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 {
                     KeepAliveInterval = Timeout.InfiniteTimeSpan,
                 };
-                var hubConnection = new HubConnectionContext(connection, NullLoggerFactory.Instance, hubOptions);
+                var hubConnection = new HubConnectionContext(connection, hubOptions, NullLoggerFactory.Instance);
                 hubConnection.Protocol = protocol;
                 _hubLifetimeManager.OnConnectedAsync(hubConnection).GetAwaiter().GetResult();
                 _hubLifetimeManager.AddToGroupAsync(connection.ConnectionId, TestGroupName).GetAwaiter().GetResult();

--- a/src/SignalR/perf/Microbenchmarks/BroadcastBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/BroadcastBenchmark.cs
@@ -46,7 +46,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
                 var pair = DuplexPipe.CreateConnectionPair(options, options);
                 var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Application, pair.Transport);
-                var hubConnection = new HubConnectionContext(connection, Timeout.InfiniteTimeSpan, NullLoggerFactory.Instance);
+                var hubOptions = new HubOptions()
+                {
+                    KeepAliveInterval = Timeout.InfiniteTimeSpan,
+                };
+                var hubConnection = new HubConnectionContext(connection, NullLoggerFactory.Instance, hubOptions);
                 hubConnection.Protocol = protocol;
                 _hubLifetimeManager.OnConnectedAsync(hubConnection).GetAwaiter().GetResult();
                 _hubLifetimeManager.AddToGroupAsync(connection.ConnectionId, TestGroupName).GetAwaiter().GetResult();

--- a/src/SignalR/perf/Microbenchmarks/BroadcastBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/BroadcastBenchmark.cs
@@ -46,11 +46,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
                 var pair = DuplexPipe.CreateConnectionPair(options, options);
                 var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Application, pair.Transport);
-                var hubOptions = new HubOptions()
+                var contextOptions = new HubConnectionContextOptions()
                 {
                     KeepAliveInterval = Timeout.InfiniteTimeSpan,
                 };
-                var hubConnection = new HubConnectionContext(connection, hubOptions, NullLoggerFactory.Instance);
+                var hubConnection = new HubConnectionContext(connection, contextOptions, NullLoggerFactory.Instance);
                 hubConnection.Protocol = protocol;
                 _hubLifetimeManager.OnConnectedAsync(hubConnection).GetAwaiter().GetResult();
                 _hubLifetimeManager.AddToGroupAsync(connection.ConnectionId, TestGroupName).GetAwaiter().GetResult();

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.IO;
 using System.IO.Pipelines;
-using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -46,7 +44,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
             var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Application, pair.Transport);
 
-            _connectionContext = new NoErrorHubConnectionContext(connection, TimeSpan.Zero, NullLoggerFactory.Instance);
+            var hubOptions = new HubOptions()
+            {
+                KeepAliveInterval = TimeSpan.Zero,
+            };
+            _connectionContext = new NoErrorHubConnectionContext(connection, NullLoggerFactory.Instance, hubOptions);
 
             _connectionContext.Protocol = new FakeHubProtocol();
         }
@@ -83,7 +85,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             public TaskCompletionSource<object> ReceivedCompleted = new TaskCompletionSource<object>();
 
-            public NoErrorHubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory) : base(connectionContext, keepAliveInterval, loggerFactory)
+            public NoErrorHubConnectionContext(ConnectionContext connectionContext, ILoggerFactory loggerFactory, HubOptions hubOptions)
+                : base(connectionContext, loggerFactory, hubOptions)
             {
             }
 

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
                 KeepAliveInterval = TimeSpan.Zero,
             };
-            _connectionContext = new NoErrorHubConnectionContext(connection, NullLoggerFactory.Instance, hubOptions);
+            _connectionContext = new NoErrorHubConnectionContext(connection, hubOptions, NullLoggerFactory.Instance);
 
             _connectionContext.Protocol = new FakeHubProtocol();
         }
@@ -85,8 +85,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             public TaskCompletionSource<object> ReceivedCompleted = new TaskCompletionSource<object>();
 
-            public NoErrorHubConnectionContext(ConnectionContext connectionContext, ILoggerFactory loggerFactory, HubOptions hubOptions)
-                : base(connectionContext, loggerFactory, hubOptions)
+            public NoErrorHubConnectionContext(ConnectionContext connectionContext, HubOptions hubOptions, ILoggerFactory loggerFactory)
+                : base(connectionContext, hubOptions, loggerFactory)
             {
             }
 

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -44,11 +44,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
             var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Application, pair.Transport);
 
-            var hubOptions = new HubOptions()
+            var contextOptions = new HubConnectionContextOptions()
             {
                 KeepAliveInterval = TimeSpan.Zero,
             };
-            _connectionContext = new NoErrorHubConnectionContext(connection, hubOptions, NullLoggerFactory.Instance);
+            _connectionContext = new NoErrorHubConnectionContext(connection, contextOptions, NullLoggerFactory.Instance);
 
             _connectionContext.Protocol = new FakeHubProtocol();
         }
@@ -85,8 +85,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             public TaskCompletionSource<object> ReceivedCompleted = new TaskCompletionSource<object>();
 
-            public NoErrorHubConnectionContext(ConnectionContext connectionContext, HubOptions hubOptions, ILoggerFactory loggerFactory)
-                : base(connectionContext, hubOptions, loggerFactory)
+            public NoErrorHubConnectionContext(ConnectionContext connectionContext, HubConnectionContextOptions contextOptions, ILoggerFactory loggerFactory)
+                : base(connectionContext, contextOptions, loggerFactory)
             {
             }
 

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 {
                     KeepAliveInterval = TimeSpan.Zero,
                 };
-                var hubConnectionContext = new HubConnectionContext(connectionContext, NullLoggerFactory.Instance, hubOptions);
+                var hubConnectionContext = new HubConnectionContext(connectionContext, hubOptions, NullLoggerFactory.Instance);
                 hubConnectionContext.UserIdentifier = userIdentifier;
                 hubConnectionContext.Protocol = jsonHubProtocol;
 

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
@@ -51,7 +51,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                     ConnectionId = connectionId,
                     Transport = new TestDuplexPipe(ForceAsync)
                 };
-                var hubConnectionContext = new HubConnectionContext(connectionContext, TimeSpan.Zero, NullLoggerFactory.Instance);
+                var hubOptions = new HubOptions()
+                {
+                    KeepAliveInterval = TimeSpan.Zero,
+                };
+                var hubConnectionContext = new HubConnectionContext(connectionContext, NullLoggerFactory.Instance, hubOptions);
                 hubConnectionContext.UserIdentifier = userIdentifier;
                 hubConnectionContext.Protocol = jsonHubProtocol;
 

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
@@ -51,11 +51,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                     ConnectionId = connectionId,
                     Transport = new TestDuplexPipe(ForceAsync)
                 };
-                var hubOptions = new HubOptions()
+                var contextOptions = new HubConnectionContextOptions()
                 {
                     KeepAliveInterval = TimeSpan.Zero,
                 };
-                var hubConnectionContext = new HubConnectionContext(connectionContext, hubOptions, NullLoggerFactory.Instance);
+                var hubConnectionContext = new HubConnectionContext(connectionContext, contextOptions, NullLoggerFactory.Instance);
                 hubConnectionContext.UserIdentifier = userIdentifier;
                 hubConnectionContext.Protocol = jsonHubProtocol;
 

--- a/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Microbenchmarks.Shared;
@@ -44,7 +43,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _pipe = new TestDuplexPipe();
 
             var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), _pipe, _pipe);
-            _hubConnectionContext = new HubConnectionContext(connection, Timeout.InfiniteTimeSpan, NullLoggerFactory.Instance);
+            var hubOptions = new HubOptions()
+            {
+                KeepAliveInterval = Timeout.InfiniteTimeSpan,
+            };
+            _hubConnectionContext = new HubConnectionContext(connection, NullLoggerFactory.Instance, hubOptions);
 
             _successHubProtocolResolver = new TestHubProtocolResolver(new NewtonsoftJsonHubProtocol());
             _failureHubProtocolResolver = new TestHubProtocolResolver(null);

--- a/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
                 KeepAliveInterval = Timeout.InfiniteTimeSpan,
             };
-            _hubConnectionContext = new HubConnectionContext(connection, NullLoggerFactory.Instance, hubOptions);
+            _hubConnectionContext = new HubConnectionContext(connection, hubOptions, NullLoggerFactory.Instance);
 
             _successHubProtocolResolver = new TestHubProtocolResolver(new NewtonsoftJsonHubProtocol());
             _failureHubProtocolResolver = new TestHubProtocolResolver(null);

--- a/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -43,11 +43,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _pipe = new TestDuplexPipe();
 
             var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), _pipe, _pipe);
-            var hubOptions = new HubOptions()
+            var contextOptions = new HubConnectionContextOptions()
             {
                 KeepAliveInterval = Timeout.InfiniteTimeSpan,
             };
-            _hubConnectionContext = new HubConnectionContext(connection, hubOptions, NullLoggerFactory.Instance);
+            _hubConnectionContext = new HubConnectionContext(connection, contextOptions, NullLoggerFactory.Instance);
 
             _successHubProtocolResolver = new TestHubProtocolResolver(new NewtonsoftJsonHubProtocol());
             _failureHubProtocolResolver = new TestHubProtocolResolver(null);

--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
@@ -127,9 +127,7 @@ namespace Microsoft.AspNetCore.SignalR
     }
     public partial class HubConnectionContext
     {
-        public HubConnectionContext(Microsoft.AspNetCore.Connections.ConnectionContext connectionContext, System.TimeSpan keepAliveInterval, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
-        public HubConnectionContext(Microsoft.AspNetCore.Connections.ConnectionContext connectionContext, System.TimeSpan keepAliveInterval, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.TimeSpan clientTimeoutInterval) { }
-        public HubConnectionContext(Microsoft.AspNetCore.Connections.ConnectionContext connectionContext, System.TimeSpan keepAliveInterval, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.TimeSpan clientTimeoutInterval, int streamBufferCapacity) { }
+        public HubConnectionContext(Microsoft.AspNetCore.Connections.ConnectionContext connectionContext, Microsoft.AspNetCore.SignalR.HubOptions hubOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public virtual System.Threading.CancellationToken ConnectionAborted { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public virtual string ConnectionId { get { throw null; } }
         public virtual Microsoft.AspNetCore.Http.Features.IFeatureCollection Features { get { throw null; } }

--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.SignalR
     }
     public partial class HubConnectionContext
     {
-        public HubConnectionContext(Microsoft.AspNetCore.Connections.ConnectionContext connectionContext, Microsoft.AspNetCore.SignalR.HubOptions hubOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public HubConnectionContext(Microsoft.AspNetCore.Connections.ConnectionContext connectionContext, Microsoft.AspNetCore.SignalR.HubConnectionContextOptions contextOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public virtual System.Threading.CancellationToken ConnectionAborted { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public virtual string ConnectionId { get { throw null; } }
         public virtual Microsoft.AspNetCore.Http.Features.IFeatureCollection Features { get { throw null; } }
@@ -138,6 +138,13 @@ namespace Microsoft.AspNetCore.SignalR
         public virtual void Abort() { }
         public virtual System.Threading.Tasks.ValueTask WriteAsync(Microsoft.AspNetCore.SignalR.Protocol.HubMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask WriteAsync(Microsoft.AspNetCore.SignalR.SerializedHubMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class HubConnectionContextOptions
+    {
+        public HubConnectionContextOptions() { }
+        public System.TimeSpan ClientTimeoutInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.TimeSpan KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int StreamBufferCapacity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class HubConnectionHandler<THub> : Microsoft.AspNetCore.Connections.ConnectionHandler where THub : Microsoft.AspNetCore.SignalR.Hub
     {

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -48,37 +48,17 @@ namespace Microsoft.AspNetCore.SignalR
         /// Initializes a new instance of the <see cref="HubConnectionContext"/> class.
         /// </summary>
         /// <param name="connectionContext">The underlying <see cref="ConnectionContext"/>.</param>
-        /// <param name="keepAliveInterval">The keep alive interval. If no messages are sent by the server in this interval, a Ping message will be sent.</param>
         /// <param name="loggerFactory">The logger factory.</param>
-        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory)
-            : this(connectionContext, keepAliveInterval, loggerFactory, HubOptionsSetup.DefaultClientTimeoutInterval, HubOptionsSetup.DefaultStreamBufferCapacity) { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HubConnectionContext"/> class.
-        /// </summary>
-        /// <param name="connectionContext">The underlying <see cref="ConnectionContext"/>.</param>
-        /// <param name="keepAliveInterval">The keep alive interval. If no messages are sent by the server in this interval, a Ping message will be sent.</param>
-        /// <param name="loggerFactory">The logger factory.</param>
-        /// <param name="clientTimeoutInterval">Clients we haven't heard from in this interval are assumed to have disconnected.</param>
-        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory, TimeSpan clientTimeoutInterval)
-            : this(connectionContext, keepAliveInterval, loggerFactory, clientTimeoutInterval, HubOptionsSetup.DefaultStreamBufferCapacity) { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HubConnectionContext"/> class.
-        /// </summary>
-        /// <param name="connectionContext">The underlying <see cref="ConnectionContext"/>.</param>
-        /// <param name="keepAliveInterval">The keep alive interval. If no messages are sent by the server in this interval, a Ping message will be sent.</param>
-        /// <param name="loggerFactory">The logger factory.</param>
-        /// <param name="clientTimeoutInterval">Clients we haven't heard from in this interval are assumed to have disconnected.</param>
-        /// <param name="streamBufferCapacity">The buffer size for client upload streams</param>
-        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory, TimeSpan clientTimeoutInterval, int streamBufferCapacity)
+        /// <param name="hubOptions">The options to configure the connection.</param>
+        public HubConnectionContext(ConnectionContext connectionContext, ILoggerFactory loggerFactory, HubOptions hubOptions)
         {
+            _keepAliveInterval = hubOptions.KeepAliveInterval?.Ticks ?? HubOptionsSetup.DefaultKeepAliveInterval.Ticks;
+            _clientTimeoutInterval = hubOptions.ClientTimeoutInterval?.Ticks ?? HubOptionsSetup.DefaultClientTimeoutInterval.Ticks;
+            _streamBufferCapacity = hubOptions.StreamBufferCapacity ?? HubOptionsSetup.DefaultStreamBufferCapacity;
+
             _connectionContext = connectionContext;
             _logger = loggerFactory.CreateLogger<HubConnectionContext>();
             ConnectionAborted = _connectionAbortedTokenSource.Token;
-            _keepAliveInterval = keepAliveInterval.Ticks;
-            _clientTimeoutInterval = clientTimeoutInterval.Ticks;
-            _streamBufferCapacity = streamBufferCapacity;
         }
 
         internal StreamTracker StreamTracker

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="connectionContext">The underlying <see cref="ConnectionContext"/>.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="hubOptions">The options to configure the connection.</param>
-        public HubConnectionContext(ConnectionContext connectionContext, ILoggerFactory loggerFactory, HubOptions hubOptions)
+        public HubConnectionContext(ConnectionContext connectionContext, HubOptions hubOptions, ILoggerFactory loggerFactory)
         {
             _keepAliveInterval = hubOptions.KeepAliveInterval?.Ticks ?? HubOptionsSetup.DefaultKeepAliveInterval.Ticks;
             _clientTimeoutInterval = hubOptions.ClientTimeoutInterval?.Ticks ?? HubOptionsSetup.DefaultClientTimeoutInterval.Ticks;

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -49,12 +49,12 @@ namespace Microsoft.AspNetCore.SignalR
         /// </summary>
         /// <param name="connectionContext">The underlying <see cref="ConnectionContext"/>.</param>
         /// <param name="loggerFactory">The logger factory.</param>
-        /// <param name="hubOptions">The options to configure the connection.</param>
-        public HubConnectionContext(ConnectionContext connectionContext, HubOptions hubOptions, ILoggerFactory loggerFactory)
+        /// <param name="contextOptions">The options to configure the HubConnectionContext.</param>
+        public HubConnectionContext(ConnectionContext connectionContext, HubConnectionContextOptions contextOptions, ILoggerFactory loggerFactory)
         {
-            _keepAliveInterval = hubOptions.KeepAliveInterval?.Ticks ?? HubOptionsSetup.DefaultKeepAliveInterval.Ticks;
-            _clientTimeoutInterval = hubOptions.ClientTimeoutInterval?.Ticks ?? HubOptionsSetup.DefaultClientTimeoutInterval.Ticks;
-            _streamBufferCapacity = hubOptions.StreamBufferCapacity ?? HubOptionsSetup.DefaultStreamBufferCapacity;
+            _keepAliveInterval = contextOptions.KeepAliveInterval.Ticks;
+            _clientTimeoutInterval = contextOptions.ClientTimeoutInterval.Ticks;
+            _streamBufferCapacity = contextOptions.StreamBufferCapacity;
 
             _connectionContext = connectionContext;
             _logger = loggerFactory.CreateLogger<HubConnectionContext>();

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    /// <summary>
+    /// Options used to configure <see cref="HubConnectionContext"/>.
+    /// </summary>
+    public class HubConnectionContextOptions
+    {
+        /// <summary>
+        /// Gets or sets the interval used to send keep alive pings to connected clients.
+        /// </summary>
+        public TimeSpan KeepAliveInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time window clients have to send a message before the server closes the connection.
+        /// </summary>
+        public TimeSpan ClientTimeoutInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max buffer size for client upload streams.
+        /// </summary>
+        public int StreamBufferCapacity { get; set; }
+    }
+}

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -82,21 +82,21 @@ namespace Microsoft.AspNetCore.SignalR
                 throw new InvalidOperationException("There are no supported protocols");
             }
 
-            var options = new HubOptions()
+            var handshakeTimeout = _hubOptions.HandshakeTimeout ?? _globalHubOptions.HandshakeTimeout ?? HubOptionsSetup.DefaultHandshakeTimeout;
+
+            var contextOptions = new HubConnectionContextOptions()
             {
                 KeepAliveInterval = _hubOptions.KeepAliveInterval ?? _globalHubOptions.KeepAliveInterval ?? HubOptionsSetup.DefaultKeepAliveInterval,
                 ClientTimeoutInterval = _hubOptions.ClientTimeoutInterval ?? _globalHubOptions.ClientTimeoutInterval ?? HubOptionsSetup.DefaultClientTimeoutInterval,
-                HandshakeTimeout = _hubOptions.HandshakeTimeout ?? _globalHubOptions.HandshakeTimeout ?? HubOptionsSetup.DefaultHandshakeTimeout,
                 StreamBufferCapacity = _hubOptions.StreamBufferCapacity ?? _globalHubOptions.StreamBufferCapacity ?? HubOptionsSetup.DefaultStreamBufferCapacity,
-                SupportedProtocols = supportedProtocols,
             };
 
             Log.ConnectedStarting(_logger);
 
-            var connectionContext = new HubConnectionContext(connection, options, _loggerFactory);
+            var connectionContext = new HubConnectionContext(connection, contextOptions, _loggerFactory);
 
-            var resolvedSupportedProtocols = (options.SupportedProtocols as IReadOnlyList<string>) ?? options.SupportedProtocols.ToList();
-            if (!await connectionContext.HandshakeAsync(options.HandshakeTimeout.Value, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))
+            var resolvedSupportedProtocols = (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList();
+            if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))
             {
                 return;
             }

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR
         // for all available protocols.
 
         /// <summary>
-        /// Gets or sets the interval used by the server to timeout incoming handshake requests by clients. The default timeout is 15 seconds
+        /// Gets or sets the interval used by the server to timeout incoming handshake requests by clients. The default timeout is 15 seconds.
         /// </summary>
         public TimeSpan? HandshakeTimeout { get; set; } = null;
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2310,6 +2310,54 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        public async Task HubOptionsCanNotHaveNullSupportedProtocols()
+        {
+            using (StartVerifiableLog())
+            {
+                var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
+                {
+                    services.AddSignalR(o =>
+                    {
+                        o.SupportedProtocols = null;
+                    });
+                }, LoggerFactory);
+
+                var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+                var msgPackOptions = serviceProvider.GetRequiredService<IOptions<MessagePackHubProtocolOptions>>();
+                using (var client = new TestClient(protocol: new MessagePackHubProtocol(msgPackOptions)))
+                {
+                    client.SupportedFormats = TransferFormat.Binary;
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () => await await client.ConnectAsync(connectionHandler, expectedHandshakeResponseMessage: false)).OrTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task HubOptionsCanNotHaveEmptySupportedProtocols()
+        {
+            using (StartVerifiableLog())
+            {
+                var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
+                {
+                    services.AddSignalR(o =>
+                    {
+                        o.SupportedProtocols = new List<string>();
+                    });
+                }, LoggerFactory);
+
+                var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+                var msgPackOptions = serviceProvider.GetRequiredService<IOptions<MessagePackHubProtocolOptions>>();
+                using (var client = new TestClient(protocol: new MessagePackHubProtocol(msgPackOptions)))
+                {
+                    client.SupportedFormats = TransferFormat.Binary;
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () => await await client.ConnectAsync(connectionHandler, expectedHandshakeResponseMessage: false)).OrTimeout();
+                }
+            }
+        }
+
+        [Fact]
         public async Task ConnectionUserIdIsAssignedByUserIdProvider()
         {
             using (StartVerifiableLog())


### PR DESCRIPTION
Fixes #11258

Reusing `HubOption` to pass values to `HubConnectionContext`.