### PR TITLE
Deal with blocking HttpSys tests

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     var ct = context.DisconnectToken;
                     Assert.True(ct.CanBeCanceled, "CanBeCanceled");
                     ct.Register(() => canceled.SetResult(0));
-                    Assert.True(ct.WaitHandle.WaitOne(interval));
                     Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
 
                     await canceled.Task.TimeoutAfter(interval);
@@ -71,7 +70,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     var ct = context.DisconnectToken;
                     Assert.False(ct.CanBeCanceled, "CanBeCanceled");
                     ct.Register(() => canceled.SetResult(0));
-                    Assert.False(ct.WaitHandle.WaitOne(interval));
                     Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
 
                     Assert.False(canceled.Task.IsCompleted, "canceled");

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
@@ -38,9 +38,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     var ct = context.DisconnectToken;
                     Assert.True(ct.CanBeCanceled, "CanBeCanceled");
                     ct.Register(() => canceled.SetResult(0));
-                    Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
-
                     await canceled.Task.TimeoutAfter(interval);
+                    Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
 
                     context.Dispose();
                 }

--- a/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 ct.Register(() => canceled.SetResult(0));
                 received.SetResult(0);
                 await aborted.Task.TimeoutAfter(interval);
-                Assert.True(ct.WaitHandle.WaitOne(interval), "CT Wait");
+                await canceled.Task.TimeoutAfter(interval);
                 Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
             }))
             {


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore-Internal/issues/2314
AzDo & Arcade have become exceptionally vulnerable to thread pool starvation. Each of these tests has a blocking call that may trigger a deadlock. I've converted them all to async.