### PR TITLE
Add Invoke API with with no completion result

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/CompletionMessage.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/CompletionMessage.java
@@ -11,7 +11,7 @@ final class CompletionMessage extends HubMessage {
 
     public CompletionMessage(String invocationId, Object result, String error) {
         if (error != null && result != null) {
-            throw new IllegalArgumentException("Expected either 'error' or 'result' to be provided, but not both");
+            throw new IllegalArgumentException("Expected either 'error' or 'result' to be provided, but not both.");
         }
         this.invocationId = invocationId;
         this.result = result;

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -601,7 +601,7 @@ public class HubConnection {
      *
      * @param method The name of the server method to invoke.
      * @param args The arguments used to invoke the server method.
-     * @return A Single that yields the return value when the invocation has completed.
+     * @return A Completable that indicates when the invocation has completed.
      */
     @SuppressWarnings("unchecked")
     public Completable invoke(String method, Object... args) {

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -617,7 +617,7 @@ public class HubConnection {
 
         Subject<Object> pendingCall = irq.getPendingCall();
 
-        pendingCall.subscribe(result -> {},
+        pendingCall.subscribe(result -> subject.onComplete(),
                 error -> subject.onError(error),
                 () -> subject.onComplete());
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/11220
This is to add the invoke overload that doesn't expect result in the completion message
There were also some issues in other tests about ensuring that `onSuccess` had run