### PR TITLE
Rename @aspnet/signalr to @microsoft/signalr

### DIFF
--- a/src/Components/Browser.JS/yarn.lock
+++ b/src/Components/Browser.JS/yarn.lock
@@ -144,6 +144,10 @@
   resolved "https://dotnet.myget.org/F/aspnetcore-dev/npm/@dotnet/jsinterop/-/@dotnet/jsinterop-3.0.0-preview6.19280.1.tgz#4c991132f33157de93bc3b6db93cffc9e964b241"
   integrity sha1-TJkRMvMxV96TvDttuTz/yelkskE=
 
+"@microsoft/signalr@link:../../SignalR/clients/ts/signalr":
+  version "0.0.0"
+  uid ""
+
 "@types/emscripten@0.0.31":
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/@types/emscripten/-/emscripten-0.0.31.tgz#160817d1324e8b7049604d39ac47d85eeeedd597"

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
@@ -66,9 +66,9 @@
       <Copy SourceFiles="@(JasmineFiles)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/jasmine" />
 
       <ItemGroup>
-        <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@aspnet/signalr/dist/browser/*" />
-        <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@aspnet/signalr-protocol-msgpack/dist/browser/*" />
-        <SignalRJSWebWorkerClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@aspnet/signalr/dist/webworker/*" />
+        <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/browser/*" />
+        <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr-protocol-msgpack/dist/browser/*" />
+        <SignalRJSWebWorkerClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/webworker/*" />
       </ItemGroup>
       <Copy SourceFiles="@(SignalRJSBrowserClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr" />
       <Copy SourceFiles="@(SignalRJSWebWorkerClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr-webworker" />

--- a/src/SignalR/clients/ts/FunctionalTests/func.jest.config.js
+++ b/src/SignalR/clients/ts/FunctionalTests/func.jest.config.js
@@ -4,7 +4,7 @@
 module.exports = {
     transformIgnorePatterns: [
         // We reference the ESM output from tests and don't want to run them through jest as it won't understand the syntax
-        ".*/node_modules/(?!@aspnet)"
+        ".*/node_modules/(?!@microsoft)"
     ],
     globals: {
         "ts-jest": {
@@ -27,7 +27,7 @@ module.exports = {
     testRegex: "(Tests)\\.(jsx?|tsx?)$",
     moduleNameMapper: {
         "^ts-jest$": "<rootDir>/../common/node_modules/ts-jest",
-        "^@aspnet/signalr$": "<rootDir>/../signalr/dist/cjs/index.js"
+        "^@microsoft/signalr$": "<rootDir>/../signalr/dist/cjs/index.js"
     },
     moduleFileExtensions: [
         "ts",

--- a/src/SignalR/clients/ts/FunctionalTests/package.json
+++ b/src/SignalR/clients/ts/FunctionalTests/package.json
@@ -5,8 +5,8 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@aspnet/signalr": "link:../signalr",
-    "@aspnet/signalr-protocol-msgpack": "link:../signalr-protocol-msgpack",
+    "@microsoft/signalr": "link:../signalr",
+    "@microsoft/signalr-protocol-msgpack": "link:../signalr-protocol-msgpack",
     "msgpack5": "^4.0.2"
   },
   "devDependencies": {

--- a/src/SignalR/clients/ts/FunctionalTests/scripts/karma.base.conf.js
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/karma.base.conf.js
@@ -14,8 +14,8 @@ try {
                 frameworks: ["jasmine"],
                 files: [
                     "wwwroot/lib/msgpack5/msgpack5.js",
-                    "node_modules/@aspnet/signalr/dist/browser/signalr.js",
-                    "node_modules/@aspnet/signalr-protocol-msgpack/dist/browser/signalr-protocol-msgpack.js",
+                    "node_modules/@microsoft/signalr/dist/browser/signalr.js",
+                    "node_modules/@microsoft/signalr-protocol-msgpack/dist/browser/signalr-protocol-msgpack.js",
                     "wwwroot/dist/signalr-functional-tests.js"
                 ],
                 preprocessors: {

--- a/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import { HttpTransportType, IHubProtocol, JsonHubProtocol } from "@aspnet/signalr";
-import { MessagePackHubProtocol } from "@aspnet/signalr-protocol-msgpack";
+import { HttpTransportType, IHubProtocol, JsonHubProtocol } from "@microsoft/signalr";
+import { MessagePackHubProtocol } from "@microsoft/signalr-protocol-msgpack";
 
 // On slower CI machines, these tests sometimes take longer than 5s
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20 * 1000;

--- a/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
@@ -4,12 +4,12 @@
 // This code uses a lot of `.then` instead of `await` and TSLint doesn't like it.
 // tslint:disable:no-floating-promises
 
-import { HttpTransportType, IHttpConnectionOptions, TransferFormat } from "@aspnet/signalr";
+import { HttpTransportType, IHttpConnectionOptions, TransferFormat } from "@microsoft/signalr";
 import { eachTransport, ECHOENDPOINT_URL } from "./Common";
 import { TestLogger } from "./TestLogger";
 
 // We want to continue testing HttpConnection, but we don't export it anymore. So just pull it in directly from the source file.
-import { HttpConnection } from "@aspnet/signalr/dist/esm/HttpConnection";
+import { HttpConnection } from "@microsoft/signalr/dist/esm/HttpConnection";
 import "./LogBannerReporter";
 
 const commonOptions: IHttpConnectionOptions = {

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -4,8 +4,8 @@
 // This code uses a lot of `.then` instead of `await` and TSLint doesn't like it.
 // tslint:disable:no-floating-promises
 
-import { AbortError, DefaultHttpClient, HttpClient, HttpRequest, HttpResponse, HttpTransportType, HubConnectionBuilder, IHttpConnectionOptions, JsonHubProtocol, NullLogger } from "@aspnet/signalr";
-import { MessagePackHubProtocol } from "@aspnet/signalr-protocol-msgpack";
+import { AbortError, DefaultHttpClient, HttpClient, HttpRequest, HttpResponse, HttpTransportType, HubConnectionBuilder, IHttpConnectionOptions, JsonHubProtocol, NullLogger } from "@microsoft/signalr";
+import { MessagePackHubProtocol } from "@microsoft/signalr-protocol-msgpack";
 
 import { eachTransport, eachTransportAndProtocol, ENDPOINT_BASE_HTTPS_URL, ENDPOINT_BASE_URL } from "./Common";
 import "./LogBannerReporter";

--- a/src/SignalR/clients/ts/FunctionalTests/ts/TestLogger.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/TestLogger.ts
@@ -1,8 +1,8 @@
-import { ILogger, LogLevel } from "@aspnet/signalr";
+import { ILogger, LogLevel } from "@microsoft/signalr";
 
 // Since JavaScript modules are file-based, we can just pull in utilities from the
 // main library directly even if they aren't exported.
-import { ConsoleLogger } from "@aspnet/signalr/dist/esm/Utils";
+import { ConsoleLogger } from "@microsoft/signalr/dist/esm/Utils";
 
 export class TestLog {
     public messages: Array<[Date, LogLevel, string]> = [];

--- a/src/SignalR/clients/ts/FunctionalTests/web.config
+++ b/src/SignalR/clients/ts/FunctionalTests/web.config
@@ -7,8 +7,11 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" startupTimeLimit="3600" requestTimeout="23:00:00">
-      <environmentVariables />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" startupTimeLimit="3600" requestTimeout="23:00:00" hostingModel="InProcess">
+      <environmentVariables>
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
+        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      </environmentVariables>
     </aspNetCore>
   </system.webServer>
 </configuration>

--- a/src/SignalR/clients/ts/FunctionalTests/web.config
+++ b/src/SignalR/clients/ts/FunctionalTests/web.config
@@ -7,11 +7,8 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" startupTimeLimit="3600" requestTimeout="23:00:00" hostingModel="InProcess">
-      <environmentVariables>
-        <environmentVariable name="COMPLUS_ForceENC" value="1" />
-        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
-      </environmentVariables>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" startupTimeLimit="3600" requestTimeout="23:00:00">
+      <environmentVariables />
     </aspNetCore>
   </system.webServer>
 </configuration>

--- a/src/SignalR/clients/ts/FunctionalTests/webpack.config.js
+++ b/src/SignalR/clients/ts/FunctionalTests/webpack.config.js
@@ -35,8 +35,8 @@ module.exports = {
         path: path.resolve(__dirname, "wwwroot", "dist"),
     },
     externals: {
-        "@aspnet/signalr": "signalR",
-        "@aspnet/signalr-protocol-msgpack": "signalR.protocols.msgpack",
+        "@microsoft/signalr": "signalR",
+        "@microsoft/signalr-protocol-msgpack": "signalR.protocols.msgpack",
         "request": "request",
     },
 };

--- a/src/SignalR/clients/ts/FunctionalTests/yarn.lock
+++ b/src/SignalR/clients/ts/FunctionalTests/yarn.lock
@@ -2,11 +2,11 @@
 # yarn lockfile v1
 
 
-"@aspnet/signalr-protocol-msgpack@link:../signalr-protocol-msgpack":
+"@microsoft/signalr-protocol-msgpack@link:../signalr-protocol-msgpack":
   version "0.0.0"
   uid ""
 
-"@aspnet/signalr@link:../signalr":
+"@microsoft/signalr@link:../signalr":
   version "0.0.0"
   uid ""
 

--- a/src/SignalR/clients/ts/jest.config.js
+++ b/src/SignalR/clients/ts/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
     testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     moduleNameMapper: {
         "^ts-jest$": "<rootDir>/common/node_modules/ts-jest",
-        "^@aspnet/signalr$": "<rootDir>/signalr/dist/cjs/index.js"
+        "^@microsoft/signalr$": "<rootDir>/signalr/dist/cjs/index.js"
     },
     moduleFileExtensions: [
         "ts",

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
@@ -3,11 +3,11 @@ MsgPack support for SignalR for ASP.NET Core
 ## Installation
 
 ```bash
-npm install @aspnet/signalr-protocol-msgpack
+npm install @microsoft/signalr-protocol-msgpack
 ```
 or
 ```bash
-yarn add @aspnet/signalr-protocol-msgpack
+yarn add @microsoft/signalr-protocol-msgpack
 ```
 
 ## Usage
@@ -20,7 +20,7 @@ To use the client in a browser, copy `*.js` files from the `dist/browser` folder
 
 ### NodeJS
 
-To use the client in a NodeJS application, install the package to your `node_modules` folder and use `require('@aspnet/signalr-protocol-msgpack')` to load the module. The object returned by `require('@aspnet/signalr-protocol-msgpack')` has the same members as the global `signalR.protocols.msgpack` object (when used in a browser).
+To use the client in a NodeJS application, install the package to your `node_modules` folder and use `require('@microsoft/signalr-protocol-msgpack')` to load the module. The object returned by `require('@microsoft/signalr-protocol-msgpack')` has the same members as the global `signalR.protocols.msgpack` object (when used in a browser).
 
 ### Example (Browser)
 
@@ -41,8 +41,8 @@ connection.start()
 ### Example (NodeJS)
 
 ```JavaScript
-const signalR = require("@aspnet/signalr");
-const signalRMsgPack = require("@aspnet/signalr-protocol-msgpack");
+const signalR = require("@microsoft/signalr");
+const signalRMsgPack = require("@microsoft/signalr-protocol-msgpack");
 
 let connection = new signalR.HubConnectionBuilder()
     .withUrl("/chat")

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aspnet/signalr-protocol-msgpack",
+  "name": "@microsoft/signalr-protocol-msgpack",
   "version": "3.0.0-dev",
   "description": "MsgPack Protocol support for ASP.NET Core SignalR",
   "main": "./dist/cjs/index.js",
@@ -42,7 +42,7 @@
     "src/**/*"
   ],
   "dependencies": {
-    "@aspnet/signalr": "link:../signalr",
+    "@microsoft/signalr": "link:../signalr",
     "msgpack5": "^4.0.2"
   },
   "devDependencies": {

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/rollup.config.js
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/rollup.config.js
@@ -5,5 +5,5 @@ import baseConfig from "../rollup-base"
 
 export default baseConfig(__dirname, {
     msgpack5: "msgpack5",
-    "@aspnet/signalr": "signalR",
+    "@microsoft/signalr": "signalR",
 });

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/signalr-protocol-msgpack.npmproj
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/signalr-protocol-msgpack.npmproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <PackageId>@aspnet/signalr-protocol-msgpack</PackageId>
+    <PackageId>@microsoft/signalr-protocol-msgpack</PackageId>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>
     <IsShippingPackage>true</IsShippingPackage>

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
@@ -7,7 +7,7 @@ import * as msgpack5 from "msgpack5";
 import {
     CancelInvocationMessage, CompletionMessage, HubMessage, IHubProtocol, ILogger, InvocationMessage,
     LogLevel, MessageHeaders, MessageType, NullLogger, StreamInvocationMessage, StreamItemMessage, TransferFormat,
-} from "@aspnet/signalr";
+} from "@microsoft/signalr";
 
 import { BinaryMessageFormat } from "./BinaryMessageFormat";
 import { isArrayBuffer } from "./Utils";

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/tests/MessagePackHubProtocol.test.ts
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/tests/MessagePackHubProtocol.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import { CompletionMessage, InvocationMessage, MessageType, NullLogger, StreamItemMessage } from "@aspnet/signalr";
+import { CompletionMessage, InvocationMessage, MessageType, NullLogger, StreamItemMessage } from "@microsoft/signalr";
 import { MessagePackHubProtocol } from "../src/MessagePackHubProtocol";
 
 describe("MessagePackHubProtocol", () => {

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/webpack.config.js
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/webpack.config.js
@@ -7,7 +7,7 @@ const baseConfig = require("../webpack.config.base");
 module.exports = baseConfig(__dirname, "signalr-protocol-msgpack", {
     externals: {
         msgpack5: "msgpack5",
-        "@aspnet/signalr": "signalR"
+        "@microsoft/signalr": "signalR"
     },
     alias: {
         buffer: path.resolve(__dirname, "node_modules", "buffer", "index.js"),

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/yarn.lock
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@aspnet/signalr@link:../signalr":
+"@microsoft/signalr@link:../signalr":
   version "0.0.0"
   uid ""
 

--- a/src/SignalR/clients/ts/signalr/README.md
+++ b/src/SignalR/clients/ts/signalr/README.md
@@ -3,11 +3,11 @@ JavaScript and TypeScript clients for SignalR for ASP.NET Core
 ## Installation
 
 ```bash
-npm install @aspnet/signalr
+npm install @microsoft/signalr
 ```
 or
 ```bash
-yarn add @aspnet/signalr
+yarn add @microsoft/signalr
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ To use the client in a webworker, copy `*.js` files from the `dist/webworker` fo
 
 ### Node.js
 
-To use the client in a NodeJS application, install the package to your `node_modules` folder and use `require('@aspnet/signalr')` to load the module. The object returned by `require('@aspnet/signalr')` has the same members as the global `signalR` object (when used in a browser).
+To use the client in a NodeJS application, install the package to your `node_modules` folder and use `require('@microsoft/signalr')` to load the module. The object returned by `require('@microsoft/signalr')` has the same members as the global `signalR` object (when used in a browser).
 
 ### Example (Browser)
 
@@ -63,7 +63,7 @@ connection.start()
 ### Example (NodeJS)
 
 ```JavaScript
-const signalR = require("@aspnet/signalr");
+const signalR = require("@microsoft/signalr");
 
 let connection = new signalR.HubConnectionBuilder()
     .withUrl("/chat")

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aspnet/signalr",
+  "name": "@microsoft/signalr",
   "version": "3.0.0-dev",
   "description": "ASP.NET Core SignalR Client",
   "main": "./dist/cjs/index.js",

--- a/src/SignalR/clients/ts/signalr/signalr.npmproj
+++ b/src/SignalR/clients/ts/signalr/signalr.npmproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <PackageId>@aspnet/signalr</PackageId>
+    <PackageId>@microsoft/signalr</PackageId>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>
     <IsShippingPackage>true</IsShippingPackage>

--- a/src/SignalR/clients/ts/signalr/src/DefaultHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/DefaultHttpClient.ts
@@ -7,11 +7,11 @@ import { ILogger } from "./ILogger";
 import { NodeHttpClient } from "./NodeHttpClient";
 import { XhrHttpClient } from "./XhrHttpClient";
 
-/** Default implementation of {@link @aspnet/signalr.HttpClient}. */
+/** Default implementation of {@link @microsoft/signalr.HttpClient}. */
 export class DefaultHttpClient extends HttpClient {
     private readonly httpClient: HttpClient;
 
-    /** Creates a new instance of the {@link @aspnet/signalr.DefaultHttpClient}, using the provided {@link @aspnet/signalr.ILogger} to log messages. */
+    /** Creates a new instance of the {@link @microsoft/signalr.DefaultHttpClient}, using the provided {@link @microsoft/signalr.ILogger} to log messages. */
     public constructor(logger: ILogger) {
         super();
 

--- a/src/SignalR/clients/ts/signalr/src/Errors.ts
+++ b/src/SignalR/clients/ts/signalr/src/Errors.ts
@@ -10,7 +10,7 @@ export class HttpError extends Error {
     /** The HTTP status code represented by this error. */
     public statusCode: number;
 
-    /** Constructs a new instance of {@link @aspnet/signalr.HttpError}.
+    /** Constructs a new instance of {@link @microsoft/signalr.HttpError}.
      *
      * @param {string} errorMessage A descriptive error message.
      * @param {number} statusCode The HTTP status code represented by this error.
@@ -32,7 +32,7 @@ export class TimeoutError extends Error {
     // tslint:disable-next-line:variable-name
     private __proto__: Error;
 
-    /** Constructs a new instance of {@link @aspnet/signalr.TimeoutError}.
+    /** Constructs a new instance of {@link @microsoft/signalr.TimeoutError}.
      *
      * @param {string} errorMessage A descriptive error message.
      */

--- a/src/SignalR/clients/ts/signalr/src/HttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpClient.ts
@@ -29,20 +29,20 @@ export interface HttpRequest {
 
 /** Represents an HTTP response. */
 export class HttpResponse {
-    /** Constructs a new instance of {@link @aspnet/signalr.HttpResponse} with the specified status code.
+    /** Constructs a new instance of {@link @microsoft/signalr.HttpResponse} with the specified status code.
      *
      * @param {number} statusCode The status code of the response.
      */
     constructor(statusCode: number);
 
-    /** Constructs a new instance of {@link @aspnet/signalr.HttpResponse} with the specified status code and message.
+    /** Constructs a new instance of {@link @microsoft/signalr.HttpResponse} with the specified status code and message.
      *
      * @param {number} statusCode The status code of the response.
      * @param {string} statusText The status message of the response.
      */
     constructor(statusCode: number, statusText: string);
 
-    /** Constructs a new instance of {@link @aspnet/signalr.HttpResponse} with the specified status code, message and string content.
+    /** Constructs a new instance of {@link @microsoft/signalr.HttpResponse} with the specified status code, message and string content.
      *
      * @param {number} statusCode The status code of the response.
      * @param {string} statusText The status message of the response.
@@ -50,7 +50,7 @@ export class HttpResponse {
      */
     constructor(statusCode: number, statusText: string, content: string);
 
-    /** Constructs a new instance of {@link @aspnet/signalr.HttpResponse} with the specified status code, message and binary content.
+    /** Constructs a new instance of {@link @microsoft/signalr.HttpResponse} with the specified status code, message and binary content.
      *
      * @param {number} statusCode The status code of the response.
      * @param {string} statusText The status message of the response.
@@ -69,18 +69,18 @@ export class HttpResponse {
  * This class provides an abstraction over an HTTP client so that a different implementation can be provided on different platforms.
  */
 export abstract class HttpClient {
-    /** Issues an HTTP GET request to the specified URL, returning a Promise that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP GET request to the specified URL, returning a Promise that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
      * @param {string} url The URL for the request.
-     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @aspnet/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
+     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @microsoft/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
      */
     public get(url: string): Promise<HttpResponse>;
 
-    /** Issues an HTTP GET request to the specified URL, returning a Promise that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP GET request to the specified URL, returning a Promise that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
      * @param {string} url The URL for the request.
      * @param {HttpRequest} options Additional options to configure the request. The 'url' field in this object will be overridden by the url parameter.
-     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @aspnet/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
+     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @microsoft/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
      */
     public get(url: string, options: HttpRequest): Promise<HttpResponse>;
     public get(url: string, options?: HttpRequest): Promise<HttpResponse> {
@@ -91,18 +91,18 @@ export abstract class HttpClient {
         });
     }
 
-    /** Issues an HTTP POST request to the specified URL, returning a Promise that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP POST request to the specified URL, returning a Promise that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
      * @param {string} url The URL for the request.
-     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @aspnet/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
+     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @microsoft/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
      */
     public post(url: string): Promise<HttpResponse>;
 
-    /** Issues an HTTP POST request to the specified URL, returning a Promise that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP POST request to the specified URL, returning a Promise that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
      * @param {string} url The URL for the request.
      * @param {HttpRequest} options Additional options to configure the request. The 'url' field in this object will be overridden by the url parameter.
-     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @aspnet/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
+     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @microsoft/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
      */
     public post(url: string, options: HttpRequest): Promise<HttpResponse>;
     public post(url: string, options?: HttpRequest): Promise<HttpResponse> {
@@ -113,18 +113,18 @@ export abstract class HttpClient {
         });
     }
 
-    /** Issues an HTTP DELETE request to the specified URL, returning a Promise that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP DELETE request to the specified URL, returning a Promise that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
      * @param {string} url The URL for the request.
-     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @aspnet/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
+     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @microsoft/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
      */
     public delete(url: string): Promise<HttpResponse>;
 
-    /** Issues an HTTP DELETE request to the specified URL, returning a Promise that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP DELETE request to the specified URL, returning a Promise that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
      * @param {string} url The URL for the request.
      * @param {HttpRequest} options Additional options to configure the request. The 'url' field in this object will be overridden by the url parameter.
-     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @aspnet/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
+     * @returns {Promise<HttpResponse>} A Promise that resolves with an {@link @microsoft/signalr.HttpResponse} describing the response, or rejects with an Error indicating a failure.
      */
     public delete(url: string, options: HttpRequest): Promise<HttpResponse>;
     public delete(url: string, options?: HttpRequest): Promise<HttpResponse> {
@@ -135,9 +135,9 @@ export abstract class HttpClient {
         });
     }
 
-    /** Issues an HTTP request to the specified URL, returning a {@link Promise} that resolves with an {@link @aspnet/signalr.HttpResponse} representing the result.
+    /** Issues an HTTP request to the specified URL, returning a {@link Promise} that resolves with an {@link @microsoft/signalr.HttpResponse} representing the result.
      *
-     * @param {HttpRequest} request An {@link @aspnet/signalr.HttpRequest} describing the request to send.
+     * @param {HttpRequest} request An {@link @microsoft/signalr.HttpRequest} describing the request to send.
      * @returns {Promise<HttpResponse>} A Promise that resolves with an HttpResponse describing the response, or rejects with an Error indicating a failure.
      */
     public abstract send(request: HttpRequest): Promise<HttpResponse>;

--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -450,11 +450,11 @@ export class HubConnection {
 
     /** Removes the specified handler for the specified hub method.
      *
-     * You must pass the exact same Function instance as was previously passed to {@link @aspnet/signalr.HubConnection.on}. Passing a different instance (even if the function
+     * You must pass the exact same Function instance as was previously passed to {@link @microsoft/signalr.HubConnection.on}. Passing a different instance (even if the function
      * body is the same) will not remove the handler.
      *
      * @param {string} methodName The name of the method to remove handlers for.
-     * @param {Function} method The handler to remove. This must be the same Function instance as the one passed to {@link @aspnet/signalr.HubConnection.on}.
+     * @param {Function} method The handler to remove. This must be the same Function instance as the one passed to {@link @microsoft/signalr.HubConnection.on}.
      */
     public off(methodName: string, method: (...args: any[]) => void): void;
     public off(methodName: string, method?: (...args: any[]) => void): void {

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -38,7 +38,7 @@ function parseLogLevel(name: string): LogLevel {
     }
 }
 
-/** A builder for configuring {@link @aspnet/signalr.HubConnection} instances. */
+/** A builder for configuring {@link @microsoft/signalr.HubConnection} instances. */
 export class HubConnectionBuilder {
     /** @internal */
     public protocol?: IHubProtocol;
@@ -53,32 +53,32 @@ export class HubConnectionBuilder {
     /** @internal */
     public reconnectPolicy?: IRetryPolicy;
 
-    /** Configures console logging for the {@link @aspnet/signalr.HubConnection}.
+    /** Configures console logging for the {@link @microsoft/signalr.HubConnection}.
      *
      * @param {LogLevel} logLevel The minimum level of messages to log. Anything at this level, or a more severe level, will be logged.
-     * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
+     * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public configureLogging(logLevel: LogLevel): HubConnectionBuilder;
 
-    /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
+    /** Configures custom logging for the {@link @microsoft/signalr.HubConnection}.
      *
-     * @param {ILogger} logger An object implementing the {@link @aspnet/signalr.ILogger} interface, which will be used to write all log messages.
-     * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
+     * @param {ILogger} logger An object implementing the {@link @microsoft/signalr.ILogger} interface, which will be used to write all log messages.
+     * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public configureLogging(logger: ILogger): HubConnectionBuilder;
 
-    /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
+    /** Configures custom logging for the {@link @microsoft/signalr.HubConnection}.
      *
      * @param {string} logLevel A string representing a LogLevel setting a minimum level of messages to log.
      *    See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
      */
     public configureLogging(logLevel: string): HubConnectionBuilder;
 
-    /** Configures custom logging for the {@link @aspnet/signalr.HubConnection}.
+    /** Configures custom logging for the {@link @microsoft/signalr.HubConnection}.
      *
-     * @param {LogLevel | string | ILogger} logging A {@link @aspnet/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @aspnet/signalr.ILogger} interface.
+     * @param {LogLevel | string | ILogger} logging A {@link @microsoft/signalr.LogLevel}, a string representing a LogLevel, or an object implementing the {@link @microsoft/signalr.ILogger} interface.
      *    See {@link https://docs.microsoft.com/en-us/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration} for more details.
-     * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
+     * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder;
     public configureLogging(logging: LogLevel | string | ILogger): HubConnectionBuilder {
@@ -96,28 +96,28 @@ export class HubConnectionBuilder {
         return this;
     }
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to use HTTP-based transports to connect to the specified URL.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to use HTTP-based transports to connect to the specified URL.
      *
      * The transport will be selected automatically based on what the server and client support.
      *
      * @param {string} url The URL the connection will use.
-     * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
+     * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public withUrl(url: string): HubConnectionBuilder;
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to use the specified HTTP-based transport to connect to the specified URL.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to use the specified HTTP-based transport to connect to the specified URL.
      *
      * @param {string} url The URL the connection will use.
      * @param {HttpTransportType} transportType The specific transport to use.
-     * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
+     * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public withUrl(url: string, transportType: HttpTransportType): HubConnectionBuilder;
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to use HTTP-based transports to connect to the specified URL.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to use HTTP-based transports to connect to the specified URL.
      *
      * @param {string} url The URL the connection will use.
      * @param {IHttpConnectionOptions} options An options object used to configure the connection.
-     * @returns The {@link @aspnet/signalr.HubConnectionBuilder} instance, for chaining.
+     * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
      */
     public withUrl(url: string, options: IHttpConnectionOptions): HubConnectionBuilder;
     public withUrl(url: string, transportTypeOrOptions?: IHttpConnectionOptions | HttpTransportType): HubConnectionBuilder {
@@ -139,9 +139,9 @@ export class HubConnectionBuilder {
         return this;
     }
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to use the specified Hub Protocol.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to use the specified Hub Protocol.
      *
-     * @param {IHubProtocol} protocol The {@link @aspnet/signalr.IHubProtocol} implementation to use.
+     * @param {IHubProtocol} protocol The {@link @microsoft/signalr.IHubProtocol} implementation to use.
      */
     public withHubProtocol(protocol: IHubProtocol): HubConnectionBuilder {
         Arg.isRequired(protocol, "protocol");
@@ -150,21 +150,21 @@ export class HubConnectionBuilder {
         return this;
     }
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to automatically attempt to reconnect if the connection is lost.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to automatically attempt to reconnect if the connection is lost.
      * By default, the client will wait 0, 2, 10 and 30 seconds respectively before trying up to 4 reconnect attempts.
      */
     public withAutomaticReconnect(): HubConnectionBuilder;
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to automatically attempt to reconnect if the connection is lost.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to automatically attempt to reconnect if the connection is lost.
      *
      * @param {number[]} retryDelays An array containing the delays in milliseconds before trying each reconnect attempt.
      * The length of the array represents how many failed reconnect attempts it takes before the client will stop attempting to reconnect.
      */
     public withAutomaticReconnect(retryDelays: number[]): HubConnectionBuilder;
 
-    /** Configures the {@link @aspnet/signalr.HubConnection} to automatically attempt to reconnect if the connection is lost.
+    /** Configures the {@link @microsoft/signalr.HubConnection} to automatically attempt to reconnect if the connection is lost.
      *
-     * @param {IRetryPolicy} reconnectPolicy An {@link @aspnet/signalR.IRetryPolicy} that controls the timing and number of reconnect attempts.
+     * @param {IRetryPolicy} reconnectPolicy An {@link @microsoft/signalR.IRetryPolicy} that controls the timing and number of reconnect attempts.
      */
     public withAutomaticReconnect(reconnectPolicy: IRetryPolicy): HubConnectionBuilder;
     public withAutomaticReconnect(retryDelaysOrReconnectPolicy?: number[] | IRetryPolicy): HubConnectionBuilder {
@@ -183,9 +183,9 @@ export class HubConnectionBuilder {
         return this;
     }
 
-    /** Creates a {@link @aspnet/signalr.HubConnection} from the configuration options specified in this builder.
+    /** Creates a {@link @microsoft/signalr.HubConnection} from the configuration options specified in this builder.
      *
-     * @returns {HubConnection} The configured {@link @aspnet/signalr.HubConnection}.
+     * @returns {HubConnection} The configured {@link @microsoft/signalr.HubConnection}.
      */
     public build(): HubConnection {
         // If httpConnectionOptions has a logger, use it. Otherwise, override it with the one

--- a/src/SignalR/clients/ts/signalr/src/IHttpConnectionOptions.ts
+++ b/src/SignalR/clients/ts/signalr/src/IHttpConnectionOptions.ts
@@ -6,18 +6,18 @@ import { ILogger, LogLevel } from "./ILogger";
 import { HttpTransportType, ITransport } from "./ITransport";
 import { EventSourceConstructor, WebSocketConstructor } from "./Polyfills";
 
-/** Options provided to the 'withUrl' method on {@link @aspnet/signalr.HubConnectionBuilder} to configure options for the HTTP-based transports. */
+/** Options provided to the 'withUrl' method on {@link @microsoft/signalr.HubConnectionBuilder} to configure options for the HTTP-based transports. */
 export interface IHttpConnectionOptions {
-    /** An {@link @aspnet/signalr.HttpClient} that will be used to make HTTP requests. */
+    /** An {@link @microsoft/signalr.HttpClient} that will be used to make HTTP requests. */
     httpClient?: HttpClient;
 
-    /** An {@link @aspnet/signalr.HttpTransportType} value specifying the transport to use for the connection. */
+    /** An {@link @microsoft/signalr.HttpTransportType} value specifying the transport to use for the connection. */
     transport?: HttpTransportType | ITransport;
 
     /** Configures the logger used for logging.
      *
-     * Provide an {@link @aspnet/signalr.ILogger} instance, and log messages will be logged via that instance. Alternatively, provide a value from
-     * the {@link @aspnet/signalr.LogLevel} enumeration and a default logger which logs to the Console will be configured to log messages of the specified
+     * Provide an {@link @microsoft/signalr.ILogger} instance, and log messages will be logged via that instance. Alternatively, provide a value from
+     * the {@link @microsoft/signalr.LogLevel} enumeration and a default logger which logs to the Console will be configured to log messages of the specified
      * level (or higher).
      */
     logger?: ILogger | LogLevel;
@@ -36,7 +36,7 @@ export interface IHttpConnectionOptions {
 
     /** A boolean indicating if negotiation should be skipped.
      *
-     * Negotiation can only be skipped when the {@link @aspnet/signalr.IHttpConnectionOptions.transport} property is set to 'HttpTransportType.WebSockets'.
+     * Negotiation can only be skipped when the {@link @microsoft/signalr.IHttpConnectionOptions.transport} property is set to 'HttpTransportType.WebSockets'.
      */
     skipNegotiation?: boolean;
 

--- a/src/SignalR/clients/ts/signalr/src/IHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/IHubProtocol.ts
@@ -6,19 +6,19 @@ import { TransferFormat } from "./ITransport";
 
 /** Defines the type of a Hub Message. */
 export enum MessageType {
-    /** Indicates the message is an Invocation message and implements the {@link @aspnet/signalr.InvocationMessage} interface. */
+    /** Indicates the message is an Invocation message and implements the {@link @microsoft/signalr.InvocationMessage} interface. */
     Invocation = 1,
-    /** Indicates the message is a StreamItem message and implements the {@link @aspnet/signalr.StreamItemMessage} interface. */
+    /** Indicates the message is a StreamItem message and implements the {@link @microsoft/signalr.StreamItemMessage} interface. */
     StreamItem = 2,
-    /** Indicates the message is a Completion message and implements the {@link @aspnet/signalr.CompletionMessage} interface. */
+    /** Indicates the message is a Completion message and implements the {@link @microsoft/signalr.CompletionMessage} interface. */
     Completion = 3,
-    /** Indicates the message is a Stream Invocation message and implements the {@link @aspnet/signalr.StreamInvocationMessage} interface. */
+    /** Indicates the message is a Stream Invocation message and implements the {@link @microsoft/signalr.StreamInvocationMessage} interface. */
     StreamInvocation = 4,
-    /** Indicates the message is a Cancel Invocation message and implements the {@link @aspnet/signalr.CancelInvocationMessage} interface. */
+    /** Indicates the message is a Cancel Invocation message and implements the {@link @microsoft/signalr.CancelInvocationMessage} interface. */
     CancelInvocation = 5,
-    /** Indicates the message is a Ping message and implements the {@link @aspnet/signalr.PingMessage} interface. */
+    /** Indicates the message is a Ping message and implements the {@link @microsoft/signalr.PingMessage} interface. */
     Ping = 6,
-    /** Indicates the message is a Close message and implements the {@link @aspnet/signalr.CloseMessage} interface. */
+    /** Indicates the message is a Close message and implements the {@link @microsoft/signalr.CloseMessage} interface. */
     Close = 7,
 }
 
@@ -40,18 +40,18 @@ export type HubMessage =
 
 /** Defines properties common to all Hub messages. */
 export interface HubMessageBase {
-    /** A {@link @aspnet/signalr.MessageType} value indicating the type of this message. */
+    /** A {@link @microsoft/signalr.MessageType} value indicating the type of this message. */
     readonly type: MessageType;
 }
 
 /** Defines properties common to all Hub messages relating to a specific invocation. */
 export interface HubInvocationMessage extends HubMessageBase {
-    /** A {@link @aspnet/signalr.MessageHeaders} dictionary containing headers attached to the message. */
+    /** A {@link @microsoft/signalr.MessageHeaders} dictionary containing headers attached to the message. */
     readonly headers?: MessageHeaders;
     /** The ID of the invocation relating to this message.
      *
-     * This is expected to be present for {@link @aspnet/signalr.StreamInvocationMessage} and {@link @aspnet/signalr.CompletionMessage}. It may
-     * be 'undefined' for an {@link @aspnet/signalr.InvocationMessage} if the sender does not expect a response.
+     * This is expected to be present for {@link @microsoft/signalr.StreamInvocationMessage} and {@link @microsoft/signalr.CompletionMessage}. It may
+     * be 'undefined' for an {@link @microsoft/signalr.InvocationMessage} if the sender does not expect a response.
      */
     readonly invocationId?: string;
 }
@@ -103,12 +103,12 @@ export interface CompletionMessage extends HubInvocationMessage {
     readonly invocationId: string;
     /** The error produced by the invocation, if any.
      *
-     * Either {@link @aspnet/signalr.CompletionMessage.error} or {@link @aspnet/signalr.CompletionMessage.result} must be defined, but not both.
+     * Either {@link @microsoft/signalr.CompletionMessage.error} or {@link @microsoft/signalr.CompletionMessage.result} must be defined, but not both.
      */
     readonly error?: string;
     /** The result produced by the invocation, if any.
      *
-     * Either {@link @aspnet/signalr.CompletionMessage.error} or {@link @aspnet/signalr.CompletionMessage.result} must be defined, but not both.
+     * Either {@link @microsoft/signalr.CompletionMessage.error} or {@link @microsoft/signalr.CompletionMessage.result} must be defined, but not both.
      */
     readonly result?: any;
 }
@@ -121,7 +121,7 @@ export interface PingMessage extends HubMessageBase {
 
 /** A hub message indicating that the sender is closing the connection.
  *
- * If {@link @aspnet/signalr.CloseMessage.error} is defined, the sender is closing the connection due to an error.
+ * If {@link @microsoft/signalr.CloseMessage.error} is defined, the sender is closing the connection due to an error.
  */
 export interface CloseMessage extends HubMessageBase {
     /** @inheritDoc */
@@ -147,21 +147,21 @@ export interface IHubProtocol {
     readonly name: string;
     /** The version of the protocol. */
     readonly version: number;
-    /** The {@link @aspnet/signalr.TransferFormat} of the protocol. */
+    /** The {@link @microsoft/signalr.TransferFormat} of the protocol. */
     readonly transferFormat: TransferFormat;
 
-    /** Creates an array of {@link @aspnet/signalr.HubMessage} objects from the specified serialized representation.
+    /** Creates an array of {@link @microsoft/signalr.HubMessage} objects from the specified serialized representation.
      *
-     * If {@link @aspnet/signalr.IHubProtocol.transferFormat} is 'Text', the `input` parameter must be a string, otherwise it must be an ArrayBuffer.
+     * If {@link @microsoft/signalr.IHubProtocol.transferFormat} is 'Text', the `input` parameter must be a string, otherwise it must be an ArrayBuffer.
      *
      * @param {string | ArrayBuffer | Buffer} input A string, ArrayBuffer, or Buffer containing the serialized representation.
      * @param {ILogger} logger A logger that will be used to log messages that occur during parsing.
      */
     parseMessages(input: string | ArrayBuffer | Buffer, logger: ILogger): HubMessage[];
 
-    /** Writes the specified {@link @aspnet/signalr.HubMessage} to a string or ArrayBuffer and returns it.
+    /** Writes the specified {@link @microsoft/signalr.HubMessage} to a string or ArrayBuffer and returns it.
      *
-     * If {@link @aspnet/signalr.IHubProtocol.transferFormat} is 'Text', the result of this method will be a string, otherwise it will be an ArrayBuffer.
+     * If {@link @microsoft/signalr.IHubProtocol.transferFormat} is 'Text', the result of this method will be a string, otherwise it will be an ArrayBuffer.
      *
      * @param {HubMessage} message The message to write.
      * @returns {string | ArrayBuffer} A string or ArrayBuffer containing the serialized representation of the message.

--- a/src/SignalR/clients/ts/signalr/src/JsonHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/JsonHubProtocol.ts
@@ -20,7 +20,7 @@ export class JsonHubProtocol implements IHubProtocol {
     /** @inheritDoc */
     public readonly transferFormat: TransferFormat = TransferFormat.Text;
 
-    /** Creates an array of {@link @aspnet/signalr.HubMessage} objects from the specified serialized representation.
+    /** Creates an array of {@link @microsoft/signalr.HubMessage} objects from the specified serialized representation.
      *
      * @param {string} input A string containing the serialized representation.
      * @param {ILogger} logger A logger that will be used to log messages that occur during parsing.
@@ -75,7 +75,7 @@ export class JsonHubProtocol implements IHubProtocol {
         return hubMessages;
     }
 
-    /** Writes the specified {@link @aspnet/signalr.HubMessage} to a string and returns it.
+    /** Writes the specified {@link @microsoft/signalr.HubMessage} to a string and returns it.
      *
      * @param {HubMessage} message The message to write.
      * @returns {string} A string containing the serialized representation of the message.

--- a/src/SignalR/clients/ts/signalr/src/Loggers.ts
+++ b/src/SignalR/clients/ts/signalr/src/Loggers.ts
@@ -5,7 +5,7 @@ import { ILogger, LogLevel } from "./ILogger";
 
 /** A logger that does nothing when log messages are sent to it. */
 export class NullLogger implements ILogger {
-    /** The singleton instance of the {@link @aspnet/signalr.NullLogger}. */
+    /** The singleton instance of the {@link @microsoft/signalr.NullLogger}. */
     public static instance: ILogger = new NullLogger();
 
     private constructor() {}

--- a/src/SignalR/clients/ts/signalr/src/Stream.ts
+++ b/src/SignalR/clients/ts/signalr/src/Stream.ts
@@ -12,18 +12,18 @@
  * @typeparam T The type of the items being sent by the server.
  */
 export interface IStreamSubscriber<T> {
-    /** A boolean that will be set by the {@link @aspnet/signalr.IStreamResult} when the stream is closed. */
+    /** A boolean that will be set by the {@link @microsoft/signalr.IStreamResult} when the stream is closed. */
     closed?: boolean;
     /** Called by the framework when a new item is available. */
     next(value: T): void;
     /** Called by the framework when an error has occurred.
      *
-     * After this method is called, no additional methods on the {@link @aspnet/signalr.IStreamSubscriber} will be called.
+     * After this method is called, no additional methods on the {@link @microsoft/signalr.IStreamSubscriber} will be called.
      */
     error(err: any): void;
     /** Called by the framework when the end of the stream is reached.
      *
-     * After this method is called, no additional methods on the {@link @aspnet/signalr.IStreamSubscriber} will be called.
+     * After this method is called, no additional methods on the {@link @microsoft/signalr.IStreamSubscriber} will be called.
      */
     complete(): void;
 }
@@ -33,20 +33,20 @@ export interface IStreamSubscriber<T> {
  * @typeparam T The type of the items being sent by the server.
  */
 export interface IStreamResult<T> {
-    /** Attaches a {@link @aspnet/signalr.IStreamSubscriber}, which will be invoked when new items are available from the stream.
+    /** Attaches a {@link @microsoft/signalr.IStreamSubscriber}, which will be invoked when new items are available from the stream.
      *
      * @param {IStreamSubscriber<T>} observer The subscriber to attach.
-     * @returns {ISubscription<T>} A subscription that can be disposed to terminate the stream and stop calling methods on the {@link @aspnet/signalr.IStreamSubscriber}.
+     * @returns {ISubscription<T>} A subscription that can be disposed to terminate the stream and stop calling methods on the {@link @microsoft/signalr.IStreamSubscriber}.
      */
     subscribe(subscriber: IStreamSubscriber<T>): ISubscription<T>;
 }
 
-/** An interface that allows an {@link @aspnet/signalr.IStreamSubscriber} to be disconnected from a stream.
+/** An interface that allows an {@link @microsoft/signalr.IStreamSubscriber} to be disconnected from a stream.
  *
  * @typeparam T The type of the items being sent by the server.
  */
 // @ts-ignore: We can't remove this, it's a breaking change, but it's not used.
 export interface ISubscription<T> {
-    /** Disconnects the {@link @aspnet/signalr.IStreamSubscriber} associated with this subscription from the stream. */
+    /** Disconnects the {@link @microsoft/signalr.IStreamSubscriber} associated with this subscription from the stream. */
     dispose(): void;
 }

--- a/src/SignalR/clients/ts/tsconfig.base.json
+++ b/src/SignalR/clients/ts/tsconfig.base.json
@@ -20,10 +20,10 @@
         "lib": [ "es5", "es2015.promise", "es2015.iterable", "dom" ],
         "baseUrl": ".",
         "paths": {
-            "@aspnet/signalr": [
+            "@microsoft/signalr": [
                 "./signalr"
             ],
-            "@aspnet/signalr-protocol-msgpack": [
+            "@microsoft/signalr-protocol-msgpack": [
                 "./signalr-protocol-msgpack"
             ]
         }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/11568
Replacing all instances of `@aspnet` with `@microsoft`. Are there any other tricks here?
Follow up items are to update docs and publish preview 7 under the `@aspnet/signalr` name with a deprecated message 