### PR TITLE
Add 'Unable to locate the .NET Core SDK' to Build.Errors / BuildFromSource (closes #3035)

### DIFF
--- a/docs/BuildErrors.md
+++ b/docs/BuildErrors.md
@@ -22,3 +22,12 @@ Similar to BUILD001, but this error is not suppressable. This error only appears
 
 This repo uses a common output directory (artifacts/bin/$(ProjectName) and artifacts/obj/$(ProjectName)). To avoid confllicts in build output, each
 project file should have a unique name.
+
+### Error MSB4236 / Unable to locate the .NET Core SDK
+  
+Executing `.\restore.cmd` or `.\build.cmd` may produce these errors:
+
+> error : Unable to locate the .NET Core SDK. Check that it is installed and that the version specified in global.json (if any) matches the installed version.
+> error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
+
+In most cases, this is because the option _Use previews of the .NET Core SDK_ in VS2019 is not checked. Start Visual Studio, go to _Tools > Options_ and check _Use previews of the .NET Core SDK_ under _Environment > Preview Features_.

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -96,6 +96,15 @@ The cause of this problem is that the solution you are using does not include th
    dotnet sln add C:\src\AspNetCore\src\Hosting\Abstractions\src\Microsoft.AspNetCore.Hosting.Abstractions.csproj
    ```
 
+### Common error: Unable to locate the .NET Core SDK
+  
+Executing `.\restore.cmd` or `.\build.cmd` may produce these errors:
+
+> error : Unable to locate the .NET Core SDK. Check that it is installed and that the version specified in global.json (if any) matches the installed version.
+> error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
+
+In most cases, this is because the option _Use previews of the .NET Core SDK_ in VS2019 is not checked. Start Visual Studio, go to _Tools > Options_ and check _Use previews of the .NET Core SDK_ under _Environment > Preview Features_.
+  
 ## Building with Visual Studio Code
 
 Using Visual Studio Code with this repo requires setting environment variables on command line first.


### PR DESCRIPTION
Addresses #3035 (in this specific format)
