### PR TITLE
Add authentication revalidation logic to IndividualLocalAuth server-side Blazor template. Implements #10698

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Areas/Identity/RevalidatingAuthenticationStateProvider.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Areas/Identity/RevalidatingAuthenticationStateProvider.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RazorComponentsWeb_CSharp.Areas.Identity
+{
+    /// <summary>
+    /// An <see cref="AuthenticationStateProvider"/> service that revalidates the
+    /// authentication state at regular intervals. If a signed-in user's security
+    /// stamp changes, this revalidation mechanism will sign the user out.
+    /// </summary>
+    /// <typeparam name="TUser">The type encapsulating a user.</typeparam>
+    public class RevalidatingAuthenticationStateProvider<TUser>
+        : AuthenticationStateProvider, IDisposable where TUser: class
+    {
+        private readonly static TimeSpan RevalidationInterval = TimeSpan.FromMinutes(30);
+
+        private readonly CancellationTokenSource _loopCancellationTokenSource = new CancellationTokenSource();
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger _logger;
+        private Task<AuthenticationState> _currentAuthenticationStateTask;
+
+        public RevalidatingAuthenticationStateProvider(
+            IServiceScopeFactory scopeFactory,
+            SignInManager<TUser> circuitScopeSignInManager,
+            ILogger<RevalidatingAuthenticationStateProvider<TUser>> logger)
+        {
+            var initialUser = circuitScopeSignInManager.Context.User;
+            _currentAuthenticationStateTask = Task.FromResult(new AuthenticationState(initialUser));
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+
+            if (initialUser.Identity.IsAuthenticated)
+            {
+                _ = RevalidationLoop();
+            }
+        }
+
+        public override Task<AuthenticationState> GetAuthenticationStateAsync()
+            => _currentAuthenticationStateTask;
+
+        private async Task RevalidationLoop()
+        {
+            var cancellationToken = _loopCancellationTokenSource.Token;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(RevalidationInterval, cancellationToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+
+                var isValid = await CheckIfAuthenticationStateIsValidAsync();
+                if (!isValid)
+                {
+                    // Force sign-out. Also stop the revalidation loop, because the user can
+                    // only sign back in by starting a new connection.
+                    var anonymousUser = new ClaimsPrincipal();
+                    _currentAuthenticationStateTask = Task.FromResult(new AuthenticationState(anonymousUser));
+                    NotifyAuthenticationStateChanged(_currentAuthenticationStateTask);
+                    _loopCancellationTokenSource.Cancel();
+                }
+            }
+        }
+
+        private async Task<bool> CheckIfAuthenticationStateIsValidAsync()
+        {
+            try
+            {
+                // Get the sign-in manager from a new scope to ensure it fetches fresh data
+                using (var scope = _scopeFactory.CreateScope())
+                {
+                    var signInManager = scope.ServiceProvider.GetRequiredService<SignInManager<TUser>>();
+                    var authenticationState = await _currentAuthenticationStateTask;
+                    var validatedUser = await signInManager.ValidateSecurityStampAsync(authenticationState.User);
+                    return validatedUser != null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while revalidating authentication state");
+                return false;
+            }
+        }
+
+        void IDisposable.Dispose()
+            => _loopCancellationTokenSource.Cancel();
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Areas/Identity/RevalidatingAuthenticationStateProvider.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Areas/Identity/RevalidatingAuthenticationStateProvider.cs
@@ -1,11 +1,11 @@
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace RazorComponentsWeb_CSharp.Areas.Identity
 {
@@ -16,7 +16,7 @@ namespace RazorComponentsWeb_CSharp.Areas.Identity
     /// </summary>
     /// <typeparam name="TUser">The type encapsulating a user.</typeparam>
     public class RevalidatingAuthenticationStateProvider<TUser>
-        : AuthenticationStateProvider, IDisposable where TUser: class
+        : AuthenticationStateProvider, IDisposable where TUser : class
     {
         private readonly static TimeSpan RevalidationInterval = TimeSpan.FromMinutes(30);
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Startup.cs
@@ -36,6 +36,9 @@ using Microsoft.Extensions.Hosting;
 #if(MultiOrgAuth)
 using Microsoft.IdentityModel.Tokens;
 #endif
+#if (IndividualLocalAuth)
+using RazorComponentsWeb_CSharp.Areas.Identity;
+#endif
 using RazorComponentsWeb_CSharp.Data;
 
 namespace RazorComponentsWeb_CSharp
@@ -64,6 +67,8 @@ namespace RazorComponentsWeb_CSharp
 #endif
             services.AddDefaultIdentity<IdentityUser>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
+
+            services.AddScoped<AuthenticationStateProvider, RevalidatingAuthenticationStateProvider<IdentityUser>>();
 #elif (OrganizationalAuth)
             services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
                 .AddAzureAD(options => Configuration.Bind("AzureAd", options));

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -894,6 +894,7 @@
         "_Imports.razor",
         "Areas/Identity/Pages/Account/LogOut.cshtml",
         "Areas/Identity/Pages/Shared/_LoginPartial.cshtml",
+        "Areas/Identity/RevalidatingAuthenticationStateProvider.cs",
         "Data/ApplicationDbContext.cs",
         "Data/WeatherForecast.cs",
         "Data/WeatherForecastService.cs",


### PR DESCRIPTION
Implements #10698

Following discussions with security and SignalR folks, we've decided we need to have some form of periodic revalidation for authentication in server-side Blazor. This is meaningful only in the Identity case, because that's what has the concept of security stamps and can re-query the DB to get updated state.

**Before broader code review, I'd first like to check with authentication/Identity experts that the logic here looks right.** Ping @HaoK. And @blowdart, is there anyone else you'd like to look at this?

The specific bit that authentication/Identity experts might most be interested in is the contents of `CheckIfAuthenticationStateIsValidAsync`. This gets called periodically (every 30 minutes by default) and is responsible for deciding whether to sign the user out. The rule is very simple: if your security stamp changed, we log you out. Then the user is forced to go through the login flow again, which refreshes everything about their `ClaimsPrincipal` (if they are still even able to log in).

So, @HaoK, can you let me know if you think the logic in `CheckIfAuthenticationStateIsValidAsync` accounts for everything necessary? For example, if a user got locked out or had their roles changed, then their security stamp will have changed, right?

If you need any further information, I'd be happy to have a brief meeting to explain any finer points of the mechanism. Let me know.