### PR TITLE
Use a mutex to guard cert creation on windows

### DIFF
--- a/src/Servers/Kestrel/shared/test/TestResources.cs
+++ b/src/Servers/Kestrel/shared/test/TestResources.cs
@@ -1,8 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Xunit;
 
 namespace Microsoft.AspNetCore.Testing
 {
@@ -13,14 +17,28 @@ namespace Microsoft.AspNetCore.Testing
         public static string TestCertificatePath { get; } = Path.Combine(_baseDir, "testCert.pfx");
         public static string GetCertPath(string name) => Path.Combine(_baseDir, name);
 
-        public static X509Certificate2 GetTestCertificate()
-        {
-            return new X509Certificate2(TestCertificatePath, "testPassword");
-        }
+        private const int MutexTimeout = 120 * 1000;
+        private static readonly Mutex importPfxMutex = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            new Mutex(initiallyOwned: false, "Global\\KestrelTests.Certificates.LoadPfxCertificate") :
+            null;
 
-        public static X509Certificate2 GetTestCertificate(string certName)
+        public static X509Certificate2 GetTestCertificate(string certName = "testCert.pfx")
         {
-            return new X509Certificate2(GetCertPath(certName), "testPassword");
+            // On Windows, applications should not import PFX files in parallel to avoid a known system-level
+            // race condition bug in native code which can cause crashes/corruption of the certificate state.
+            if (importPfxMutex != null)
+            {
+                Assert.True(importPfxMutex.WaitOne(MutexTimeout), "Cannot acquire the global certificate mutex.");
+            }
+
+            try
+            {
+                return new X509Certificate2(GetCertPath(certName), "testPassword");
+            }
+            finally
+            {
+                importPfxMutex?.ReleaseMutex();
+            }
         }
     }
 }


### PR DESCRIPTION
- It should prevent some test flakyness around importing certs in some cases.

Example of a failure:

```
| System.ComponentModel.Win32Exception (0x8009030D): The credentials supplied to the package were not recognized
|    at System.Net.SSPIWrapper.AcquireCredentialsHandle(SSPIInterface secModule, String package, CredentialUse intent, SCHANNEL_CRED scc)
|    at System.Net.Security.SslStreamPal.AcquireCredentialsHandle(CredentialUse credUsage, SCHANNEL_CRED secureCredential)
|    at System.Net.Security.SslStreamPal.AcquireCredentialsHandle(X509Certificate certificate, SslProtocols protocols, EncryptionPolicy policy, Boolean isServer)
|    at System.Net.Security.SecureChannel.AcquireServerCredentials(Byte[]& thumbPrint, Byte[] clientHello)
|    at System.Net.Security.SecureChannel.GenerateToken(Byte[] input, Int32 offset, Int32 count, Byte[]& output)
|    at System.Net.Security.SecureChannel.NextMessage(Byte[] incoming, Int32 offset, Int32 count)
|    at System.Net.Security.SslStream.StartSendBlob(Byte[] incoming, Int32 count, AsyncProtocolRequest asyncRequest)
|    at System.Net.Security.SslStream.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
|    at System.Net.Security.SslStream.StartReadFrame(Byte[] buffer, Int32 readBytes, AsyncProtocolRequest asyncRequest)
|    at System.Net.Security.SslStream.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
|    at System.Net.Security.SslStream.ForceAuthentication(Boolean receiveFirst, Byte[] buffer, AsyncProtocolRequest asyncRequest)
|    at System.Net.Security.SslStream.ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
|    at System.Net.Security.SslStream.BeginAuthenticateAsServer(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken, AsyncCallback asyncCallback, Object asyncState)
|    at System.Net.Security.SslStream.<>c.<AuthenticateAsServerAsync>b__69_0(SslServerAuthenticationOptions arg1, CancellationToken arg2, AsyncCallback callback, Object state)
|    at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl[TArg1,TArg2](Func`5 beginMethod, Func`2 endFunction, Action`1 endAction, TArg1 arg1, TArg2 arg2, Object state, TaskCreationOptions creationOptions)
|    at System.Threading.Tasks.TaskFactory.FromAsync[TArg1,TArg2](Func`5 beginMethod, Action`1 endMethod, TArg1 arg1, TArg2 arg2, Object state, TaskCreationOptions creationOptions)
|    at System.Threading.Tasks.TaskFactory.FromAsync[TArg1,TArg2](Func`5 beginMethod, Action`1 endMethod, TArg1 arg1, TArg2 arg2, Object state)
|    at System.Net.Security.SslStream.AuthenticateAsServerAsync(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken)
|    at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionMiddleware.InnerOnConnectionAsync(ConnectionContext context) in /_/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs:line 196
|    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.ConnectionDispatcher.Execute(KestrelConnection connection) in /_/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs:line 85
```