### PR TITLE
_maxRentedBufferSize up to 1MB

### DIFF
--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
 
             _bytePool = bytePool;
-            if (memoryThreshold < _maxRentedBufferSize)
+            if (memoryThreshold <= _maxRentedBufferSize)
             {
                 _rentedBuffer = bytePool.Rent(memoryThreshold);
                 _buffer = new MemoryStream(_rentedBuffer);
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             }
 
             _bytePool = bytePool;
-            if (memoryThreshold < _maxRentedBufferSize)
+            if (memoryThreshold <= _maxRentedBufferSize)
             {
                 _rentedBuffer = bytePool.Rent(memoryThreshold);
                 _buffer = new MemoryStream(_rentedBuffer);


### PR DESCRIPTION
FileBufferingReadStream `_maxRentedBufferSize` allowing up to 1MB.

Addresses #9838
