### PR TITLE
Remove unnecessary curly braces from gRPC service definition

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Protos/greet.proto
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Protos/greet.proto
@@ -7,7 +7,7 @@ package Greet;
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.


### PR DESCRIPTION
Update template example proto file to match the common syntax convention.

Clean up from change in https://github.com/aspnet/AspNetCore/pull/12241