### PR TITLE
Use Enterprise Queue to reduce provisioning issues

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -104,12 +104,8 @@ jobs:
           queue: BuildPool.Windows.10.Amd64.VS2019.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCoreInternal-Pool
-        ${{ if ne(parameters.isTestingJob, true) }}:
-          # Visual Studio Build Tools
-          queue: BuildPool.Windows.10.Amd64.VS2019.BT
-        ${{ if eq(parameters.isTestingJob, true) }}:
-          # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Windows.10.Amd64.VS2019
+        # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
+        queue: BuildPool.Windows.10.Amd64.VS2019
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
Switch to enterprise queue for better provisioning. This should help with our "Abandoned builds" problem. e.g. https://dnceng.visualstudio.com/internal/_build/results?buildId=232662.
