### PR TITLE
Use a single lock for writing to ConcurrentPipeWriter

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private readonly MemoryPool<byte> _memoryPool;
 
         // This locks access to all of the below fields
-        private readonly object _contextLock = new object();
 
         private bool _pipeWriterCompleted;
         private bool _aborted;
@@ -114,7 +113,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public ValueTask<FlushResult> WriteStreamSuffixAsync()
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 if (_writeStreamSuffixCalled)
                 {
@@ -143,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 if (_pipeWriterCompleted)
                 {
@@ -194,7 +193,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Memory<byte> GetMemory(int sizeHint = 0)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -219,7 +218,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Span<byte> GetSpan(int sizeHint = 0)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -244,7 +243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public void Advance(int bytes)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -288,7 +287,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         // This method is for chunked http responses that directly call response.WriteAsync
         public ValueTask<FlushResult> WriteChunkAsync(ReadOnlySpan<byte> buffer, CancellationToken cancellationToken)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -330,7 +329,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public void WriteResponseHeaders(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appComplete)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -405,7 +404,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public void Dispose()
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 _pipeWriter.Abort();
 
@@ -450,7 +449,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             // Abort can be called after Dispose if there's a flush timeout.
             // It's important to still call _lifetimeFeature.Abort() in this case.
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 if (_aborted)
                 {
@@ -466,7 +465,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public void Stop()
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 CompletePipe();
             }
@@ -479,7 +478,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -499,7 +498,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 
@@ -538,7 +537,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             ReadOnlySpan<byte> buffer,
             CancellationToken cancellationToken = default)
         {
-            lock (_contextLock)
+            lock (_pipeWriter.Sync)
             {
                 ThrowIfSuffixSent();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         private static readonly Exception _successfullyCompletedSentinel = new Exception();
 
-        public readonly object _sync;
+        private readonly object _sync;
         private readonly PipeWriter _innerPipeWriter;
         private readonly MemoryPool<byte> _pool;
         private readonly BufferSegmentStack _bufferSegmentPool = new BufferSegmentStack(InitialSegmentPoolSize);

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
@@ -61,89 +61,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         public override Memory<byte> GetMemory(int sizeHint = 0)
         {
-            lock (_sync)
+            if (_currentFlushTcs == null && _head == null)
             {
-                if (_currentFlushTcs == null && _head == null)
-                {
-                    return _innerPipeWriter.GetMemory(sizeHint);
-                }
-
-                AllocateMemoryUnsynchronized(sizeHint);
-                return _tailMemory;
+                return _innerPipeWriter.GetMemory(sizeHint);
             }
+
+            AllocateMemoryUnsynchronized(sizeHint);
+            return _tailMemory;
         }
 
         public override Span<byte> GetSpan(int sizeHint = 0)
         {
-            lock (_sync)
+            if (_currentFlushTcs == null && _head == null)
             {
-                if (_currentFlushTcs == null && _head == null)
-                {
-                    return _innerPipeWriter.GetSpan(sizeHint);
-                }
-
-                AllocateMemoryUnsynchronized(sizeHint);
-                return _tailMemory.Span;
+                return _innerPipeWriter.GetSpan(sizeHint);
             }
+
+            AllocateMemoryUnsynchronized(sizeHint);
+            return _tailMemory.Span;
         }
 
         public override void Advance(int bytes)
         {
-            lock (_sync)
+            if (_currentFlushTcs == null && _head == null)
             {
-                if (_currentFlushTcs == null && _head == null)
-                {
-                    _innerPipeWriter.Advance(bytes);
-                    return;
-                }
-
-                if ((uint)bytes > (uint)_tailMemory.Length)
-                {
-                    ThrowArgumentOutOfRangeException(nameof(bytes));
-                }
-
-                _tailBytesBuffered += bytes;
-                _bytesBuffered += bytes;
-                _tailMemory = _tailMemory.Slice(bytes);
-                _bufferedWritePending = false;
+                _innerPipeWriter.Advance(bytes);
+                return;
             }
+
+            if ((uint)bytes > (uint)_tailMemory.Length)
+            {
+                ThrowArgumentOutOfRangeException(nameof(bytes));
+            }
+
+            _tailBytesBuffered += bytes;
+            _bytesBuffered += bytes;
+            _tailMemory = _tailMemory.Slice(bytes);
+            _bufferedWritePending = false;
         }
 
         public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
         {
-            lock (_sync)
+            if (_currentFlushTcs != null)
+            {
+                return new ValueTask<FlushResult>(_currentFlushTcs.Task);
+            }
+
+            if (_bytesBuffered > 0)
+            {
+                CopyAndReturnSegmentsUnsynchronized();
+            }
+
+            var flushTask = _innerPipeWriter.FlushAsync(cancellationToken);
+
+            if (flushTask.IsCompletedSuccessfully)
             {
                 if (_currentFlushTcs != null)
                 {
-                    return new ValueTask<FlushResult>(_currentFlushTcs.Task);
+                    CompleteFlushUnsynchronized(flushTask.GetAwaiter().GetResult(), null);
                 }
 
-                if (_bytesBuffered > 0)
-                {
-                    CopyAndReturnSegmentsUnsynchronized();
-                }
-
-                var flushTask = _innerPipeWriter.FlushAsync(cancellationToken);
-
-                if (flushTask.IsCompletedSuccessfully)
-                {
-                    if (_currentFlushTcs != null)
-                    {
-                        CompleteFlushUnsynchronized(flushTask.GetAwaiter().GetResult(), null);
-                    }
-
-                    return flushTask;
-                }
-
-                // Use a TCS instead of something resettable so it can be awaited by multiple awaiters.
-                _currentFlushTcs = new TaskCompletionSource<FlushResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var result = new ValueTask<FlushResult>(_currentFlushTcs.Task);
-
-                // FlushAsyncAwaited clears the TCS prior to completing. Make sure to construct the ValueTask
-                // from the TCS before calling FlushAsyncAwaited in case FlushAsyncAwaited completes inline.
-                _ = FlushAsyncAwaited(flushTask, cancellationToken);
-                return result;
+                return flushTask;
             }
+
+            // Use a TCS instead of something resettable so it can be awaited by multiple awaiters.
+            _currentFlushTcs = new TaskCompletionSource<FlushResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var result = new ValueTask<FlushResult>(_currentFlushTcs.Task);
+
+            // FlushAsyncAwaited clears the TCS prior to completing. Make sure to construct the ValueTask
+            // from the TCS before calling FlushAsyncAwaited in case FlushAsyncAwaited completes inline.
+            _ = FlushAsyncAwaited(flushTask, cancellationToken);
+            return result;
         }
 
         private async Task FlushAsyncAwaited(ValueTask<FlushResult> flushTask, CancellationToken cancellationToken)
@@ -201,40 +189,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         public override void Complete(Exception exception = null)
         {
-            lock (_sync)
+            // We store the complete exception or  s sentinel exception instance in a field  if a flush was ongoing.
+            // We call the inner Complete() method after the flush loop ended.
+
+            // To simply ensure everything gets returned after the PipeWriter is left in some unknown state (say GetMemory() was
+            // called but not Advance(), or there's a flush pending), but you don't want to complete the inner pipe, just call Abort().
+            _completeException = exception ?? _successfullyCompletedSentinel;
+
+            if (_currentFlushTcs == null)
             {
-                // We store the complete exception or  s sentinel exception instance in a field  if a flush was ongoing.
-                // We call the inner Complete() method after the flush loop ended.
-
-                // To simply ensure everything gets returned after the PipeWriter is left in some unknown state (say GetMemory() was
-                // called but not Advance(), or there's a flush pending), but you don't want to complete the inner pipe, just call Abort().
-                _completeException = exception ?? _successfullyCompletedSentinel;
-
-                if (_currentFlushTcs == null)
+                if (_bytesBuffered > 0)
                 {
-                    if (_bytesBuffered > 0)
-                    {
-                        CopyAndReturnSegmentsUnsynchronized();
-                    }
-
-                    CleanupSegmentsUnsynchronized();
-
-                    _innerPipeWriter.Complete(exception);
+                    CopyAndReturnSegmentsUnsynchronized();
                 }
+
+                CleanupSegmentsUnsynchronized();
+
+                _innerPipeWriter.Complete(exception);
             }
         }
 
         public void Abort()
         {
-            lock (_sync)
-            {
-                _aborted = true;
+            _aborted = true;
 
-                // If we're flushing, the cleanup will happen after the flush.
-                if (_currentFlushTcs == null)
-                {
-                    CleanupSegmentsUnsynchronized();
-                }
+            // If we're flushing, the cleanup will happen after the flush.
+            if (_currentFlushTcs == null)
+            {
+                CleanupSegmentsUnsynchronized();
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         private static readonly Exception _successfullyCompletedSentinel = new Exception();
 
-        public readonly object _sync = new object();
+        public readonly object _sync;
         private readonly PipeWriter _innerPipeWriter;
         private readonly MemoryPool<byte> _pool;
         private readonly BufferSegmentStack _bufferSegmentPool = new BufferSegmentStack(InitialSegmentPoolSize);
@@ -51,13 +51,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
         private bool _aborted;
         private Exception _completeException;
 
-        public ConcurrentPipeWriter(PipeWriter innerPipeWriter, MemoryPool<byte> pool)
+        public ConcurrentPipeWriter(PipeWriter innerPipeWriter, MemoryPool<byte> pool, object sync)
         {
             _innerPipeWriter = innerPipeWriter;
             _pool = pool;
+            _sync = sync;
         }
-
-        public object Sync => _sync;
 
         public override Memory<byte> GetMemory(int sizeHint = 0)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         private static readonly Exception _successfullyCompletedSentinel = new Exception();
 
-        private readonly object _sync = new object();
+        public readonly object _sync = new object();
         private readonly PipeWriter _innerPipeWriter;
         private readonly MemoryPool<byte> _pool;
         private readonly BufferSegmentStack _bufferSegmentPool = new BufferSegmentStack(InitialSegmentPoolSize);
@@ -56,6 +56,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
             _innerPipeWriter = innerPipeWriter;
             _pool = pool;
         }
+
+        public object Sync => _sync;
 
         public override Memory<byte> GetMemory(int sizeHint = 0)
         {

--- a/src/Servers/Kestrel/Core/test/ConcurrentPipeWriterTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConcurrentPipeWriterTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 };
 
                 var mockPipeWriter = new MockPipeWriter(pipeWriterFlushTcsArray);
-                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool);
+                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool, new object());
 
                 var memory = concurrentPipeWriter.GetMemory();
                 Assert.Equal(1, mockPipeWriter.GetMemoryCallCount);
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 };
 
                 var mockPipeWriter = new MockPipeWriter(pipeWriterFlushTcsArray);
-                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool);
+                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool, new object());
 
                 var memory = concurrentPipeWriter.GetMemory();
                 Assert.Equal(1, mockPipeWriter.GetMemoryCallCount);
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 };
 
                 var mockPipeWriter = new MockPipeWriter(pipeWriterFlushTcsArray);
