### PR TITLE
Reintroduce required @ chars to benchmarks output

### DIFF
--- a/src/Components/Blazor/testassets/Microsoft.AspNetCore.Blazor.E2EPerformance/Pages/Json.razor
+++ b/src/Components/Blazor/testassets/Microsoft.AspNetCore.Blazor.E2EPerformance/Pages/Json.razor
@@ -9,10 +9,10 @@
 <button id="serialize-small" @onclick=SerializeSmall>Serialize (small)</button>
 <button id="serialize-large" @onclick=SerializeLarge>Serialize (large)</button>
 
-<p><pre style="border: 1px solid black; overflow: scroll;">serializedValue</pre></p>
+<p><pre style="border: 1px solid black; overflow: scroll;">@serializedValue</pre></p>
 @if (serializedValue != null)
 {
-    <p>Serialized length: <strong id="serialized-length">serializedValue.Length</strong> chars</p>
+    <p>Serialized length: <strong id="serialized-length">@serializedValue.Length</strong> chars</p>
 }
 
 <button id="deserialize-small" @onclick=DeserializeSmall>Deserialize (small)</button>


### PR DESCRIPTION
These `@` characters were [removed a few days ago](https://github.com/aspnet/AspNetCore/commit/bff743acedceae9d1933cecb8bcbe182656a12db#diff-03d95bde186ff2081d84ea484f5739df) by mistake.

That's a totally understandable mistake to make, but less understandable is that **we didn't find out because our E2E tests are not currently running in CI** 😱 

@javiercn and I have been chatting today - he's working on getting the E2E tests back on in CI ASAP. Build team (@dougbu @JunTaoLuo) could you please prioritize helping @javiercn with anything that's necessary to get his change to re-enable E2E tests? We cannot consider any build as being a valid candidate for preview 7 without this. /cc @Pilchie 