### PR TITLE
Improved HttpContext pooling

### DIFF
--- a/src/Hosting/TestHost/test/WebSocketClientTests.cs
+++ b/src/Hosting/TestHost/test/WebSocketClientTests.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Microsoft.AspNetCore.TestHost.Tests
@@ -19,7 +18,9 @@ namespace Microsoft.AspNetCore.TestHost.Tests
         [InlineData("http://localhost:81/connect", "localhost:81")]
         public async Task ConnectAsync_ShouldSetRequestProperties(string requestUri, string expectedHost)
         {
-            HttpRequest capturedRequest = null;
+            string capturedScheme = null;
+            string capturedHost = null;
+            string capturedPath = null;
 
             using (var testServer = new TestServer(new WebHostBuilder()
                 .Configure(app =>
@@ -28,7 +29,9 @@ namespace Microsoft.AspNetCore.TestHost.Tests
                     {
                         if (ctx.Request.Path.StartsWithSegments("/connect"))
                         {
-                            capturedRequest = ctx.Request;
+                            capturedScheme = ctx.Request.Scheme;
+                            capturedHost = ctx.Request.Host.Value;
+                            capturedPath = ctx.Request.Path;
                         }
                         return Task.FromResult(0);
                     });
@@ -48,9 +51,9 @@ namespace Microsoft.AspNetCore.TestHost.Tests
                 }
             }
 
-            Assert.Equal("http", capturedRequest.Scheme);
-            Assert.Equal(expectedHost, capturedRequest.Host.Value);
-            Assert.Equal("/connect", capturedRequest.Path);
+            Assert.Equal("http", capturedScheme);
+            Assert.Equal(expectedHost, capturedHost);
+            Assert.Equal("/connect", capturedPath);
         }
     }
 }

--- a/src/Http/Http.Features/src/FeatureReferences.cs
+++ b/src/Http/Http.Features/src/FeatureReferences.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Http.Features
         public FeatureReferences(IFeatureCollection collection)
         {
             Collection = collection;
-            Cache = default(TCache);
+            Cache = default;
             Revision = collection.Revision;
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Http.Features
             Func<TState, TFeature> factory) where TFeature : class
         {
             var flush = false;
-            var revision = Collection.Revision;
+            var revision = Collection?.Revision ?? ContextDisposed();
             if (Revision != revision)
             {
                 // Clear cached value to force call to UpdateCached
@@ -108,5 +108,17 @@ namespace Microsoft.AspNetCore.Http.Features
 
         public TFeature Fetch<TFeature>(ref TFeature cached, Func<IFeatureCollection, TFeature> factory)
             where TFeature : class => Fetch(ref cached, Collection, factory);
+
+        private static int ContextDisposed()
+        {
+            ThrowContextDisposed();
+            return 0;
+        }
+
+        private static void ThrowContextDisposed()
+        {
+            // Can't use nameof as Microsoft.AspNetCore.Http.Abstractions is higher in the stack.
+            throw new ObjectDisposedException("HttpContext", "Request has finished and HttpContext disposed.");
+        }
     }
 }

