### PR TITLE
Acquire HubConnectionStateLock before Send/Invoke/Stream

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -643,7 +643,6 @@ public class HubConnection {
      */
     @SuppressWarnings("unchecked")
     public <T> Single<T> invoke(Class<T> returnType, String method, Object... args) {
-        ConnectionState localConnectionState;
         InvocationRequest irq;
         String id;
         hubConnectionStateLock.lock();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -651,8 +651,7 @@ public class HubConnection {
         } finally {
             hubConnectionStateLock.unlock();
         }
-
-
+        
         String id = connectionState.getNextInvocationId();
 
         SingleSubject<T> subject = SingleSubject.create();

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1609,6 +1609,15 @@ class HubConnectionTest {
     }
 
     @Test
+    public void cannotStreamBeforeStart()  {
+        HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+        Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.stream(String.class, "inc", "arg1"));
+        assertEquals("The 'stream' method cannot be called if the connection is not active.", exception.getMessage());
+    }
+
+    @Test
     public void doesNotErrorWhenReceivingInvokeWithIncorrectArgumentLength()  {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
@@ -2036,7 +2045,7 @@ class HubConnectionTest {
 
         TestHttpClient client = new TestHttpClient()
                 .on("POST", "http://example.com/negotiate", (req) -> {
-                    if(redirectCount.get() == 0){
+                    if (redirectCount.get() == 0) {
                         redirectCount.incrementAndGet();
                         redirectToken.set(req.getHeaders().get("Authorization"));
                         return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"firstRedirectToken\"}"));

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
-import io.reactivex.Single;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 
 class WebSocketTransportUrlFormatTest {
     private static Stream<Arguments> protocols() {

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportUrlFormatTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-
 class WebSocketTransportUrlFormatTest {
     private static Stream<Arguments> protocols() {
         return Stream.of(

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
@@ -37,6 +37,6 @@ public class Chat {
             hubConnection.send("Send", message);
         }
 
-        hubConnection.stop();
+        hubConnection.stop().blockingAwait();
     }
 }


### PR DESCRIPTION
Issue: https://github.com/aspnet/AspNetCore/issues/11995 , https://github.com/aspnet/AspNetCore/issues/12076

We need to acquire the hubConnectionStateLock before running the hubConnectionState checks in send/invoke/stream

We actually weren't checking the state at all when calling stream.