### PR TITLE
TestServer Reset support, fix up Abort

### DIFF
--- a/src/Hosting/TestHost/ref/Microsoft.AspNetCore.TestHost.netcoreapp3.0.cs
+++ b/src/Hosting/TestHost/ref/Microsoft.AspNetCore.TestHost.netcoreapp3.0.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNetCore.TestHost
         public static System.Net.Http.HttpClient GetTestClient(this Microsoft.Extensions.Hosting.IHost host) { throw null; }
         public static Microsoft.AspNetCore.TestHost.TestServer GetTestServer(this Microsoft.Extensions.Hosting.IHost host) { throw null; }
     }
+    public partial class HttpResetTestException : System.Exception
+    {
+        public HttpResetTestException(int errorCode) { }
+        public int ErrorCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
     public partial class RequestBuilder
     {
         public RequestBuilder(Microsoft.AspNetCore.TestHost.TestServer server, string path) { }

--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -22,9 +22,6 @@ namespace Microsoft.AspNetCore.TestHost
     /// </summary>
     public class ClientHandler : HttpMessageHandler
     {
-        private readonly Version V11 = new Version(1, 1);
-        private readonly Version V20 = new Version(2, 0);
-
         private readonly ApplicationWrapper _application;
         private readonly PathString _pathBase;
 
@@ -73,7 +70,7 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 var req = context.Request;
 
-                if (request.Version == V20)
+                if (request.Version == HttpVersion.Version20)
                 {
                     // https://tools.ietf.org/html/rfc7540
                     req.Protocol = "HTTP/2";

--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -22,6 +22,9 @@ namespace Microsoft.AspNetCore.TestHost
     /// </summary>
     public class ClientHandler : HttpMessageHandler
     {
+        private readonly Version V11 = new Version(1, 1);
+        private readonly Version V20 = new Version(2, 0);
+
         private readonly ApplicationWrapper _application;
         private readonly PathString _pathBase;
 
@@ -70,7 +73,15 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 var req = context.Request;
 
-                req.Protocol = "HTTP/" + request.Version.ToString(fieldCount: 2);
+                if (request.Version == V20)
+                {
+                    // https://tools.ietf.org/html/rfc7540
+                    req.Protocol = "HTTP/2";
+                }
+                else
+                {
+                    req.Protocol = "HTTP/" + request.Version.ToString(fieldCount: 2);
+                }
                 req.Method = request.Method.ToString();
 
                 req.Scheme = request.RequestUri.Scheme;

--- a/src/Hosting/TestHost/src/HttpResetTestException.cs
+++ b/src/Hosting/TestHost/src/HttpResetTestException.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    /// <summary>
+    /// Used to surface to the test client that the application invoked <see cref="IHttpResetFeature.Reset"/>
+    /// </summary>
+    public class HttpResetTestException : Exception
+    {
+        /// <summary>
+        /// Creates a new test exception
+        /// </summary>
+        /// <param name="errorCode">The error code passed to <see cref="IHttpResetFeature.Reset"/></param>
+        public HttpResetTestException(int errorCode)
+            : base($"The application reset the request with error code {errorCode}.")
+        {
+            ErrorCode = errorCode;
+        }
+
+        /// <summary>
+        /// The error code passed to <see cref="IHttpResetFeature.Reset"/>
+        /// </summary>
+        public int ErrorCode { get; }
+    }
+}

--- a/src/Hosting/TestHost/test/ClientHandlerTests.cs
+++ b/src/Hosting/TestHost/test/ClientHandlerTests.cs
@@ -301,8 +301,7 @@ namespace Microsoft.AspNetCore.TestHost
             Task<int> readTask = responseStream.ReadAsync(new byte[100], 0, 100);
             Assert.False(readTask.IsCompleted);
             responseStream.Dispose();
-            var read = await readTask.WithTimeout();
-            Assert.Equal(0, read);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => readTask.WithTimeout());
             block.SetResult(0);
         }
 

--- a/src/Hosting/TestHost/test/RequestLifetimeTests.cs
+++ b/src/Hosting/TestHost/test/RequestLifetimeTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    public class RequestLifetimeTests
+    {
+        [Fact]
+        public async Task LifetimeFeature_Abort_TriggersRequestAbortedToken()
+        {
+            var requestAborted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                httpContext.RequestAborted.Register(() => requestAborted.SetResult(0));
+                httpContext.Abort();
+
+                await requestAborted.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            var ex = await Assert.ThrowsAsync<Exception>(() => client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead));
+            Assert.Equal("The application aborted the request.", ex.Message);
+            await requestAborted.Task.WithTimeout();
+        }
+
+        [Fact]
+        public async Task LifetimeFeature_AbortBeforeHeadersSent_ClientThrows()
+        {
+            var abortReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                httpContext.Abort();
+                await abortReceived.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            var ex = await Assert.ThrowsAsync<Exception>(() => client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead));
+            Assert.Equal("The application aborted the request.", ex.Message);
+            abortReceived.SetResult(0);
+        }
+
+        [Fact]
+        public async Task LifetimeFeature_AbortAfterHeadersSent_ClientBodyThrows()
+        {
+            var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var abortReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                await httpContext.Response.Body.FlushAsync();
+                await responseReceived.Task.WithTimeout();
+                httpContext.Abort();
+                await abortReceived.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
+            responseReceived.SetResult(0);
+            response.EnsureSuccessStatusCode();
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());
+            var rex = ex.GetBaseException();
+            Assert.Equal("The application aborted the request.", rex.Message);
+            abortReceived.SetResult(0);
+        }
+
+        [Fact]
+        public async Task LifetimeFeature_AbortAfterSomeDataSent_ClientBodyThrows()
+        {
+            var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var abortReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                await httpContext.Response.WriteAsync("Hello World");
+                await responseReceived.Task.WithTimeout();
+                httpContext.Abort();
+                await abortReceived.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
+            responseReceived.SetResult(0);
+            response.EnsureSuccessStatusCode();
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());
+            var rex = ex.GetBaseException();
+            Assert.Equal("The application aborted the request.", rex.Message);
+            abortReceived.SetResult(0);
+        }
+
+        // TODO: Abort after CompleteAsync - No-op, the request is already complete.
+
+        private Task<IHost> CreateHost(RequestDelegate appDelegate)
+        {
+            return new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder
+                        .UseTestServer()
+                        .Configure(app =>
+                        {
+                            app.Run(appDelegate);
+                        });
+                })
+                .StartAsync();
+        }
+    }
+}

