### PR TITLE
Make some pubternal types in data protection

### DIFF
--- a/src/DataProtection/DataProtection/ref/Microsoft.AspNetCore.DataProtection.netstandard2.0.cs
+++ b/src/DataProtection/DataProtection/ref/Microsoft.AspNetCore.DataProtection.netstandard2.0.cs
@@ -217,26 +217,8 @@ namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.Configurat
         public System.Xml.Linq.XElement SerializedDescriptorElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
 }
-namespace Microsoft.AspNetCore.DataProtection.Cng.Internal
-{
-    public abstract partial class CngAuthenticatedEncryptorBase : Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.IAuthenticatedEncryptor, System.IDisposable
-    {
-        protected CngAuthenticatedEncryptorBase() { }
-        public byte[] Decrypt(System.ArraySegment<byte> ciphertext, System.ArraySegment<byte> additionalAuthenticatedData) { throw null; }
-        protected unsafe abstract byte[] DecryptImpl(byte* pbCiphertext, uint cbCiphertext, byte* pbAdditionalAuthenticatedData, uint cbAdditionalAuthenticatedData);
-        public abstract void Dispose();
-        public byte[] Encrypt(System.ArraySegment<byte> plaintext, System.ArraySegment<byte> additionalAuthenticatedData) { throw null; }
-        public byte[] Encrypt(System.ArraySegment<byte> plaintext, System.ArraySegment<byte> additionalAuthenticatedData, uint preBufferSize, uint postBufferSize) { throw null; }
-        protected unsafe abstract byte[] EncryptImpl(byte* pbPlaintext, uint cbPlaintext, byte* pbAdditionalAuthenticatedData, uint cbAdditionalAuthenticatedData, uint cbPreBuffer, uint cbPostBuffer);
-    }
-}
 namespace Microsoft.AspNetCore.DataProtection.Internal
 {
-    public partial class DataProtectionBuilder : Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder
-    {
-        public DataProtectionBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
-        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-    }
     public partial interface IActivator
     {
         object CreateInstance(System.Type expectedBaseType, string implementationTypeName);

--- a/src/DataProtection/DataProtection/src/Cng/Internal/CngAuthenticatedEncryptorBase.cs
+++ b/src/DataProtection/DataProtection/src/Cng/Internal/CngAuthenticatedEncryptorBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.DataProtection.Cng.Internal
     /// <summary>
     /// Base class used for all CNG-related authentication encryption operations.
     /// </summary>
-    public unsafe abstract class CngAuthenticatedEncryptorBase : IOptimizedAuthenticatedEncryptor, IDisposable
+    internal unsafe abstract class CngAuthenticatedEncryptorBase : IOptimizedAuthenticatedEncryptor, IDisposable
     {
         public byte[] Decrypt(ArraySegment<byte> ciphertext, ArraySegment<byte> additionalAuthenticatedData)
         {

--- a/src/DataProtection/DataProtection/src/Internal/DataProtectionBuilder.cs
+++ b/src/DataProtection/DataProtection/src/Internal/DataProtectionBuilder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.DataProtection.Internal
     /// <summary>
     /// Default implementation of <see cref="IDataProtectionBuilder"/>.
     /// </summary>
-    public class DataProtectionBuilder : IDataProtectionBuilder
+    internal class DataProtectionBuilder : IDataProtectionBuilder
     {
         /// <summary>
         /// Creates a new configuration object linked to a <see cref="IServiceCollection"/>.

--- a/src/DataProtection/DataProtection/test/Cng/CngAuthenticatedEncryptorBaseTests.cs
+++ b/src/DataProtection/DataProtection/test/Cng/CngAuthenticatedEncryptorBaseTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.DataProtection.Cng.Internal
             Assert.Equal(new byte[] { 0x20, 0x21, 0x22 }, retVal);
         }
 
-        public abstract class MockableEncryptor : CngAuthenticatedEncryptorBase
+        internal abstract class MockableEncryptor : CngAuthenticatedEncryptorBase
         {
             public override void Dispose()
             {


### PR DESCRIPTION
- Make CngAuthenticatedEncryptorBase internal
- Left IActivator public because they are used in constructors the XmlKeyManager ctor

Contributes to #11312
