### PR TITLE
Ensure non-final builds have unique package GUIDs

### DIFF
--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -21,9 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GuidInputs>$(Version);$(Platform)</GuidInputs>
-    <!-- Ensure for non-final builds the GUID will be different for each build -->
-    <GuidInputs Condition="'$(DotNetFinalVersionKind)' != 'release' AND '$(DotNetFinalVersionKind)' != 'prerelease'">$(GuidInputs);(VersionSuffix)</GuidInputs>
+    <GuidInputs>$(Version);$(Platform);(VersionSuffix)</GuidInputs>
   </PropertyGroup>
 
   <Target Name="GenerateGUIDs" BeforeTargets="BeforeBuild" DependsOnTargets="_GeneratePackageGuids;_GenerateBundleGuids" Condition=" '$(DisableGuidGeneration)' != 'true' " />

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -22,6 +22,8 @@
 
   <PropertyGroup>
     <GuidInputs>$(Version);$(Platform)</GuidInputs>
+    <!-- Ensure for non-final builds the GUID will be different for each build -->
+    <GuidInputs Condition="'$(DotNetFinalVersionKind)' != 'release' AND '$(DotNetFinalVersionKind)' != 'prerelease'">$(GuidInputs);(VersionSuffix)</GuidInputs>
   </PropertyGroup>
 
   <Target Name="GenerateGUIDs" BeforeTargets="BeforeBuild" DependsOnTargets="_GeneratePackageGuids;_GenerateBundleGuids" Condition=" '$(DisableGuidGeneration)' != 'true' " />


### PR DESCRIPTION
This addresses https://github.com/dotnet/core-sdk/issues/2655

The regression seems to be https://github.com/aspnet/AspNetCore/commit/41ce223c1cf4ffd482c4ea36e88ed44a94db37b3#diff-8a63ea279503159f0bb870af84feae00L10. I'm assuming it was an oversight when removing the `BuildNumberSuffix` variable. I'm updating the logic to mimic the previous behaviour, albeit using different variables.

I've verified with this change that the product code and upgrade code are now unique between builds. However, I don't think I'll be able to do end to end verification.

I plan on merging as soon as builds are green, so the change can be consumed downstream.

cc @johnbeisner 
