### PR TITLE
Revert "Remove some dead code in Blazor hosting"

### DIFF
--- a/src/Components/Blazor/Server/src/Builder/BlazorHostingEndpointRouteBuilderExtensions.cs
+++ b/src/Components/Blazor/Server/src/Builder/BlazorHostingEndpointRouteBuilderExtensions.cs
@@ -168,7 +168,19 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(filePath));
             }
 
+            var config = BlazorConfig.Read(clientAssemblyFilePath);
+
+            // We want to serve "index.html" from whichever directory contains it in this priority order:
+            // 1. Client app "dist" directory
+            // 2. Client app "wwwroot" directory
+            // 3. Server app "wwwroot" directory
             var directory = endpoints.ServiceProvider.GetRequiredService<IWebHostEnvironment>().WebRootPath;
+            var indexHtml = config.FindIndexHtmlFile();
+            if (indexHtml != null)
+            {
+                directory = Path.GetDirectoryName(indexHtml);
+            }
+
             var options = new StaticFileOptions()
             {
                 FileProvider = new PhysicalFileProvider(directory),


### PR DESCRIPTION
This reverts commit d8b1af39f06e4c170dae3fd01b5ca4d49e16c4a3.

This wasn't dead-code after all. Removing this code breaks the
Components functional tests (at least running locally).

@aspnet/build @pranavkm @SteveSandersonMS  - I did a bad. Need someone to approve this to fix tests. 
