### PR TITLE
ResponseCaching: include required headers in 304

### DIFF
--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -164,9 +164,8 @@ namespace Microsoft.AspNetCore.ResponseCaching
 
                     if (context.CachedResponseHeaders != null)
                     {
-                        for (var i = 0; i < HeadersToIncludeIn304.Length; i++)
+                        foreach (var key in HeadersToIncludeIn304)
                         {
-                            var key = HeadersToIncludeIn304[i];
                             if (context.CachedResponseHeaders.TryGetValue(key, out var values))
                             {
                                 context.HttpContext.Response.Headers[key] = values;

--- a/src/Middleware/ResponseCaching/test/ResponseCachingTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -592,19 +592,25 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [Fact]
         public async Task Serves304_IfIfModifiedSince_Satisfied()
         {
-            var builders = TestUtils.CreateBuildersWithResponseCaching();
+            var builders = TestUtils.CreateBuildersWithResponseCaching(contextAction: context =>
+            {
+                context.Response.GetTypedHeaders().ETag = new EntityTagHeaderValue("\"E1\"");
+                context.Response.Headers[HeaderNames.ContentLocation] = "/";
+                context.Response.Headers[HeaderNames.Vary] = HeaderNames.From;
+            });
 
             foreach (var builder in builders)
             {
                 using (var server = new TestServer(builder))
                 {
                     var client = server.CreateClient();
-                    var initialResponse = await client.GetAsync("");
+                    var initialResponse = await client.GetAsync("?Expires=90");
                     client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.MaxValue;
                     var subsequentResponse = await client.GetAsync("");
 
                     initialResponse.EnsureSuccessStatusCode();
                     Assert.Equal(System.Net.HttpStatusCode.NotModified, subsequentResponse.StatusCode);
+                    Assert304Headers(initialResponse, subsequentResponse);
                 }
             }
         }
@@ -631,19 +637,25 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [Fact]
         public async Task Serves304_IfIfNoneMatch_Satisfied()
         {
-            var builders = TestUtils.CreateBuildersWithResponseCaching(contextAction: context => context.Response.GetTypedHeaders().ETag = new EntityTagHeaderValue("\"E1\""));
+            var builders = TestUtils.CreateBuildersWithResponseCaching(contextAction: context =>
+            {
+                context.Response.GetTypedHeaders().ETag = new EntityTagHeaderValue("\"E1\"");
+                context.Response.Headers[HeaderNames.ContentLocation] = "/";
+                context.Response.Headers[HeaderNames.Vary] = HeaderNames.From;
+            });
 
             foreach (var builder in builders)
             {
                 using (var server = new TestServer(builder))
                 {
                     var client = server.CreateClient();
-                    var initialResponse = await client.GetAsync("");
+                    var initialResponse = await client.GetAsync("?Expires=90");
                     client.DefaultRequestHeaders.IfNoneMatch.Add(new System.Net.Http.Headers.EntityTagHeaderValue("\"E1\""));
                     var subsequentResponse = await client.GetAsync("");
 
                     initialResponse.EnsureSuccessStatusCode();
                     Assert.Equal(System.Net.HttpStatusCode.NotModified, subsequentResponse.StatusCode);
+                    Assert304Headers(initialResponse, subsequentResponse);
                 }
             }
         }
@@ -812,6 +824,22 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                     await AssertCachedResponseAsync(initialResponse, subsequentResponse);
                 }
             }
+        }
+
+        private static void Assert304Headers(HttpResponseMessage initialResponse, HttpResponseMessage subsequentResponse)
+        {
+            // https://tools.ietf.org/html/rfc7232#section-4.1
+            // The server generating a 304 response MUST generate any of the
+            // following header fields that would have been sent in a 200 (OK)
+            // response to the same request: Cache-Control, Content-Location, Date,
+            // ETag, Expires, and Vary.
+
+            Assert.Equal(initialResponse.Headers.CacheControl, subsequentResponse.Headers.CacheControl);
+            Assert.Equal(initialResponse.Content.Headers.ContentLocation, subsequentResponse.Content.Headers.ContentLocation);
+            Assert.Equal(initialResponse.Headers.Date, subsequentResponse.Headers.Date);
+            Assert.Equal(initialResponse.Headers.ETag, subsequentResponse.Headers.ETag);
+            Assert.Equal(initialResponse.Content.Headers.Expires, subsequentResponse.Content.Headers.Expires);
+            Assert.Equal(initialResponse.Headers.Vary, subsequentResponse.Headers.Vary);
         }
 
         private static async Task AssertCachedResponseAsync(HttpResponseMessage initialResponse, HttpResponseMessage subsequentResponse)


### PR DESCRIPTION
Include the required headers for 304 response according to RFC 7232
https://tools.ietf.org/html/rfc7232#section-4.1

> The server generating a 304 response MUST generate any of the
>  following header fields that would have been sent in a 200 (OK)
>  response to the same request: Cache-Control, Content-Location, Date,
>  ETag, Expires, and Vary.

Addresses #10583

/cc @anurse 
