### PR TITLE
Remove package guids from client-side Blazor templates

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/.template.config.src/vs-2017.3.host.json
+++ b/src/Components/Blazor/Templates/src/content/BlazorHosted-CSharp/.template.config.src/vs-2017.3.host.json
@@ -2,7 +2,6 @@
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
     "text": "Blazor (ASP.NET Core hosted)",
-    "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1050"
   },
   "description": {

--- a/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/.template.config.src/vs-2017.3.host.json
+++ b/src/Components/Blazor/Templates/src/content/BlazorStandalone-CSharp/.template.config.src/vs-2017.3.host.json
@@ -2,7 +2,6 @@
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
     "text": "Blazor (client-side)",
-    "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1050"
   },
   "description": {


### PR DESCRIPTION
Fixes #11706 

The client-side Blazor templates currently show up with the same name and description in VS 16.3 P1. This is because the updated localization content for these templates already went into 16.3 before the work to rename and refactor the templates was done (see #10348).

We worked with the web tools folks on a resolution and the recommended workaround for this issue is to remove the package GUIDs from the VS host files for these templates. This will cause the localized content in VS to not be used for these templates and instead the strings from the templates will be used. This was tested and verified with the help of @phenning. 

After the localized template content is moved to this repo (see https://github.com/aspnet/AspNetCore/pull/11040) we can reenable localization for these templates in VS. 

/cc @vijayrkn 