### PR TITLE
Make CertificateLoader public

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp3.0.cs
@@ -242,6 +242,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 }
 namespace Microsoft.AspNetCore.Server.Kestrel.Https
 {
+    public static partial class CertificateLoader
+    {
+        public static System.Security.Cryptography.X509Certificates.X509Certificate2 LoadFromStoreCert(string subject, string storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, bool allowInvalid) { throw null; }
+    }
     public enum ClientCertificateMode
     {
         NoCertificate = 0,
@@ -260,12 +264,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public System.Func<Microsoft.AspNetCore.Connections.ConnectionContext, string, System.Security.Cryptography.X509Certificates.X509Certificate2> ServerCertificateSelector { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void AllowAnyClientCertificate() { }
-    }
-}
-namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
-{
-    public static partial class CertificateLoader
-    {
-        public static System.Security.Cryptography.X509Certificates.X509Certificate2 LoadFromStoreCert(string subject, string storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, bool allowInvalid) { throw null; }
     }
 }

--- a/src/Servers/Kestrel/Core/src/CertificateLoader.cs
+++ b/src/Servers/Kestrel/Core/src/CertificateLoader.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
+namespace Microsoft.AspNetCore.Server.Kestrel.Https
 {
     public static class CertificateLoader
     {

--- a/src/Servers/Kestrel/samples/SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/SampleApp/Startup.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/CertificateLoaderTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/CertificateLoaderTests.cs
@@ -3,7 +3,7 @@
 
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;


### PR DESCRIPTION
#11312 This gets rid of Kestrel.Https.Internal by making CertificateLoader public. It includes some useful filters like the EKU check, expiration, private key, etc..
