### PR TITLE
Spike an IConnectionFactory for the sockets transport

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
@@ -11,6 +11,12 @@ namespace Microsoft.AspNetCore.Hosting
 }
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
+    public partial class SocketConnectionFactory : Microsoft.AspNetCore.Connections.IConnectionFactory
+    {
+        public SocketConnectionFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Connections.ConnectionContext> ConnectAsync(System.Net.EndPoint endPoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
     public sealed partial class SocketTransportFactory : Microsoft.AspNetCore.Connections.IConnectionListenerFactory
     {
         public SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }

--- a/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp3.0.cs
@@ -11,9 +11,21 @@ namespace Microsoft.AspNetCore.Hosting
 }
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
+    public partial class SharedSocketOptions
+    {
+        public SharedSocketOptions() { }
+        public long? MaxReadBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public long? MaxWriteBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool NoDelay { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public partial class SocketClientOptions : Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SharedSocketOptions
+    {
+        public SocketClientOptions() { }
+        public System.IO.Pipelines.PipeScheduler Scheduler { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
     public partial class SocketConnectionFactory : Microsoft.AspNetCore.Connections.IConnectionFactory
     {
-        public SocketConnectionFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public SocketConnectionFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketClientOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Connections.ConnectionContext> ConnectAsync(System.Net.EndPoint endPoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
@@ -22,12 +34,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Connections.IConnectionListener> BindAsync(System.Net.EndPoint endpoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class SocketTransportOptions
+    public partial class SocketTransportOptions : Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SharedSocketOptions
     {
         public SocketTransportOptions() { }
         public int IOQueueCount { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public long? MaxReadBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public long? MaxWriteBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public bool NoDelay { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SharedSocketOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SharedSocketOptions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
+{
+    public class SharedSocketOptions
+    {
+        /// <summary>
+        /// Set to false to enable Nagle's algorithm for all connections.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to true.
+        /// </remarks>
+        public bool NoDelay { get; set; } = true;
+
+        /// <summary>
+        /// The maximum size before the transport will stop proactively reading from the transport.
+        /// </summary>
+        public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
+
+        /// <summary>
+        /// The maximum size the transport will buffer outside of OS buffers before pausing writes.
+        /// </summary>
+        public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
+
+        internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.SlabMemoryPoolFactory.Create;
+    }
+}

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketClientOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketClientOptions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
+{
+    public class SocketClientOptions : SharedSocketOptions
+    {
+        /// <summary>
+        /// Determines where read and write callbacks run.
+        /// </summary>
+        public PipeScheduler Scheduler { get; set; } = new IOQueue();
+    }
+}

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactory.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
+{
+    /// <summary>
+    /// Defines a class for creating socket connections based on the specified endpoint.
+    /// </summary>
+    public class SocketConnectionFactory : IConnectionFactory
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates the <see cref="SocketConnectionFactory"/>.
+        /// </summary>
+        /// <param name="loggerFactory">The logger factory</param>
+        public SocketConnectionFactory(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<SocketConnectionFactory>();
+        }
+
+        /// <summary>
+        /// Creates a new socket connection to the specified endpoint.
+        /// </summary>
+        /// <param name="endPoint">The <see cref="EndPoint"/> to connect to.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}" /> that represents the asynchronous connect, yielding the <see cref="ConnectionContext" /> for the new connection when completed.
+        /// </returns>
+        public async ValueTask<ConnectionContext> ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken = default)
+        {
+            var protocolType = endPoint is UnixDomainSocketEndPoint ? ProtocolType.Unspecified : ProtocolType.Tcp;
+
+            var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, protocolType);
+
+            await socket.ConnectAsync(endPoint);
+
+            var connection = new SocketConnection(socket, memoryPool: null, PipeScheduler.ThreadPool, new SocketsTrace(_logger));
+            connection.Start();
+
+            return connection;
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
-    public class SocketTransportOptions
+    public class SocketTransportOptions : SharedSocketOptions
     {
         /// <summary>
         /// The number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
@@ -15,19 +14,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
         /// </remarks>
         public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
-
-        /// <summary>
-        /// Set to false to enable Nagle's algorithm for all connections.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to true.
-        /// </remarks>
-        public bool NoDelay { get; set; } = true;
-
-        public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
-
-        public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
-
-        internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.SlabMemoryPoolFactory.Create;
     }
 }

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
@@ -81,7 +82,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     await host.StartAsync();
 
-                    var factory = new SocketConnectionFactory(LoggerFactory);
+                    var factory = new SocketConnectionFactory(Options.Create(new SocketClientOptions()), LoggerFactory);
                     var endPoint = new UnixDomainSocketEndPoint(path);
                     await using (var connection = await factory.ConnectAsync(endPoint))
                     {

--- a/src/Servers/Kestrel/test/Libuv.FunctionalTests/Libuv.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Libuv.FunctionalTests/Libuv.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="..\FunctionalTests\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)\Pipelines\*.cs" LinkBase="Pipelines" />
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
     <Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />

--- a/src/Servers/Kestrel/test/Sockets.FunctionalTests/Sockets.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Sockets.FunctionalTests/Sockets.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="..\FunctionalTests\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)\Pipelines\*.cs" LinkBase="Pipelines" />
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
     <Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />

--- a/src/Shared/Pipelines/PipeReaderExtensions.cs
+++ b/src/Shared/Pipelines/PipeReaderExtensions.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.IO.Pipelines
+{
+    public static class PipeReaderExtensions
+    {
+        public static async Task<bool> WaitToReadAsync(this PipeReader pipeReader)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+
+                try
+                {
+                    if (!result.Buffer.IsEmpty)
+                    {
+                        return true;
+                    }
+
+                    if (result.IsCompleted)
+                    {
+                        return false;
+                    }
+                }
+                finally
+                {
+                    // Don't consume or advance
+                    pipeReader.AdvanceTo(result.Buffer.Start, result.Buffer.Start);
+                }
+            }
+        }
+
+        public static async Task<byte[]> ReadSingleAsync(this PipeReader pipeReader)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+
+                try
+                {
+                    return result.Buffer.ToArray();
+                }
+                finally
+                {
+                    pipeReader.AdvanceTo(result.Buffer.End);
+                }
+            }
+        }
+
+        public static async Task ConsumeAsync(this PipeReader pipeReader, int numBytes)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+                if (result.Buffer.Length < numBytes)
+                {
+                    pipeReader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+                    continue;
+                }
+
+                pipeReader.AdvanceTo(result.Buffer.GetPosition(numBytes));
+                break;
+            }
+        }
+
+        public static async Task<byte[]> ReadAllAsync(this PipeReader pipeReader)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+
+                if (result.IsCompleted)
+                {
+                    return result.Buffer.ToArray();
+                }
+
+                // Consume nothing, just wait for everything
+                pipeReader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+            }
+        }
+
+        public static async Task<byte[]> ReadAsync(this PipeReader pipeReader, int numBytes)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+                if (result.Buffer.Length < numBytes)
+                {
+                    pipeReader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+                    continue;
+                }
+
+                var buffer = result.Buffer.Slice(0, numBytes);
+
+                var bytes = buffer.ToArray();
+
+                pipeReader.AdvanceTo(buffer.End);
+
+                return bytes;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Made the unix domain sockets test use it

I'd like to have more than one implementation of the `IConnectionFactory` to make sure the API is sound. This is one potential implementation.