### PR TITLE
Fix authentication state revalidation code in project template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Areas/Identity/RevalidatingAuthenticationStateProvider.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Areas/Identity/RevalidatingAuthenticationStateProvider.cs
@@ -64,7 +64,7 @@ namespace RazorComponentsWeb_CSharp.Areas.Identity
                 {
                     // Force sign-out. Also stop the revalidation loop, because the user can
                     // only sign back in by starting a new connection.
-                    var anonymousUser = new ClaimsPrincipal();
+                    var anonymousUser = new ClaimsPrincipal(new ClaimsIdentity());
                     _currentAuthenticationStateTask = Task.FromResult(new AuthenticationState(anonymousUser));
                     NotifyAuthenticationStateChanged(_currentAuthenticationStateTask);
                     _loopCancellationTokenSource.Cancel();

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Startup.cs
@@ -67,8 +67,6 @@ namespace RazorComponentsWeb_CSharp
 #endif
             services.AddDefaultIdentity<IdentityUser>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
-
-            services.AddScoped<AuthenticationStateProvider, RevalidatingAuthenticationStateProvider<IdentityUser>>();
 #elif (OrganizationalAuth)
             services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
                 .AddAzureAD(options => Configuration.Bind("AzureAd", options));
@@ -127,6 +125,9 @@ namespace RazorComponentsWeb_CSharp
 #endif
             services.AddRazorPages();
             services.AddServerSideBlazor();
+#if (IndividualLocalAuth)
+            services.AddScoped<AuthenticationStateProvider, RevalidatingAuthenticationStateProvider<IdentityUser>>();
+#endif
             services.AddSingleton<WeatherForecastService>();
         }
 


### PR DESCRIPTION
Two issues found in new template logic during validation:

 * The `AuthenticationStateProvider` service was being registered in the wrong place and hence didn't take effect
 * When logging out a user due to security stamp changing, the new `ClaimsPrincipal` didn't have any identity, but it should do in order to match how we represent unauthenticated users by default
