### PR TITLE
Explicitly implement SetParametersAsync

### DIFF
--- a/src/Components/Blazor/testassets/StandaloneApp/Pages/FetchData.razor
+++ b/src/Components/Blazor/testassets/StandaloneApp/Pages/FetchData.razor
@@ -48,10 +48,9 @@ else
 
     WeatherForecast[] forecasts;
 
-    public override Task SetParametersAsync(ParameterCollection parameters)
+    protected override void OnParametersSetting()
     {
         StartDate = DateTime.Now;
-        return base.SetParametersAsync(parameters);
     }
 
     protected override async Task OnParametersSetAsync()

--- a/src/Components/Components/src/Forms/InputComponents/InputBase.cs
+++ b/src/Components/Components/src/Forms/InputComponents/InputBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Components.Forms
 {
@@ -166,12 +165,9 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
         }
 
-
         /// <inheritdoc />
-        public override Task SetParametersAsync(ParameterCollection parameters)
+        protected override void OnParametersSet()
         {
-            parameters.SetParameterProperties(this);
-
             if (EditContext == null)
             {
                 // This is the first run
@@ -204,9 +200,6 @@ namespace Microsoft.AspNetCore.Components.Forms
                 throw new InvalidOperationException($"{GetType()} does not support changing the " +
                     $"{nameof(Forms.EditContext)} dynamically.");
             }
-
-            // For derived components, retain the usual lifecycle with OnInit/OnParametersSet/etc.
-            return base.SetParametersAsync(ParameterCollection.Empty);
         }
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithParameters.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithParameters.razor
@@ -1,5 +1,6 @@
 @page "/WithParameters/Name/{firstName}"
 @page "/WithParameters/Name/{firstName}/LastName/{lastName}"
+@implements IComponent
 <div id="test-info">Your full name is @FirstName @LastName.</div>
 <Links />
 
@@ -9,11 +10,10 @@
 
     [Parameter] string LastName { get ; set; }
 
-    public override Task SetParametersAsync(ParameterCollection parameters)
+    protected override void OnParametersSetting()
     {
         // Manually reset parameters to defaults so we don't retain any from an earlier URL
         FirstName = default;
         LastName = default;
-        return base.SetParametersAsync(parameters);
     }
 }


### PR DESCRIPTION
This change converts SetParametersAsync to be an explicit interface
implmenentation, and adds lifecyle methods for running code before or
after the parameters are set.

This is a design prototype, and not ready to be merged. I'll add tests
if we like the general direction of this.
