### PR TITLE
Simplify attribute splatting

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -766,7 +766,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         public void AddContent<T>(int sequence, Microsoft.AspNetCore.Components.RenderFragment<T> fragment, T value) { }
         public void AddElementReferenceCapture(int sequence, System.Action<Microsoft.AspNetCore.Components.ElementRef> elementReferenceCaptureAction) { }
         public void AddMarkupContent(int sequence, string markupContent) { }
-        public void AddMultipleAttributes<T>(int sequence, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, T>> attributes) { }
+        public void AddMultipleAttributes(int sequence, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> attributes) { }
         public void Clear() { }
         public void CloseComponent() { }
         public void CloseElement() { }

--- a/src/Components/Components/src/ParameterAttribute.cs
+++ b/src/Components/Components/src/ParameterAttribute.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Components
         /// </para>
         /// <para>
         /// <see cref="CaptureUnmatchedValues"/> should only be applied to parameters of a type that
-        /// can be used with <see cref="RenderTreeBuilder.AddMultipleAttributes{T}(int, System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, T}})"/>
+        /// can be used with <see cref="RenderTreeBuilder.AddMultipleAttributes(int, System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, System.Object}})"/>
         /// such as <see cref="Dictionary{String, Object}"/>.
         /// </para>
         /// </remarks>

--- a/src/Components/Components/src/RenderTree/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeBuilder.cs
@@ -485,19 +485,10 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         /// <summary>
         /// Adds frames representing multiple attributes with the same sequence number.
         /// </summary>
-        /// <typeparam name="T">The attribute value type.</typeparam>
         /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
         /// <param name="attributes">A collection of key-value pairs representing attributes.</param>
-        public void AddMultipleAttributes<T>(int sequence, IEnumerable<KeyValuePair<string, T>> attributes)
+        public void AddMultipleAttributes(int sequence, IEnumerable<KeyValuePair<string, object>> attributes)
         {
-            // NOTE: The IEnumerable<KeyValuePair<string, T>> is the simplest way to support a variety of
-            // different types like IReadOnlyDictionary<>, Dictionary<>, and IDictionary<>.
-            //
-            // None of those types are contravariant, and since we want to support attributes having a value
-            // of type object, the simplest thing to do is drop down to IEnumerable<KeyValuePair<>> which
-            // is contravariant. This also gives us things like List<KeyValuePair<>> and KeyValuePair<>[]
-            // for free even though we don't expect those types to be common.
-
             // Calling this up-front just to make sure we validate before mutating anything.
             AssertCanAddAttribute();
 

--- a/src/Components/Components/test/RenderTreeBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeBuilderTest.cs
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act
             builder.OpenElement(0, "myelement");
-            builder.AddMultipleAttributes<object>(0, null);
+            builder.AddMultipleAttributes(0, null);
             builder.CloseElement();
 
             // Assert
@@ -308,20 +308,6 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void CanAddMultipleAttributes_DictionaryString()
-        {
-            var attributes = new Dictionary<string, string>
-            {
-                { "attribute1", "test1" },
-                { "attribute2", "123" },
-                { "attribute3", "456" },
-            };
-
-            // Act & Assert
-            CanAddMultipleAttributesTest(attributes);
-        }
-
-        [Fact]
         public void CanAddMultipleAttributes_DictionaryObject()
         {
             var attributes = new Dictionary<string, object>
@@ -333,20 +319,6 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act & Assert
             CanAddMultipleAttributesTest(attributes);
-        }
-
-        [Fact]
-        public void CanAddMultipleAttributes_IReadOnlyDictionaryString()
-        {
-            var attributes = new Dictionary<string, string>
-            {
-                { "attribute1", "test1" },
-                { "attribute2", "123" },
-                { "attribute3", "456" },
-            };
-
-            // Act & Assert
-            CanAddMultipleAttributesTest((IReadOnlyDictionary<string, string>)attributes);
         }
 
         [Fact]
@@ -364,20 +336,6 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public void CanAddMultipleAttributes_ListKvpString()
-        {
-            var attributes = new List<KeyValuePair<string, object>>()
-            {
-                new KeyValuePair<string, object>("attribute1", "test1"),
-                new KeyValuePair<string, object>("attribute2", "123"),
-                new KeyValuePair<string, object>("attribute3", "456"),
-            };
-
-            // Act & Assert
-            CanAddMultipleAttributesTest(attributes);
-        }
-
-        [Fact]
         public void CanAddMultipleAttributes_ListKvpObject()
         {
             var attributes = new List<KeyValuePair<string, object>>()
@@ -385,20 +343,6 @@ namespace Microsoft.AspNetCore.Components.Test
                 new KeyValuePair<string, object>("attribute1", "test1"),
                 new KeyValuePair<string, object>("attribute2", "123"),
                 new KeyValuePair<string, object>("attribute3", true),
-            };
-
-            // Act & Assert
-            CanAddMultipleAttributesTest(attributes);
-        }
-
-        [Fact]
-        public void CanAddMultipleAttributes_ArrayKvpString()
-        {
-            var attributes = new KeyValuePair<string, string>[]
-            {
-                new KeyValuePair<string, string>("attribute1", "test1"),
-                new KeyValuePair<string, string>("attribute2", "123"),
-                new KeyValuePair<string, string>("attribute3", "456"),
             };
 
             // Act & Assert
@@ -419,7 +363,7 @@ namespace Microsoft.AspNetCore.Components.Test
             CanAddMultipleAttributesTest(attributes);
         }
 
-        private void CanAddMultipleAttributesTest<T>(IEnumerable<KeyValuePair<string, T>> attributes)
+        private void CanAddMultipleAttributesTest(IEnumerable<KeyValuePair<string, object>> attributes)
         {
             // Arrange
             var builder = new RenderTreeBuilder(new TestRenderer());


### PR DESCRIPTION
Removes handling for IEnumerable<KVP<string, string>>. This isn't
something we really need for the main scenario and it MASSIVELY
complicates the codegen part of the feature. Requiring the dictionary to
be an object-valued dictionary should cover the cases we care about.
