### PR TITLE
AllowSynchronousIO makes JsonTextWriter throw in SignalR sample

### DIFF
--- a/src/SignalR/samples/SignalRSamples/SignalRSamples.csproj
+++ b/src/SignalR/samples/SignalRSamples/SignalRSamples.csproj
@@ -19,7 +19,6 @@
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
-    <Reference Include="Newtonsoft.Json" />
     <Reference Include="System.Reactive.Linq" />
   </ItemGroup>
 


### PR DESCRIPTION
Hello,

in `SignalRSamples` project [there is a `/deployment` route](https://github.com/aspnet/AspNetCore/blob/master/src/SignalR/samples/SignalRSamples/Startup.cs#L60).
This route try to writes to the Response stream [using `JsonTextWriter` wich is a `IDisposable`](https://github.com/aspnet/AspNetCore/blob/master/src/SignalR/samples/SignalRSamples/Startup.cs#L66) (not `IAsyncDisposable`)
The result is a call to `Dispose()` which ends of calling a cascade of `Sync` (did not dig far, but i would guess `Flush()`) , ending end throwing when calling `/deployment` with AllowSynchronousIO turned off

Summary of the changes (Less than 80 chars)
- Changed sample using `context.Response.BodyWriter`
- Change `Json.Net` for `System.Text.Json.Utf8JsonWriter`
- use of `await using()`
- json is now indented
- remove the reference to `Json.Net` in csproj <== not sure of this one (thought it was the using file

Addresses #12164 (in this specific format)

#### Side notes :
I have no idea is using `release/3.0-preview7` is a good idea to be fair.
And i also have no idea if removing `Newtonsoft.Json` have side effect on all possible Api tested in these sample.