### PR TITLE
Api Explorer: multiple complex properties

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -585,6 +585,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     if (Visited.Add(key))
                     {
                         Visit(propertyContext, source ?? ambientSource, newContainerName);
+                        Visited.Remove(key);
                     }
                     else
                     {

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1486,6 +1486,66 @@ namespace Microsoft.AspNetCore.Mvc.Description
         }
 
         [Fact]
+        public void GetApiDescription_ParameterDescription_DuplicatePropertiesWithChildren_ExpandBoth()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(AcceptsMultipleProperties));
+            var parameterDescriptor = action.Parameters.Single();
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(4, description.ParameterDescriptions.Count);
+
+            var parentNames = new[] { "Parent1", "Parent2" };
+
+            foreach (var parentName in parentNames)
+            {
+                var id = Assert.Single(description.ParameterDescriptions, p => p.Name == $"{parentName}.Child.Id");
+                Assert.Same(BindingSource.Query, id.Source);
+                Assert.Equal(typeof(int), id.Type);
+
+                var name = Assert.Single(description.ParameterDescriptions, p => p.Name == $"{parentName}.Child.Name");
+                Assert.Same(BindingSource.Query, name.Source);
+                Assert.Equal(typeof(string), name.Type);
+            }
+        }
+
+        [Fact]
+        public void GetApiDescription_ParameterDescription_DuplicatePropertiesWithChildren_Nested_ExpandAll()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(AcceptsMultiplePropertiesNested));
+            var parameterDescriptor = action.Parameters.Single();
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(8, description.ParameterDescriptions.Count);
+
+            var groupNames = new[] { "Group1", "Group2" };
+            var parentNames = new[] { "Parent1", "Parent2" };
+
+            foreach (var groupName in groupNames)
+            {
+                foreach (var parentName in parentNames)
+                {
+                    var id = Assert.Single(description.ParameterDescriptions, p => p.Name == $"{groupName}.{parentName}.Child.Id");
+                    Assert.Same(BindingSource.Query, id.Source);
+                    Assert.Equal(typeof(int), id.Type);
+
+                    var name = Assert.Single(description.ParameterDescriptions, p => p.Name == $"{groupName}.{parentName}.Child.Name");
+                    Assert.Same(BindingSource.Query, name.Source);
+                    Assert.Equal(typeof(string), name.Type);
+                }
+            }
+        }
+
+        [Fact]
         public void GetApiDescription_ParameterDescription_BreaksCycles()
         {
             // Arrange
@@ -2081,6 +2141,14 @@ namespace Microsoft.AspNetCore.Mvc.Description
         {
         }
 
+        private void AcceptsMultipleProperties([FromQuery]MultipleProperties model)
+        {
+        }
+
+        private void AcceptsMultiplePropertiesNested([FromQuery]MultiplePropertiesContainer model)
+        {
+        }
+
         private void ParameterDefaultValue(int value = 10) { }
 
         private class TestController
@@ -2235,6 +2303,23 @@ namespace Microsoft.AspNetCore.Mvc.Description
 
             [FromForm]
             public int Id { get; set; }
+        }
+
+        private class MultiplePropertiesContainer
+        {
+            public MultipleProperties Group1 { get; set; }
+            public MultipleProperties Group2 { get; set; }
+        }
+
+        private class MultipleProperties
+        {
+            public Parent Parent1 { get; set; }
+            public Parent Parent2 { get; set; }
+        }
+
+        private class Parent
+        {
+            public Child Child { get; set; }
         }
 
         private class MockInputFormatter : TextInputFormatter


### PR DESCRIPTION
Currently the API Explorer Visitor logic cycles detection is too greedy, so if the same complex type is referenced by two different properties, the second time is skipped.

This PR pop the node after it has been visited, so that while still stopping the visitor when detecting a cycle, it now allows to have the same model referenced by different properties.

Addresses #10110

_Apologies for the edits, I found a better solution after submitting the PR_