-                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool);
+                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool, new object());
 
                 var memory = concurrentPipeWriter.GetMemory();
                 Assert.Equal(1, mockPipeWriter.GetMemoryCallCount);
@@ -218,7 +218,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 };
 
                 var mockPipeWriter = new MockPipeWriter(pipeWriterFlushTcsArray);
-                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool);
+                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool, new object());
 
                 var memory = concurrentPipeWriter.GetMemory();
                 Assert.Equal(1, mockPipeWriter.GetMemoryCallCount);
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 };
 
                 var mockPipeWriter = new MockPipeWriter(pipeWriterFlushTcsArray);
-                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool);
+                var concurrentPipeWriter = new ConcurrentPipeWriter(mockPipeWriter, diagnosticPool, new object());
 
                 var memory = concurrentPipeWriter.GetMemory();
                 Assert.Equal(1, mockPipeWriter.GetMemoryCallCount);


### PR DESCRIPTION
Follow up to https://github.com/aspnet/AspNetCore/pull/12081

**Before:**
```
All results:
| Description |       RPS | CPU (%) | Memory (MB) | Avg. Latency (ms) | Startup (ms) | First Request (ms) | Latency (ms) | Errors |
| ----------- | --------- | ------- | ----------- | ----------------- | ------------ | ------------------ | ------------ | ------ |
|           √ | 4,063,529 |     100 |         106 |               0.9 |       230.23 |            46.8208 |       0.1244 |      0 |
|           √ | 4,092,813 |      99 |         109 |              1.26 |     230.6499 |            46.6005 |       0.1598 |      0 |
|           √ | 4,036,415 |      99 |         103 |              1.03 |      229.846 |            46.5652 |       0.1287 |      0 |

RequestsPerSecond:           4,064,252
Max CPU (%):                 99
WorkingSet (MB):             106
Avg. Latency (ms):           1.06
Startup (ms):                230
First Request (ms):          46.66
Latency (ms):                0.14
Total Requests:              61,368,471
Duration: (ms)               15,100
Socket Errors:               0
Bad Responses:               0
SDK:                         3.0.100-preview8-013304
Runtime:                     3.0.0-preview8-27914-06
ASP.NET Core:                3.0.0-preview8.19367.2
```

