### PR TITLE
Use task.IsCompletedSuccessfully rather than ReferenceEquals

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/Buffers/PagedBufferedTextWriter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Buffers/PagedBufferedTextWriter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
 
             // FlushAsyncCore will return CompletedTask if nothing sync buffered
             // Fast-path and skip async state-machine if only a single async operation
-            return ReferenceEquals(flushTask, Task.CompletedTask) ? 
+            return flushTask.IsCompletedSuccessfully ? 
                 _inner.WriteAsync(value) :
                 WriteAsyncAwaited(flushTask, value);
         }
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
 
             // FlushAsyncCore will return CompletedTask if nothing sync buffered
             // Fast-path and skip async state-machine if only a single async operation
-            return ReferenceEquals(flushTask, Task.CompletedTask) ?
+            return flushTask.IsCompletedSuccessfully ?
                 _inner.WriteAsync(buffer, index, count) :
                 WriteAsyncAwaited(flushTask, buffer, index, count);
         }
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
 
             // FlushAsyncCore will return CompletedTask if nothing sync buffered
             // Fast-path and skip async state-machine if only a single async operation
-            return ReferenceEquals(flushTask, Task.CompletedTask) ?
+            return flushTask.IsCompletedSuccessfully ?
                 _inner.WriteAsync(value) :
                 WriteAsyncAwaited(flushTask, value);
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/Buffers/PagedBufferedTextWriter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Buffers/PagedBufferedTextWriter.cs
@@ -109,8 +109,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
         {
             var flushTask = FlushAsyncCore();
 
-            // FlushAsyncCore will return CompletedTask if nothing sync buffered
-            // Fast-path and skip async state-machine if only a single async operation
             return flushTask.IsCompletedSuccessfully ? 
                 _inner.WriteAsync(value) :
                 WriteAsyncAwaited(flushTask, value);
@@ -126,8 +124,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
         {
             var flushTask = FlushAsyncCore();
 
-            // FlushAsyncCore will return CompletedTask if nothing sync buffered
-            // Fast-path and skip async state-machine if only a single async operation
             return flushTask.IsCompletedSuccessfully ?
                 _inner.WriteAsync(buffer, index, count) :
                 WriteAsyncAwaited(flushTask, buffer, index, count);
@@ -143,8 +139,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
         {
             var flushTask = FlushAsyncCore();
 
-            // FlushAsyncCore will return CompletedTask if nothing sync buffered
-            // Fast-path and skip async state-machine if only a single async operation
             return flushTask.IsCompletedSuccessfully ?
                 _inner.WriteAsync(value) :
                 WriteAsyncAwaited(flushTask, value);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -767,7 +767,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 while (onStarting.TryPop(out var entry))
                 {
                     var task = entry.Key.Invoke(entry.Value);
-                    if (!ReferenceEquals(task, Task.CompletedTask))
+                    if (!task.IsCompletedSuccessfully)
                     {
                         return FireOnStartingAwaited(task, onStarting);
                     }
@@ -817,7 +817,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 try
                 {
                     var task = entry.Key.Invoke(entry.Value);
-                    if (!ReferenceEquals(task, Task.CompletedTask))
+                    if (!task.IsCompletedSuccessfully)
                     {
                         return FireOnCompletedAwaited(task, onCompleted);
                     }
@@ -953,8 +953,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public Task InitializeResponseAsync(int firstWriteByteCount)
         {
             var startingTask = FireOnStarting();
-            // If return is Task.CompletedTask no awaiting is required
-            if (!ReferenceEquals(startingTask, Task.CompletedTask))
+            if (!startingTask.IsCompletedSuccessfully)
             {
                 return InitializeResponseAwaited(startingTask, firstWriteByteCount);
             }
@@ -1397,8 +1396,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (!HasResponseStarted)
             {
                 var initializeTask = InitializeResponseAsync(0);
-                // If return is Task.CompletedTask no awaiting is required
-                if (!ReferenceEquals(initializeTask, Task.CompletedTask))
+                if (!initializeTask.IsCompletedSuccessfully)
                 {
                     return FlushAsyncAwaited(initializeTask, cancellationToken);
                 }
@@ -1509,8 +1507,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             Debug.Assert(!HasResponseStarted);
 
             var startingTask = FireOnStarting();
-
-            if (!ReferenceEquals(startingTask, Task.CompletedTask))
+            if (!startingTask.IsCompletedSuccessfully)
             {
                 return FirstWriteAsyncAwaited(startingTask, data, cancellationToken);
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 try
                 {
                     var task = entry.Key.Invoke(entry.Value);
-                    if (!ReferenceEquals(task, Task.CompletedTask))
+                    if (!task.IsCompletedSuccessfully)
                     {
                         return CompleteAsyncAwaited(task, onCompleted);
                     }


### PR DESCRIPTION
As ASP.NET Core now targets .NET Core it can use `task.IsCompletedSuccessfully`; this is preferable to comparing to Task.CompletedTask as an async method uses a different completed task than Task.CompletedTask so it will catch more instances.

Also will make @stephentoub happier 😄 