### PR TITLE
Make ~/ resolution show up at design time.

### DIFF
--- a/src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
             new DiagnosticDescriptor(
                 "MVC1006",
                 "Methods containing TagHelpers must be async and return Task.",
-                "The method contains a TagHelper and therefore must be async and return a Task.",
+                "The method contains a TagHelper and therefore must be async and return a Task. For instance, usage of ~/ typically results in a TagHelper and requires an async Task returning parent method.",
                 "Usage",
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true);

--- a/src/Mvc/Mvc.Razor/ref/Microsoft.AspNetCore.Mvc.Razor.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Razor/ref/Microsoft.AspNetCore.Mvc.Razor.netcoreapp3.0.cs
@@ -356,7 +356,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
     [Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute("track", Attributes="[src^='~/']", TagStructure=Microsoft.AspNetCore.Razor.TagHelpers.TagStructure.WithoutEndTag)]
     [Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute("video", Attributes="[poster^='~/']")]
     [Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute("video", Attributes="[src^='~/']")]
-    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class UrlResolutionTagHelper : Microsoft.AspNetCore.Razor.TagHelpers.TagHelper
     {
         public UrlResolutionTagHelper(Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory urlHelperFactory, System.Text.Encodings.Web.HtmlEncoder htmlEncoder) { }

--- a/src/Mvc/Mvc.Razor/src/TagHelpers/UrlResolutionTagHelper.cs
+++ b/src/Mvc/Mvc.Razor/src/TagHelpers/UrlResolutionTagHelper.cs
@@ -50,7 +50,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
     [HtmlTargetElement("track", Attributes = "[src^='~/']", TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("video", Attributes = "[src^='~/']")]
     [HtmlTargetElement("video", Attributes = "[poster^='~/']")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
     public class UrlResolutionTagHelper : TagHelper
     {
         // Valid whitespace characters defined by the HTML5 spec.


### PR DESCRIPTION
- This change results in proper errors for tags that utilize `~/`inside of local functions at design time.

Turns out my VS changes that I did for the last release 99% cover improper coloring of this scenario. The 1 case that it doesn't is when a user utilizes the `itemid` attribute on a non-standard HTML tag:

![image](https://user-images.githubusercontent.com/2008729/60054038-46de3180-968e-11e9-9868-e509d7185ec0.png)


Addresses #10734