### PR TITLE
Correct the log message for IAsyncEnumerable

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                 return Task.CompletedTask;
             }
 
-            Logger.ObjectResultExecuting(result.Value);
+            Logger.ObjectResultExecuting(value);
 
             result.OnFormatting(context);
             return selectedFormatter.WriteAsync(formatterContext);


### PR DESCRIPTION
Makes the logs more accurate:

```C#
dbug: Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor[1]
      Buffering IAsyncEnumerable instance of type 'Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[[validation.Topping, validation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]'.

...

info: Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor[1]
      Executing ObjectResult, writing value of type 'System.Collections.Generic.List`1[[validation.Topping, validation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]'.
```