--- a/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
+++ b/src/Http/Http/ref/Microsoft.AspNetCore.Http.netcoreapp3.0.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Http
     }
     public partial interface IDefaultHttpContextContainer
     {
-        Microsoft.AspNetCore.Http.DefaultHttpContext HttpContext { get; }
+        Microsoft.AspNetCore.Http.DefaultHttpContext HttpContext { get; set; }
     }
     public partial class MiddlewareFactory : Microsoft.AspNetCore.Http.IMiddlewareFactory
     {

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Http
         private IHttpRequestIdentifierFeature RequestIdentifierFeature =>
             _features.Fetch(ref _features.Cache.RequestIdentifier, _newHttpRequestIdentifierFeature);
 
-        public override IFeatureCollection Features => _features.Collection;
+        public override IFeatureCollection Features => _features.Collection ?? ContextDisposed();
 
         public override HttpRequest Request => _request;
 
@@ -167,6 +167,16 @@ namespace Microsoft.AspNetCore.Http
         public override void Abort()
         {
             LifetimeFeature.Abort();
+        }
+        private static IFeatureCollection ContextDisposed()
+        {
+            ThrowContextDisposed();
+            return null;
+        }
+
+        private static void ThrowContextDisposed()
+        {
+            throw new ObjectDisposedException(nameof(HttpContext), $"Request has finished and {nameof(HttpContext)} disposed.");
         }
 
         struct FeatureInterfaces

--- a/src/Http/Http/src/DefaultHttpContextFactory.cs
+++ b/src/Http/Http/src/DefaultHttpContextFactory.cs
@@ -47,7 +47,16 @@ namespace Microsoft.AspNetCore.Http
         {
             if (featureCollection is IDefaultHttpContextContainer container)
             {
-                return container.HttpContext;
+                var httpContext = container.HttpContext;
+                if (httpContext is null)
+                {
+                    httpContext = new DefaultHttpContext(featureCollection);
+                    container.HttpContext = httpContext;
+                }
+                else
+                {
+                    httpContext.Initialize(featureCollection);
+                }
             }
 
             return new DefaultHttpContext(featureCollection);
@@ -58,6 +67,11 @@ namespace Microsoft.AspNetCore.Http
             if (_httpContextAccessor != null)
             {
                 _httpContextAccessor.HttpContext = null;
+            }
+
+            if (httpContext is DefaultHttpContext defaultHttpContext)
+            {
+                defaultHttpContext.Uninitialize();
             }
         }
     }

--- a/src/Http/Http/src/HttpContextFactory.cs
+++ b/src/Http/Http/src/HttpContextFactory.cs
@@ -70,7 +70,16 @@ namespace Microsoft.AspNetCore.Http
         {
             if (featureCollection is IDefaultHttpContextContainer container)
             {
-                return container.HttpContext;
+                var httpContext = container.HttpContext;
+                if (httpContext is null)
+                {
+                    httpContext = new DefaultHttpContext(featureCollection);
+                    container.HttpContext = httpContext;
+                }
+                else
+                {
+                    httpContext.Initialize(featureCollection);
+                }
             }
 
             return new DefaultHttpContext(featureCollection);
@@ -81,6 +90,11 @@ namespace Microsoft.AspNetCore.Http
             if (_httpContextAccessor != null)
             {
                 _httpContextAccessor.HttpContext = null;
+            }
+
+            if (httpContext is DefaultHttpContext defaultHttpContext)
+            {
+                defaultHttpContext.Uninitialize();
             }
         }
     }

--- a/src/Http/Http/src/IDefaultHttpContextContainer.cs
+++ b/src/Http/Http/src/IDefaultHttpContextContainer.cs
@@ -1,11 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.Http
 {
     public interface IDefaultHttpContextContainer
     {
-        DefaultHttpContext HttpContext { get; }
+        DefaultHttpContext HttpContext { get; set; }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -64,7 +64,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private long _responseBytesWritten;
 
         private readonly HttpConnectionContext _context;
-        private DefaultHttpContext _httpContext;
         private RouteValueDictionary _routeValues;
         private Endpoint _endpoint;
 
@@ -296,22 +295,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected HttpResponseHeaders HttpResponseHeaders { get; } = new HttpResponseHeaders();
 
-        DefaultHttpContext IDefaultHttpContextContainer.HttpContext
-        {
-            get
-            {
-                if (_httpContext is null)
-                {
-                    _httpContext = new DefaultHttpContext(this);
-                }
-                else
-                {
-                    _httpContext.Initialize(this);
-                }
-
-                return _httpContext;
-            }
-        }
+        DefaultHttpContext IDefaultHttpContextContainer.HttpContext { get; set; }
 
         public void InitializeBodyControl(MessageBody messageBody)
         {
@@ -408,8 +392,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _requestHeadersParsed = 0;
 
             _responseBytesWritten = 0;
-
-            _httpContext?.Uninitialize();
 
             OnReset();
         }


### PR DESCRIPTION
Improved HttpContext pooling from https://github.com/aspnet/AspNetCore/pull/10319

Moves pooling from Kestrel to HttpContextFactory

Resolves #11069

/cc @davidfowl 