### PR TITLE
Don't reuse the same exception through multiple paths

### DIFF
--- a/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.netstandard2.0.cs
+++ b/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.netstandard2.0.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Connections
         public ConnectionAbortedException() { }
         public ConnectionAbortedException(string message) { }
         public ConnectionAbortedException(string message, System.Exception inner) { }
+        public ConnectionAbortedException(string message, System.Exception inner, System.Threading.CancellationToken cancellationToken) { }
     }
     public partial class ConnectionBuilder : Microsoft.AspNetCore.Connections.IConnectionBuilder
     {

--- a/src/Servers/Connections.Abstractions/src/Exceptions/ConnectionAbortedException.cs
+++ b/src/Servers/Connections.Abstractions/src/Exceptions/ConnectionAbortedException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Threading;
 
 namespace Microsoft.AspNetCore.Connections
 {
@@ -10,11 +11,18 @@ namespace Microsoft.AspNetCore.Connections
 
         }
 
-        public ConnectionAbortedException(string message) : base(message)
+        public ConnectionAbortedException(string message)
+            : base(message)
         {
         }
 
-        public ConnectionAbortedException(string message, Exception inner) : base(message, inner)
+        public ConnectionAbortedException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        public ConnectionAbortedException(string message, Exception inner, CancellationToken cancellationToken)
+            : base(message, inner, cancellationToken)
         {
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -493,7 +493,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        protected void PoisonRequestBodyStream(Exception abortReason)
+        protected void PoisonRequestBodyStream(ConnectionAbortedException abortReason)
+        {
+            _bodyControl?.Abort(abortReason);
+        }
+
+        protected void PoisonRequestBodyStream(IOException abortReason)
         {
             _bodyControl?.Abort(abortReason);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestPipeReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestPipeReader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         private MessageBody _body;
         private HttpStreamState _state;
-        private Exception _error;
+        private ExceptionDispatchInfo _error;
 
         public HttpRequestPipeReader()
         {
@@ -99,7 +99,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_state != HttpStreamState.Closed)
             {
                 _state = HttpStreamState.Aborted;
-                _error = error;
+
+                if (error != null)
+                {
+                    _error = ExceptionDispatchInfo.Capture(error);
+                }
             }
         }
 
@@ -119,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_error != null)
                 {
-                    ExceptionDispatchInfo.Capture(_error).Throw();
+                    _error.Throw();
                 }
                 else
                 {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -476,8 +476,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             AbortRequest();
 
             // Unblock the request body.
-            PoisonRequestBodyStream(abortReason);
-            RequestBodyPipe.Writer.Complete(abortReason);
+            PoisonRequestBodyStream(new ConnectionAbortedException(abortReason.Message, abortReason));
+            RequestBodyPipe.Writer.Complete(new ConnectionAbortedException(abortReason.Message, abortReason));
 
             _inputFlowControl.Abort();
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -473,8 +473,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             AbortCore();
 
             // Unblock the request body.
-            PoisonRequestBodyStream(new ConnectionAbortedException(abortReason.Message, abortReason));
-            RequestBodyPipe.Writer.Complete(new ConnectionAbortedException(abortReason.Message, abortReason));
+            PoisonRequestBodyStream(new ConnectionAbortedException(abortReason.Message, abortReason, abortReason.CancellationToken));
+            RequestBodyPipe.Writer.Complete(new ConnectionAbortedException(abortReason.Message, abortReason, abortReason.CancellationToken));
 
             _inputFlowControl.Abort();
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -72,8 +73,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public void Abort(Exception error)
         {
-            _requestReader.Abort(error);
-            _emptyRequestReader.Abort(error);
+            _requestReader.Abort(new ConnectionAbortedException(error.Message, error));
+            _emptyRequestReader.Abort(new ConnectionAbortedException(error.Message, error));
             _responseWriter.Abort();
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -80,8 +80,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public void Abort(ConnectionAbortedException error)
         {
-            _requestReader.Abort(new ConnectionAbortedException(error.Message, error));
-            _emptyRequestReader.Abort(new ConnectionAbortedException(error.Message, error));
+            _requestReader.Abort(new ConnectionAbortedException(error.Message, error, error.CancellationToken));
+            _emptyRequestReader.Abort(new ConnectionAbortedException(error.Message, error, error.CancellationToken));
             _responseWriter.Abort();
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -71,7 +71,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             return _responseWriter.StopAcceptingWritesAsync();
         }
 
-        public void Abort(Exception error)
+        public void Abort(IOException error)
+        {
+            _requestReader.Abort(new IOException(error.Message, error));
+            _emptyRequestReader.Abort(new IOException(error.Message, error));
+            _responseWriter.Abort();
+        }
+
+        public void Abort(ConnectionAbortedException error)
         {
             _requestReader.Abort(new ConnectionAbortedException(error.Message, error));
             _emptyRequestReader.Abort(new ConnectionAbortedException(error.Message, error));

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TimingPipeFlusher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TimingPipeFlusher.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
             catch (OperationCanceledException ex) when (outputAborter != null)
             {
-                outputAborter.Abort(new ConnectionAbortedException(CoreStrings.ConnectionOrStreamAbortedByCancellationToken, ex));
+                outputAborter.Abort(new ConnectionAbortedException(CoreStrings.ConnectionOrStreamAbortedByCancellationToken, ex, ex.CancellationToken));
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/Core/test/BodyControlTests.cs
+++ b/src/Servers/Kestrel/Core/test/BodyControlTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -26,9 +27,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await response.WriteAsync(new byte[1], 0, 1);
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(() => request.ReadAsync(new byte[1], 0, 1)));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(() => request.ReadAsync(new byte[1], 0, 1))).InnerException);
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(async () => await requestPipe.ReadAsync()));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(async () => await requestPipe.ReadAsync())).InnerException);
         }
 
         [Fact]
