### PR TITLE
Kestrel Override Client Cert Validation

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -293,6 +293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
     public partial class HttpsConnectionAdapterOptions
     {
         public HttpsConnectionAdapterOptions() { }
+        public bool AllowAnyClientCertificate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool CheckCertificateRevocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode ClientCertificateMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ClientCertificateValidation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -293,7 +293,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
     public partial class HttpsConnectionAdapterOptions
     {
         public HttpsConnectionAdapterOptions() { }
-        public bool AllowAnyClientCertificate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool CheckCertificateRevocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode ClientCertificateMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ClientCertificateValidation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
@@ -302,6 +301,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public System.Security.Cryptography.X509Certificates.X509Certificate2 ServerCertificate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Func<Microsoft.AspNetCore.Connections.ConnectionContext, string, System.Security.Cryptography.X509Certificates.X509Certificate2> ServerCertificateSelector { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void AllowAnyClientCertificate() { }
     }
 }
 namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal

--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public bool CheckCertificateRevocation { get; set; }
 
         /// <summary>
-        /// When set to true, allows any client certificate
+        /// When set to true, allows any client certificate.
         /// </summary>
         public bool AllowAnyClientCertificate { get; set; }
 

--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
     public class HttpsConnectionAdapterOptions
     {
         private TimeSpan _handshakeTimeout;
-        private Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> _clientCertificateValidation;
 
         /// <summary>
         /// Initializes a new instance of <see cref="HttpsConnectionAdapterOptions"/>.
@@ -57,16 +56,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public ClientCertificateMode ClientCertificateMode { get; set; }
 
         /// <summary>
-        /// Specifies a callback for additional client certificate validation that will be invoked during authentication.
+        /// Specifies a callback for additional client certificate validation that will be invoked during authentication. This will be ignored
+        /// if <see cref="AllowAnyClientCertificate"/> is set to true.
         /// </summary>
-        public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ClientCertificateValidation {
-            get
-            {
-                return AllowAnyClientCertificate ? (_, __, ___) => true : _clientCertificateValidation;
-            }
-
-            set => _clientCertificateValidation = value;
-        }
+        public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ClientCertificateValidation { get; set; }
 
         /// <summary>
         /// Specifies allowable SSL protocols. Defaults to <see cref="SslProtocols.Tls12" /> and <see cref="SslProtocols.Tls11"/>.
@@ -85,7 +78,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public bool CheckCertificateRevocation { get; set; }
 
         /// <summary>
-        /// When set to true, allows any client certificate.
+        /// When set to true, <see cref="ClientCertificateValidation"/>  is ignored and any client certificate is allowed.
         /// </summary>
         public bool AllowAnyClientCertificate { get; set; }
 

--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
 
         /// <summary>
         /// Specifies a callback for additional client certificate validation that will be invoked during authentication. This will be ignored
-        /// if <see cref="AllowAnyClientCertificate"/> is set to true.
+        /// if <see cref="AllowAnyClientCertificate"/> is called after this callback is set.
         /// </summary>
         public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ClientCertificateValidation { get; set; }
 
@@ -78,9 +78,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public bool CheckCertificateRevocation { get; set; }
 
         /// <summary>
-        /// When set to true, <see cref="ClientCertificateValidation"/>  is ignored and any client certificate is allowed.
+        /// Overrides the current <see cref="ClientCertificateValidation"/> callback and allows any client certificate.
         /// </summary>
-        public bool AllowAnyClientCertificate { get; set; }
+        public void AllowAnyClientCertificate()
+        {
+            ClientCertificateValidation = (_, __, ___) => true;
+        }
 
         /// <summary>
         /// Provides direct configuration of the <see cref="SslServerAuthenticationOptions"/> on a per-connection basis.

--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
     public class HttpsConnectionAdapterOptions
     {
         private TimeSpan _handshakeTimeout;
+        private Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> _clientCertificateValidation;
 
         /// <summary>
         /// Initializes a new instance of <see cref="HttpsConnectionAdapterOptions"/>.
@@ -58,7 +59,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         /// <summary>
         /// Specifies a callback for additional client certificate validation that will be invoked during authentication.
         /// </summary>
-        public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ClientCertificateValidation { get; set; }
+        public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ClientCertificateValidation {
+            get
+            {
+                return AllowAnyClientCertificate ? (_, __, ___) => true : _clientCertificateValidation;
+            }
+
+            set => _clientCertificateValidation = value;
+        }
 
         /// <summary>
         /// Specifies allowable SSL protocols. Defaults to <see cref="SslProtocols.Tls12" /> and <see cref="SslProtocols.Tls11"/>.
@@ -75,6 +83,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         /// Specifies whether the certificate revocation list is checked during authentication.
         /// </summary>
         public bool CheckCertificateRevocation { get; set; }
+
+        /// <summary>
+        /// When set to true, allows any client certificate
+        /// </summary>
+        public bool AllowAnyClientCertificate { get; set; }
 
         /// <summary>
         /// Provides direct configuration of the <see cref="SslServerAuthenticationOptions"/> on a per-connection basis.

--- a/src/Servers/Kestrel/Core/src/Internal/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpsConnectionMiddleware.cs
@@ -131,12 +131,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                             return _options.ClientCertificateMode != ClientCertificateMode.RequireCertificate;
                         }
 
-                        // If AllowAnyClientCertificate is true then we don't need to do any client cert validation.
-                        if (_options.AllowAnyClientCertificate)
-                        {
-                            return true;
-                        }
-
                         if (_options.ClientCertificateValidation == null)
                         {
                             if (sslPolicyErrors != SslPolicyErrors.None)

--- a/src/Servers/Kestrel/Core/src/Internal/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpsConnectionMiddleware.cs
@@ -131,6 +131,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                             return _options.ClientCertificateMode != ClientCertificateMode.RequireCertificate;
                         }
 
+                        // If AllowAnyClientCertificate is true then we don't need to do any client cert validation.
+                        if (_options.AllowAnyClientCertificate)
+                        {
+                            return true;
+                        }
+
                         if (_options.ClientCertificateValidation == null)
                         {
                             if (sslPolicyErrors != SslPolicyErrors.None)

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
@@ -18,19 +18,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
             Assert.Equal(TimeSpan.FromSeconds(10), new HttpsConnectionAdapterOptions().HandshakeTimeout);
         }
 
-        [Fact]
-        public void AllowAnyCertificateOverridesValidationFunc()
-        {
-            var connectionAdapterOptions = new HttpsConnectionAdapterOptions
-            {
-                ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                ClientCertificateValidation = (x509Cert, x509Chain, sslPolicyErrors) => false,
-                AllowAnyClientCertificate = true
-            };
-
-            Assert.True(connectionAdapterOptions.ClientCertificateValidation(null, null, SslPolicyErrors.None));
-        }
-
         [Theory]
         [MemberData(nameof(TimeoutValidData))]
         public void HandshakeTimeoutValid(TimeSpan value)

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
@@ -3,19 +3,15 @@
 
 using System;
 using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Tests
 {
     public class HttpsConnectionAdapterOptionsTests
     {
-        private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
-        private static X509Certificate2 _x509Certificate2NoExt = TestResources.GetTestCertificate("no_extensions.pfx");
 
         [Fact]
         public void HandshakeTimeoutDefault()
@@ -28,7 +24,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         {
             var connectionAdapterOptions = new HttpsConnectionAdapterOptions
             {
-                ServerCertificate = _x509Certificate2,
                 ClientCertificateMode = ClientCertificateMode.RequireCertificate,
                 ClientCertificateValidation = (x509Cert, x509Chain, sslPolicyErrors) => false,
                 AllowAnyClientCertificate = true

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Net.Security;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
@@ -12,7 +12,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
 {
     public class HttpsConnectionAdapterOptionsTests
     {
-
         [Fact]
         public void HandshakeTimeoutDefault()
         {

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConnectionAdapterOptionsTest.cs
@@ -1,20 +1,40 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Tests
 {
     public class HttpsConnectionAdapterOptionsTests
     {
+        private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
+        private static X509Certificate2 _x509Certificate2NoExt = TestResources.GetTestCertificate("no_extensions.pfx");
+
         [Fact]
         public void HandshakeTimeoutDefault()
         {
             Assert.Equal(TimeSpan.FromSeconds(10), new HttpsConnectionAdapterOptions().HandshakeTimeout);
+        }
+
+        [Fact]
+        public void AllowAnyCertificateOverridesValidationFunc()
+        {
+            var connectionAdapterOptions = new HttpsConnectionAdapterOptions
+            {
+                ServerCertificate = _x509Certificate2,
+                ClientCertificateMode = ClientCertificateMode.RequireCertificate,
+                ClientCertificateValidation = (x509Cert, x509Chain, sslPolicyErrors) => false,
+                AllowAnyClientCertificate = true
+            };
+
+            Assert.True(connectionAdapterOptions.ClientCertificateValidation(null, null, SslPolicyErrors.None));
         }
 
         [Theory]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -339,14 +339,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
                 listenOptions.Protocols = httpProtocols;
-                var options = new HttpsConnectionAdapterOptions
+                listenOptions.UseHttps(options =>
                 {
-                    ServerCertificate = _x509Certificate2,
-                    ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                };
-
-                options.AllowAnyClientCertificate();
-                listenOptions.UseHttps(options);
+                    options.ServerCertificate = _x509Certificate2;
+                    options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
+                    options.AllowAnyClientCertificate();
+                });
             }
 
             await using (var server = new TestServer(context =>
@@ -390,14 +388,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
-                var options = new HttpsConnectionAdapterOptions
+                listenOptions.UseHttps(options =>
                 {
-                    ServerCertificate = _x509Certificate2,
-                    ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                };
-
-                options.AllowAnyClientCertificate();
-                listenOptions.UseHttps(options);
+                    options.ServerCertificate = _x509Certificate2;
+                    options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
+                    options.AllowAnyClientCertificate();
+                });
             }
 
 
@@ -507,16 +503,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
-                var options = new HttpsConnectionAdapterOptions
+                listenOptions.UseHttps(options =>
                 {
-                    ServerCertificate = _x509Certificate2,
-                    ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => false,
-                };
-
-                options.AllowAnyClientCertificate();
-
-                listenOptions.UseHttps(options);
+                    options.ServerCertificate = _x509Certificate2;
+                    options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
+                    options.ClientCertificateValidation = (certificate, x509Chain, sslPolicyErrors) => false;
+                    options.AllowAnyClientCertificate();
+                });
             }
 
             await using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory) { ExpectedConnectionMiddlewareCount = 1 }, ConfigureListenOptions))
@@ -535,14 +528,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
-                var options = new HttpsConnectionAdapterOptions
+                listenOptions.UseHttps(options =>
                 {
-                    ServerCertificate = _x509Certificate2,
-                    ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                };
-
-                options.AllowAnyClientCertificate();
-                listenOptions.UseHttps(options);
+                    options.ServerCertificate = _x509Certificate2;
+                    options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
+                    options.AllowAnyClientCertificate();
+                });
             }
 
             RequestDelegate app = context =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -339,12 +339,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
                 listenOptions.Protocols = httpProtocols;
-                listenOptions.UseHttps(new HttpsConnectionAdapterOptions
+                var options = new HttpsConnectionAdapterOptions
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    AllowAnyClientCertificate = true
-                });
+                };
+
+                options.AllowAnyClientCertificate();
+                listenOptions.UseHttps(options);
             }
 
             await using (var server = new TestServer(context =>
@@ -388,12 +390,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
-                listenOptions.UseHttps(new HttpsConnectionAdapterOptions
+                var options = new HttpsConnectionAdapterOptions
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    AllowAnyClientCertificate = true
-                });
+                };
+
+                options.AllowAnyClientCertificate();
+                listenOptions.UseHttps(options);
             }
 
 
@@ -503,13 +507,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
-                listenOptions.UseHttps(new HttpsConnectionAdapterOptions
+                var options = new HttpsConnectionAdapterOptions
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
                     ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => false,
-                    AllowAnyClientCertificate = true
-                });
+                };
+
+                options.AllowAnyClientCertificate();
+
+                listenOptions.UseHttps(options);
             }
 
             await using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory) { ExpectedConnectionMiddlewareCount = 1 }, ConfigureListenOptions))
@@ -528,12 +535,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
-                listenOptions.UseHttps(new HttpsConnectionAdapterOptions
+                var options = new HttpsConnectionAdapterOptions
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    AllowAnyClientCertificate = true
-                });
+                };
+
+                options.AllowAnyClientCertificate();
+                listenOptions.UseHttps(options);
             }
 
             RequestDelegate app = context =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => true
+                    AllowAnyClientCertificate = true
                 });
             }
 
@@ -392,7 +392,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => true
+                    AllowAnyClientCertificate = true
                 });
             }
 
@@ -507,7 +507,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     ServerCertificate = _x509Certificate2,
                     ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                    ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => true
+                    AllowAnyClientCertificate = true
                 });
             }
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/10351

Adding an option to accept any client certificate.

Roast me.
