### PR TITLE
Remove flaky HttpSys test Server_MultipleOutstandingSyncRequests_Success

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
@@ -148,40 +148,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2415", FlakyOn.All)]
-        public void Server_MultipleOutstandingSyncRequests_Success()
-        {
-            int requestLimit = 10;
-            int requestCount = 0;
-            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
-
-            string address;
-            using (Utilities.CreateHttpServer(out address, httpContext =>
-            {
-                if (Interlocked.Increment(ref requestCount) == requestLimit)
-                {
-                    tcs.TrySetResult(null);
-                }
-                else
-                {
-                    tcs.Task.Wait();
-                }
-
-                return Task.FromResult(0);
-            }))
-            {
-                List<Task> requestTasks = new List<Task>();
-                for (int i = 0; i < requestLimit; i++)
-                {
-                    Task<string> requestTask = SendRequestAsync(address);
-                    requestTasks.Add(requestTask);
-                }
-
-                Assert.True(Task.WaitAll(requestTasks.ToArray(), TimeSpan.FromSeconds(60)), "Timed out");
-            }
-        }
-
-        [ConditionalFact]
         public void Server_MultipleOutstandingAsyncRequests_Success()
         {
             int requestLimit = 10;


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/2415
Since switching to Arcade this has become the second flakiest test.
https://dev.azure.com/dnceng/public/_test/analytics?definitionId=278&contextType=build
It's intentionally trying to test sync thread blocking, but that makes it extremely vulnerable to thread pool starvation that we've experienced elsewhere in our tests. Even leaving the test here marked as flaky has a negative impact on other tests.

This test has limited value so I'm removing it.