### PR TITLE
Revert the output pipe in the DuplexStreamPipeAdapter

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -89,7 +89,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                 _completed = true;
                 _connectionOutputFlowControl.Abort();
-                _outputWriter.Complete();
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -103,7 +103,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
 
             if (_options.ClientCertificateMode == ClientCertificateMode.NoCertificate)
             {
-                sslDuplexPipe = new SslDuplexPipe(context.Transport, inputPipeOptions, outputPipeOptions);
+                sslDuplexPipe = new SslDuplexPipe(context.Transport, inputPipeOptions, outputPipeOptions)
+                {
+                    Log = _logger
+                };
                 certificateRequired = false;
             }
             else
@@ -140,7 +143,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                         }
 
                         return true;
-                    }));
+                    }))
+                {
+                    Log = _logger
+                };
 
                 certificateRequired = true;
             }

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             Output = new Pipe(outputOptions);
         }
 
-        public ILogger Log { get; private set; }
+        public ILogger Log { get; set; }
 
         public TStream Stream { get; }
 
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             }
             catch (Exception ex)
             {
-                Log.LogError(0, ex, $"{GetType().Name}.{nameof(WriteOutputAsync)}");
+                Log?.LogError(0, ex, $"{GetType().Name}.{nameof(WriteOutputAsync)}");
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
@@ -4,7 +4,10 @@
 using System;
 using System.IO;
 using System.IO.Pipelines;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -14,36 +17,186 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     /// <typeparam name="TStream"></typeparam>
     internal class DuplexPipeStreamAdapter<TStream> : DuplexPipeStream, IDuplexPipe where TStream : Stream
     {
+        private Task _inputTask;
+        private Task _outputTask;
+        private int _minAllocBufferSize;
+
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, Func<Stream, TStream> createStream) :
             this(duplexPipe, new StreamPipeReaderOptions(leaveOpen: true), new StreamPipeWriterOptions(leaveOpen: true), createStream)
         {
         }
 
-        public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, TStream> createStream) : base(duplexPipe.Input, duplexPipe.Output)
+        public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, TStream> createStream) :
+            base(duplexPipe.Input, duplexPipe.Output, throwOnCancelled: true)
         {
             Stream = createStream(this);
-            Input = PipeReader.Create(Stream, readerOptions);
-            Output = PipeWriter.Create(Stream, writerOptions);
+
+            var inputOptions = new PipeOptions(pool: readerOptions.Pool,
+                                               readerScheduler: PipeScheduler.Inline,
+                                               writerScheduler: PipeScheduler.Inline,
+                                               minimumSegmentSize: readerOptions.BufferSize,
+                                               pauseWriterThreshold: 1,
+                                               resumeWriterThreshold: 1,
+                                               useSynchronizationContext: false);
+
+            var outputOptions = new PipeOptions(pool: writerOptions.Pool,
+                                                readerScheduler: PipeScheduler.Inline,
+                                                writerScheduler: PipeScheduler.Inline,
+                                                pauseWriterThreshold: 1,
+                                                resumeWriterThreshold: 1,
+                                                minimumSegmentSize: writerOptions.MinimumBufferSize,
+                                                useSynchronizationContext: false);
+
+            Input = new Pipe(inputOptions);
+            Output = new Pipe(outputOptions);
+
+            _minAllocBufferSize = readerOptions.MinimumReadSize;
         }
+
+        public ILogger Log { get; private set; }
 
         public TStream Stream { get; }
 
-        public PipeReader Input { get; }
+        private Pipe Input { get; }
 
-        public PipeWriter Output { get; }
+        private Pipe Output { get; }
 
-        protected override void Dispose(bool disposing)
+        PipeReader IDuplexPipe.Input
         {
-            Input.Complete();
-            Output.Complete();
-            base.Dispose(disposing);
+            get
+            {
+                if (_inputTask == null)
+                {
+                    _inputTask = ReadInputAsync();
+                }
+                return Input.Reader;
+            }
         }
 
