### PR TITLE
Improved for loop for faster negotiate response

### DIFF
--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -60,8 +60,10 @@ namespace Microsoft.AspNetCore.Http.Connections
 
                 if (response.AvailableTransports != null)
                 {
-                    foreach (var availableTransport in response.AvailableTransports)
+                    var transportCount = response.AvailableTransports.Count;
+                    for(var i = 0; i < transportCount; ++i)
                     {
+                        var availableTransport = response.AvailableTransports[i];
                         writer.WriteStartObject();
                         if (availableTransport.Transport != null)
                         {
@@ -76,9 +78,10 @@ namespace Microsoft.AspNetCore.Http.Connections
 
                         if (availableTransport.TransferFormats != null)
                         {
-                            foreach (var transferFormat in availableTransport.TransferFormats)
+                            var formatCount = availableTransport.TransferFormats.Count;
+                            for (var j = 0; j < formatCount; ++j)
                             {
-                                writer.WriteStringValue(transferFormat);
+                                writer.WriteStringValue(availableTransport.TransferFormats[j]);
                             }
                         }
 

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Http.Connections
                 if (response.AvailableTransports != null)
                 {
                     var transportCount = response.AvailableTransports.Count;
-                    for(var i = 0; i < transportCount; ++i)
+                    for (var i = 0; i < transportCount; ++i)
                     {
                         var availableTransport = response.AvailableTransports[i];
                         writer.WriteStartObject();


### PR DESCRIPTION
Started auditing SignalR's `for`/`foreach` loops to look for obvious perf gains and found this one immediately.

Before:

Method |     Mean |    Error |   StdDev |   Median |        Op/s |  Gen 0 | Allocated |
--------------------------------- |---------:|---------:|---------:|---------:|------------:|-------:|----------:|
WriteResponse_MemoryBufferWriter | 595.1 ns | 14.50 ns | 33.90 ns | 583.1 ns | 1,680,415.1 | 0.0048 |     144 B |

After:

Method |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
--------------------------------- |---------:|---------:|---------:|------------:|-------:|----------:|
WriteResponse_MemoryBufferWriter | 503.4 ns | 9.909 ns | 14.21 ns | 1,986,464.1 | 0.0019 |      64 B |