### PR TITLE
Amortize HttpRequestStream & DuplexPipeStream ReadAsync calls

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -69,11 +69,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override bool TryRead(out ReadResult readResult)
         {
-            var result = _context.RequestBodyPipe.Reader.TryRead(out readResult);
-            _readResult = readResult;
-            CountBytesRead(readResult.Buffer.Length);
+            TryStart();
 
-            return result;
+            var hasResult = _context.RequestBodyPipe.Reader.TryRead(out readResult);
+
+            if (hasResult)
+            {
+                _readResult = readResult;
+
+                CountBytesRead(readResult.Buffer.Length);
+
+                if (readResult.IsCompleted)
+                {
+                    TryStop();
+                }
+            }
+
+            return hasResult;
         }
 
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/AsyncEnumerableReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/AsyncEnumerableReader.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    internal class AsyncEnumerableReader : IValueTaskSource<int>
+    {
+        private readonly Action _onCompletedAction;
+
+        private ManualResetValueTaskSourceCore<int> _valueTaskSource;
+        private IAsyncEnumerable<int> _readerSource;
+        private IAsyncEnumerator<int> _reader;
+
+        public Memory<byte> Buffer { get; private set; }
+        public CancellationToken CancellationToken { get; private set; }
+
+        private ValueTaskAwaiter<bool> _readAwaiter;
+
+        private volatile bool _inProgress;
+        public bool InProgress => _inProgress;
+
+        public AsyncEnumerableReader()
+        {
+            _onCompletedAction = OnCompleted;
+        }
+
+        internal void Initialize(IAsyncEnumerable<int> readerSource)
+        {
+            _readerSource = readerSource;
+            _reader = readerSource.GetAsyncEnumerator();
+        }
+
+        public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            if (_readerSource is null)
+            {
+                ThrowNotInitialized();
+            }
+
+            if (_inProgress)
+            {
+                ThrowConcurrentReadsNotSupported();
+            }
+            _inProgress = true;
+
+            Buffer = buffer;
+            CancellationToken = cancellationToken;
+
+            var task = _reader.MoveNextAsync();
+            _readAwaiter = task.GetAwaiter();
+
+            return new ValueTask<int>(this, _valueTaskSource.Version);
+        }
+
+        int IValueTaskSource<int>.GetResult(short token)
+        {
+            var isValid = token == _valueTaskSource.Version;
+            try
+            {
+                return _valueTaskSource.GetResult(token);
+            }
+            finally
+            {
+                if (isValid)
+                {
+                    Buffer = default;
+                    CancellationToken = default;
+                    _inProgress = false;
+                    _valueTaskSource.Reset();
+                }
+            }
+        }
+
+        ValueTaskSourceStatus IValueTaskSource<int>.GetStatus(short token)
+            => _valueTaskSource.GetStatus(token);
+
+        void IValueTaskSource<int>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            if (!InProgress)
+            {
+                ThrowNoReadInProgress();
+            }
+
+            _valueTaskSource.OnCompleted(continuation, state, token, flags);
+
+            _readAwaiter.UnsafeOnCompleted(_onCompletedAction);
+        }
+
+        private void OnCompleted()
+        {
+            try
+            {
+                if (_readAwaiter.GetResult())
+                {
+                    _valueTaskSource.SetResult(_reader.Current);
+                }
+                else
+                {
+                    _valueTaskSource.SetResult(-1);
+                }
+            }
+            catch (Exception ex)
+            {
+                // If the GetResult throws for this ReadAsync (e.g. cancellation),
+                // that will cause all next ReadAsyncs to also throw, so we create
+                // a fresh unerrored AsyncEnumerable to restore the next ReadAsyncs
+                // to the normal flow
+                _reader = _readerSource.GetAsyncEnumerator();
+                _valueTaskSource.SetException(ex);
+            }
+        }
+
+        static void ThrowConcurrentReadsNotSupported()
+        {
+            throw new InvalidOperationException("Concurrent reads are not supported");
+        }
+
+        static void ThrowNoReadInProgress()
+        {
+            throw new InvalidOperationException("No read in progress, await will not complete");
+        }
+
+        static void ThrowNotInitialized()
+        {
+            throw new InvalidOperationException(nameof(AsyncEnumerableReader) + " has not been initialized");
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStream.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStream.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Buffers;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -16,6 +18,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         private readonly PipeWriter _output;
         private readonly bool _throwOnCancelled;
         private volatile bool _cancelCalled;
+
+        private AsyncEnumerableReader _asyncReader;
 
         public DuplexPipeStream(PipeReader input, PipeWriter output, bool throwOnCancelled = false)
         {
@@ -114,12 +118,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             return WriteAsync(null, 0, 0, cancellationToken);
         }
 
-        private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
+        private ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
+        {
+            if (_asyncReader?.InProgress ?? false)
+            {
+                // Throw if there are overlapping reads; throwing unwrapped as it suggests last read was not awaited 
+                // so we surface it directly rather than wrapped in a Task (as this one will likely also not be awaited).
+                throw new InvalidOperationException("Concurrent reads are not supported; await the " + nameof(ValueTask<int>) + " before starting next read.");
+            }
+
+            try
+            {
+                while (true)
+                {
+                    if (!_input.TryRead(out var result))
+                    {
+                        break;
+                    }
+
+                    var readableBuffer = result.Buffer;
+                    try
+                    {
+                        if (_throwOnCancelled && result.IsCanceled && _cancelCalled)
+                        {
+                            // Reset the bool
+                            _cancelCalled = false;
+                            throw new OperationCanceledException();
+                        }
+
+                        if (!readableBuffer.IsEmpty)
+                        {
+                            // buffer.Count is int
+                            var count = (int)Math.Min(readableBuffer.Length, destination.Length);
+                            readableBuffer = readableBuffer.Slice(0, count);
+                            readableBuffer.CopyTo(destination.Span);
+                            return new ValueTask<int>(count);
+                        }
+
+                        if (result.IsCompleted)
+                        {
+                            return new ValueTask<int>(0);
+                        }
+                    }
+                    finally
+                    {
+                        _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+
+            var asyncReader = _asyncReader;
+            if (asyncReader is null)
+            {
+                _asyncReader = asyncReader = new AsyncEnumerableReader();
+                asyncReader.Initialize(ReadAsyncAwaited(asyncReader));
+            }
+
+            return asyncReader.ReadAsync(destination, cancellationToken);
+        }
+
+        private async IAsyncEnumerable<int> ReadAsyncAwaited(AsyncEnumerableReader reader)
         {
             while (true)
             {
-                var result = await _input.ReadAsync(cancellationToken);
+                var result = await _input.ReadAsync(reader.CancellationToken);
                 var readableBuffer = result.Buffer;
+
+                var advanced = false;
                 try
                 {
                     if (_throwOnCancelled && result.IsCanceled && _cancelCalled)
@@ -128,24 +197,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                         _cancelCalled = false;
                         throw new OperationCanceledException();
                     }
-
-                    if (!readableBuffer.IsEmpty)
+                    else if (!readableBuffer.IsEmpty)
                     {
                         // buffer.Count is int
-                        var count = (int)Math.Min(readableBuffer.Length, destination.Length);
+                        var count = (int)Math.Min(readableBuffer.Length, reader.Buffer.Length);
                         readableBuffer = readableBuffer.Slice(0, count);
-                        readableBuffer.CopyTo(destination.Span);
-                        return count;
-                    }
+                        readableBuffer.CopyTo(reader.Buffer.Span);
 
-                    if (result.IsCompleted)
+                        // Finally blocks in enumerators aren't excuted prior to the yield return,
+                        // so we advance here
+                        advanced = true;
+                        _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+                        yield return count;
+                    }
+                    else if (result.IsCompleted)
                     {
-                        return 0;
+                        // Finally blocks in enumerators aren't excuted prior to the yield return,
+                        // so we advance here
+                        advanced = true;
+                        _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+                        yield return 0;
                     }
                 }
                 finally
                 {
-                    _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+                    if (!advanced)
+                    {
+                        _input.AdvanceTo(readableBuffer.End, readableBuffer.End);
+                    }
                 }
             }
         }


### PR DESCRIPTION
if `_pipeReader.TryRead` fails to get the data synchronously defer to an `IAsyncEnumerable<int>` that is allocated once on the first failure. (Use case WebSockets/SignalR over TLS)

Before

![image](https://user-images.githubusercontent.com/1142958/60764465-56904980-a082-11e9-9be2-3f217b4a1cb2.png)

After

![image](https://user-images.githubusercontent.com/1142958/60770462-f70e5a00-a0d2-11e9-81b5-26d26289b478.png)

I used an IAsyncEnumerable as then the code very closely mimics the original read loop; other than adding `yield` before the `return`s and a slightly modified behaviour for the `finally` clause.

Resolves: https://github.com/aspnet/AspNetCore/issues/11940

/cc @stephentoub @davidfowl @halter73 