### PR TITLE
Mark flaky AddressRegistrationTests with the FlakyAttribute

### DIFF
--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -48,8 +47,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             await RegisterAddresses_Success(addressInput, testUrl);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(AddressRegistrationDataIPv4Port5000Default))]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public async Task RegisterAddresses_IPv4Port5000Default_Success(string addressInput, string testUrl)
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 5000))
@@ -60,8 +60,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             await RegisterAddresses_Success(addressInput, testUrl, 5000);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(AddressRegistrationDataIPv4Port80))]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public async Task RegisterAddresses_IPv4Port80_Success(string addressInput, string testUrl)
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 80))
@@ -109,6 +110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [ConditionalTheory]
         [MemberData(nameof(IPEndPointRegistrationDataPort443))]
         [IPv6SupportedCondition]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public async Task RegisterIPEndPoint_Port443_Success(IPEndPoint endpoint, string testUrl)
         {
             if (!CanBindToEndpoint(endpoint.Address, 443))
@@ -130,6 +132,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [ConditionalTheory]
         [MemberData(nameof(AddressRegistrationDataIPv6Port5000Default))]
         [IPv6SupportedCondition]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public async Task RegisterAddresses_IPv6Port5000Default_Success(string addressInput, string[] testUrls)
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5000))
@@ -143,6 +146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [ConditionalTheory]
         [MemberData(nameof(AddressRegistrationDataIPv6Port80))]
         [IPv6SupportedCondition]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public async Task RegisterAddresses_IPv6Port80_Success(string addressInput, string[] testUrls)
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 80) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 80))
@@ -320,7 +324,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private Task RegisterIPEndPoint_StaticPort_Success(IPAddress address, string testUrl)
             => RunTestWithStaticPort(port => RegisterIPEndPoint_Success(new IPEndPoint(address, port), testUrl, port));
 
-        [ConditionalFact]
+        [Fact]
         public async Task ListenAnyIP_IPv4_Success()
         {
             await ListenAnyIP_Success(new[] { "http://localhost", "http://127.0.0.1" });
@@ -369,7 +373,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ListenLocalhost_IPv4LocalhostStaticPort_Success()
         {
             await ListenLocalhost_StaticPort_Success(new[] { "http://localhost", "http://127.0.0.1" });
@@ -413,6 +417,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Fact]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public Task DefaultsServerAddress_BindsToIPv4()
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 5000))
@@ -425,6 +430,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [IPv6SupportedCondition]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public Task DefaultsServerAddress_BindsToIPv6()
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5000))
@@ -435,7 +441,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             return RegisterDefaultServerAddresses_Success(new[] { "http://127.0.0.1:5000", "http://[::1]:5000" });
         }
 
-        [ConditionalFact]
+        [Fact]
+        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2711", FlakyOn.AzP.macOS)]
         public Task DefaultsServerAddress_BindsToIPv4WithHttps()
         {
             if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.Loopback, 5001))


### PR DESCRIPTION
Addresses https://github.com/aspnet/AspNetCore-Internal/issues/2711

This marks all the AddressRegistrationTest that try to bind to a specific port *not* retrieved by GetNextPort() on macOS. All these tests check if the port is in use before running, but that isn't reliable enough. GetNextPort()-derived ports seem to be saved from conflicts in practice because of GetNextPort's around-the-horn-behavior relative to other tests that are also binding to "port 0".

I agree with @anurse that we should look into running AddressRegistrationTests in a different environment where these kind of port conflicts are impossible.