**After:**
```
All results:
| Description |       RPS | CPU (%) | Memory (MB) | Avg. Latency (ms) | Startup (ms) | First Request (ms) | Latency (ms) | Errors |
| ----------- | --------- | ------- | ----------- | ----------------- | ------------ | ------------------ | ------------ | ------ |
|           √ | 4,106,103 |      99 |         102 |              1.09 |     243.4135 |            85.7877 |       0.1238 |      0 |
|           √ | 4,122,374 |      99 |         110 |              1.13 |     244.1361 |            86.1066 |       0.1254 |      0 |
|           √ | 4,155,889 |      99 |         106 |              1.14 |     242.9591 |            86.0695 |       0.1264 |      0 |

RequestsPerSecond:           4,128,122
Max CPU (%):                 99
WorkingSet (MB):             106
Avg. Latency (ms):           1.12
Startup (ms):                244
First Request (ms):          85.99
Latency (ms):                0.13
Total Requests:              62,333,715
Duration: (ms)               15,100
Socket Errors:               0
Bad Responses:               0
SDK:                         3.0.100-preview8-013305
Runtime:                     3.0.0-preview8-27914-06
ASP.NET Core:                3.0.0-preview8.19367.2
```

The first request numbers are weird. Both https://github.com/aspnet/AspNetCore/pull/12265 and this change show a 2x regression on the first request. I feel like there is something that slows down first request when passing in output files.

I wasn't sure if I could remove the lock in Http2Framewriter. I'll follow up with @halter73 with regards to that.
