### PR TITLE
Update error message to avoid ambiguity

### DIFF
--- a/src/Components/Components/src/Forms/EditForm.cs
+++ b/src/Components/Components/src/Forms/EditForm.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             if ((EditContext == null) == (Model == null))
             {
                 throw new InvalidOperationException($"{nameof(EditForm)} requires a {nameof(Model)} " +
-                    $"parameter, or an {nameof(EditContext)} parameter, but not both.");
+                    $"parameter or an {nameof(EditContext)} parameter (but not both).");
             }
 
             // If you're using OnSubmit, it becomes your responsibility to trigger validation manually


### PR DESCRIPTION
`EditForm requires a Model parameter, or an EditContext parameter, but not both.`

When this error happened to me, I read it as "you can have one or the other, but not both". This made me think I had declared one of each but what I had actually done was declared neither.

I propose a new message:

`EditForm requires a Model parameter or an EditContext parameter (but not both).`

For me, adding the brackets around `but not both` makes it clearer that I have added neither `Model` nor `EditContext` and to fix the error I should add one of either a `Model` or `EditContext`, although I should not add both.


