### PR TITLE
Experiment with flaky tests Internal/2729

### DIFF
--- a/src/Servers/HttpSys/HttpSysServer.sln
+++ b/src/Servers/HttpSys/HttpSysServer.sln
@@ -42,6 +42,34 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server.HttpSys", "src\Microsoft.AspNetCore.Server.HttpSys.csproj", "{339FECED-134D-4222-9876-C78B1CA4428A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".dependencies", ".dependencies", "{4DA3C456-5050-4AC0-A554-795F6DEC8660}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Hosting.Server.Abstractions", "..\..\Hosting\Server.Abstractions\src\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj", "{CB793DD5-182E-478D-AB0E-336E9FF4393D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Authentication.Abstractions", "..\..\Http\Authentication.Abstractions\src\Microsoft.AspNetCore.Authentication.Abstractions.csproj", "{9E9AC836-16E3-4300-A9E8-F931BAAA122F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Authentication.Core", "..\..\Http\Authentication.Core\src\Microsoft.AspNetCore.Authentication.Core.csproj", "{56B3244E-BB96-40DA-87D8-C7F8D403FB57}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Http.Headers", "..\..\Http\Headers\src\Microsoft.Net.Http.Headers.csproj", "{386E5B41-F4A7-41DA-A990-23B8B92A564D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Http", "..\..\Http\Http\src\Microsoft.AspNetCore.Http.csproj", "{59845EFF-90A1-48C0-9EA2-6CEE66395F56}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Http.Abstractions", "..\..\Http\Http.Abstractions\src\Microsoft.AspNetCore.Http.Abstractions.csproj", "{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Http.Extensions", "..\..\Http\Http.Extensions\src\Microsoft.AspNetCore.Http.Extensions.csproj", "{81E54F36-597A-4BB1-A3DB-972DF0391B79}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Http.Features", "..\..\Http\Http.Features\src\Microsoft.AspNetCore.Http.Features.csproj", "{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Metadata", "..\..\Http\Metadata\src\Microsoft.AspNetCore.Metadata.csproj", "{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.WebUtilities", "..\..\Http\WebUtilities\src\Microsoft.AspNetCore.WebUtilities.csproj", "{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Hosting.Abstractions", "..\..\Hosting\Abstractions\src\Microsoft.AspNetCore.Hosting.Abstractions.csproj", "{19DC60DE-C413-43A2-985E-0D0F20AD2302}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Hosting", "..\..\Hosting\Hosting\src\Microsoft.AspNetCore.Hosting.csproj", "{D93575B3-BFA3-4523-B060-D268D6A0A66B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Connections.Abstractions", "..\Connections.Abstractions\src\Microsoft.AspNetCore.Connections.Abstractions.csproj", "{00A88B8D-D539-45DD-B071-1E955AF89A4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -120,6 +148,162 @@ Global
 		{339FECED-134D-4222-9876-C78B1CA4428A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{339FECED-134D-4222-9876-C78B1CA4428A}.Release|x86.ActiveCfg = Release|Any CPU
 		{339FECED-134D-4222-9876-C78B1CA4428A}.Release|x86.Build.0 = Release|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D}.Release|x86.Build.0 = Release|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F}.Release|x86.Build.0 = Release|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Debug|x86.Build.0 = Debug|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Release|x86.ActiveCfg = Release|Any CPU
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57}.Release|x86.Build.0 = Release|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Debug|x86.Build.0 = Debug|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Release|x86.ActiveCfg = Release|Any CPU
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D}.Release|x86.Build.0 = Release|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Debug|x86.Build.0 = Debug|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Release|x86.ActiveCfg = Release|Any CPU
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56}.Release|x86.Build.0 = Release|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Debug|x86.Build.0 = Debug|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Release|x86.ActiveCfg = Release|Any CPU
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4}.Release|x86.Build.0 = Release|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Debug|x86.Build.0 = Debug|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Release|x86.ActiveCfg = Release|Any CPU
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79}.Release|x86.Build.0 = Release|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Debug|x86.Build.0 = Debug|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Release|x86.ActiveCfg = Release|Any CPU
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C}.Release|x86.Build.0 = Release|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8}.Release|x86.Build.0 = Release|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Debug|x86.Build.0 = Debug|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75}.Release|x86.Build.0 = Release|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Debug|x86.Build.0 = Debug|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Release|x86.ActiveCfg = Release|Any CPU
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302}.Release|x86.Build.0 = Release|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Debug|x86.Build.0 = Debug|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Release|x86.ActiveCfg = Release|Any CPU
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B}.Release|x86.Build.0 = Release|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -132,6 +316,19 @@ Global
 		{E6EA8535-BC62-49F2-960F-4FDB9FF37B9A} = {E183C826-1360-4DFF-9994-F33CED5C8525}
 		{4F202E87-2496-471C-8161-CFB7446EB96F} = {E183C826-1360-4DFF-9994-F33CED5C8525}
 		{339FECED-134D-4222-9876-C78B1CA4428A} = {99D5E5F3-88F5-4CCF-8D8C-717C8925DF09}
