### PR TITLE
Use non-returning throw methods

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -722,8 +722,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             if (_writeStreamSuffixCalled)
             {
-                throw new InvalidOperationException("Writing is not allowed after writer was completed.");
+                ThrowSuffixSent();
             }
+        }
+
+        [StackTraceHidden]
+        private static void ThrowSuffixSent()
+        {
+            throw new InvalidOperationException("Writing is not allowed after writer was completed.");
         }
 
         /// <summary>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1442,7 +1442,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     // so it can be observed by BodyWriter.Complete(). If this isn't possible because an
                     // async OnStarting callback hadn't yet run, it's OK, since the Exception will be observed with
                     // the call to _bodyControl.StopAsync() in ProcessRequests().
-                    throw lengthException;
+                    ThrowException(lengthException);
                 }
 
                 return ProduceEnd();
@@ -1459,11 +1459,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (!VerifyResponseContentLength(out var lengthException))
                 {
-                    throw lengthException;
+                    ThrowException(lengthException);
                 }
 
                 await ProduceEnd();
             }
+        }
+
+        [StackTraceHidden]
+        private static void ThrowException(Exception exception)
+        {
+            throw exception;
         }
 
         public ValueTask<FlushResult> WritePipeAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -437,8 +437,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             if (_suffixSent)
             {
-                throw new InvalidOperationException("Writing is not allowed after writer was completed.");
+                ThrowSuffixSent();
             }
+        }
+
+        [StackTraceHidden]
+        private static void ThrowSuffixSent()
+        {
+            throw new InvalidOperationException("Writing is not allowed after writer was completed.");
         }
 
         private static Pipe CreateDataPipe(MemoryPool<byte> pool)


### PR DESCRIPTION
Means the `if` check can inline without bloating the method with the `throw` or the throw preventing the method from inlining.