### PR TITLE
Be more defensive in BufferingDisabled test

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/ApplicationDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/ApplicationDeployer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 }
                 else
                 {
-                    _publishedApplication.Dispose();
+                    _publishedApplication?.Dispose();
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2826

We [use `?.` in `master`](https://github.com/aspnet/AspNetCore/blob/f56cb72b7fa01ea09c3d3b128aaeb9cee937b371/src/Hosting/Server.IntegrationTesting/src/Deployers/ApplicationDeployer.cs#L103) and it seems like the test can end up in this state (by the linked issue) so back-porting that defensive measure seems reasonable.

Test-only change requires shiproom notification but not approval. I'll do the needful there.