### PR TITLE
RequestQueue namespace cleanup

### DIFF
--- a/src/Middleware/RequestThrottling/ref/Microsoft.AspNetCore.RequestThrottling.netcoreapp3.0.cs
+++ b/src/Middleware/RequestThrottling/ref/Microsoft.AspNetCore.RequestThrottling.netcoreapp3.0.cs
@@ -10,20 +10,6 @@ namespace Microsoft.AspNetCore.Builder
 }
 namespace Microsoft.AspNetCore.RequestThrottling
 {
-    public partial class RequestThrottlingMiddleware
-    {
-        public RequestThrottlingMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.RequestThrottling.QueuePolicies.IQueuePolicy queue, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.RequestThrottling.RequestThrottlingOptions> options) { }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
-        public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
-    }
-    public partial class RequestThrottlingOptions
-    {
-        public RequestThrottlingOptions() { }
-        public Microsoft.AspNetCore.Http.RequestDelegate OnRejected { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-    }
-}
-namespace Microsoft.AspNetCore.RequestThrottling.QueuePolicies
-{
     public partial interface IQueuePolicy
     {
         void OnExit();
@@ -35,12 +21,23 @@ namespace Microsoft.AspNetCore.RequestThrottling.QueuePolicies
         public int MaxConcurrentRequests { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int RequestQueueLimit { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
+    public partial class RequestThrottlingMiddleware
+    {
+        public RequestThrottlingMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.RequestThrottling.IQueuePolicy queue, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.RequestThrottling.RequestThrottlingOptions> options) { }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
+    }
+    public partial class RequestThrottlingOptions
+    {
+        public RequestThrottlingOptions() { }
+        public Microsoft.AspNetCore.Http.RequestDelegate OnRejected { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
 }
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class QueuePolicyServiceCollectionExtensions
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddStackQueue(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.RequestThrottling.QueuePolicies.QueuePolicyOptions> configure) { throw null; }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddTailDropQueue(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.RequestThrottling.QueuePolicies.QueuePolicyOptions> configure) { throw null; }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddStackQueue(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.RequestThrottling.QueuePolicyOptions> configure) { throw null; }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddTailDropQueue(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.RequestThrottling.QueuePolicyOptions> configure) { throw null; }
     }
 }

--- a/src/Middleware/RequestThrottling/src/QueuePolicies/IQueuePolicy.cs
+++ b/src/Middleware/RequestThrottling/src/QueuePolicies/IQueuePolicy.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Microsoft.AspNetCore.RequestThrottling.QueuePolicies
+namespace Microsoft.AspNetCore.RequestThrottling
 {
     /// <summary>
     /// Queueing policies, meant to be used with the <see cref="RequestThrottlingMiddleware"></see>.

--- a/src/Middleware/RequestThrottling/src/QueuePolicies/QueuePolicyOptions.cs
+++ b/src/Middleware/RequestThrottling/src/QueuePolicies/QueuePolicyOptions.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.AspNetCore.RequestThrottling.QueuePolicies
+namespace Microsoft.AspNetCore.RequestThrottling
 {
     /// <summary>
-    /// Specifies options for the <see cref="IQueuePolicy"/>
+    /// Specifies options for the 
     /// </summary>
     public class QueuePolicyOptions
     {

--- a/src/Middleware/RequestThrottling/src/QueuePolicies/QueuePolicyOptions.cs
+++ b/src/Middleware/RequestThrottling/src/QueuePolicies/QueuePolicyOptions.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Microsoft.AspNetCore.RequestThrottling
 {
     /// <summary>
-    /// Specifies options for the 
+    /// Specifies options for the <see cref="IQueuePolicy"/>
     /// </summary>
     public class QueuePolicyOptions
     {

--- a/src/Middleware/RequestThrottling/src/QueuePolicies/QueuePolicyServiceCollectionExtensions.cs
+++ b/src/Middleware/RequestThrottling/src/QueuePolicies/QueuePolicyServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.RequestThrottling;
-using Microsoft.AspNetCore.RequestThrottling.QueuePolicies;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Middleware/RequestThrottling/src/QueuePolicies/StackQueuePolicy.cs
+++ b/src/Middleware/RequestThrottling/src/QueuePolicies/StackQueuePolicy.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
-namespace Microsoft.AspNetCore.RequestThrottling.QueuePolicies
+namespace Microsoft.AspNetCore.RequestThrottling
 {
     internal class StackQueuePolicy : IQueuePolicy
     {

--- a/src/Middleware/RequestThrottling/src/QueuePolicies/TailDropQueuePolicy.cs
+++ b/src/Middleware/RequestThrottling/src/QueuePolicies/TailDropQueuePolicy.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
-namespace Microsoft.AspNetCore.RequestThrottling.QueuePolicies
+namespace Microsoft.AspNetCore.RequestThrottling
 {
     internal class TailDropQueuePolicy : IQueuePolicy, IDisposable
     {

--- a/src/Middleware/RequestThrottling/src/RequestThrottlingEventSource.cs
+++ b/src/Middleware/RequestThrottling/src/RequestThrottlingEventSource.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.RequestThrottling
     internal sealed class RequestThrottlingEventSource : EventSource
     {
         public static readonly RequestThrottlingEventSource Log = new RequestThrottlingEventSource();
-        private static QueueFrame CachedNonTimerResult = new QueueFrame(null, Log);
+        private static readonly QueueFrame CachedNonTimerResult = new QueueFrame(null, Log);
 
         private PollingCounter _rejectedRequestsCounter;
         private PollingCounter _queueLengthCounter;

--- a/src/Middleware/RequestThrottling/src/RequestThrottlingEventSource.cs
+++ b/src/Middleware/RequestThrottling/src/RequestThrottlingEventSource.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.RequestThrottling
     internal sealed class RequestThrottlingEventSource : EventSource
     {
         public static readonly RequestThrottlingEventSource Log = new RequestThrottlingEventSource();
-        private static readonly QueueFrame CachedNonTimerResult = new QueueFrame(null, Log);
+        private static readonly QueueFrame CachedNonTimerResult = new QueueFrame(timer: null, parent: Log);
 
         private PollingCounter _rejectedRequestsCounter;
         private PollingCounter _queueLengthCounter;

--- a/src/Middleware/RequestThrottling/src/RequestThrottlingMiddleware.cs
+++ b/src/Middleware/RequestThrottling/src/RequestThrottlingMiddleware.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.RequestThrottling.QueuePolicies;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Middleware/RequestThrottling/test/MiddlewareTests.cs
+++ b/src/Middleware/RequestThrottling/test/MiddlewareTests.cs
@@ -2,11 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.RequestThrottling.QueuePolicies;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Xunit;
 
 namespace Microsoft.AspNetCore.RequestThrottling.Tests

--- a/src/Middleware/RequestThrottling/test/PolicyTests/StackQueueTests.cs
+++ b/src/Middleware/RequestThrottling/test/PolicyTests/StackQueueTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.RequestThrottling.QueuePolicies;
 using Microsoft.Extensions.Options;
 using Xunit;
 

--- a/src/Middleware/RequestThrottling/test/TestUtils.cs
+++ b/src/Middleware/RequestThrottling/test/TestUtils.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.RequestThrottling.QueuePolicies;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 


### PR DESCRIPTION
Merged the last PR without addressing two suggestions, my bad.

Removed the extra namespace, kept the specific implementations as internal. Added a `readonly`.