### PR TITLE
Make some MVC routing types public

### DIFF
--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -1270,13 +1270,13 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
         public bool Accept(Microsoft.AspNetCore.Mvc.ActionConstraints.ActionConstraintContext context) { throw null; }
         public abstract bool IsValidForRequest(Microsoft.AspNetCore.Routing.RouteContext routeContext, Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor action);
     }
-    public sealed partial class HttpMethodActionConstraint : Microsoft.AspNetCore.Mvc.ActionConstraints.IActionConstraint, Microsoft.AspNetCore.Mvc.ActionConstraints.IActionConstraintMetadata
+    public partial class HttpMethodActionConstraint : Microsoft.AspNetCore.Mvc.ActionConstraints.IActionConstraint, Microsoft.AspNetCore.Mvc.ActionConstraints.IActionConstraintMetadata
     {
         public static readonly int HttpMethodConstraintOrder;
         public HttpMethodActionConstraint(System.Collections.Generic.IEnumerable<string> httpMethods) { }
         public System.Collections.Generic.IEnumerable<string> HttpMethods { get { throw null; } }
         public int Order { get { throw null; } }
-        public bool Accept(Microsoft.AspNetCore.Mvc.ActionConstraints.ActionConstraintContext context) { throw null; }
+        public virtual bool Accept(Microsoft.AspNetCore.Mvc.ActionConstraints.ActionConstraintContext context) { throw null; }
     }
 }
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -1270,6 +1270,14 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
         public bool Accept(Microsoft.AspNetCore.Mvc.ActionConstraints.ActionConstraintContext context) { throw null; }
         public abstract bool IsValidForRequest(Microsoft.AspNetCore.Routing.RouteContext routeContext, Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor action);
     }
+    public sealed partial class HttpMethodActionConstraint : Microsoft.AspNetCore.Mvc.ActionConstraints.IActionConstraint, Microsoft.AspNetCore.Mvc.ActionConstraints.IActionConstraintMetadata
+    {
+        public static readonly int HttpMethodConstraintOrder;
+        public HttpMethodActionConstraint(System.Collections.Generic.IEnumerable<string> httpMethods) { }
+        public System.Collections.Generic.IEnumerable<string> HttpMethods { get { throw null; } }
+        public int Order { get { throw null; } }
+        public bool Accept(Microsoft.AspNetCore.Mvc.ActionConstraints.ActionConstraintContext context) { throw null; }
+    }
 }
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
@@ -1940,6 +1948,11 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
     public sealed partial class ActionResultStatusCodeAttribute : System.Attribute
     {
         public ActionResultStatusCodeAttribute() { }
+    }
+    public partial class AmbiguousActionException : System.InvalidOperationException
+    {
+        protected AmbiguousActionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public AmbiguousActionException(string message) { }
     }
     public partial class CompatibilitySwitch<TValue> : Microsoft.AspNetCore.Mvc.Infrastructure.ICompatibilitySwitch where TValue : struct
     {

--- a/src/Mvc/Mvc.Core/src/ActionConstraints/HttpMethodActionConstraint.cs
+++ b/src/Mvc/Mvc.Core/src/ActionConstraints/HttpMethodActionConstraint.cs
@@ -4,16 +4,32 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.ActionConstraints
 {
-    internal class HttpMethodActionConstraint : IActionConstraint
+    /// <summary>
+    /// The implementation of <see cref="IActionResult" /> used to enforce
+    /// HTTP method filtering when MVC is used with legacy <see cref="IRouter" />
+    /// support. The <see cref="HttpMethodActionConstraint" /> can be used to determine
+    /// the set of HTTP methods supported by an action.
+    /// </summary>
+    public sealed class HttpMethodActionConstraint : IActionConstraint
     {
+        /// <summary>
+        /// The <see cref="IActionConstraint.Order" /> value used by <see cref="HttpMethodActionConstraint" />.
+        /// </summary>
         public static readonly int HttpMethodConstraintOrder = 100;
 
         private readonly IReadOnlyList<string> _httpMethods;
 
-        // Empty collection means any method will be accepted.
+        /// <summary>
+        /// Creates a new instance of <see cref="HttpMethodActionConstraint" />.
+        /// </summary>
+        /// <param name="httpMethods">
+        /// The list of HTTP methods to allow. Providing an empty list will allow
+        /// any HTTP method.
+        /// </param>
         public HttpMethodActionConstraint(IEnumerable<string> httpMethods)
         {
             if (httpMethods == null)
@@ -36,11 +52,14 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
             _httpMethods = new ReadOnlyCollection<string>(methods);
         }
 
+        /// <summary>
+        /// Gets the list of allowed HTTP methods. Will return an empty list if all HTTP methods are allowed.
+        /// </summary>
         public IEnumerable<string> HttpMethods => _httpMethods;
 
-        public int Order => HttpMethodConstraintOrder;
+        int IActionConstraint.Order => HttpMethodConstraintOrder;
 
-        public virtual bool Accept(ActionConstraintContext context)
+        bool IActionConstraint.Accept(ActionConstraintContext context)
         {
             if (context == null)
             {

--- a/src/Mvc/Mvc.Core/src/ActionConstraints/HttpMethodActionConstraint.cs
+++ b/src/Mvc/Mvc.Core/src/ActionConstraints/HttpMethodActionConstraint.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
     /// support. The <see cref="HttpMethodActionConstraint" /> can be used to determine
     /// the set of HTTP methods supported by an action.
     /// </summary>
-    public sealed class HttpMethodActionConstraint : IActionConstraint
+    public class HttpMethodActionConstraint : IActionConstraint
     {
         /// <summary>
         /// The <see cref="IActionConstraint.Order" /> value used by <see cref="HttpMethodActionConstraint" />.
@@ -57,9 +57,11 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
         /// </summary>
         public IEnumerable<string> HttpMethods => _httpMethods;
 
-        int IActionConstraint.Order => HttpMethodConstraintOrder;
+        /// <inheritdoc />
+        public int Order => HttpMethodConstraintOrder;
 
-        bool IActionConstraint.Accept(ActionConstraintContext context)
+        /// <inheritdoc />
+        public virtual bool Accept(ActionConstraintContext context)
         {
             if (context == null)
             {

--- a/src/Mvc/Mvc.Core/src/Infrastructure/AmbiguousActionException.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/AmbiguousActionException.cs
@@ -10,13 +10,22 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
     /// An exception which indicates multiple matches in action selection.
     /// </summary>
     [Serializable]
-    internal class AmbiguousActionException : InvalidOperationException
+    public class AmbiguousActionException : InvalidOperationException
     {
+        /// <summary>
+        /// Creates a new instance of <see cref="AmbiguousActionException" />.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
         public AmbiguousActionException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Framework infrastructure. Do not call directly.
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="context"></param>
         protected AmbiguousActionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {


### PR DESCRIPTION
We've heard some demand to make these types public again after trying
them as internal.

API Versioning calls the action selector and handles
AmbiguousActionException to give more specific responses.

API Versioning (and others) look for HttpMethodActionConstraint to
determine the supported HTTP methods of an IRouter-based action method.

@commonsensesoftware