### PR TITLE
Stop shipping a runtime.dev.json file

### DIFF
--- a/src/Mvc/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Mvc/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -39,11 +39,9 @@
 
     <!--
       If 'true' (the default), build projects referenced in @(OpenApiProjectReference) items before retrieving that
-      project's Open API documents list (or generating code). Recommend setting this to 'false' when the referenced
-      projects do not share target framework values (avoiding build errors and / or warnings).
-
-      If 'false', ensure the referenced projects build before this one in the solution or through other means. IDEs may
-      be confused about the project dependency graph in this case.
+      project's Open API documents list (or generating code). If 'false', ensure the referenced projects build before
+      this one in the solution or through other means. IDEs may be confused about the project dependency graph in this
+      case.
     -->
     <OpenApiBuildReferencedProjects
         Condition="'$(OpenApiBuildReferencedProjects)' == ''">true</OpenApiBuildReferencedProjects>

--- a/src/Mvc/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
@@ -14,6 +14,13 @@
     <IsShippingPackage>true</IsShippingPackage>
     <VersionPrefix>$(ExperimentalVersionPrefix)</VersionPrefix>
     <DevelopmentDependency>true</DevelopmentDependency>
+
+    <!--
+      Publish the referenced projects when building .NET Core bits. This is not needed for full framework builds
+      because publish output matches what was built.
+    -->
+    <ProjectReferenceBuildTargets
+        Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">Build;Publish</ProjectReferenceBuildTargets>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,13 +32,6 @@
     <NuspecProperty Include="artifactsBinDir=$(ArtifactsBinDir)" />
     <NuspecProperty Include="configuration=$(Configuration)" />
   </ItemGroup>
-
-  <Target Name="PublishGetDocument" BeforeTargets="GenerateNuspec">
-    <MSBuild Projects="../../dotnet-getdocument/src/dotnet-getdocument.csproj"
-        BuildInParallel="$(BuildInParallel)"
-        RemoveProperties="RuntimeIdentifier;TargetFrameworks;TargetFramework"
-        Targets="Publish" />
-  </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/Mvc/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
@@ -8,8 +8,8 @@
     <file src="build\*" target="build" />
     <file src="buildMultiTargeting\*" target="buildMultiTargeting" />
     <file src="$artifactsBinDir$\dotnet-getdocument\$configuration$\netcoreapp2.1\publish\*.*" target="tools" />
-    <file src="$artifactsBinDir$\GetDocumentInsider\$configuration$\net461\GetDocument.Insider.*" target="tools\net461" />
-    <file src="$artifactsBinDir$\GetDocumentInsider\x86\$configuration$\net461\GetDocument.Insider.*" target="tools\net461-x86" />
-    <file src="$artifactsBinDir$\GetDocumentInsider\$configuration$\netcoreapp2.1\GetDocument.Insider.*" target="tools\netcoreapp2.1" />
+    <file src="$artifactsBinDir$\GetDocumentInsider\$configuration$\net461\*.*" target="tools\net461" />
+    <file src="$artifactsBinDir$\GetDocumentInsider\x86\$configuration$\net461\*.*" target="tools\net461-x86" />
+    <file src="$artifactsBinDir$\GetDocumentInsider\$configuration$\netcoreapp2.1\publish\*.*" target="tools\netcoreapp2.1" />
   </files>
 </package>


### PR DESCRIPTION
- #10958
- publish _both_ `dotnet-getdocument` and `GetDocumentInsider` before packing
- simplify how Microsoft.Extensions.ApiDescription.Server gets published files for the tools

nit: correct information in a comment