### PR TITLE
Add semi-colon to gRPC service definition for consistency

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Protos/greet.proto
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Protos/greet.proto
@@ -7,7 +7,7 @@ package Greet;
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
 }
 
 // The request message containing the user's name.


### PR DESCRIPTION
Per the following documentation, it's acceptable to terminate the service definition code with a semi-colon:
https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#service_definition

Since semi-colons are used elsewhere in the proto file, this PR applies one in the service definition for the sake of consistency in the template.