### PR TITLE
gRPC template fixes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -217,7 +217,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>0.1.22-pre1</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>0.1.22-pre2</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0-preview3.4</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0-preview3.4</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0-preview3.4</IdentityServer4PackageVersion>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "GrpcService-CSharp": {
       "commandName": "Project",
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:50051",
+      "applicationUrl": "https://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
 }


### PR DESCRIPTION
1.	Update the version of gRPC packages in our templates to what will be shipped by the gRPC team. This change is expected since the gRPC team produces the package after our branching, and this is the only way we ship with external packages in lock step.
2.	Update the port used by the gRPC template from https://localhost:50051 to the default for AspNetCore templates https://localhost:5001. This was missed in my original PR: https://github.com/aspnet/AspNetCore/pull/11473#discussion_r297010875
3.	Enforce HTTP2 only on gRPC templates. This enforcement was removed in https://github.com/aspnet/AspNetCore/pull/11473 by accident.

