### PR TITLE
Correct the comment example for AuthenticationSchemeOptions.ForwardSignOut.

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationSchemeOptions.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationSchemeOptions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Authentication
 
         /// <summary>
         /// If set, this specifies a default scheme that authentication handlers should forward all authentication operations to
-        /// by default. The default forwarding logic will check the most specific ForwardAuthenticate/Challenge/Forbid/SignIn/SignOut 
+        /// by default. The default forwarding logic will check the most specific ForwardAuthenticate/Challenge/Forbid/SignIn/SignOut
         /// setting first, followed by checking the ForwardDefaultSelector, followed by ForwardDefault. The first non null result
         /// will be used as the target scheme to forward to.
         /// </summary>
@@ -76,14 +76,14 @@ namespace Microsoft.AspNetCore.Authentication
 
         /// <summary>
         /// If set, this specifies the target scheme that this scheme should forward SignOutAsync calls to.
-        /// For example Context.SignOutAsync("ThisScheme") => Context.SignInAsync("ForwardSignOutValue");
+        /// For example Context.SignOutAsync("ThisScheme") => Context.SignOutAsync("ForwardSignOutValue");
         /// Set the target to the current scheme to disable forwarding and allow normal processing.
         /// </summary>
         public string ForwardSignOut { get; set; }
 
         /// <summary>
         /// Used to select a default scheme for the current request that authentication handlers should forward all authentication operations to
-        /// by default. The default forwarding logic will check the most specific ForwardAuthenticate/Challenge/Forbid/SignIn/SignOut 
+        /// by default. The default forwarding logic will check the most specific ForwardAuthenticate/Challenge/Forbid/SignIn/SignOut
         /// setting first, followed by checking the ForwardDefaultSelector, followed by ForwardDefault. The first non null result
         /// will be used as the target scheme to forward to.
         /// </summary>


### PR DESCRIPTION
Addresses #11978.

My VS Code auto-format also killed a couple of eol whitespaces. If that's not cool, I can put them back.
