### PR TITLE
Don't apply analyzer restrictions to cascading parameters.

### DIFF
--- a/src/Components/Analyzers/src/ComponentParameterAnalyzer.cs
+++ b/src/Components/Analyzers/src/ComponentParameterAnalyzer.cs
@@ -46,9 +46,9 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                     var type = (INamedTypeSymbol)context.Symbol;
                     foreach (var member in type.GetMembers())
                     {
-                        if (member is IPropertySymbol property && ComponentFacts.IsAnyParameter(symbols, property))
+                        if (member is IPropertySymbol property && ComponentFacts.IsParameter(symbols, property))
                         {
-                            // Annotated with [Parameter] or [CascadingParameter]
+                            // Annotated with [Parameter]. We ignore [CascadingParameter]'s because they don't interact with tooling and don't currently have any analyzer restrictions.
                             properties.Add(property);
                         }
                     }

--- a/src/Components/Analyzers/test/ComponentParameterSettersShouldBePublicTest.cs
+++ b/src/Components/Analyzers/test/ComponentParameterSettersShouldBePublicTest.cs
@@ -11,6 +11,22 @@ namespace Microsoft.AspNetCore.Components.Analyzers
     public class ComponentParameterSettersShouldBePublicTest : DiagnosticVerifier
     {
         [Fact]
+        public void IgnoresCascadingParameterProperties()
+        {
+            var test = $@"
+    namespace ConsoleApplication1
+    {{
+        using {typeof(CascadingParameterAttribute).Namespace};
+        class TypeName
+        {{
+            [CascadingParameter] string MyProperty {{ get; set; }}
+        }}
+    }}" + ComponentsTestDeclarations.Source;
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
         public void IgnoresPublicSettersProperties()
         {
             var test = $@"

--- a/src/Components/Analyzers/test/ComponentParametersShouldBePublicCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/ComponentParametersShouldBePublicCodeFixProviderTest.cs
@@ -37,7 +37,6 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
         class TypeName
         {
             [Parameter] private string BadProperty1 { get; set; }
-            [CascadingParameter] private object BadProperty2 { get; set; }
         }
     }" + ComponentsTestDeclarations.Source;
 
@@ -51,16 +50,6 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                     {
                         new DiagnosticResultLocation("Test0.cs", 8, 40)
                     }
-                },
-                new DiagnosticResult
-                {
-                    Id = DiagnosticDescriptors.ComponentParametersShouldBePublic.Id,
-                    Message = "Component parameter 'ConsoleApplication1.TypeName.BadProperty2' should be public.",
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations = new[]
-                    {
-                        new DiagnosticResultLocation("Test0.cs", 9, 49)
-                    }
                 });
 
             VerifyCSharpFix(test, @"
@@ -71,7 +60,6 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
         class TypeName
         {
             [Parameter] public string BadProperty1 { get; set; }
-            [CascadingParameter] public object BadProperty2 { get; set; }
         }
     }" + ComponentsTestDeclarations.Source);
         }


### PR DESCRIPTION
- Today all of our analyzer warnings only operate on `[Parameter]` properties.
- Updated existing test to not expect `CascadingParameter` as a possible error case.
- Added a new test to ensure we skip `CascadingParameter`s.

#8825