@@ -45,13 +46,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(CoreStrings.ResponseStreamWasUpgraded, writeEx.Message);
 
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(() => request.ReadAsync(new byte[1], 0, 1)));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(() => request.ReadAsync(new byte[1], 0, 1))).InnerException);
 
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(() => upgrade.ReadAsync(new byte[1], 0, 1)));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(() => upgrade.ReadAsync(new byte[1], 0, 1))).InnerException);
 
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(async () => await requestPipe.ReadAsync()));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(async () => await requestPipe.ReadAsync())).InnerException);
 
             await upgrade.WriteAsync(new byte[1], 0, 1);
         }
@@ -71,12 +72,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(CoreStrings.ResponseStreamWasUpgraded, writeEx.Message);
 
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(() => request.ReadAsync(new byte[1], 0, 1)));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(() => request.ReadAsync(new byte[1], 0, 1))).InnerException);
 
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(() => upgrade.ReadAsync(new byte[1], 0, 1)));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(() => upgrade.ReadAsync(new byte[1], 0, 1))).InnerException);
             Assert.Same(ex,
-                await Assert.ThrowsAsync<Exception>(async () => await requestPipe.ReadAsync()));
+                (await Assert.ThrowsAsync<ConnectionAbortedException>(async () => await requestPipe.ReadAsync())).InnerException);
 
             await upgrade.WriteAsync(new byte[1], 0, 1);
         }
