### PR TITLE
Dispatch connection execution

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -51,7 +51,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                             break;
                         }
 
-                        _ = Execute(new KestrelConnection(connection, _serviceContext.Log));
+                        var id = Interlocked.Increment(ref _lastConnectionId);
+                        var kestrelConnection = new KestrelConnection(id, _serviceContext, _connectionDelegate, connection, _serviceContext.Log);
+                        ThreadPool.UnsafeQueueUserWorkItem(kestrelConnection, preferLocal: false);
                     }
                 }
                 catch (Exception ex)
@@ -64,56 +66,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                     _acceptLoopTcs.TrySetResult(null);
                 }
             }
-        }
-
-        internal async Task Execute(KestrelConnection connection)
-        {
-            var id = Interlocked.Increment(ref _lastConnectionId);
-            var connectionContext = connection.TransportConnection;
-
-            try
-            {
-                _serviceContext.ConnectionManager.AddConnection(id, connection);
-
-                Log.ConnectionStart(connectionContext.ConnectionId);
-                KestrelEventSource.Log.ConnectionStart(connectionContext);
-
-                using (BeginConnectionScope(connectionContext))
-                {
-                    try
-                    {
-                        await _connectionDelegate(connectionContext);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.LogError(0, ex, "Unhandled exception while processing {ConnectionId}.", connectionContext.ConnectionId);
-                    }
-                }
-            }
-            finally
-            {
-                await connection.FireOnCompletedAsync();
-
-                Log.ConnectionStop(connectionContext.ConnectionId);
-                KestrelEventSource.Log.ConnectionStop(connectionContext);
-
-                // Dispose the transport connection, this needs to happen before removing it from the
-                // connection manager so that we only signal completion of this connection after the transport
-                // is properly torn down.
-                await connection.TransportConnection.DisposeAsync();
-
-                _serviceContext.ConnectionManager.RemoveConnection(id);
-            }
-        }
-
-        private IDisposable BeginConnectionScope(ConnectionContext connectionContext)
-        {
-            if (Log.IsEnabled(LogLevel.Critical))
-            {
-                return Log.BeginScope(new ConnectionLogScope(connectionContext.ConnectionId));
-            }
-
-            return null;
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
@@ -175,9 +175,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _connectionClosingCts.Dispose();
         }
 
-        public void Execute()
+        void IThreadPoolWorkItem.Execute()
         {
             _ = ExecuteAsync(this);
+        }
+
+        internal Task ExecuteAsync()
+        {
+            return ExecuteAsync(this);
         }
 
         private async Task ExecuteAsync(KestrelConnection connection)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
