### PR TITLE
Fix MusicStore tests

### DIFF
--- a/src/MusicStore/samples/MusicStore/Models/Album.cs
+++ b/src/MusicStore/samples/MusicStore/Models/Album.cs
@@ -39,12 +39,8 @@ namespace MusicStore.Models
         [Required]
         public DateTime Created { get; set; }
 
-        /// <summary>
-        /// TODO: Temporary hack to populate the orderdetails until EF does this automatically. 
-        /// </summary>
         public Album()
         {
-            OrderDetails = new List<OrderDetail>();
             Created = DateTime.UtcNow;
         }
     }

--- a/src/MusicStore/samples/MusicStore/Models/MusicStoreContext.cs
+++ b/src/MusicStore/samples/MusicStore/Models/MusicStoreContext.cs
@@ -11,8 +11,6 @@ namespace MusicStore.Models
         public MusicStoreContext(DbContextOptions<MusicStoreContext> options)
             : base(options)
         {
-            // TODO: #639
-            //ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         }
 
         public DbSet<Album> Albums { get; set; }

--- a/src/MusicStore/test/MusicStore.Test/ShoppingCartControllerTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/ShoppingCartControllerTest.cs
@@ -124,7 +124,16 @@ namespace MusicStore.Controllers
 
             // Creates the albums of AlbumId = 1 ~ 10.
             var dbContext = _fixture.Context;
-            var albums = CreateTestAlbums(itemPrice: 10);
+            var albums = CreateTestAlbums(
+                10,
+                new Artist
+                {
+                    ArtistId = 1, Name = "Kung Fu Kenny"
+                }, new Genre
+                {
+                    GenreId = 1, Name = "Rap"
+                });
+
             dbContext.AddRange(albums);
             dbContext.SaveChanges();
 
@@ -204,7 +213,14 @@ namespace MusicStore.Controllers
 
         private static CartItem[] CreateTestCartItems(string cartId, decimal itemPrice, int numberOfItem)
         {
-            var albums = CreateTestAlbums(itemPrice);
+            var albums = CreateTestAlbums(
+                itemPrice, new Artist
+                {
+                    ArtistId = 1, Name = "Kung Fu Kenny"
+                }, new Genre
+                {
+                    GenreId = 1, Name = "Rap"
+                });
 
             var cartItems = Enumerable.Range(1, numberOfItem).Select(n =>
                 new CartItem()
@@ -218,7 +234,7 @@ namespace MusicStore.Controllers
             return cartItems;
         }
 
-        private static Album[] CreateTestAlbums(decimal itemPrice)
+        private static Album[] CreateTestAlbums(decimal itemPrice, Artist artist, Genre genre)
         {
             return Enumerable.Range(1, 10).Select(n =>
                 new Album
@@ -226,16 +242,8 @@ namespace MusicStore.Controllers
                     Title = "Greatest Hits",
                     AlbumId = n,
                     Price = itemPrice,
-                    Artist = new Artist
-                    {
-                        ArtistId = 1,
-                        Name = "Kung Fu Kenny"
-                    },
-                    Genre = new Genre
-                    {
-                        GenreId = 1,
-                        Name = "Rap"
-                    }
+                    Artist = artist,
+                    Genre = genre
                 }).ToArray();
         }
 


### PR DESCRIPTION
Fixes #12097

The issue here is that the tests were incorrectly creating multiple instances of the same entity. This was being masked by a bug in EF which has just been fixed. The fix here is to not try to track multiple instances with the same ID.