### PR TITLE
Add reference to Microsoft.AspNetCore.Components.Analyzers.

### DIFF
--- a/src/Components/Analyzers/src/Microsoft.AspNetCore.Components.Analyzers.csproj
+++ b/src/Components/Analyzers/src/Microsoft.AspNetCore.Components.Analyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -19,13 +19,25 @@
     <Reference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 
+  <Target Name="_GetNuspecDependencyPackageVersions">
+    <MSBuild Targets="_GetPackageVersionInfo"
+        BuildInParallel="$(BuildInParallel)"
+        Projects="../../Analyzers/src/Microsoft.AspNetCore.Components.Analyzers.csproj;../../../Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectPathWithVersion" />
+    </MSBuild>
+    <ItemGroup>
+      <NuspecProperty Include="@(_ProjectPathWithVersion->WithMetadataValue('PackageId', 'Microsoft.AspnetCore.Components.Analyzers')->'componentAnalyzerPackageVersion=%(PackageVersion)')" />
+      <NuspecProperty Include="@(_ProjectPathWithVersion->WithMetadataValue('PackageId', 'Microsoft.AspnetCore.Authorization')->'authorizationPackageVersion=%(PackageVersion)')" />
+    </ItemGroup>
+  </Target>
+
   <!-- Pack settings -->
   <PropertyGroup>
     <NuspecFile>Microsoft.AspNetCore.Components.nuspec</NuspecFile>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_GetNuspecDependencyPackageVersions</GenerateNuspecDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
-    <NuspecProperty Include="coherentPackageVersion=$(PackageVersion)" />
     <NuspecProperty Include="jsInteropPackageVersion=$(MicrosoftJSInteropPackageVersion)" />
     <NuspecProperty Include="systemComponentModelAnnotationsPackageVersion=$(SystemComponentModelAnnotationsPackageVersion)" />
     <NuspecProperty Include="outputPath=$(OutputPath)" />

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,7 +9,7 @@
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
     <Compile Include="..\..\Shared\src\JsonSerializerOptionsProvider.cs" />
   </ItemGroup>
 
@@ -17,6 +17,19 @@
     <Reference Include="Microsoft.AspNetCore.Authorization" />
     <Reference Include="Microsoft.JSInterop" />
     <Reference Include="System.ComponentModel.Annotations" />
+  </ItemGroup>
+
+  <!-- Pack settings -->
+  <PropertyGroup>
+    <NuspecFile>Microsoft.AspNetCore.Components.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <NuspecProperty Include="coherentPackageVersion=$(PackageVersion)" />
+    <NuspecProperty Include="jsInteropPackageVersion=$(MicrosoftJSInteropPackageVersion)" />
+    <NuspecProperty Include="systemComponentModelAnnotationsPackageVersion=$(SystemComponentModelAnnotationsPackageVersion)" />
+    <NuspecProperty Include="outputPath=$(OutputPath)" />
+    <NuspecProperty Include="assemblyName=$(AssemblyName)" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.nuspec
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.nuspec
@@ -4,8 +4,8 @@
     $CommonMetadataElements$
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Microsoft.AspNetCore.Components.Analyzers" version="$coherentPackageVersion$" />
-        <dependency id="Microsoft.AspNetCore.Authorization" version="$coherentPackageVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Components.Analyzers" version="$componentAnalyzerPackageVersion$" />
+        <dependency id="Microsoft.AspNetCore.Authorization" version="$authorizationPackageVersion$" exclude="Build,Analyzers" />
         <dependency id="Microsoft.JSInterop" version="$jsInteropPackageVersion$" exclude="Build,Analyzers" />
         <dependency id="System.ComponentModel.Annotations" version="$systemComponentModelAnnotationsPackageVersion$" exclude="Build,Analyzers" />
       </group>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.nuspec
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.AspNetCore.Components.Analyzers" version="$coherentPackageVersion$" />
+        <dependency id="Microsoft.AspNetCore.Authorization" version="$coherentPackageVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.JSInterop" version="$jsInteropPackageVersion$" exclude="Build,Analyzers" />
+        <dependency id="System.ComponentModel.Annotations" version="$systemComponentModelAnnotationsPackageVersion$" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$outputPath$$assemblyName$.dll" target="lib\netstandard2.0\$assemblyname$.dll" />
+    <file src="$outputPath$$assemblyName$.xml" target="lib\netstandard2.0\$assemblyname$.xml" />
+    <file src="$outputPath$$assemblyName$.pdb" target="lib\netstandard2.0\$assemblyname$.pdb" />
+    <file src="..\..\THIRD-PARTY-NOTICES.txt" target=".\THIRD-PARTY-NOTICES.txt" />
+  </files>
+</package>


### PR DESCRIPTION
- At first I thought this wouldn't result in a package that allowed transitive component analyzers without also including them at publish time. Turns out I was wrong, tried out all of those scenarios and the simplicity of this change accounts for it all.

#8825