### PR TITLE
No Authorization in ReactRedux

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Controllers/WeatherForecastController.cs
@@ -10,9 +10,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.WebApplication1.Controllers
 {
-#if (!NoAuth)
-    [Authorize]
-#endif
     [ApiController]
     [Route("[controller]")]
     public class WeatherForecastController : ControllerBase

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Controllers/WeatherForecastController.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-#if (!NoAuth)
-using Microsoft.AspNetCore.Authorization;
-#endif
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 

--- a/src/ProjectTemplates/test/SpaTemplateTest/ReactReduxTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/ReactReduxTemplateTest.cs
@@ -3,8 +3,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.E2ETesting;
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +17,6 @@ namespace Templates.Test.SpaTemplateTest
         }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2407", FlakyOn.AzP.Windows)]
         public Task ReactReduxTemplate_Works_NetCore()
             => SpaTemplateImplAsync("reactredux", "reactredux", useLocalDb: false, usesAuth: false);
     }


### PR DESCRIPTION
The inclusion of this attribute causes all calls to this endpoint to fail because there is no authorization system registered.