### PR TITLE
Add usings to Razor Components template. Fixes #11687

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;
 #endif
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components;
 #if (IndividualLocalAuth)
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/_Imports.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorComponentsWeb-CSharp/_Imports.razor
@@ -1,4 +1,5 @@
 ﻿@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing


### PR DESCRIPTION
Addresses #11687, plus a further issue found in verification whereby the new `RevalidatingAuthenticationStateProvider` type isn't in scope.