### PR TITLE
Don't try to unsubscribe from fixed cascading parameters. Fixes #11653

### DIFF
--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -165,7 +165,11 @@ namespace Microsoft.AspNetCore.Components.Rendering
             var numCascadingParameters = _cascadingParameters.Count;
             for (var i = 0; i < numCascadingParameters; i++)
             {
-                _cascadingParameters[i].ValueSupplier.Unsubscribe(this);
+                var supplier = _cascadingParameters[i].ValueSupplier;
+                if (!supplier.CurrentValueIsFixed)
+                {
+                    supplier.Unsubscribe(this);
+                }
             }
         }
     }


### PR DESCRIPTION
Updated version of https://github.com/aspnet/AspNetCore/pull/11803

The test diff looks bigger than it really is. It's because I renamed the nested `builder` variables so the names are distinct.