### PR TITLE
Sign Windows zips

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -97,6 +97,9 @@ jobs:
     # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
     # consider running code-signing inline with the other previous steps.
     # Sign check is disabled because it is run in a separate step below, after installers are built.
+    - powershell: get-childitem artifacts\installers -rec | where {!$_.PSIsContainer} |  foreach-object -process {$_.FullName}
+      displayName: List artifacts files
+
     - script: ./build.cmd
               -ci
               -noBuild

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -97,9 +97,6 @@ jobs:
     # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
     # consider running code-signing inline with the other previous steps.
     # Sign check is disabled because it is run in a separate step below, after installers are built.
-    - powershell: get-childitem artifacts\installers -rec | where {!$_.PSIsContainer} |  foreach-object -process {$_.FullName}
-      displayName: List artifacts files
-
     - script: ./build.cmd
               -ci
               -noBuild

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,6 +14,8 @@
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.jar"  />
     <ItemsToSign Include="$(InstallersOutputPath)**\*.zip" />
+    <InstallerGlobPatternA Include="$(InstallersOutputPath)**\*.zip" />
+    <InstallerGlobPatternB Include="$(InstallersOutputPath)*.zip" />
 
     <!--
       Map file extensions to a code-sign cert.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -13,9 +13,7 @@
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" Exclude="$(ArtifactsPackagesDir)**\*symbols.nupkg" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.jar"  />
-    <ItemsToSign Include="$(InstallersOutputPath)**\*.zip" />
-    <InstallerGlobPatternA Include="$(InstallersOutputPath)**\*.zip" />
-    <InstallerGlobPatternB Include="$(InstallersOutputPath)*.zip" />
+    <ItemsToSign Include="$(ArtifactsDir)installers\$(Configuration)\**\*.zip" />
 
     <!--
       Map file extensions to a code-sign cert.


### PR DESCRIPTION
Signing of the windows zip was broken during the arcade conversion. Signing.props is imported by the Arcade Sign.proj. However, it doesn't import Directory.Build.props which defines `InstallersOutputPath`. `ArtifactsDir` is  defined so let's use that instead.

I'll do a quick check of the other artifacts we expect to be signed.