### PR TITLE
RazorComponents - Mix of IsFixed Cascading values causes Exception #11653

### DIFF
--- a/src/Components/Components/src/CascadingValue.cs
+++ b/src/Components/Components/src/CascadingValue.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Components
 
         void ICascadingValueComponent.Unsubscribe(ComponentState subscriber)
         {
-            _subscribers.Remove(subscriber);
+            _subscribers?.Remove(subscriber);
         }
 
         private void NotifySubscribers()


### PR DESCRIPTION
I needed this fix too...

Summary of the changes
 - fixes null reference, checked other places in the class

Addresses #11653 
