### PR TITLE
Handle chunks containing multiple EOL (#6146)

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/Util/EventedStreamReader.cs
+++ b/src/Middleware/SpaServices.Extensions/src/Util/EventedStreamReader.cs
@@ -89,17 +89,23 @@ namespace Microsoft.AspNetCore.NodeServices.Util
 
                 OnChunk(new ArraySegment<char>(buf, 0, chunkLength));
 
-                var lineBreakPos = Array.IndexOf(buf, '\n', 0, chunkLength);
-                if (lineBreakPos < 0)
+                int lineBreakPos = -1;
+                int startPos = 0;
+
+                // get all the newlines
+                while ((lineBreakPos = Array.IndexOf(buf, '\n', startPos, chunkLength - startPos)) >= 0 && startPos < chunkLength)
                 {
-                    _linesBuffer.Append(buf, 0, chunkLength);
-                }
-                else
-                {
-                    _linesBuffer.Append(buf, 0, lineBreakPos + 1);
+                    var length = (lineBreakPos + 1) - startPos;
+                    _linesBuffer.Append(buf, startPos, length);
                     OnCompleteLine(_linesBuffer.ToString());
                     _linesBuffer.Clear();
-                    _linesBuffer.Append(buf, lineBreakPos + 1, chunkLength - (lineBreakPos + 1));
+                    startPos = lineBreakPos + 1;
+                }
+
+                // get the rest
+                if (lineBreakPos < 0 && startPos < chunkLength)
+                {
+                    _linesBuffer.Append(buf, startPos, chunkLength);
                 }
             }
         }


### PR DESCRIPTION
Folks trying to use VueJS were having trouble relying on `ScriptRunner`, as it didn't detect (via string matching) the completion of a vue-cli build when in debug mode. 
The issue was discussed here: https://github.com/EEParker/aspnetcore-vueclimiddleware/issues/2#issuecomment-452630520
The fix in this PR ( credit to @EEParker https://github.com/EEParker/aspnetcore-vueclimiddleware/commit/a169dd6d39912d7e6ecbb13e5fa349860c26af0b#diff-6d394759c0a824a137b47986d0cce571R158 ) ensured that a `OnCompleteLine()` was called for every single received line (and not just the first line of the chunk).

Addresses #6146