### PR TITLE
Resolve some reactredux warnings

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/store/Counter.ts
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/store/Counter.ts
@@ -24,8 +24,8 @@ export type KnownAction = IncrementCountAction | DecrementCountAction;
 // They don't directly mutate state, but they can have external side-effects (such as loading data).
 
 export const actionCreators = {
-    increment: () => <IncrementCountAction>{ type: 'INCREMENT_COUNT' },
-    decrement: () => <DecrementCountAction>{ type: 'DECREMENT_COUNT' }
+    increment: () => ({ type: 'INCREMENT_COUNT' } as IncrementCountAction),
+    decrement: () => ({ type: 'DECREMENT_COUNT' } as DecrementCountAction)
 };
 
 // ----------------

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/store/configureStore.ts
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/store/configureStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, combineReducers, compose, createStore, Reducer } from 'redux';
+import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { connectRouter, routerMiddleware } from 'connected-react-router';
 import { History } from 'history';


### PR DESCRIPTION
This seems to have started causing failures when we updated our typescript version. It was missed because those tests were marked as flaky.