+		{CB793DD5-182E-478D-AB0E-336E9FF4393D} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{9E9AC836-16E3-4300-A9E8-F931BAAA122F} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{56B3244E-BB96-40DA-87D8-C7F8D403FB57} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{386E5B41-F4A7-41DA-A990-23B8B92A564D} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{59845EFF-90A1-48C0-9EA2-6CEE66395F56} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{33AA0FB6-13A4-4664-950D-96C2CD5DD4C4} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{81E54F36-597A-4BB1-A3DB-972DF0391B79} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{BC5B65C8-22D9-4D4F-9DF5-A3131247B95C} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{E26D9806-C77A-4CE2-97E8-35140EDBFDB8} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{8BDC7CD9-58D8-42FC-A459-2D3132FA9E75} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{19DC60DE-C413-43A2-985E-0D0F20AD2302} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{D93575B3-BFA3-4523-B060-D268D6A0A66B} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{00A88B8D-D539-45DD-B071-1E955AF89A4A} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34B42B42-FA09-41AB-9216-14073990C504}

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseBodyTests.cs
@@ -229,7 +229,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeFirstWrite_WriteThrows()
         {
             string address;
@@ -250,23 +249,23 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
                 await disconnectCts.Task.WithTimeout();
 
-                Assert.Throws<IOException>(() =>
+                await Assert.ThrowsAsync<IOException>(async () =>
                 {
                     // It can take several tries before Write notices the disconnect.
                     for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                     {
-                        context.Response.Body.Write(new byte[1000], 0, 1000);
+                        context.Response.Body.Write(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
+                        await Task.Delay(TimeSpan.FromMilliseconds(50));
                     }
                 });
 
-                Assert.Throws<ObjectDisposedException>(() => context.Response.Body.Write(new byte[1000], 0, 1000));
+                Assert.Throws<ObjectDisposedException>(() => context.Response.Body.Write(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length));
 
                 context.Dispose();
             }
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeFirstWriteAsync_WriteThrows()
         {
             string address;
@@ -291,18 +290,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     // It can take several tries before Write notices the disconnect.
                     for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                     {
-                        await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                        await context.Response.Body.WriteAsync(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
+                        await Task.Delay(TimeSpan.FromMilliseconds(50));
                     }
                 });
 
-                await Assert.ThrowsAsync<ObjectDisposedException>(() => context.Response.Body.WriteAsync(new byte[1000], 0, 1000));
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => context.Response.Body.WriteAsync(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length));
 
                 context.Dispose();
             }
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBody_ClientDisconnectsBeforeFirstWrite_WriteCompletesSilently()
         {
             string address;
@@ -324,14 +323,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // It can take several tries before Write notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                 {
-                    context.Response.Body.Write(new byte[1000], 0, 1000);
+                    context.Response.Body.Write(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
                 }
                 context.Dispose();
             }
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBody_ClientDisconnectsBeforeFirstWriteAsync_WriteCompletesSilently()
         {
             string address;
@@ -352,14 +350,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // It can take several tries before Write notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                 {
-                    await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                    await context.Response.Body.WriteAsync(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
                 }
                 context.Dispose();
             }
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeSecondWrite_WriteThrows()
         {
             string address;
@@ -386,12 +383,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     await disconnectCts.Task.WithTimeout();
                 }
 
-                Assert.Throws<IOException>(() =>
+                await Assert.ThrowsAsync<IOException>(async () =>
                 {
                     // It can take several tries before Write notices the disconnect.
                     for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                     {
-                        context.Response.Body.Write(new byte[1000], 0, 1000);
+                        context.Response.Body.Write(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
+                        await Task.Delay(TimeSpan.FromMilliseconds(50));
                     }
                 });
                 context.Dispose();
@@ -399,7 +397,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeSecondWriteAsync_WriteThrows()
         {
             string address;
@@ -430,7 +427,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     // It can take several tries before Write notices the disconnect.
                     for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                     {
-                        await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                        await context.Response.Body.WriteAsync(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
+                        await Task.Delay(TimeSpan.FromMilliseconds(50));
                     }
                 });
                 context.Dispose();
@@ -438,7 +436,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBody_ClientDisconnectsBeforeSecondWrite_WriteCompletesSilently()
         {
             string address;
@@ -467,14 +464,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // It can take several tries before Write notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                 {
-                    context.Response.Body.Write(new byte[1000], 0, 1000);
+                    context.Response.Body.Write(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
                 }
                 context.Dispose();
             }
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2729", FlakyOn.AzP.Windows)]
         public async Task ResponseBody_ClientDisconnectsBeforeSecondWriteAsync_WriteCompletesSilently()
         {
             string address;
@@ -502,7 +498,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // It can take several tries before Write notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)
                 {
-                    await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                    await context.Response.Body.WriteAsync(Utilities.WriteBuffer, 0, Utilities.WriteBuffer.Length);
                 }
                 context.Dispose();
             }

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
     internal static class Utilities
     {
         internal static readonly int WriteRetryLimit = 1000;
+        internal static readonly byte[] WriteBuffer = new byte[1024 * 1024];
 
         // When tests projects are run in parallel, overlapping port ranges can cause a race condition when looking for free
         // ports during dynamic port allocation.


### PR DESCRIPTION
These have been extremely flaky in the last week.
https://github.com/aspnet/AspNetCore-Internal/issues/2729

Using bigger buffers and yielding to break tight loops has helped.

I ran them all with 100x repeat multiple times on the CI and they look stable now.

Also adding all the dependencies to the sln so the projects will build.