### PR TITLE
Use writer/serializer json interop in SignalR

### DIFF
--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -500,8 +500,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             }
             else if (message.HasResult)
             {
-                using var token = GetParsedObject(message.Result, message.Result?.GetType());
-                token.RootElement.WriteProperty(ResultPropertyNameBytes.EncodedUtf8Bytes, writer);
+                writer.WritePropertyName(ResultPropertyNameBytes);
+                JsonSerializer.WriteValue(writer, message.Result, message.Result?.GetType(), _payloadSerializerOptions);
             }
         }
 
@@ -514,8 +514,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         {
             WriteInvocationId(message, writer);
 
-            using var token = GetParsedObject(message.Item, message.Item?.GetType());
-            token.RootElement.WriteProperty(ItemPropertyNameBytes.EncodedUtf8Bytes, writer);
+            writer.WritePropertyName(ItemPropertyNameBytes);
+            JsonSerializer.WriteValue(writer, message.Item, message.Item?.GetType(), _payloadSerializerOptions);
         }
 
         private void WriteInvocationMessage(InvocationMessage message, Utf8JsonWriter writer)
@@ -562,18 +562,10 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 }
                 else
                 {
-                    using var token = GetParsedObject(argument, type);
-                    token.RootElement.WriteValue(writer);
+                    JsonSerializer.WriteValue(writer, argument, type, _payloadSerializerOptions);
                 }
             }
             writer.WriteEndArray();
-        }
-
-        private JsonDocument GetParsedObject(object obj, Type type)
-        {
-            var bytes = JsonSerializer.ToUtf8Bytes(obj, type, _payloadSerializerOptions);
-            var token = JsonDocument.Parse(bytes);
-            return token;
         }
 
         private void WriteStreamIds(string[] streamIds, Utf8JsonWriter writer)


### PR DESCRIPTION
System.Text.Json vs. NewtonsoftJson

Method |          Input |      HubProtocol |        Mean |        Error |       StdDev |        Op/s |  Gen 0 | Allocated |
------------------- |--------------- |----------------- |------------:|-------------:|-------------:|------------:|-------:|----------:|
WriteSingleMessage |   FewArguments | System.Text.Json |  1,662.9 ns |    31.874 ns |    37.944 ns |   601,349.7 | 0.0038 |     176 B |
WriteSingleMessage |   FewArguments |   NewtonsoftJson |  2,612.3 ns |    51.454 ns |    83.089 ns |   382,799.7 | 0.0229 |     784 B |
WriteSingleMessage | LargeArguments | System.Text.Json | 35,299.4 ns |   691.042 ns | 1,246.091 ns |    28,329.1 | 0.6409 |   24040 B |
WriteSingleMessage | LargeArguments |   NewtonsoftJson | 63,363.4 ns | 1,261.830 ns | 2,370.022 ns |    15,782.0 | 0.6714 |   24768 B |
WriteSingleMessage |  ManyArguments | System.Text.Json |  3,615.5 ns |    71.133 ns |   133.606 ns |   276,587.4 | 0.0076 |     376 B |
WriteSingleMessage |  ManyArguments |   NewtonsoftJson |  5,503.3 ns |   107.776 ns |   224.969 ns |   181,710.2 | 0.0610 |    1992 B |
WriteSingleMessage |    NoArguments | System.Text.Json |    374.6 ns |     7.371 ns |    11.257 ns | 2,669,597.2 | 0.0019 |      72 B |
WriteSingleMessage |    NoArguments |   NewtonsoftJson |    876.1 ns |     6.557 ns |     5.475 ns | 1,141,404.5 | 0.0095 |     384 B |

Before vs. After

Method |          Input |    HubProtocol |        Mean |        Error |       StdDev |        Op/s |  Gen 0 | Allocated |
------------------- |--------------- |--------------- |------------:|-------------:|-------------:|------------:|-------:|----------:|
WriteSingleMessage |   FewArguments |           Json |  1,662.9 ns |    31.874 ns |    37.944 ns |   601,349.7 | 0.0038 |     176 B |
WriteSingleMessage |   FewArguments |    Json-Before |  4,060.1 ns |    80.331 ns |    176.33 ns |   246,297.2 | 0.0229 |     848 B |
WriteSingleMessage | LargeArguments |           Json | 35,299.4 ns |   691.042 ns | 1,246.091 ns |    28,329.1 | 0.6409 |   24040 B |
WriteSingleMessage | LargeArguments |    Json-Before | 82,787.4 ns | 1,629.772 ns |  3,401.94 ns |    12,079.1 | 1.3428 |   48384 B |
WriteSingleMessage |  ManyArguments |           Json |  3,615.5 ns |    71.133 ns |   133.606 ns |   276,587.4 | 0.0076 |     376 B |
WriteSingleMessage |  ManyArguments |    Json-Before |  9,234.4 ns |   192.030 ns |   471.053 ns |   108,291.3 | 0.0610 |    2184 B |
WriteSingleMessage |    NoArguments |           Json |    374.6 ns |     7.371 ns |    11.257 ns | 2,669,597.2 | 0.0019 |      72 B |
WriteSingleMessage |    NoArguments |    Json-Before |    380.7 ns |     7.507 ns |     11.69 ns | 2,626,996.8 | 0.0019 |      72 B |