@@ -92,17 +93,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await response.WriteAsync(new byte[1], 0, 1);
             Assert.Same(ex,
-                Assert.Throws<Exception>(() => requestPipe.AdvanceTo(new SequencePosition())));
+                (Assert.Throws<ConnectionAbortedException>(() => requestPipe.AdvanceTo(new SequencePosition()))).InnerException);
             Assert.Same(ex,
-                Assert.Throws<Exception>(() => requestPipe.AdvanceTo(new SequencePosition(), new SequencePosition())));
+                (Assert.Throws<ConnectionAbortedException>(() => requestPipe.AdvanceTo(new SequencePosition(), new SequencePosition()))).InnerException);
             Assert.Same(ex,
-                Assert.Throws<Exception>(() => requestPipe.CancelPendingRead()));
+                (Assert.Throws<ConnectionAbortedException>(() => requestPipe.CancelPendingRead())).InnerException);
             Assert.Same(ex,
-                Assert.Throws<Exception>(() => requestPipe.TryRead(out var res)));
+                (Assert.Throws<ConnectionAbortedException>(() => requestPipe.TryRead(out var res))).InnerException);
             Assert.Same(ex,
-                Assert.Throws<Exception>(() => requestPipe.Complete()));
+                (Assert.Throws<ConnectionAbortedException>(() => requestPipe.Complete())).InnerException);
             Assert.Same(ex,
-                Assert.Throws<Exception>(() => requestPipe.OnWriterCompleted(null, null)));
+                (Assert.Throws<ConnectionAbortedException>(() => requestPipe.OnWriterCompleted(null, null))).InnerException);
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -809,7 +809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task ContentLength_Received_SingleDataFrameOverSize_Reset()
         {
-            Exception thrownEx = null;
+            IOException thrownEx = null;
 
             var headers = new[]
             {
@@ -820,7 +820,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
             await InitializeConnectionAsync(async context =>
             {
-                thrownEx = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                thrownEx = await Assert.ThrowsAsync<IOException>(async () =>
                 {
                     var buffer = new byte[100];
                     while (await context.Request.Body.ReadAsync(buffer, 0, buffer.Length) > 0) { }
@@ -838,13 +838,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.NotNull(thrownEx);
             Assert.Equal(expectedError.Message, thrownEx.InnerException.Message);
-            Assert.IsType<ConnectionAbortedException>(thrownEx.InnerException);
+            Assert.IsType<IOException>(thrownEx.InnerException);
         }
 
         [Fact]
         public async Task ContentLength_Received_SingleDataFrameUnderSize_Reset()
         {
-            ConnectionAbortedException thrownEx = null;
+            IOException thrownEx = null;
 
             var headers = new[]
             {
@@ -855,7 +855,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
             await InitializeConnectionAsync(async context =>
             {
-                thrownEx = await Assert.ThrowsAsync<ConnectionAbortedException>(async () =>
+                thrownEx = await Assert.ThrowsAsync<IOException>(async () =>
                 {
                     var buffer = new byte[100];
                     while (await context.Request.Body.ReadAsync(buffer, 0, buffer.Length) > 0) { }
@@ -873,13 +873,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.NotNull(thrownEx);
             Assert.Equal(expectedError.Message, thrownEx.Message);
-            Assert.IsType<ConnectionAbortedException>(thrownEx.InnerException);
+            Assert.IsType<IOException>(thrownEx.InnerException);
         }
 
         [Fact]
         public async Task ContentLength_Received_MultipleDataFramesOverSize_Reset()
         {
-            ConnectionAbortedException thrownEx = null;
+            IOException thrownEx = null;
 
             var headers = new[]
             {
@@ -890,7 +890,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
             await InitializeConnectionAsync(async context =>
             {
-                thrownEx = await Assert.ThrowsAsync<ConnectionAbortedException>(async () =>
+                thrownEx = await Assert.ThrowsAsync<IOException>(async () =>
                 {
                     var buffer = new byte[100];
                     while (await context.Request.Body.ReadAsync(buffer, 0, buffer.Length) > 0) { }
@@ -909,13 +909,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.NotNull(thrownEx);
             Assert.Equal(expectedError.Message, thrownEx.Message);
-            Assert.IsType<ConnectionAbortedException>(thrownEx.InnerException);
+            Assert.IsType<IOException>(thrownEx.InnerException);
         }
 
         [Fact]
         public async Task ContentLength_Received_MultipleDataFramesUnderSize_Reset()
         {
-            Exception thrownEx = null;
+            IOException thrownEx = null;
 
             var headers = new[]
             {
@@ -926,7 +926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
             await InitializeConnectionAsync(async context =>
             {
-                thrownEx = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                thrownEx = await Assert.ThrowsAsync<IOException>(async () =>
                 {
                     var buffer = new byte[100];
                     while (await context.Request.Body.ReadAsync(buffer, 0, buffer.Length) > 0) { }
@@ -944,8 +944,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var expectedError = new Http2StreamErrorException(1, CoreStrings.Http2StreamErrorLessDataThanLength, Http2ErrorCode.PROTOCOL_ERROR);
 
             Assert.NotNull(thrownEx);
-            Assert.Equal(expectedError.Message, thrownEx.InnerException.Message);
-            Assert.IsType<ConnectionAbortedException>(thrownEx.InnerException);
+            Assert.Equal(expectedError.Message, thrownEx.Message);
+            Assert.IsType<IOException>(thrownEx.InnerException);
         }
 
         [Fact]
@@ -2211,7 +2211,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                     _runningStreams[streamIdFeature.StreamId].TrySetException(new Exception("ReadAsync was expected to throw."));
                 }
-                catch (TaskCanceledException ex) when (ex.InnerException is ConnectionAbortedException)// Expected failure
+                catch (IOException) // Expected failure
                 {
                     await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 
@@ -2254,7 +2254,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                     _runningStreams[streamIdFeature.StreamId].TrySetException(new Exception("ReadAsync was expected to throw."));
                 }
-                catch (TaskCanceledException ex) when (ex.InnerException is ConnectionAbortedException) // Expected failure
+                catch (IOException) // Expected failure
                 {
                     await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 


### PR DESCRIPTION
Am guessing this is the cause of the long chain in https://github.com/aspnet/AspNetCore/issues/11804 (though doesn't fix the underlying issue)
```
crit: Microsoft.AspNetCore.Server.Kestrel[0]
      Http2OutpuProducer.ProcessDataWrites() observed an unexpected exception.
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
   at System.IO.Pipelines.BufferSegment.set_End(Int32 value)
   at System.IO.Pipelines.Pipe.CommitUnsynchronized()
   at System.IO.Pipelines.Pipe.PrepareFlush(CompletionData& completionData, ValueTask`1& result, CancellationToken cancellationToken)
   at System.IO.Pipelines.Pipe.FlushAsync(CancellationToken cancellationToken)
   at System.IO.Pipelines.Pipe.DefaultPipeWriter.FlushAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.TimeFlushAsync(MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.AwaitLastFlushAndTimeFlushAsync(ValueTask`1 lastFlushTask, MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2OutputProducer.ProcessDataWrites()
```

/cc @halter73 @davidfowl @stephentoub 