### PR TITLE
Version the SPA template package

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -152,7 +152,7 @@
     <PackageArtifact Include="Microsoft.DotNet.Web.Client.ItemTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.DotNet.Web.ItemTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.DotNet.Web.ProjectTemplates.2.2" Category="ship" />
-    <PackageArtifact Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Category="ship" />
+    <PackageArtifact Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2" Category="ship" />
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Abstractions" Category="ship" />
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Analyzers" Category="ship" />
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Cosmos" Category="noship" />

--- a/src/Templating/NuGetPackageVerifier.json
+++ b/src/Templating/NuGetPackageVerifier.json
@@ -24,7 +24,7 @@
           "Template"
         ]
       },
-      "Microsoft.DotNet.Web.Spa.ProjectTemplates": {
+      "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2": {
         "packageTypes": [
           "Template"
         ]

--- a/src/Templating/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj
+++ b/src/Templating/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <PackageId>Microsoft.DotNet.Web.Spa.ProjectTemplates.$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</PackageId>
     <Description>Single Page Application templates for ASP.NET Core
 
     To install the templates in this package, run 'dotnet new --install $(PackageId)::$(PackageVersion)'.</Description>


### PR DESCRIPTION
We’ve met with the tooling team and discussed the recent changes in the tooling, which require packages to be uniquely named across runtimes.
Because that isn’t still the case, the change the tooling team made resulted in our SPA project templates to disappear from the New ASP.NET Core project dialog.
They’ve introduced a temporary workaround, making it so that the package from the newest runtime shows up. This, however, has a lot of issues and should be treated as a temporary mitigation.

The changes below are to make the SPA project templates packages unique per runtime, similar to how we have this setup for other project templates.
