### PR TITLE
[WIP] Improves logging for JS interop

### DIFF
--- a/src/Components/Server/src/CircuitOptions.cs
+++ b/src/Components/Server/src/CircuitOptions.cs
@@ -47,15 +47,15 @@ namespace Microsoft.AspNetCore.Components.Server
         public TimeSpan DisconnectedCircuitRetentionPeriod { get; set; } = TimeSpan.FromMinutes(3);
 
         /// <summary>
-        /// Gets or sets a value that determines whether or not to send detailed exception messages from .NET interop method invocation
-        /// exceptions to JavaScript.
+        /// Gets or sets a value that determines whether or not to send detailed exception messages to JavaScript when an unhandled exception
+        /// happens on the circuit or when a .NET method invocation through JS interop results in an exception.
         /// </summary>
         /// <remarks>
         /// This value should only be turned on in development scenarios as turning it on in production might result in the leak of
         /// sensitive information to untrusted parties.
         /// </remarks>
         /// <value>Defaults to <c>false</c>.</value>
-        public bool JSInteropDetailedErrors { get; set; }
+        public bool DetailedErrors { get; set; }
 
         /// <summary>
         /// Gets or sets a value that indicates how long the server will wait before timing out an asynchronous JavaScript function invocation.

--- a/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
+++ b/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.Server
 
         public void Configure(CircuitOptions options)
         {
-            options.JSInteropDetailedErrors = Configuration.GetValue<bool>(WebHostDefaults.DetailedErrorsKey);
+            options.DetailedErrors = Configuration.GetValue<bool>(WebHostDefaults.DetailedErrorsKey);
         }
     }
 }

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
@@ -11,12 +12,15 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
     internal class RemoteJSRuntime : JSRuntimeBase
     {
         private readonly CircuitOptions _options;
+        private readonly ILogger<RemoteJSRuntime> _logger;
         private CircuitClientProxy _clientProxy;
 
-        public RemoteJSRuntime(IOptions<CircuitOptions> options)
+        public RemoteJSRuntime(IOptions<CircuitOptions> options, ILogger<RemoteJSRuntime> logger)
         {
             _options = options.Value;
+            _logger = logger;
             DefaultAsyncTimeout = _options.JSInteropDefaultCallTimeout;
+
         }
 
         internal void Initialize(CircuitClientProxy clientProxy)
@@ -26,13 +30,13 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
         protected override object OnDotNetInvocationException(Exception exception, string assemblyName, string methodIdentifier)
         {
-            if (_options.JSInteropDetailedErrors)
+            if (_options.DetailedErrors)
             {
                 return base.OnDotNetInvocationException(exception, assemblyName, methodIdentifier);
             }
 
             var message = $"There was an exception invoking '{methodIdentifier}' on assembly '{assemblyName}'. For more details turn on " +
-                $"detailed exceptions in '{typeof(CircuitOptions).Name}.{nameof(CircuitOptions.JSInteropDetailedErrors)}'";
+                $"detailed exceptions in '{typeof(CircuitOptions).Name}.{nameof(CircuitOptions.DetailedErrors)}'";
 
             return message;
         }
@@ -47,7 +51,22 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     "attempted during prerendering or while the client is disconnected.");
             }
 
+            Log.BeginInvokeJS(_logger, asyncHandle, identifier);
             _clientProxy.SendAsync("JS.BeginInvokeJS", asyncHandle, identifier, argsJson);
+        }
+
+        public static class Log
+        {
+            private static readonly Action<ILogger, long, string, Exception> _beginInvokeJS =
+                LoggerMessage.Define<long, string>(
+                    LogLevel.Debug,
+                    new EventId(1, "BeginInvokeJS"),
+                    "Begin invoke JS interop '{AsyncHandle}': '{FunctionIdentifier}'");
+
+            internal static void BeginInvokeJS(ILogger logger, long asyncHandle, string identifier)
+            {
+                _beginInvokeJS(logger, asyncHandle, identifier, null);
+            }
         }
     }
 }

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -38,7 +39,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             serviceScope = serviceScope ?? Mock.Of<IServiceScope>();
             clientProxy = clientProxy ?? new CircuitClientProxy(Mock.Of<IClientProxy>(), Guid.NewGuid().ToString());
             var renderRegistry = new RendererRegistry();
-            var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()));
+            var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
 
             if (remoteRenderer == null)
             {

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             string GetExpectedMessage(string method) =>
                 $"\"There was an exception invoking '{method}' on assembly 'BasicTestApp'. For more details turn on " +
-                $"detailed exceptions in '{typeof(CircuitOptions).Name}.{nameof(CircuitOptions.JSInteropDetailedErrors)}'\"";
+                $"detailed exceptions in '{typeof(CircuitOptions).Name}.{nameof(CircuitOptions.DetailedErrors)}'\"";
         }
     }
 }

--- a/src/Components/test/testassets/TestServer/Startup.cs
+++ b/src/Components/test/testassets/TestServer/Startup.cs
@@ -30,7 +30,7 @@ namespace TestServer
                 .AddCircuitOptions(o =>
                 {
                     var detailedErrors = Configuration.GetValue<bool>("circuit-detailed-errors");
-                    o.JSInteropDetailedErrors = detailedErrors;
+                    o.DetailedErrors = detailedErrors;
                 });
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie();
 


### PR DESCRIPTION
* Logs incoming .NET calls and outgoing JS interop calls.
* Sanitizes unhandled exceptions on the circuit before sending an error.

There are a few missing things for this PR because they require deeper changes on the ComponentHub and JSInterop sides

- [ ] Separate internal calls from regular JS interop calls.
  * We use JS interop to dispatch events. We don't want to change this for blazor client-side, but on the server-side client code we can detect this case (as we know what method we are invoking) and dispatch it to a hub method directly instead.
- [ ] .NET invocations are implemented through JS interop too, we can instead, deliver .NET method invocations through a hub method.
- [ ] JS interop async completions are delivered also through JS interop, we can simply call Dispatcher.EndInvoke from a method hub directly.
  * On the client side we will special case the beginInvokeDotNetFromJS to shortcircuit that call.