### PR TITLE
Don't capture HttpContext into the log objects

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
@@ -13,7 +13,8 @@ namespace Microsoft.AspNetCore.Hosting
     {
         internal static readonly Func<object, Exception, string> Callback = (state, exception) => ((HostingRequestFinishedLog)state).ToString();
 
-        private readonly HttpContext _httpContext;
+        private readonly string _contentType;
+        private readonly int _statusCode;
         private readonly TimeSpan _elapsed;
 
         private string _cachedToString;
@@ -29,9 +30,9 @@ namespace Microsoft.AspNetCore.Hosting
                     case 0:
                         return new KeyValuePair<string, object>("ElapsedMilliseconds", _elapsed.TotalMilliseconds);
                     case 1:
-                        return new KeyValuePair<string, object>("StatusCode", _httpContext.Response.StatusCode);
+                        return new KeyValuePair<string, object>("StatusCode", _statusCode);
                     case 2:
-                        return new KeyValuePair<string, object>("ContentType", _httpContext.Response.ContentType);
+                        return new KeyValuePair<string, object>("ContentType", _contentType);
                     default:
                         throw new IndexOutOfRangeException(nameof(index));
                 }
@@ -40,7 +41,8 @@ namespace Microsoft.AspNetCore.Hosting
 
         public HostingRequestFinishedLog(HttpContext httpContext, TimeSpan elapsed)
         {
-            _httpContext = httpContext;
+            _contentType = httpContext.Response.ContentType;
+            _statusCode = httpContext.Response.StatusCode;
             _elapsed = elapsed;
         }
 
@@ -52,8 +54,8 @@ namespace Microsoft.AspNetCore.Hosting
                     CultureInfo.InvariantCulture,
                     "Request finished in {0}ms {1} {2}",
                     _elapsed.TotalMilliseconds,
-                    _httpContext.Response.StatusCode,
-                    _httpContext.Response.ContentType);
+                    _statusCode,
+                    _contentType);
             }
 
             return _cachedToString;

--- a/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
@@ -13,7 +13,15 @@ namespace Microsoft.AspNetCore.Hosting
     {
         internal static readonly Func<object, Exception, string> Callback = (state, exception) => ((HostingRequestStartingLog)state).ToString();
 
-        private readonly HttpRequest _request;
+        public string Protocol { get; }
+        public string Method { get; }
+        public string ContentType { get; }
+        public long? ContentLength { get; }
+        public string Scheme { get; }
+        public string Host { get; }
+        public string PathBase { get; }
+        public string Path { get; }
+        public string QueryString { get; }
 
         private string _cachedToString;
 
@@ -26,23 +34,23 @@ namespace Microsoft.AspNetCore.Hosting
                 switch (index)
                 {
                     case 0:
-                        return new KeyValuePair<string, object>("Protocol", _request.Protocol);
+                        return new KeyValuePair<string, object>("Protocol", Protocol);
                     case 1:
-                        return new KeyValuePair<string, object>("Method", _request.Method);
+                        return new KeyValuePair<string, object>("Method", Method);
                     case 2:
-                        return new KeyValuePair<string, object>("ContentType", _request.ContentType);
+                        return new KeyValuePair<string, object>("ContentType", ContentType);
                     case 3:
-                        return new KeyValuePair<string, object>("ContentLength", _request.ContentLength);
+                        return new KeyValuePair<string, object>("ContentLength", ContentLength);
                     case 4:
-                        return new KeyValuePair<string, object>("Scheme", _request.Scheme);
+                        return new KeyValuePair<string, object>("Scheme", Scheme);
                     case 5:
-                        return new KeyValuePair<string, object>("Host", _request.Host.ToString());
+                        return new KeyValuePair<string, object>("Host", Host);
                     case 6:
-                        return new KeyValuePair<string, object>("PathBase", _request.PathBase.ToString());
+                        return new KeyValuePair<string, object>("PathBase", PathBase);
                     case 7:
-                        return new KeyValuePair<string, object>("Path", _request.Path.ToString());
+                        return new KeyValuePair<string, object>("Path", Path);
                     case 8:
-                        return new KeyValuePair<string, object>("QueryString", _request.QueryString.ToString());
+                        return new KeyValuePair<string, object>("QueryString", QueryString);
                     default:
                         throw new IndexOutOfRangeException(nameof(index));
                 }
@@ -51,7 +59,17 @@ namespace Microsoft.AspNetCore.Hosting
 
         public HostingRequestStartingLog(HttpContext httpContext)
         {
-            _request = httpContext.Request;
+            var request = httpContext.Request;
+
+            Protocol = request.Protocol;
+            Method = request.Method;
+            ContentType = !string.IsNullOrEmpty(request.ContentType) ? Uri.EscapeUriString(request.ContentType) : string.Empty;
+            ContentLength = request.ContentLength;
+            Scheme = request.Scheme;
+            Host = request.Host.Value;
+            PathBase = request.PathBase.Value;
+            Path = request.Path.Value;
+            QueryString = request.QueryString.Value;
         }
 
         public override string ToString()
@@ -61,15 +79,15 @@ namespace Microsoft.AspNetCore.Hosting
                 _cachedToString = string.Format(
                     CultureInfo.InvariantCulture,
                     "Request starting {0} {1} {2}://{3}{4}{5}{6} {7} {8}",
-                    _request.Protocol,
-                    _request.Method,
-                    _request.Scheme,
-                    _request.Host.Value,
-                    _request.PathBase.Value,
-                    _request.Path.Value,
-                    _request.QueryString.Value,
-                    _request.ContentType,
-                    _request.ContentLength);
+                    Protocol,
+                    Method,
+                    Scheme,
+                    Host,
+                    PathBase,
+                    Path,
+                    QueryString,
+                    ContentType,
+                    ContentLength);
             }
 
             return _cachedToString;

--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -428,6 +428,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             features = new FeatureCollection();
             features.Set<IHttpRequestFeature>(new HttpRequestFeature());
+            features.Set<IHttpResponseFeature>(new HttpResponseFeature());
             var context = new DefaultHttpContext(features);
             configure?.Invoke(context);
             httpContextFactory.Setup(s => s.Create(It.IsAny<IFeatureCollection>())).Returns(context);


### PR DESCRIPTION
Don't capture HttpContext into the log objects from https://github.com/aspnet/AspNetCore/pull/10319

Resolves #10556
Resolves #10557

/cc @davidfowl 