--- a/src/Hosting/TestHost/test/ResponseResetTests.cs
+++ b/src/Hosting/TestHost/test/ResponseResetTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -15,9 +16,6 @@ namespace Microsoft.AspNetCore.TestHost
 {
     public class ResponseResetTests
     {
-        private readonly Version V11 = new Version(1, 1);
-        private readonly Version V2 = new Version(2, 0);
-
         [Fact]
         // Reset is only present for HTTP/2
         public async Task ResetFeature_Http11_Missing()
@@ -30,7 +28,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            client.DefaultRequestVersion = V11;
+            client.DefaultRequestVersion = HttpVersion.Version11;
             var response = await client.GetAsync("/");
             response.EnsureSuccessStatusCode();
         }
@@ -46,7 +44,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            client.DefaultRequestVersion = V2;
+            client.DefaultRequestVersion = HttpVersion.Version20;
             var response = await client.GetAsync("/");
             response.EnsureSuccessStatusCode();
         }
@@ -65,7 +63,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            client.DefaultRequestVersion = V2;
+            client.DefaultRequestVersion = HttpVersion.Version20;
             var rex = await Assert.ThrowsAsync<HttpResetTestException>(() => client.GetAsync("/"));
             Assert.Equal("The application reset the request with error code 12345.", rex.Message);
             Assert.Equal(12345, rex.ErrorCode);
@@ -84,7 +82,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            client.DefaultRequestVersion = V2;
+            client.DefaultRequestVersion = HttpVersion.Version20;
             var rex = await Assert.ThrowsAsync<HttpResetTestException>(() => client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead));
             Assert.Equal("The application reset the request with error code 12345.", rex.Message);
             Assert.Equal(12345, rex.ErrorCode);
@@ -106,7 +104,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            client.DefaultRequestVersion = V2;
+            client.DefaultRequestVersion = HttpVersion.Version20;
             var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
             responseReceived.SetResult(0);
             response.EnsureSuccessStatusCode();
@@ -132,7 +130,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            client.DefaultRequestVersion = V2;
+            client.DefaultRequestVersion = HttpVersion.Version20;
             var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
             responseReceived.SetResult(0);
             response.EnsureSuccessStatusCode();

