### PR TITLE
Fix race with CTS disposing

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                     if (TransportType == HttpTransportType.WebSockets)
                     {
-                        // The websocket transport will close the application output automatically when reading is cancelled
+                        // The websocket transport will close the application output automatically when reading is canceled
                         Cancellation?.Cancel();
                     }
                     else
@@ -440,6 +440,37 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 // Connection was disposed
                 nonClonedContext.Response.StatusCode = StatusCodes.Status404NotFound;
                 nonClonedContext.Response.ContentType = "text/plain";
+            }
+        }
+
+        internal async Task<bool> CancelPreviousPoll(HttpContext context)
+        {
+            CancellationTokenSource cts;
+            lock (_stateLock)
+            {
+                // Need to sync cts access with DisposeAsync as that will dispose the cts
+                cts = Status == HttpConnectionStatus.Disposed ? null : Cancellation;
+            }
+
+            using (cts)
+            {
+                // Cancel the previous request
+                cts?.Cancel();
+
+                try
+                {
+                    // Wait for the previous request to drain
+                    await PreviousPollTask;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Previous poll canceled due to connection closing, close this poll too
+                    context.Response.ContentType = "text/plain";
+                    context.Response.StatusCode = StatusCodes.Status204NoContent;
+                    return false;
+                }
+
+                return true;
             }
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -449,7 +449,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             lock (_stateLock)
             {
                 // Need to sync cts access with DisposeAsync as that will dispose the cts
-                cts = Status == HttpConnectionStatus.Disposed ? null : Cancellation;
+                if (Status == HttpConnectionStatus.Disposed)
+                {
+                    cts = null;
+                }
+                else
+                {
+                    cts = Cancellation;
+                    Cancellation = null;
+                }
             }
 
             using (cts)

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1148,9 +1148,20 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 Assert.True(request1.IsCompleted);
 
                 request1 = dispatcher.ExecuteAsync(context1, options, app);
+                // Wait until the request has started internally
+                while (connection.TransportTask.IsCompleted)
+                {
+                    await Task.Delay(1);
+                }
+                var transportTask = connection.TransportTask;
                 var request2 = dispatcher.ExecuteAsync(context2, options, app);
 
                 await request1;
+                // Wait until the second request has started internally
+                while (connection.TransportTask.IsCompleted)
+                {
+                    await Task.Delay(1);
+                }
 
                 Assert.Equal(StatusCodes.Status204NoContent, context1.Response.StatusCode);
                 Assert.Equal(HttpConnectionStatus.Active, connection.Status);

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1148,18 +1148,22 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 Assert.True(request1.IsCompleted);
 
                 request1 = dispatcher.ExecuteAsync(context1, options, app);
+                var count = 0;
                 // Wait until the request has started internally
-                while (connection.TransportTask.IsCompleted)
+                while (connection.TransportTask.IsCompleted && count < 50)
                 {
+                    count++;
                     await Task.Delay(1);
                 }
                 var transportTask = connection.TransportTask;
                 var request2 = dispatcher.ExecuteAsync(context2, options, app);
 
                 await request1;
+                count = 0;
                 // Wait until the second request has started internally
-                while (connection.TransportTask.IsCompleted)
+                while (connection.TransportTask.IsCompleted && count < 50)
                 {
+                    count++;
                     await Task.Delay(1);
                 }
 

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1153,19 +1153,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 while (connection.TransportTask.IsCompleted && count < 50)
                 {
                     count++;
-                    await Task.Delay(1);
+                    await Task.Delay(15);
                 }
-                var transportTask = connection.TransportTask;
+                if (count == 50)
+                {
+                    Assert.True(false, "Poll took too long to start");
+                }
+
                 var request2 = dispatcher.ExecuteAsync(context2, options, app);
 
-                await request1;
-                count = 0;
-                // Wait until the second request has started internally
-                while (connection.TransportTask.IsCompleted && count < 50)
-                {
-                    count++;
-                    await Task.Delay(1);
-                }
+                // Wait for poll to be canceled
+                await request1.OrTimeout();
 
                 Assert.Equal(StatusCodes.Status204NoContent, context1.Response.StatusCode);
                 Assert.Equal(HttpConnectionStatus.Active, connection.Status);

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1177,7 +1177,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2040", "All")]
         public async Task MultipleRequestsToActiveConnectionId409ForLongPolling()
         {
             using (StartVerifiableLog())


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2293

`DisposeAsync` will dispose the CTS and then set it to null, however we could still try to cancel it between the dispose and the null resulting in ODE.

Couldn't think of a great way to do this without locking, but it shouldn't be a contested lock so it's fine.