### PR TITLE
Fix runtime targeting pack to contain full paths to dlls

### DIFF
--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -23,6 +23,10 @@ namespace RepoTasks
         [Required]
         public string TargetFile { get; set; }
 
+        public string ManagedRoot { get; set; } = "";
+
+        public string NativeRoot { get; set; } = "";
+
         /// <summary>
         /// Extra attributes to place on the root node.
         ///
@@ -46,7 +50,6 @@ namespace RepoTasks
                 {
                     Item = item,
                     Filename = Path.GetFileName(item.ItemSpec),
-                    TargetPath = item.GetMetadata("TargetPath"),
                     AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
                     FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
                     IsNative = item.GetMetadata("IsNativeImage") == "true",
@@ -55,15 +58,14 @@ namespace RepoTasks
                 .Where(f =>
                     !f.IsSymbolFile &&
                     (f.Filename.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || f.IsNative))
-                .OrderBy(f => f.TargetPath, StringComparer.Ordinal)
-                .ThenBy(f => f.Filename, StringComparer.Ordinal))
+                .OrderBy(f => f.Filename, StringComparer.Ordinal))
             {
                 var element = new XElement(
                     "File",
                     new XAttribute("Type", f.IsNative ? "Native" : "Managed"),
                     new XAttribute(
                         "Path",
-                        Path.Combine(f.TargetPath, f.Filename).Replace('\\', '/')));
+                        Path.Combine(f.IsNative ? NativeRoot : ManagedRoot, f.Filename).Replace('\\', '/')));
 
                 if (f.AssemblyName != null)
                 {

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -25,6 +25,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <!-- NuGet appends target framework to this value. Example: runtimes/win-x64/lib/netcoreapp3.0/ -->
     <BuildOutputTargetFolder>runtimes/$(RuntimeIdentifier)/lib/</BuildOutputTargetFolder>
+    <!-- We still need the native path to these assets though for the RuntimeList.xml manifest -->
+    <ManagedAssetsPackagePath>$(BuildOutputTargetFolder)$(DefaultNetCoreTargetFramework)</ManagedAssetsPackagePath>
     <!-- Target framework is not append to this because native assets to not have a target framework. -->
     <NativeAssetsPackagePath>runtimes/$(RuntimeIdentifier)/native/</NativeAssetsPackagePath>
 
@@ -457,6 +459,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <RepoTasks.CreateFrameworkListFile
       Files="@(SharedFxContent)"
       TargetFile="$(FrameworkListOutputPath)"
+      ManagedRoot="$(ManagedAssetsPackagePath)"
+      NativeRoot="$(NativeAssetsPackagePath)"
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/11577

Looks like the TargetPath isn't set for us like it is here: https://github.com/dotnet/core-setup/blob/master/src/pkg/projects/dir.targets#L98. For now, I just passed in the managed and native roots into the CreateFrameworkListFile task and prepended them. I can also do the target paths approach, but it's about the same complexity and I went with what was simpler for now. 

Here is an example of the two types of output:
```xml
<FileList Name="ASP.NET Core 3.0" TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="3.0" FrameworkName="Microsoft.AspNetCore.App">
  <File Type="Managed" Path="runtimes/win-x64/lib/netcoreapp3.0/Microsoft.AspNetCore.Antiforgery.dll" AssemblyName="Microsoft.AspNetCore.Antiforgery" PublicKeyToken="adb9793829ddae60" AssemblyVersion="42.42.42.42" FileVersion="42.42.42.42424" />
  <File Type="Native" Path="runtimes/win-x64/native/aspnetcorev2_inprocess.dll" FileVersion="13.0.19177.0" />

```
