### PR TITLE
[Addresses #11619] Remove blank lines in Configure Services for Razor and Mvc

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
@@ -52,7 +52,6 @@ namespace Company.WebApplication1
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-
 #if (IndividualLocalAuth)
             services.AddDbContext<ApplicationDbContext>(options =>
 #if (UseLocalDB)
@@ -108,8 +107,8 @@ namespace Company.WebApplication1
             services.AddAuthentication(AzureADB2CDefaults.AuthenticationScheme)
                 .AddAzureADB2C(options => Configuration.Bind("AzureAdB2C", options));
 #endif
-
 #if (OrganizationalAuth)
+
             services.AddRazorPages().AddMvcOptions(options =>
             {
                 var policy = new AuthorizationPolicyBuilder()

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
@@ -52,7 +52,6 @@ namespace Company.WebApplication1
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-
 #if (IndividualLocalAuth)
             services.AddDbContext<ApplicationDbContext>(options =>
 #if (UseLocalDB)
@@ -108,8 +107,8 @@ namespace Company.WebApplication1
             services.AddAuthentication(AzureADB2CDefaults.AuthenticationScheme)
                 .AddAzureADB2C(options => Configuration.Bind("AzureAdB2C", options));
 #endif
-
 #if (OrganizationalAuth)
+
             services.AddControllersWithViews(options =>
             {
                 var policy = new AuthorizationPolicyBuilder()


### PR DESCRIPTION
Removed the blank lines in razor and mvc templates when there's no authentication options and added the lines back when there's authentication configured in creation.

Addresses #11619