--- a/src/Hosting/TestHost/test/ResponseResetTests.cs
+++ b/src/Hosting/TestHost/test/ResponseResetTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    public class ResponseResetTests
+    {
+        private readonly Version V11 = new Version(1, 1);
+        private readonly Version V2 = new Version(2, 0);
+
+        [Fact]
+        // Reset is only present for HTTP/2
+        public async Task ResetFeature_Http11_Missing()
+        {
+            using var host = await CreateHost(httpContext =>
+            {
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                Assert.Null(feature);
+                return Task.CompletedTask;
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            client.DefaultRequestVersion = V11;
+            var response = await client.GetAsync("/");
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task ResetFeature_Http2_Present()
+        {
+            using var host = await CreateHost(httpContext =>
+            {
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                Assert.NotNull(feature);
+                return Task.CompletedTask;
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            client.DefaultRequestVersion = V2;
+            var response = await client.GetAsync("/");
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task ResetFeature_Reset_TriggersRequestAbortedToken()
+        {
+            var requestAborted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                httpContext.RequestAborted.Register(() => requestAborted.SetResult(0));
+
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                feature.Reset(12345);
+                await requestAborted.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            client.DefaultRequestVersion = V2;
+            var rex = await Assert.ThrowsAsync<HttpResetTestException>(() => client.GetAsync("/"));
+            Assert.Equal("The application reset the request with error code 12345.", rex.Message);
+            Assert.Equal(12345, rex.ErrorCode);
+            await requestAborted.Task.WithTimeout();
+        }
+
+        [Fact]
+        public async Task ResetFeature_ResetBeforeHeadersSent_ClientThrows()
+        {
+            var resetReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                feature.Reset(12345);
+                await resetReceived.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            client.DefaultRequestVersion = V2;
+            var rex = await Assert.ThrowsAsync<HttpResetTestException>(() => client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead));
+            Assert.Equal("The application reset the request with error code 12345.", rex.Message);
+            Assert.Equal(12345, rex.ErrorCode);
+            resetReceived.SetResult(0);
+        }
+
+        [Fact]
+        public async Task ResetFeature_ResetAfterHeadersSent_ClientBodyThrows()
+        {
+            var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var resetReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                await httpContext.Response.Body.FlushAsync();
+                await responseReceived.Task.WithTimeout();
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                feature.Reset(12345);
+                await resetReceived.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            client.DefaultRequestVersion = V2;
+            var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
+            responseReceived.SetResult(0);
+            response.EnsureSuccessStatusCode();
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());
+            var rex = Assert.IsAssignableFrom<HttpResetTestException>(ex.GetBaseException());
+            Assert.Equal("The application reset the request with error code 12345.", rex.Message);
+            Assert.Equal(12345, rex.ErrorCode);
+            resetReceived.SetResult(0);
+        }
+
+        [Fact]
+        public async Task ResetFeature_ResetAfterSomeDataSent_ClientBodyThrows()
+        {
+            var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var resetReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var host = await CreateHost(async httpContext =>
+            {
+                await httpContext.Response.WriteAsync("Hello World");
+                await responseReceived.Task.WithTimeout();
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                feature.Reset(12345);
+                await resetReceived.Task.WithTimeout();
+            });
+
+            var client = host.GetTestServer().CreateClient();
+            client.DefaultRequestVersion = V2;
+            var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
+            responseReceived.SetResult(0);
+            response.EnsureSuccessStatusCode();
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());
+            var rex = Assert.IsAssignableFrom<HttpResetTestException>(ex.GetBaseException());
+            Assert.Equal("The application reset the request with error code 12345.", rex.Message);
+            Assert.Equal(12345, rex.ErrorCode);
+            resetReceived.SetResult(0);
+        }
+
+        // TODO: Reset after CompleteAsync - Not sure how to surface this. CompleteAsync hasn't been implemented yet anyways.
+
+        private Task<IHost> CreateHost(RequestDelegate appDelegate)
+        {
+            return new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder
+                        .UseTestServer()
+                        .Configure(app =>
+                        {
+                            app.Run(appDelegate);
+                        });
+                })
+                .StartAsync();
+        }
+    }
+}

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -420,7 +420,7 @@ namespace Microsoft.AspNetCore.TestHost
             var client = server.CreateClient();
             var cts = new CancellationTokenSource();
             cts.CancelAfter(500);
-            var response = await client.GetAsync("http://localhost:12345", cts.Token);
+            var response = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync("http://localhost:12345", cts.Token));
 
             // Assert
             var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await tcs.Task);


### PR DESCRIPTION
 #11598 Implemented the response reset feature to throw a custom exception to the client with the reset error code.

I had intended this to mirror the normal Abort logic, but I found out that Abort hadn't been fully implemented yet. Abort would fire RequestAborted, but it wouldn't notify the client. Now it throws on the client.

Will follow-up with a CompleteAsync implementation.