### PR TITLE
Improve IIS UrlRewrite parsing

### DIFF
--- a/src/Middleware/Rewrite/src/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Middleware/Rewrite/src/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
             if (xmlRoot == null)
             {
-                return null;
+                throw new InvalidUrlRewriteFormatException(new XElement(RewriteTags.Rewrite), "The root element '<rewrite>' is missing");
             }
 
             _inputParser = new InputParser(RewriteMapParser.Parse(xmlRoot), alwaysUseManagedServerVariables);
@@ -113,9 +113,15 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
             var grouping = ParseEnum(conditions, RewriteTags.LogicalGrouping, LogicalGrouping.MatchAll);
             var trackAllCaptures = ParseBool(conditions, RewriteTags.TrackAllCaptures, defaultValue: false);
+            var adds = conditions.Elements(RewriteTags.Add);
+            if (adds == null || adds.Count() == 0)
+            {
+                return;
+            }
+
             builder.ConfigureConditionBehavior(grouping, trackAllCaptures);
 
-            foreach (var cond in conditions.Elements(RewriteTags.Add))
+            foreach (var cond in adds)
             {
                 ParseCondition(cond, builder, patternSyntax);
             }

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/FileParserTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/FileParserTests.cs
@@ -158,6 +158,27 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
             Assert.False(rules[1].Global);
         }
 
+        [Fact]
+        public void Should_skip_empty_conditions()
+        {
+            // arrange
+            var xml = @"<rewrite>
+                            <rules>
+                                <rule name=""redirect-aspnet-mvc"" enabled=""true"" stopProcessing=""true"">
+                                    <match url=""^aspnet/Mvc"" />
+                                    <conditions logicalGrouping=""MatchAll"" trackAllCaptures=""false"" />
+                                    <action type=""Redirect"" url=""https://github.com/aspnet/AspNetCore"" />
+                                </rule>
+                            </rules>
+                        </rewrite>";
+
+            // act
+            var rules = new UrlRewriteFileParser().Parse(new StringReader(xml), false);
+
+            // assert
+            Assert.Null(rules[0].Conditions);
+        }
+
         // Creates a rule with appropriate default values of the url rewrite rule.
         private IISUrlRewriteRule CreateTestRule(ConditionCollection conditions,
             string name = "",

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/InvalidUrlRewriteFormatExceptionHandlingTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/InvalidUrlRewriteFormatExceptionHandlingTests.cs
@@ -208,6 +208,9 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
     </rules>
 </rewrite>",
             "Could not parse the UrlRewrite file. Message: 'The appendQueryString parameter 'foo' was not recognized'. Line number '5': '14'.")]
+        [InlineData(
+            "<rules><rule></rule></rules>",
+            "Could not parse the UrlRewrite file. Message: 'The root element '<rewrite>' is missing'. Line number '0': '0'.")]
         public void ThrowInvalidUrlRewriteFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert


### PR DESCRIPTION
This PR addresses two null reference exceptions.
*  If the `<rewrite>` tag is missing in the UrlRewite xml file, the following NullReferenceException is thrown.
```text
Application startup exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.AspNetCore.Rewrite.IISUrlRewriteOptionsExtensions.AddIISUrlRewrite(RewriteOptions options, TextReader reader, Boolean alwaysUseManagedServerVariables) in C:\Dev\github\AspNetCore\src\Middleware\Rewrite\src\IISUrlRewriteOptionsExtensions.cs:line 64
```
* If a `rule` element contains a `conditions` without child `add` , the following NullReferenceException is thrown. If using  IIS UrlRewrite Module, the `conditions` is ignored and the `rule` works.
```text
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite.ConditionEvaluator.Evaluate(ConditionCollection conditions, RewriteContext context, BackReferenceCollection backReferences) in C:\Dev\github\AspNetCore\src\Middleware\Rewrite\src\Internal\IISUrlRewrite\ConditionEvaluator.cs:line 46
```
