### PR TITLE
Don't throw Exceptions from PipeWriter APIs after RST_STREAM

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -114,8 +114,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             lock (_contextLock)
             {
-                if (_suffixSent)
+                if (_suffixSent || !_autoChunk)
                 {
+                    _suffixSent = true;
                     return default;
                 }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             await FlushAsync();
 
-            return bodyControl.Upgrade();
+            return _bodyControl.Upgrade();
         }
 
         void IHttpRequestLifetimeFeature.Abort()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponsePipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponsePipeWriter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public override void Complete(Exception exception = null)
         {
             ValidateState();
-            _pipeControl.Complete(exception);
+            _ = _pipeControl.CompleteAsync(exception);
         }
 
         public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponsePipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponsePipeWriter.cs
@@ -11,8 +11,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal sealed class HttpResponsePipeWriter : PipeWriter
     {
-        private HttpStreamState _state;
         private readonly IHttpResponseControl _pipeControl;
+
+        private HttpStreamState _state;
+        private Task _completeTask = Task.CompletedTask;
 
         public HttpResponsePipeWriter(IHttpResponseControl pipeControl)
         {
@@ -35,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public override void Complete(Exception exception = null)
         {
             ValidateState();
-            _ = _pipeControl.CompleteAsync(exception);
+            _completeTask = _pipeControl.CompleteAsync(exception);
         }
 
         public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
@@ -77,11 +79,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public void StopAcceptingWrites()
+        public Task StopAcceptingWritesAsync()
         {
             // Can't use dispose (or close) as can be disposed too early by user code
             // As exampled in EngineTests.ZeroContentLengthNotSetAutomaticallyForCertainStatusCodes
             _state = HttpStreamState.Closed;
+            return _completeTask;
         }
 
         public void Abort()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Span<byte> GetSpan(int sizeHint = 0);
         Memory<byte> GetMemory(int sizeHint = 0);
         void CancelPendingFlush();
-        void Complete();
+        void Stop();
         ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
         ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
         void Reset();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpResponseControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpResponseControl.cs
@@ -17,6 +17,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         ValueTask<FlushResult> FlushPipeAsync(CancellationToken cancellationToken);
         ValueTask<FlushResult> WritePipeAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken);
         void CancelPendingFlush();
-        void Complete(Exception exception = null);
+        Task CompleteAsync(Exception exception = null);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -333,8 +333,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public void Stop()
         {
-            // This needs to be further thought out. See: https://github.com/aspnet/AspNetCore/issues/7370
-
             lock (_dataWriterLock)
             {
                 if (!_completed)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -335,17 +335,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             lock (_dataWriterLock)
             {
-                if (!_completed)
+                if (_completed)
                 {
-                    _completed = true;
-
-                    // Complete with an exception to prevent an end of stream data frame from being sent without an
-                    // explicit call to WriteStreamSuffixAsync. ConnectionAbortedExceptions are swallowed, so the
-                    // message doesn't matter
-                    _dataPipe.Writer.Complete(new OperationCanceledException());
-
-                    _frameWriter.AbortPendingStreamDataWrites(_flowControl);
+                    return;
                 }
+
+                _completed = true;
+
+                // Complete with an exception to prevent an end of stream data frame from being sent without an
+                // explicit call to WriteStreamSuffixAsync. ConnectionAbortedExceptions are swallowed, so the
+                // message doesn't matter
+                _dataPipe.Writer.Complete(new OperationCanceledException());
+
+                _frameWriter.AbortPendingStreamDataWrites(_flowControl);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
@@ -56,24 +56,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        async Task IHttpResponseCompletionFeature.CompleteAsync()
+        Task IHttpResponseCompletionFeature.CompleteAsync()
         {
-            // Finalize headers
-            if (!HasResponseStarted)
-            {
-                await FireOnStarting();
-            }
-
-            // Flush headers, body, trailers...
-            if (!HasResponseCompleted)
-            {
-                if (!VerifyResponseContentLength(out var lengthException))
-                {
-                    throw lengthException;
-                }
-
-                await ProduceEnd();
-            }
+            return CompleteAsync(null);
         }
 
         void IHttpResetFeature.Reset(int errorCode)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         Task IHttpResponseCompletionFeature.CompleteAsync()
         {
-            return CompleteAsync(null);
+            return CompleteAsync();
         }
 
         void IHttpResetFeature.Reset(int errorCode)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -469,9 +469,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private void AbortCore(Exception abortReason)
         {
-            // Call _http2Output.Dispose() prior to poisoning the request body stream or pipe to
+            // Call _http2Output.Complete() prior to poisoning the request body stream or pipe to
             // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
-            _http2Output.Dispose();
+            _http2Output.Complete();
 
             AbortRequest();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -469,9 +469,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private void AbortCore(Exception abortReason)
         {
-            // Call _http2Output.Complete() prior to poisoning the request body stream or pipe to
+            // Call _http2Output.Stop() prior to poisoning the request body stream or pipe to
             // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
-            _http2Output.Complete();
+            _http2Output.Stop();
 
             AbortRequest();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.IO.Pipelines;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -62,11 +63,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
-        public void Stop()
+        public Task StopAsync()
         {
             _requestReader.StopAcceptingReads();
             _emptyRequestReader.StopAcceptingReads();
-            _responseWriter.StopAcceptingWrites();
+            return _responseWriter.StopAcceptingWritesAsync();
         }
 
         public void Abort(Exception error)

--- a/src/Servers/Kestrel/Core/test/BodyControlTests.cs
+++ b/src/Servers/Kestrel/Core/test/BodyControlTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var (_, response, requestPipe, responsePipe) = bodyControl.Start(new MockMessageBody());
 
-            bodyControl.Stop();
+            await bodyControl.StopAsync();
 
             Assert.Throws<ObjectDisposedException>(() => requestPipe.AdvanceTo(new SequencePosition()));
             Assert.Throws<ObjectDisposedException>(() => requestPipe.AdvanceTo(new SequencePosition(), new SequencePosition()));
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var (_, response, requestPipe, responsePipe) = bodyControl.Start(new MockMessageBody());
 
-            bodyControl.Stop();
+            await bodyControl.StopAsync();
 
             Assert.Throws<ObjectDisposedException>(() => responsePipe.Advance(1));
             Assert.Throws<ObjectDisposedException>(() => responsePipe.CancelPendingFlush());

--- a/src/Servers/Kestrel/Core/test/HttpResponsePipeWriterTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponsePipeWriterTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = CreateHttpResponsePipeWriter();
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { pipeWriter.Advance(1); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = CreateHttpResponsePipeWriter();
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { pipeWriter.GetMemory(); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = CreateHttpResponsePipeWriter();
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { pipeWriter.GetSpan(); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = CreateHttpResponsePipeWriter();
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { pipeWriter.Complete(); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = CreateHttpResponsePipeWriter();
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { pipeWriter.FlushAsync(); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = CreateHttpResponsePipeWriter();
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { pipeWriter.WriteAsync(new Memory<byte>()); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }

--- a/src/Servers/Kestrel/Core/test/HttpResponseStreamTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseStreamTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var pipeWriter = new HttpResponsePipeWriter(Mock.Of<IHttpResponseControl>());
             var stream = new HttpResponseStream(Mock.Of<IHttpBodyControlFeature>(), pipeWriter);
             pipeWriter.StartAcceptingWrites();
-            pipeWriter.StopAcceptingWrites();
+            pipeWriter.StopAcceptingWritesAsync();
             var ex = Assert.Throws<ObjectDisposedException>(() => { stream.WriteAsync(new byte[1], 0, 1); });
             Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -3981,6 +3981,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task PipeWriterComplete_AfterBodyStarted_WithTrailers_TruncatedContentLength_ThrowsAndReset()
+        {
+            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+
+            await InitializeConnectionAsync(async context =>
+            {
+                try
+                {
+                    context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+
+                    context.Response.ContentLength = 25;
+                    await context.Response.WriteAsync("Hello World");
+                    Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
+                    Assert.True(context.Response.Headers.IsReadOnly);
+
+                    context.Response.AppendTrailer("CustomName", "Custom Value");
+
+                    var ex = Assert.Throws<InvalidOperationException>(() => context.Response.BodyWriter.Complete());
+                    Assert.Equal(CoreStrings.FormatTooFewBytesWritten(11, 25), ex.Message);
+
+                    Assert.False(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
+
+                    // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
+                    await clientTcs.Task.DefaultTimeout();
+                    appTcs.SetResult(0);
+                }
+                catch (Exception ex)
+                {
+                    appTcs.SetException(ex);
+                }
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 56,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var bodyFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+
+            clientTcs.SetResult(0);
+
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR,
+                expectedErrorMessage: CoreStrings.FormatTooFewBytesWritten(11, 25));
+
+            await appTcs.Task;
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("25", _decodedHeaders[HeaderNames.ContentLength]);
+
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(bodyFrame.Payload.Span));
+        }
+
+        [Fact]
         public async Task AbortAfterCompleteAsync_GETWithResponseBodyAndTrailers_ResetsAfterResponse()
         {
             var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -3319,11 +3319,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
                 withStreamId: 1);
 
-            await ExpectAsync(Http2FrameType.RST_STREAM,
-                withLength: 4,
-                withFlags: (byte)Http2DataFrameFlags.NONE,
-                withStreamId: 1);
-
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
             _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -145,7 +145,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly RequestDelegate _largeHeadersApplication;
         protected readonly RequestDelegate _waitForAbortApplication;
         protected readonly RequestDelegate _waitForAbortFlushingApplication;
-        protected readonly RequestDelegate _waitForAbortWithDataApplication;
         protected readonly RequestDelegate _readRateApplication;
         protected readonly RequestDelegate _echoMethod;
         protected readonly RequestDelegate _echoHost;
@@ -318,28 +317,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 await sem.WaitAsync().DefaultTimeout();
 
                 await context.Response.Body.FlushAsync();
-
-                _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
-            };
-
-            _waitForAbortWithDataApplication = async context =>
-            {
-                var streamIdFeature = context.Features.Get<IHttp2StreamIdFeature>();
-                var sem = new SemaphoreSlim(0);
-
-                context.RequestAborted.Register(() =>
-                {
-                    lock (_abortedStreamIdsLock)
-                    {
-                        _abortedStreamIds.Add(streamIdFeature.StreamId);
-                    }
-
-                    sem.Release();
-                });
-
-                await sem.WaitAsync().DefaultTimeout();
-
-                await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 
                 _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
             };


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/38911#issuecomment-506574681