-    internal class KestrelConnection : IConnectionHeartbeatFeature, IConnectionCompleteFeature, IConnectionLifetimeNotificationFeature
+    internal class KestrelConnection : IConnectionHeartbeatFeature, IConnectionCompleteFeature, IConnectionLifetimeNotificationFeature, IThreadPoolWorkItem
     {
         private List<(Action<object> handler, object state)> _heartbeatHandlers;
         private readonly object _heartbeatLock = new object();
@@ -21,9 +21,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         private readonly CancellationTokenSource _connectionClosingCts = new CancellationTokenSource();
         private readonly TaskCompletionSource<object> _completionTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly long _id;
+        private readonly ServiceContext _serviceContext;
+        private readonly ConnectionDelegate _connectionDelegate;
 
-        public KestrelConnection(ConnectionContext connectionContext, ILogger logger)
+        public KestrelConnection(long id,
+                                 ServiceContext serviceContext,
+                                 ConnectionDelegate connectionDelegate,
+                                 ConnectionContext connectionContext,
+                                 IKestrelTrace logger)
         {
+            _id = id;
+            _serviceContext = serviceContext;
+            _connectionDelegate = connectionDelegate;
             Logger = logger;
             TransportConnection = connectionContext;
 
@@ -33,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             ConnectionClosedRequested = _connectionClosingCts.Token;
         }
 
-        private ILogger Logger { get; }
+        private IKestrelTrace Logger { get; }
 
         public ConnectionContext TransportConnection { get; set; }
         public CancellationToken ConnectionClosedRequested { get; set; }
@@ -163,6 +173,60 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _completionTcs.TrySetResult(null);
 
             _connectionClosingCts.Dispose();
+        }
+
+        public void Execute()
+        {
+            _ = ExecuteAsync(this);
+        }
+
+        private async Task ExecuteAsync(KestrelConnection connection)
+        {
+            var connectionContext = connection.TransportConnection;
+
+            try
+            {
+                _serviceContext.ConnectionManager.AddConnection(_id, connection);
+
+                Logger.ConnectionStart(connectionContext.ConnectionId);
+                KestrelEventSource.Log.ConnectionStart(connectionContext);
+
+                using (BeginConnectionScope(connectionContext))
+                {
+                    try
+                    {
+                        await _connectionDelegate(connectionContext);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(0, ex, "Unhandled exception while processing {ConnectionId}.", connectionContext.ConnectionId);
+                    }
+                }
+            }
+            finally
+            {
+                await connection.FireOnCompletedAsync();
+
+                Logger.ConnectionStop(connectionContext.ConnectionId);
+                KestrelEventSource.Log.ConnectionStop(connectionContext);
+
+                // Dispose the transport connection, this needs to happen before removing it from the
+                // connection manager so that we only signal completion of this connection after the transport
+                // is properly torn down.
+                await connection.TransportConnection.DisposeAsync();
+
+                _serviceContext.ConnectionManager.RemoveConnection(_id);
+            }
+        }
+
+        private IDisposable BeginConnectionScope(ConnectionContext connectionContext)
+        {
+            if (Logger.IsEnabled(LogLevel.Critical))
+            {
+                return Logger.BeginScope(new ConnectionLogScope(connectionContext.ConnectionId));
+            }
+
+            return null;
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/HttpConnectionManagerTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpConnectionManagerTests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -39,9 +41,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             ConnectionManager httpConnectionManager,
             Mock<IKestrelTrace> trace)
         {
+            var serviceContext = new TestServiceContext();
             var mock = new Mock<DefaultConnectionContext>() { CallBase = true };
             mock.Setup(m => m.ConnectionId).Returns(connectionId);
-            var httpConnection = new KestrelConnection(mock.Object, Mock.Of<ILogger>());
+            var httpConnection = new KestrelConnection(0, serviceContext, _ => Task.CompletedTask, mock.Object, Mock.Of<IKestrelTrace>());
 
             httpConnectionManager.AddConnection(0, httpConnection);
 


### PR DESCRIPTION
- Dispatch connection initialization to the thread pool to avoid executing the first read on the IO thread (longer explanation in the bug).

Fixes https://github.com/aspnet/AspNetCore/issues/10956

Before:

```
RequestsPerSecond:           8,762
Max CPU (%):                 27
WorkingSet (MB):             152
Avg. Latency (ms):           18.5
Startup (ms):                305
First Request (ms):          56.04
Latency (ms):                0.61
Total Requests:              132,096
Duration: (ms)               15,080
Socket Errors:               0
Bad Responses:               0
SDK:                         3.0.100-preview8-013280
Runtime:                     3.0.0-preview8-27914-06
ASP.NET Core:                3.0.0-preview8.19366.5
```

After:

```
RequestsPerSecond:           10,232
Max CPU (%):                 34
WorkingSet (MB):             152
Avg. Latency (ms):           15.84
Startup (ms):                355
First Request (ms):          86.5
Latency (ms):                0.56
Total Requests:              154,456
Duration: (ms)               15,100
Socket Errors:               0
Bad Responses:               0
SDK:                         3.0.100-preview8-013280
Runtime:                     3.0.0-preview8-27914-06
ASP.NET Core:                3.0.0-preview8.19366.5
```