### PR TITLE
fix: remove a typo in /eng/common/tools.ps1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -169,7 +169,7 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $arc
   InstallDotNet $dotnetRoot $version $architecture
 }
 
-function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $architecture = "", [string] $runtime = "", [bool] $skipNonVersionedFiles = $false) {  $installScript = GetDotNetInstallScript $dotnetRoot
+function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $architecture = "", [string] $runtime = "", [bool] $skipNonVersionedFiles = $false) {
   $installScript = GetDotNetInstallScript $dotnetRoot
   $installParameters = @{
     Version = $version


### PR DESCRIPTION
`GetDotNetInstallScript` was called twice

Summary of the changes (Less than 80 chars)
 - Removed the call to `GetDotNetInstallScript` that was on the `function` declaration

#### Addresses #12275  (in this specific format)

#### Side notes 
It's like this from the very first commit,
it looks like it was created by either an automation or from an already existing script, so this may be existing in another repo somewhere publicly or internaly
https://github.com/aspnet/AspNetCore/commit/347ddcb6e20a5ef291972604407894baf5f14526#diff-58d6d2c2760628d9551cc8b40461ce53