-        public override ValueTask DisposeAsync()
+        PipeWriter IDuplexPipe.Output
         {
-            Input.Complete();
-            Output.Complete();
-            return base.DisposeAsync();
+            get
+            {
+                if (_outputTask == null)
+                {
+                    _outputTask = WriteOutputAsync();
+                }
+
+                return Output.Writer;
+            }
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            Output.Writer.Complete();
+            Input.Reader.Complete();
+
+
+            if (_outputTask != null)
+            {
+                // Wait for the output task to complete, this ensures that we've copied
+                // the application data to the underlying stream
+                await _outputTask;
+            }
+
+            // Cancel the underlying stream so that the input task yields
+            CancelPendingRead();
+
+            if (_inputTask != null)
+            {
+                // The input task should yield now that we've cancelled it
+                await _inputTask;
+            }
+        }
+
+        private async Task WriteOutputAsync()
+        {
+            try
+            {
+                while (true)
+                {
+                    var result = await Output.Reader.ReadAsync();
+                    var buffer = result.Buffer;
+
+                    try
+                    {
+                        if (buffer.IsEmpty)
+                        {
+                            if (result.IsCompleted)
+                            {
+                                break;
+                            }
+                            await Stream.FlushAsync();
+                        }
+                        else if (buffer.IsSingleSegment)
+                        {
+                            await Stream.WriteAsync(buffer.First);
+                        }
+                        else
+                        {
+                            foreach (var memory in buffer)
+                            {
+                                await Stream.WriteAsync(memory);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        Output.Reader.AdvanceTo(buffer.End);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.LogError(0, ex, $"{GetType().Name}.{nameof(WriteOutputAsync)}");
+            }
+            finally
+            {
+                Output.Reader.Complete();
+            }
+        }
+
+        private async Task ReadInputAsync()
+        {
+            Exception error = null;
+
+            try
+            {
+                while (true)
+                {
+                    var outputBuffer = Input.Writer.GetMemory(_minAllocBufferSize);
+                    var bytesRead = await Stream.ReadAsync(outputBuffer);
+                    Input.Writer.Advance(bytesRead);
+
+                    if (bytesRead == 0)
+                    {
+                        // FIN
+                        break;
+                    }
+
+                    var result = await Input.Writer.FlushAsync();
+
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (OperationCanceledException ex)
+            {
+                // Propagate the exception if it's ConnectionAbortedException
+                error = ex as ConnectionAbortedException;
+            }
+            catch (Exception ex)
+            {
+                // Don't rethrow the exception. It should be handled by the Pipeline consumer.
+                error = ex;
+            }
+            finally
+            {
+                Input.Writer.Complete(error);
+            }
         }
     }
 }
+

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
@@ -80,39 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             try
             {
-                while (true)
-                {
-                    var result = await _output.Reader.ReadAsync();
-                    var buffer = result.Buffer;
-
-                    try
-                    {
-                        if (buffer.IsEmpty)
-                        {
-                            if (result.IsCompleted)
-                            {
-                                break;
-                            }
-
-                            await Stream.FlushAsync();
-                        }
-                        else if (buffer.IsSingleSegment)
-                        {
-                            await Stream.WriteAsync(buffer.First);
-                        }
-                        else
-                        {
-                            foreach (var memory in buffer)
-                            {
-                                await Stream.WriteAsync(memory);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        _output.Reader.AdvanceTo(buffer.End);
-                    }
-                }
+                await _output.Reader.CopyToAsync(Stream);
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             }
             catch (Exception ex)
             {
-                Log?.LogError(0, ex, $"{GetType().Name}.{nameof(WriteOutputAsync)}");
+                Log?.LogCritical(0, ex, $"{GetType().Name}.{nameof(WriteOutputAsync)}");
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
@@ -4,9 +4,7 @@
 using System;
 using System.IO;
 using System.IO.Pipelines;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
@@ -17,9 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     /// <typeparam name="TStream"></typeparam>
     internal class DuplexPipeStreamAdapter<TStream> : DuplexPipeStream, IDuplexPipe where TStream : Stream
     {
-        private Task _inputTask;
         private Task _outputTask;
-        private int _minAllocBufferSize;
 
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, Func<Stream, TStream> createStream) :
             this(duplexPipe, new StreamPipeReaderOptions(leaveOpen: true), new StreamPipeWriterOptions(leaveOpen: true), createStream)
@@ -27,17 +23,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         }
 
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, TStream> createStream) :
-            base(duplexPipe.Input, duplexPipe.Output, throwOnCancelled: true)
+            base(duplexPipe.Input, duplexPipe.Output)
         {
             Stream = createStream(this);
-
-            var inputOptions = new PipeOptions(pool: readerOptions.Pool,
-                                               readerScheduler: PipeScheduler.Inline,
-                                               writerScheduler: PipeScheduler.Inline,
-                                               minimumSegmentSize: readerOptions.BufferSize,
-                                               pauseWriterThreshold: 1,
-                                               resumeWriterThreshold: 1,
-                                               useSynchronizationContext: false);
 
             var outputOptions = new PipeOptions(pool: writerOptions.Pool,
                                                 readerScheduler: PipeScheduler.Inline,
@@ -47,32 +35,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                                                 minimumSegmentSize: writerOptions.MinimumBufferSize,
                                                 useSynchronizationContext: false);
 
-            Input = new Pipe(inputOptions);
+            Input = PipeReader.Create(Stream, readerOptions);
             Output = new Pipe(outputOptions);
-
-            _minAllocBufferSize = readerOptions.MinimumReadSize;
         }
 
         public ILogger Log { get; private set; }
 
         public TStream Stream { get; }
 
-        private Pipe Input { get; }
-
         private Pipe Output { get; }
 
-        PipeReader IDuplexPipe.Input
-        {
-            get
-            {
-                if (_inputTask == null)
-                {
-                    _inputTask = ReadInputAsync();
-                }
-                return Input.Reader;
-            }
-        }
-
+        public PipeReader Input { get; }
+        
         PipeWriter IDuplexPipe.Output
         {
             get
@@ -88,24 +62,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public override async ValueTask DisposeAsync()
         {
+            Input.Complete();
             Output.Writer.Complete();
-            Input.Reader.Complete();
-
 
             if (_outputTask != null)
             {
                 // Wait for the output task to complete, this ensures that we've copied
                 // the application data to the underlying stream
                 await _outputTask;
-            }
-
-            // Cancel the underlying stream so that the input task yields
-            CancelPendingRead();
-
-            if (_inputTask != null)
-            {
-                // The input task should yield now that we've cancelled it
-                await _inputTask;
             }
         }
 
@@ -153,48 +117,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             finally
             {
                 Output.Reader.Complete();
-            }
-        }
-
-        private async Task ReadInputAsync()
-        {
-            Exception error = null;
-
-            try
-            {
-                while (true)
-                {
-                    var outputBuffer = Input.Writer.GetMemory(_minAllocBufferSize);
-                    var bytesRead = await Stream.ReadAsync(outputBuffer);
-                    Input.Writer.Advance(bytesRead);
-
-                    if (bytesRead == 0)
-                    {
-                        // FIN
-                        break;
-                    }
-
-                    var result = await Input.Writer.FlushAsync();
-
-                    if (result.IsCompleted)
-                    {
-                        break;
-                    }
-                }
-            }
-            catch (OperationCanceledException ex)
-            {
-                // Propagate the exception if it's ConnectionAbortedException
-                error = ex as ConnectionAbortedException;
-            }
-            catch (Exception ex)
-            {
-                // Don't rethrow the exception. It should be handled by the Pipeline consumer.
-                error = ex;
-            }
-            finally
-            {
-                Input.Writer.Complete(error);
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/Middleware/LoggingConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/LoggingConnectionMiddleware.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             public LoggingDuplexPipe(IDuplexPipe transport, ILogger logger) :
                 base(transport, stream => new LoggingStream(stream, logger))
             {
+                Log = logger;
             }
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -467,7 +467,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 CreateConnection();
             }
 
-            _connectionTask = _connection.ProcessRequestsAsync(new DummyApplication(application));
+            var connectionTask = _connection.ProcessRequestsAsync(new DummyApplication(application));
+
+            async Task CompletePipeOnTaskCompletion()
+            {
+                try
+                {
+                    await connectionTask;
+                }
+                finally
+                {
+                    _pair.Transport.Input.Complete();
+                    _pair.Transport.Output.Complete();
+                }
+            }
+
+            _connectionTask = CompletePipeOnTaskCompletion();
 
             await SendPreambleAsync().ConfigureAwait(false);
             await SendSettingsAsync();


### PR DESCRIPTION
- Don't complete the connection pipe in Http2FrameWriter 
- Replace the output pipe only
- Updated tests

Fixes #11560 