### PR TITLE
Don't invoke continuations inline in OnCompleted

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/OutputFlowControlAwaitable.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/OutputFlowControlAwaitable.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl
 {
@@ -29,7 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl
             if (ReferenceEquals(_callback, _callbackCompleted) ||
                 ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
             {
-                continuation();
+                Task.Run(continuation);
             }
         }
 

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             // should always be on the libuv thread
             if (ReferenceEquals(_callback, _callbackCompleted))
             {
-                Debug.Assert(false, $"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, scheduling callback.");
+                Debug.Fail($"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, scheduling callback.");
             }
 
             _callback = continuation;

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
@@ -54,15 +53,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         {
             // There should never be a race between IsCompleted and OnCompleted since both operations
             // should always be on the libuv thread
-
-            if (ReferenceEquals(_callback, _callbackCompleted) ||
-                ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
+            if (ReferenceEquals(_callback, _callbackCompleted))
             {
-                Debug.Fail($"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, scheduling callback.");
-
-                // Just schedule it
-                Task.Run(continuation);
+                Debug.Assert(false, $"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, scheduling callback.");
             }
+
+            _callback = continuation;
         }
 
         public void UnsafeOnCompleted(Action continuation)

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
@@ -57,10 +58,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             if (ReferenceEquals(_callback, _callbackCompleted) ||
                 ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
             {
-                Debug.Fail($"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, running callback inline.");
+                Debug.Fail($"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, scheduling callback.");
 
-                // Just run it inline
-                continuation();
+                // Just schedule it
+                Task.Run(continuation);
             }
         }
 


### PR DESCRIPTION
This should be impossible for LibuvAwaitable anyway since both OnCompleted and its Callback property are always invoked from the same thread.