### PR TITLE
Fixes #11405 - Adds AuthenticationProperties to ExternalLoginInfo

### DIFF
--- a/src/Identity/Core/ref/Microsoft.AspNetCore.Identity.netcoreapp3.0.cs
+++ b/src/Identity/Core/ref/Microsoft.AspNetCore.Identity.netcoreapp3.0.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Identity
     public partial class ExternalLoginInfo : Microsoft.AspNetCore.Identity.UserLoginInfo
     {
         public ExternalLoginInfo(System.Security.Claims.ClaimsPrincipal principal, string loginProvider, string providerKey, string displayName) : base (default(string), default(string), default(string)) { }
+        public Microsoft.AspNetCore.Authentication.AuthenticationProperties AuthenticationProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authentication.AuthenticationToken> AuthenticationTokens { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Security.Claims.ClaimsPrincipal Principal { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/Identity/Core/src/ExternalLoginInfo.cs
+++ b/src/Identity/Core/src/ExternalLoginInfo.cs
@@ -35,5 +35,10 @@ namespace Microsoft.AspNetCore.Identity
         /// The <see cref="AuthenticationToken"/>s associated with this login.
         /// </summary>
         public IEnumerable<AuthenticationToken> AuthenticationTokens { get; set; }
+
+        /// <summary>
+        /// The <see cref="Authentication.AuthenticationProperties"/> associated with this login.
+        /// </summary>
+        public AuthenticationProperties AuthenticationProperties { get; set; }
     }
 }

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -668,7 +668,8 @@ namespace Microsoft.AspNetCore.Identity
                                       ?? provider;
             return new ExternalLoginInfo(auth.Principal, provider, providerKey, providerDisplayName)
             {
-                AuthenticationTokens = auth.Properties.GetTokens()
+                AuthenticationTokens = auth.Properties.GetTokens(),
+                AuthenticationProperties = auth.Properties
             };
         }
 


### PR DESCRIPTION
Hola Microsoft,

Fixes #11405 - Adds `AuthenticationProperties` to `ExternalLoginInfo` in `SignInManager.GetExternalLoginInfoAsync()`.

Summary of the changes
 - Adds new `AuthenticationProperties` property to `ExternalLoginInfo`.
 - Saves reference to `auth.Properties` in `SignInManager.GetExternalLoginInfoAsync()` before returning `ExternalLoginInfo`.
 - `ref` source updated.
 - Added `ExternalLoginInfoAsyncReturnsAuthenticationPropertiesWithCustomValue` unit test.

Addresses #11405

//cc @HaoK 

Thanks,
Brian Chavez

:walking_man: :walking_woman: **[Missing Persons - Walking in L.A.](https://www.youtube.com/watch?v=R_UpLtGEWoY)**
