### PR TITLE
Fix IISHttpContext.cs(aspnet#11032)

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -380,6 +380,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                     var headerValueBytes = Encoding.UTF8.GetBytes(headerValues[i]);
                     fixed (byte* pHeaderValue = headerValueBytes)
                     {
+                        if (headerValueBytes.Length == 0)
+                        {
+                            throw new ArgumentException("Header value cannot be an empty string");
+                        }
+
                         if (knownHeaderIndex == -1)
                         {
                             var headerNameBytes = Encoding.UTF8.GetBytes(headerPair.Key);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - "Pre-check" the header value and throw ArgumentException with a message before calling the native code.

Addresses #11032(in this specific format)
