### PR TITLE
Address some rough edges in service reference feature

### DIFF
--- a/src/Mvc/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Mvc/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -25,8 +25,9 @@
       @(OpenApiProjectReference) items.
     -->
     <ProjectReference Include="@(OpenApiProjectReference)" Exclude="@(ProjectReference)">
-      <NoWarn>NU1702</NoWarn>
+      <GlobalPropertiesToRemove>TargetFramework</GlobalPropertiesToRemove>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
     </ProjectReference>
     <ProjectReference Update="@(OpenApiProjectReference)">
       <OpenApiReference>true</OpenApiReference>

--- a/src/Mvc/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
@@ -12,7 +12,7 @@
     <PackageId>$(MSBuildProjectName)</PackageId>
     <PackageTags>MSBuild;Swagger;Open API;code generation;Web API</PackageTags>
     <IsShippingPackage>true</IsShippingPackage>
-    <PackageVersion>$(ExperimentalPackageVersion)</PackageVersion>
+    <VersionPrefix>$(ExperimentalVersionPrefix)</VersionPrefix>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 

--- a/src/Mvc/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.props
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.props
@@ -8,21 +8,21 @@
       Options added to the Open API document generation tool ('dotnet-getdocument') command line. Available options
       control console output: 'no-color', 'prefix-output' and 'verbose'. All require a double-dash prefix.
     -->
-    <OpenApiGenerateDocumentsOptions Condition=" '$(OpenApiGenerateDocumentsOptions)' == '' "></OpenApiGenerateDocumentsOptions>
+    <OpenApiGenerateDocumentsOptions Condition=" '$(OpenApiGenerateDocumentsOptions)' == '' " />
 
     <!--
-      If 'true' (the default), enable generation of Open API documents. Otherwise, this feature is completely disabled.
-      This controls whether the 'OpenApiGenerateDocuments' project capability is visible, enables / disables the
-      'GenerateOpenApiDocuments' target and provides the $(OpenApiGenerateDocumentsOnBuild) default.
+      If 'true' (the default when targeting .NET Framework or .NET Core 2.1 and later), enable generation of Open API
+      documents. Otherwise, this feature is completely disabled. This controls whether the 'OpenApiGenerateDocuments'
+      project capability is visible, enables / disables the 'GenerateOpenApiDocuments' target and provides the
+      $(OpenApiGenerateDocumentsOnBuild) default.
     -->
-    <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' ">true</OpenApiGenerateDocuments>
+    <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' " />
 
     <!--
       If 'true' (the default if $(OpenApiGenerateDocuments) is 'true'), will generate Open API documents after every
       build. Set to 'false' when targets are invoked from the command line or tied to another target.
     -->
-    <OpenApiGenerateDocumentsOnBuild
-        Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == '' ">$(OpenApiGenerateDocuments)</OpenApiGenerateDocumentsOnBuild>
+    <OpenApiGenerateDocumentsOnBuild Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == '' " />
 
     <!--
       Where to place Open API documents generated from the application. Value is interpreted relative to the project

--- a/src/Mvc/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -1,8 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
+  <PropertyGroup Condition=" '$(OpenApiGenerateDocuments)' == '' ">
+    <OpenApiGenerateDocuments
+        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1' ">false</OpenApiGenerateDocuments>
+    <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' ">true</OpenApiGenerateDocuments>
+  </PropertyGroup>
   <PropertyGroup>
     <_OpenApiDocumentsCache>$(BaseIntermediateOutputPath)$(MSBuildProjectName).OpenApiFiles.cache</_OpenApiDocumentsCache>
+    <OpenApiGenerateDocumentsOnBuild
+        Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == '' ">$(OpenApiGenerateDocuments)</OpenApiGenerateDocumentsOnBuild>
   </PropertyGroup>
+
   <ItemGroup Condition=" '$(OpenApiGenerateDocuments)' == 'true' ">
     <ProjectCapability Include="OpenApiGenerateDocuments" />
   </ItemGroup>
@@ -13,7 +21,10 @@
     </ReadLinesFromFile>
   </Target>
 
-  <Target Name="GenerateOpenApiDocuments" Condition=" '$(OpenApiGenerateDocuments)' == 'true' ">
+  <Target Name="GenerateOpenApiDocuments"
+      Condition=" '$(OpenApiGenerateDocuments)' == 'true' "
+      Inputs="$(TargetPath)"
+      Outputs="$(_OpenApiDocumentsCache)">
     <PropertyGroup>
       <_Command>dotnet "$(MSBuildThisFileDirectory)/../tools/dotnet-getdocument.dll" --assembly "$(TargetPath)"</_Command>
       <_Command>$(_Command) --file-list "$(_OpenApiDocumentsCache)" --framework "$(TargetFrameworkMoniker)"</_Command>

--- a/src/Mvc/Extensions.ApiDescription.Server/src/buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
+  <PropertyGroup>
+    <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' ">true</OpenApiGenerateDocuments>
+    <OpenApiGenerateDocumentsOnBuild
+        Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == '' ">$(OpenApiGenerateDocuments)</OpenApiGenerateDocumentsOnBuild>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(OpenApiGenerateDocuments)' == 'true' ">
     <ProjectCapability Include="OpenApiGenerateDocuments" />
   </ItemGroup>
@@ -17,11 +23,27 @@
       DependsOnTargets="GenerateOpenApiDocuments" />
 
   <Target Name="OpenApiGetDocuments" Returns="@(_OpenApiProjectDocuments)">
+    <ItemGroup>
+      <_Temporary Remove="@(_Temporary)" />
+      <_Temporary Include="$(TargetFrameworks)" Exclude="netcoreapp1.0;netcoreapp1.1;netcoreapp2.0" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_Temporary>@(_Temporary)</_Temporary>
+    </PropertyGroup>
+
     <MSBuild Projects="$(MSBuildProjectFile)"
         Targets="OpenApiGetDocuments"
-        Properties="TargetFramework=$(TargetFrameworks.Split(';')[0])"
+        Condition=" '$(_Temporary)' != '' "
+        Properties="TargetFramework=$(_Temporary.Split(';')[0])"
         RemoveProperties="RuntimeIdentifier">
       <Output TaskParameter="TargetOutputs" ItemName="_OpenApiProjectDocuments" />
     </MSBuild>
+
+    <ItemGroup>
+      <_Temporary Remove="@(_Temporary)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_Temporary />
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
- #11393
- avoid NU1702 warnings
- move defaults for `$(OpenApiGenerateDocuments)` and `$(OpenApiGenerateDocumentsOnBuild)` later, into .targets
  - do not generate documents for .NET Core 2.0 and earlier TFMs (feature is not supported there)
- add `Inputs` and `Outputs` to the `GenerateOpenApiDocuments` target, reducing redundant builds

nit: correct Microsoft.Extensions.ApiDescription.Server package version when building locally