### PR TITLE
Remove supposed optimization of local builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,11 +59,9 @@
   <PropertyGroup>
     <SharedSourceRoot>$(MSBuildThisFileDirectory)src\Shared\</SharedSourceRoot>
     <GoogleTestSubmoduleRoot>$(RepoRoot)src\submodules\googletest\</GoogleTestSubmoduleRoot>
+
     <!-- Embed source files that are not tracked by the source control manager in the PDB. -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-
-    <!-- Disable source link on local builds for faster local builds. -->
-    <EnableSourceLink Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">false</EnableSourceLink>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- minor issue uncovered while investigating #7073
- sourcelink speed has significantly improved lately
- removing this enables local builds that are a closer match to CI configuration