### PR TITLE
Fixes RequestHeader to allow working with KeyValuePair

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/RequestHeaderTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestHeaderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
@@ -57,7 +58,26 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 await SendRequestAsync(address, "Custom-Header", customValues);
             }
         }
-        
+
+        [ConditionalFact]
+        public async Task RequestHeaders_ServerAddsCustomHeaders_Success()
+        {
+            string address;
+            using (Utilities.CreateHttpServer(out address, httpContext =>
+            {
+                var requestHeaders = httpContext.Request.Headers;
+                var header = KeyValuePair.Create("Custom-Header", new StringValues("custom"));
+                requestHeaders.Add(header);
+
+                Assert.True(requestHeaders.Contains(header));
+                return Task.FromResult(0);
+            }))
+            {
+                string response = await SendRequestAsync(address);
+                Assert.Equal(string.Empty, response);
+            }
+        }
+
         private async Task<string> SendRequestAsync(string uri)
         {
             using (HttpClient client = new HttpClient())

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         void ICollection<KeyValuePair<string, StringValues>>.Add(KeyValuePair<string, StringValues> item)
         {
-            ((IDictionary<string, object>)this).Add(item.Key, item.Value);
+            ((IDictionary<string, StringValues>)this).Add(item.Key,item.Value);
         }
 
         void ICollection<KeyValuePair<string, StringValues>>.Clear()
@@ -124,8 +124,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         bool ICollection<KeyValuePair<string, StringValues>>.Contains(KeyValuePair<string, StringValues> item)
         {
-            object value;
-            return ((IDictionary<string, object>)this).TryGetValue(item.Key, out value) && Object.Equals(value, item.Value);
+            return ((IDictionary<string, StringValues>)this).TryGetValue(item.Key, out var value) && Equals(value, item.Value);
         }
 
         void ICollection<KeyValuePair<string, StringValues>>.CopyTo(KeyValuePair<string, StringValues>[] array, int arrayIndex)


### PR DESCRIPTION
 - Fixed `ICollection.Add(KeyValuePair)` and `ICollection.Contains(KeyValuePair)` as `StringValues` cannot be cast to `object`
 - Added test

Addresses #12114
