### PR TITLE
Fix default value for ResponseType in doc comments

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// <para>BackchannelTimeout: 1 minute.</para>
         /// <para>ProtocolValidator: new <see cref="OpenIdConnectProtocolValidator"/>.</para>
         /// <para>RefreshOnIssuerKeyNotFound: true</para>
-        /// <para>ResponseType: <see cref="OpenIdConnectResponseType.CodeIdToken"/></para>
+        /// <para>ResponseType: <see cref="OpenIdConnectResponseType.IdToken"/></para>
         /// <para>Scope: <see cref="OpenIdConnectScope.OpenIdProfile"/>.</para>
         /// <para>TokenValidationParameters: new <see cref="TokenValidationParameters"/> with AuthenticationScheme = authenticationScheme.</para>
         /// <para>UseTokenLifetime: false.</para>


### PR DESCRIPTION
The comment says that the default value for `ResponseType` is `CodeIdToken` (hybrid flow), but the property is actually set to `IdToken` (implicit flow)