### PR TITLE
Make the IHubActivator a singleton

### DIFF
--- a/src/SignalR/perf/Microbenchmarks/DefaultHubActivatorBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubActivatorBenchmark.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             var services = new ServiceCollection();
 
             _activator = new DefaultHubActivator<MyHub>();
-            services.BuildServiceProvider();
+            _serviceProvider = services.BuildServiceProvider();
         }
 
         [Benchmark]

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubActivatorBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubActivatorBenchmark.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,19 +11,22 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
     public class DefaultHubActivatorBenchmark
     {
         private DefaultHubActivator<MyHub> _activator;
+        private IServiceProvider _serviceProvider;
 
         [GlobalSetup]
         public void GlobalSetup()
         {
             var services = new ServiceCollection();
 
-            _activator = new DefaultHubActivator<MyHub>(services.BuildServiceProvider());
+            _activator = new DefaultHubActivator<MyHub>();
+            services.BuildServiceProvider();
         }
 
         [Benchmark]
         public int Create()
         {
-            var hub = _activator.Create();
+            var handle = _activator.Create(_serviceProvider);
+            var hub = handle.Hub;
             var result = hub.Addition();
             return result;
         }

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             var serviceScopeFactory = provider.GetService<IServiceScopeFactory>();
 
             _dispatcher = new DefaultHubDispatcher<TestHub>(
+                new DefaultHubActivator<TestHub>(),
                 serviceScopeFactory,
                 new HubContext<TestHub>(new DefaultHubLifetimeManager<TestHub>(NullLogger<DefaultHubLifetimeManager<TestHub>>.Instance)),
                 Options.Create(new HubOptions<TestHub>()),

--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
@@ -172,6 +172,18 @@ namespace Microsoft.AspNetCore.SignalR
             public void Reset() { }
         }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct HubHandle<THub> where THub : Microsoft.AspNetCore.SignalR.Hub
+    {
+        [System.Diagnostics.DebuggerBrowsableAttribute(System.Diagnostics.DebuggerBrowsableState.Never)]
+        [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+        private readonly THub _Hub_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public HubHandle(THub hub, bool created) { throw null; }
+        public bool Created { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public THub Hub { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
     public partial class HubInvocationContext
     {
         public HubInvocationContext(Microsoft.AspNetCore.SignalR.HubCallerContext context, string hubMethodName, object[] hubMethodArguments) { }
@@ -248,8 +260,8 @@ namespace Microsoft.AspNetCore.SignalR
     }
     public partial interface IHubActivator<THub> where THub : Microsoft.AspNetCore.SignalR.Hub
     {
-        THub Create();
-        void Release(THub hub);
+        Microsoft.AspNetCore.SignalR.HubHandle<THub> Create();
+        void Release(Microsoft.AspNetCore.SignalR.HubHandle<THub> hub);
     }
     public partial interface IHubCallerClients : Microsoft.AspNetCore.SignalR.IHubCallerClients<Microsoft.AspNetCore.SignalR.IClientProxy>, Microsoft.AspNetCore.SignalR.IHubClients<Microsoft.AspNetCore.SignalR.IClientProxy>
     {

--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
@@ -180,9 +180,10 @@ namespace Microsoft.AspNetCore.SignalR
         private readonly THub _Hub_k__BackingField;
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public HubHandle(THub hub, bool created) { throw null; }
+        public HubHandle(THub hub, bool created, object state) { throw null; }
         public bool Created { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public THub Hub { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public object State { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public partial class HubInvocationContext
     {
@@ -260,8 +261,8 @@ namespace Microsoft.AspNetCore.SignalR
     }
     public partial interface IHubActivator<THub> where THub : Microsoft.AspNetCore.SignalR.Hub
     {
-        Microsoft.AspNetCore.SignalR.HubHandle<THub> Create();
-        void Release(Microsoft.AspNetCore.SignalR.HubHandle<THub> hub);
+        Microsoft.AspNetCore.SignalR.HubHandle<THub> Create(System.IServiceProvider serviceProvider);
+        void Release(in Microsoft.AspNetCore.SignalR.HubHandle<THub> hub);
     }
     public partial interface IHubCallerClients : Microsoft.AspNetCore.SignalR.IHubCallerClients<Microsoft.AspNetCore.SignalR.IClientProxy>, Microsoft.AspNetCore.SignalR.IHubClients<Microsoft.AspNetCore.SignalR.IClientProxy>
     {

--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.SignalR
     }
     public partial class HubConnectionHandler<THub> : Microsoft.AspNetCore.Connections.ConnectionHandler where THub : Microsoft.AspNetCore.SignalR.Hub
     {
-        public HubConnectionHandler(Microsoft.AspNetCore.SignalR.HubLifetimeManager<THub> lifetimeManager, Microsoft.AspNetCore.SignalR.IHubProtocolResolver protocolResolver, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.HubOptions> globalHubOptions, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.HubOptions<THub>> hubOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.SignalR.IUserIdProvider userIdProvider, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
+        public HubConnectionHandler(Microsoft.AspNetCore.SignalR.HubLifetimeManager<THub> lifetimeManager, Microsoft.AspNetCore.SignalR.IHubProtocolResolver protocolResolver, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.HubOptions> globalHubOptions, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.HubOptions<THub>> hubOptions, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.SignalR.IUserIdProvider userIdProvider, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, Microsoft.AspNetCore.SignalR.IHubActivator<THub> hubActivator) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.Task OnConnectedAsync(Microsoft.AspNetCore.Connections.ConnectionContext connection) { throw null; }
     }

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="userIdProvider">The user ID provider used to get the user ID from a hub connection.</param>
         /// <param name="serviceScopeFactory">The service scope factory.</param>
+        /// <param name="hubActivator">The hub activator.</param>
         /// <remarks>This class is typically created via dependency injection.</remarks>
         public HubConnectionHandler(HubLifetimeManager<THub> lifetimeManager,
                                     IHubProtocolResolver protocolResolver,
@@ -48,7 +49,8 @@ namespace Microsoft.AspNetCore.SignalR
                                     IOptions<HubOptions<THub>> hubOptions,
                                     ILoggerFactory loggerFactory,
                                     IUserIdProvider userIdProvider,
-                                    IServiceScopeFactory serviceScopeFactory
+                                    IServiceScopeFactory serviceScopeFactory,
+                                    IHubActivator<THub> hubActivator
         )
         {
             _protocolResolver = protocolResolver;
@@ -63,6 +65,7 @@ namespace Microsoft.AspNetCore.SignalR
             _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize ?? _globalHubOptions.MaximumReceiveMessageSize;
 
             _dispatcher = new DefaultHubDispatcher<THub>(
+                hubActivator,
                 serviceScopeFactory,
                 new HubContext<THub>(lifetimeManager),
                 hubOptions,

--- a/src/SignalR/server/Core/src/HubHandle.cs
+++ b/src/SignalR/server/Core/src/HubHandle.cs
@@ -9,10 +9,11 @@ namespace Microsoft.AspNetCore.SignalR
     /// <typeparam name="THub"></typeparam>
     public readonly struct HubHandle<THub> where THub : Hub
     {
-        public HubHandle(THub hub, bool created)
+        public HubHandle(THub hub, bool created, object state)
         {
             Hub = hub;
             Created = created;
+            State = state;
         }
 
         /// <summary>
@@ -24,5 +25,10 @@ namespace Microsoft.AspNetCore.SignalR
         /// Determines if the hub was created by this the activator
         /// </summary>
         public bool Created { get; }
+
+        /// <summary>
+        /// State
+        /// </summary>
+        public object State { get; }
     }
 }

--- a/src/SignalR/server/Core/src/HubHandle.cs
+++ b/src/SignalR/server/Core/src/HubHandle.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    /// <summary>
+    /// A handle to the hub instance.
+    /// </summary>
+    /// <typeparam name="THub"></typeparam>
+    public readonly struct HubHandle<THub> where THub : Hub
+    {
+        public HubHandle(THub hub, bool created)
+        {
+            Hub = hub;
+            Created = created;
+        }
+
+        /// <summary>
+        /// The <typeparamref name="THub"/> that was created
+        /// </summary>
+        public THub Hub { get; }
+
+        /// <summary>
+        /// Determines if the hub was created by this the activator
+        /// </summary>
+        public bool Created { get; }
+    }
+}

--- a/src/SignalR/server/Core/src/IHubActivator.cs
+++ b/src/SignalR/server/Core/src/IHubActivator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,12 +15,12 @@ namespace Microsoft.AspNetCore.SignalR
         /// Creates a hub.
         /// </summary>
         /// <returns>The created hub.</returns>
-        THub Create();
+        HubHandle<THub> Create();
 
         /// <summary>
         /// Releases the specified hub.
         /// </summary>
         /// <param name="hub">The hub to release.</param>
-        void Release(THub hub);
+        void Release(HubHandle<THub> hub);
     }
 }

--- a/src/SignalR/server/Core/src/IHubActivator.cs
+++ b/src/SignalR/server/Core/src/IHubActivator.cs
@@ -14,13 +14,14 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Creates a hub.
         /// </summary>
+        /// <param name="serviceProvider">A <see cref="IServiceProvider"/> that can be used to resolve dependencies.</param>
         /// <returns>The created hub.</returns>
-        HubHandle<THub> Create();
+        HubHandle<THub> Create(IServiceProvider serviceProvider);
 
         /// <summary>
         /// Releases the specified hub.
         /// </summary>
         /// <param name="hub">The hub to release.</param>
-        void Release(HubHandle<THub> hub);
+        void Release(in HubHandle<THub> hub);
     }
 }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubActivator.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubActivator.cs
@@ -2,40 +2,33 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    internal class DefaultHubActivator<THub> : IHubActivator<THub> where THub: Hub
+    internal class DefaultHubActivator<THub> : IHubActivator<THub> where THub : Hub
     {
         // Object factory for THub instances
         private readonly ObjectFactory _objectFactory = ActivatorUtilities.CreateFactory(typeof(THub), Type.EmptyTypes);
-        private readonly IServiceProvider _serviceProvider;
 
-        public DefaultHubActivator(IServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-
-        public virtual HubHandle<THub> Create()
+        public virtual HubHandle<THub> Create(IServiceProvider serviceProvider)
         {
             var created = false;
-            var hub = _serviceProvider.GetService<THub>();
+            var hub = serviceProvider.GetService<THub>();
             if (hub == null)
             {
-                hub = (THub)_objectFactory(_serviceProvider, Array.Empty<object>());
+                hub = (THub)_objectFactory(serviceProvider, Array.Empty<object>());
                 created = true;
             }
 
-            return new HubHandle<THub>(hub, created);
+            return new HubHandle<THub>(hub, created, state: null);
         }
 
-        public virtual void Release(HubHandle<THub> hub)
+        public virtual void Release(in HubHandle<THub> handle)
         {
-            if (hub.Created)
+            if (handle.Created)
             {
-                hub.Hub.Dispose();
+                handle.Hub.Dispose();
             }
         }
     }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 scope = _serviceScopeFactory.CreateScope();
 
                 var hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
-                var handle = hubActivator.Create();
+                var handle = hubActivator.Create(scope.ServiceProvider);
                 var hub = handle.Hub;
                 try
                 {
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 scope = _serviceScopeFactory.CreateScope();
 
                 var hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
-                var handle = hubActivator.Create();
+                var handle = hubActivator.Create(scope.ServiceProvider);
                 var hub = handle.Hub;
                 try
                 {
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 }
 
                 hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
-                handle = hubActivator.Create();
+                handle = hubActivator.Create(scope.ServiceProvider);
                 hub = handle.Hub;
 
                 try
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         }
 
         private ValueTask CleanupInvocation(HubConnectionContext connection, HubMethodInvocationMessage hubMessage, IHubActivator<THub> hubActivator,
-            HubHandle<THub> handle, IServiceScope scope)
+            in HubHandle<THub> handle, IServiceScope scope)
         {
             if (hubMessage.StreamIds != null)
             {

--- a/src/SignalR/server/Core/src/SignalRDependencyInjectionExtensions.cs
+++ b/src/SignalR/server/Core/src/SignalRDependencyInjectionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton(typeof(HubConnectionHandler<>), typeof(HubConnectionHandler<>));
             services.TryAddSingleton(typeof(IUserIdProvider), typeof(DefaultUserIdProvider));
             services.TryAddSingleton(typeof(HubDispatcher<>), typeof(DefaultHubDispatcher<>));
-            services.TryAddScoped(typeof(IHubActivator<>), typeof(DefaultHubActivator<>));
+            services.TryAddSingleton(typeof(IHubActivator<>), typeof(DefaultHubActivator<>));
             services.AddAuthorization();
 
             var builder = new SignalRServerBuilder(services);

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -1,6 +1,7 @@
 // Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             serviceCollection.AddSingleton<IUserIdProvider, CustomIdProvider>();
             serviceCollection.AddSingleton(typeof(HubLifetimeManager<>), typeof(CustomHubLifetimeManager<>));
             serviceCollection.AddSingleton<IHubProtocolResolver, CustomHubProtocolResolver>();
-            serviceCollection.AddScoped(typeof(IHubActivator<>), typeof(CustomHubActivator<>));
+            serviceCollection.AddSingleton(typeof(IHubActivator<>), typeof(CustomHubActivator<>));
             serviceCollection.AddSingleton(typeof(IHubContext<>), typeof(CustomHubContext<>));
             serviceCollection.AddSingleton(typeof(IHubContext<,>), typeof(CustomHubContext<,>));
             var hubOptions = new HubOptionsSetup(new List<IHubProtocol>());
@@ -52,7 +53,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             serviceCollection.AddSingleton<IUserIdProvider, CustomIdProvider>();
             serviceCollection.AddSingleton(typeof(HubLifetimeManager<>), typeof(CustomHubLifetimeManager<>));
             serviceCollection.AddSingleton<IHubProtocolResolver, CustomHubProtocolResolver>();
-            serviceCollection.AddScoped(typeof(IHubActivator<>), typeof(CustomHubActivator<>));
+            serviceCollection.AddSingleton(typeof(IHubActivator<>), typeof(CustomHubActivator<>));
             serviceCollection.AddSingleton(typeof(IHubContext<>), typeof(CustomHubContext<>));
             serviceCollection.AddSingleton(typeof(IHubContext<,>), typeof(CustomHubContext<,>));
 
@@ -128,12 +129,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
     public class CustomHubActivator<THub> : IHubActivator<THub> where THub : Hub
     {
-        public THub Create()
+        public HubHandle<THub> Create(IServiceProvider serviceProvider)
         {
             throw new System.NotImplementedException();
         }
 
-        public void Release(THub hub)
+        public void Release(in HubHandle<THub> hub)
         {
             throw new System.NotImplementedException();
         }

--- a/src/SignalR/server/SignalR/test/DefaultHubActivatorTests.cs
+++ b/src/SignalR/server/SignalR/test/DefaultHubActivatorTests.cs
@@ -26,12 +26,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Fact]
         public void HubCanBeResolvedFromServiceProvider()
         {
-            var hub = Mock.Of<Hub>();
+            var hub = Mock.Of<CreatableHub>();
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider
-                .Setup(sp => sp.GetService(typeof(Hub)))
+                .Setup(sp => sp.GetService(typeof(CreatableHub)))
                 .Returns(hub);
-            var handle = new DefaultHubActivator<Hub>().Create(mockServiceProvider.Object);
+            var handle = new DefaultHubActivator<CreatableHub>().Create(mockServiceProvider.Object);
 
             Assert.Same(hub, handle.Hub);
             Assert.False(handle.Created);
@@ -44,15 +44,15 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider
-                .Setup(sp => sp.GetService(typeof(Hub)))
+                .Setup(sp => sp.GetService(typeof(CreatableHub)))
                 .Returns(() =>
                 {
-                    var m = new Mock<Hub>();
+                    var m = new Mock<CreatableHub>();
                     m.Protected().Setup("Dispose", ItExpr.IsAny<bool>());
                     return m.Object;
                 });
 
-            var hubActivator = new DefaultHubActivator<Hub>();
+            var hubActivator = new DefaultHubActivator<CreatableHub>();
             var handle = hubActivator.Create(mockServiceProvider.Object);
             hubActivator.Release(handle);
             Mock.Get(handle.Hub).Protected().Verify("Dispose", Times.Never(), ItExpr.IsAny<bool>());


### PR DESCRIPTION
- Make the `IHubActivator<T>` a singleton. Introduce `HubHandle<T>` to store creation information instead of storing that state in the IHubActivator

@anurse Tell me how you feel about this change.