### PR TITLE
Don't double-flush HTTP/1 Content-Length responses

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -2903,7 +2903,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var expectedString = new string('a', expectedLength);
             await using (var server = new TestServer(async httpContext =>
             {
-                httpContext.Response.Headers["Content-Length"] = new[] { expectedLength.ToString() };
+                httpContext.Response.ContentLength = expectedLength;
                 await httpContext.Response.WriteAsync(expectedString);
                 Assert.True(httpContext.Response.HasStarted);
             }, testContext))
@@ -2926,7 +2926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task UnflushedContentLengthResponseIsFlushedAutomtatically()
+        public async Task UnflushedContentLengthResponseIsFlushedAutomatically()
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var expectedLength = 100000;
@@ -2949,7 +2949,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             await using (var server = new TestServer(httpContext =>
             {
-                httpContext.Response.Headers["Content-Length"] = new[] { expectedLength.ToString() };
+                httpContext.Response.ContentLength = expectedLength;
 
                 WriteStringWithoutFlushing(httpContext.Response.BodyWriter, expectedString);
 


### PR DESCRIPTION
This should fix the biggest single cause of the perf regression discussed in #11778. The regression was introduced by #11675 which caused PipeWriter.FlushAsync() to be called twice per response in the TechEmpower plaintext benchmark instead of once like before.

I fixed this by checking whether `_unflushedBytes > 0` in Http1OutputProducer.WriteStreamSuffixAsync() for non-chunked responses. If there are no remaining unflushed bytes, we now skip the redundant flush.