### PR TITLE
Enforce selenium tests run on the expected platforms

### DIFF
--- a/src/ProjectTemplates/test/RazorComponentsTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorComponentsTemplateTest.cs
@@ -56,6 +56,10 @@ namespace Templates.Test
                     aspNetProcess.VisitInBrowser(Browser);
                     TestBasicNavigation();
                 }
+                else
+                {
+                    BrowserFixture.EnforceSupportedConfigurations();
+                }
             }
 
             using (var aspNetProcess = Project.StartPublishedProjectAsync())
@@ -69,6 +73,10 @@ namespace Templates.Test
                 {
                     aspNetProcess.VisitInBrowser(Browser);
                     TestBasicNavigation();
+                }
+                else
+                {
+                    BrowserFixture.EnforceSupportedConfigurations();
                 }
             }
         }
@@ -106,7 +114,12 @@ namespace Templates.Test
                     aspNetProcess.VisitInBrowser(Browser);
                     TestBasicNavigation();
                 }
+                else
+                {
+                    BrowserFixture.EnforceSupportedConfigurations();
+                }
             }
+
 
             using (var aspNetProcess = Project.StartPublishedProjectAsync())
             {

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -113,6 +113,10 @@ namespace Templates.Test.SpaTemplateTest
                     aspNetProcess.VisitInBrowser(browser);
                     TestBasicNavigation(visitFetchData: shouldVisitFetchData, usesAuth, browser, logs);
                 }
+                else
+                {
+                    BrowserFixture.EnforceSupportedConfigurations();
+                }
             }
 
             if (usesAuth)
@@ -134,6 +138,10 @@ namespace Templates.Test.SpaTemplateTest
                     var (browser, logs) = await BrowserFixture.GetOrCreateBrowserAsync(Output, $"{Project.ProjectName}.publish");
                     aspNetProcess.VisitInBrowser(browser);
                     TestBasicNavigation(visitFetchData: shouldVisitFetchData, usesAuth, browser, logs);
+                }
+                else
+                {
+                    BrowserFixture.EnforceSupportedConfigurations();
                 }
             }
         }

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -26,6 +27,14 @@ namespace Microsoft.AspNetCore.E2ETesting
         public ILogs Logs { get; private set; }
 
         public IMessageSink DiagnosticsMessageSink { get; }
+
+        public static void EnforceSupportedConfigurations()
+        {
+            // Do not change the current platform support without explicit approval.
+            Assert.False(
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.X64,
+                "Selenium tests should be running in this platform.");
+        }
 
         public static bool IsHostAutomationSupported()
         {


### PR DESCRIPTION
Throw an exception in places where we conditionally execute selenium tests to ensure they run where we expect them to do.