### PR TITLE
Rename SignalR Server Transports

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -397,7 +397,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                         nonClonedContext.Response.RegisterForDispose(timeoutSource);
                         nonClonedContext.Response.RegisterForDispose(tokenSource);
 
-                        var longPolling = new LongPollingTransport(timeoutSource.Token, Application.Input, loggerFactory);
+                        var longPolling = new LongPollingServerTransport(timeoutSource.Token, Application.Input, loggerFactory);
 
                         // Start the transport
                         TransportTask = longPolling.ProcessRequestAsync(nonClonedContext, tokenSource.Token);

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 connection.SupportedFormats = TransferFormat.Text;
 
                 // We only need to provide the Input channel since writing to the application is handled through /send.
-                var sse = new ServerSentEventsTransport(connection.Application.Input, connection.ConnectionId, _loggerFactory);
+                var sse = new ServerSentEventsServerTransport(connection.Application.Input, connection.ConnectionId, _loggerFactory);
 
                 await DoPersistentConnection(connectionDelegate, sse, context, connection);
             }
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 // Allow the reads to be cancelled
                 connection.Cancellation = new CancellationTokenSource();
 
-                var ws = new WebSocketsTransport(options.WebSockets, connection.Application, connection, _loggerFactory);
+                var ws = new WebSocketsServerTransport(options.WebSockets, connection.Application, connection, _loggerFactory);
 
                 await DoPersistentConnection(connectionDelegate, ws, context, connection);
             }

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
@@ -11,17 +11,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
 {
-    internal class LongPollingTransport : IHttpTransport
+    internal class LongPollingServerTransport : IHttpTransport
     {
         private readonly PipeReader _application;
         private readonly ILogger _logger;
         private readonly CancellationToken _timeoutToken;
 
-        public LongPollingTransport(CancellationToken timeoutToken, PipeReader application, ILoggerFactory loggerFactory)
+        public LongPollingServerTransport(CancellationToken timeoutToken, PipeReader application, ILoggerFactory loggerFactory)
         {
             _timeoutToken = timeoutToken;
             _application = application;
-            _logger = loggerFactory.CreateLogger<LongPollingTransport>();
+            _logger = loggerFactory.CreateLogger<LongPollingServerTransport>();
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         {
             _timeoutToken = timeoutToken;
             _application = application;
+
+            // We create the logger with a string to preserve the logging namespace after the server side transport renames.
             _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Connections.Internal.Transports.LongPollingTransport");
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         {
             _timeoutToken = timeoutToken;
             _application = application;
-            _logger = loggerFactory.CreateLogger("LongPollingTransport");
+            _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Connections.Internal.Transports.LongPollingTransport");
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/LongPollingServerTransport.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         {
             _timeoutToken = timeoutToken;
             _application = application;
-            _logger = loggerFactory.CreateLogger<LongPollingServerTransport>();
+            _logger = loggerFactory.CreateLogger("LongPollingTransport");
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
@@ -11,17 +11,17 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
 {
-    internal class ServerSentEventsTransport : IHttpTransport
+    internal class ServerSentEventsServerTransport : IHttpTransport
     {
         private readonly PipeReader _application;
         private readonly string _connectionId;
         private readonly ILogger _logger;
 
-        public ServerSentEventsTransport(PipeReader application, string connectionId, ILoggerFactory loggerFactory)
+        public ServerSentEventsServerTransport(PipeReader application, string connectionId, ILoggerFactory loggerFactory)
         {
             _application = application;
             _connectionId = connectionId;
-            _logger = loggerFactory.CreateLogger<ServerSentEventsTransport>();
+            _logger = loggerFactory.CreateLogger<ServerSentEventsServerTransport>();
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         {
             _application = application;
             _connectionId = connectionId;
-            _logger = loggerFactory.CreateLogger<ServerSentEventsServerTransport>();
+            _logger = loggerFactory.CreateLogger("ServerSentEventsTransport");
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         {
             _application = application;
             _connectionId = connectionId;
-            _logger = loggerFactory.CreateLogger("ServerSentEventsTransport");
+            _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Connections.Internal.Transports.ServerSentEventsTransport");
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         {
             _application = application;
             _connectionId = connectionId;
+
+            // We create the logger with a string to preserve the logging namespace after the server side transport renames.
             _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Connections.Internal.Transports.ServerSentEventsTransport");
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
             _options = options;
             _application = application;
             _connection = connection;
-            _logger = loggerFactory.CreateLogger("WebSocketsTransport");
+            _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Connections.Internal.Transports.WebSocketsTransport");
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
 {
-    internal partial class WebSocketsTransport : IHttpTransport
+    internal partial class WebSocketsServerTransport : IHttpTransport
     {
         private readonly WebSocketOptions _options;
         private readonly ILogger _logger;
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
         private readonly HttpConnectionContext _connection;
         private volatile bool _aborted;
 
-        public WebSocketsTransport(WebSocketOptions options, IDuplexPipe application, HttpConnectionContext connection, ILoggerFactory loggerFactory)
+        public WebSocketsServerTransport(WebSocketOptions options, IDuplexPipe application, HttpConnectionContext connection, ILoggerFactory loggerFactory)
         {
             if (options == null)
             {
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
             _options = options;
             _application = application;
             _connection = connection;
-            _logger = loggerFactory.CreateLogger<WebSocketsTransport>();
+            _logger = loggerFactory.CreateLogger<WebSocketsServerTransport>();
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -40,6 +40,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
             _options = options;
             _application = application;
             _connection = connection;
+
+            // We create the logger with a string to preserve the logging namespace after the server side transport renames.
             _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Connections.Internal.Transports.WebSocketsTransport");
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
             _options = options;
             _application = application;
             _connection = connection;
-            _logger = loggerFactory.CreateLogger<WebSocketsServerTransport>();
+            _logger = loggerFactory.CreateLogger("WebSocketsTransport");
         }
 
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsTransport.Log.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsTransport.Log.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
 {
-    internal partial class WebSocketsTransport
+    internal partial class WebSocketsServerTransport
     {
         private static class Log
         {

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1777,7 +1777,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         {
             bool ExpectedErrors(WriteContext writeContext)
             {
-                return (writeContext.LoggerName == typeof(LongPollingTransport).FullName &&
+                return (writeContext.LoggerName == typeof(LongPollingServerTransport).FullName &&
                        writeContext.EventId.Name == "LongPollingTerminated") ||
                        (writeContext.LoggerName == typeof(HttpConnectionManager).FullName &&
                        writeContext.EventId.Name == "FailedDispose");

--- a/src/SignalR/common/Http.Connections/test/LongPollingTests.cs
+++ b/src/SignalR/common/Http.Connections/test/LongPollingTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 var context = new DefaultHttpContext();
 
-                var poll = new LongPollingTransport(CancellationToken.None, connection.Application.Input, LoggerFactory);
+                var poll = new LongPollingServerTransport(CancellationToken.None, connection.Application.Input, LoggerFactory);
 
                 connection.Transport.Output.Complete();
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var context = new DefaultHttpContext();
 
                 var timeoutToken = new CancellationToken(true);
-                var poll = new LongPollingTransport(timeoutToken, connection.Application.Input, LoggerFactory);
+                var poll = new LongPollingServerTransport(timeoutToken, connection.Application.Input, LoggerFactory);
 
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken, context.RequestAborted))
                 {
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var connection = new DefaultConnectionContext("foo", pair.Transport, pair.Application);
                 var context = new DefaultHttpContext();
 
-                var poll = new LongPollingTransport(CancellationToken.None, connection.Application.Input, LoggerFactory);
+                var poll = new LongPollingServerTransport(CancellationToken.None, connection.Application.Input, LoggerFactory);
                 var ms = new MemoryStream();
                 context.Response.Body = ms;
 
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var connection = new DefaultConnectionContext("foo", pair.Transport, pair.Application);
                 var context = new DefaultHttpContext();
 
-                var poll = new LongPollingTransport(CancellationToken.None, connection.Application.Input, LoggerFactory);
+                var poll = new LongPollingServerTransport(CancellationToken.None, connection.Application.Input, LoggerFactory);
                 var ms = new MemoryStream();
                 context.Response.Body = ms;
 

--- a/src/SignalR/common/Http.Connections/test/ServerSentEventsTests.cs
+++ b/src/SignalR/common/Http.Connections/test/ServerSentEventsTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var connection = new DefaultConnectionContext("foo", pair.Transport, pair.Application);
                 var context = new DefaultHttpContext();
 
-                var sse = new ServerSentEventsTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
+                var sse = new ServerSentEventsServerTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
 
                 connection.Transport.Output.Complete();
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 var feature = new HttpBufferingFeature();
                 context.Features.Set<IHttpBufferingFeature>(feature);
-                var sse = new ServerSentEventsTransport(connection.Application.Input, connectionId: connection.ConnectionId, LoggerFactory);
+                var sse = new ServerSentEventsServerTransport(connection.Application.Input, connectionId: connection.ConnectionId, LoggerFactory);
 
                 connection.Transport.Output.Complete();
 
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 var ms = new MemoryStream();
                 context.Response.Body = ms;
-                var sse = new ServerSentEventsTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
+                var sse = new ServerSentEventsServerTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
 
                 var task = sse.ProcessRequestAsync(context, context.RequestAborted);
 
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 var ms = new MemoryStream();
                 context.Response.Body = ms;
-                var sse = new ServerSentEventsTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
+                var sse = new ServerSentEventsServerTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
 
                 var task = sse.ProcessRequestAsync(context, context.RequestAborted);
 
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var connection = new DefaultConnectionContext("foo", pair.Transport, pair.Application);
                 var context = new DefaultHttpContext();
 
-                var sse = new ServerSentEventsTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
+                var sse = new ServerSentEventsServerTransport(connection.Application.Input, connectionId: string.Empty, LoggerFactory);
                 var ms = new MemoryStream();
                 context.Response.Body = ms;
 

--- a/src/SignalR/common/Http.Connections/test/WebSocketsTests.cs
+++ b/src/SignalR/common/Http.Connections/test/WebSocketsTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null, LoggerFactory.CreateLogger("HttpConnectionContext2"));
-                    var ws = new WebSocketsTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
 
                     // Give the server socket to the transport and run it
                     var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 {
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null, LoggerFactory.CreateLogger("HttpConnectionContext2"));
                     connectionContext.ActiveFormat = transferFormat;
-                    var ws = new WebSocketsTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
 
                     // Give the server socket to the transport and run it
                     var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     }
 
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null, LoggerFactory.CreateLogger("HttpConnectionContext2"));
-                    var ws = new WebSocketsTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
 
                     // Give the server socket to the transport and run it
                     var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null);
-                    var ws = new WebSocketsTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(new WebSocketOptions(), connection.Application, connectionContext, LoggerFactory);
 
                     // Give the server socket to the transport and run it
                     var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     };
 
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null);
-                    var ws = new WebSocketsTransport(options, connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(options, connection.Application, connectionContext, LoggerFactory);
 
                     var serverSocket = await feature.AcceptAsync();
                     // Give the server socket to the transport and run it
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     };
 
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null);
-                    var ws = new WebSocketsTransport(options, connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(options, connection.Application, connectionContext, LoggerFactory);
 
                     var serverSocket = await feature.AcceptAsync();
                     // Give the server socket to the transport and run it
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     };
 
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null);
-                    var ws = new WebSocketsTransport(options, connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(options, connection.Application, connectionContext, LoggerFactory);
 
                     var serverSocket = await feature.AcceptAsync();
                     // Give the server socket to the transport and run it
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     };
 
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null);
-                    var ws = new WebSocketsTransport(options, connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(options, connection.Application, connectionContext, LoggerFactory);
 
                     var serverSocket = await feature.AcceptAsync();
                     // Give the server socket to the transport and run it
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     };
 
                     var connectionContext = new HttpConnectionContext(string.Empty, null, null);
-                    var ws = new WebSocketsTransport(options, connection.Application, connectionContext, LoggerFactory);
+                    var ws = new WebSocketsServerTransport(options, connection.Application, connectionContext, LoggerFactory);
 
                     // Create an HttpContext
                     var context = new DefaultHttpContext();


### PR DESCRIPTION
Adding "Server" to the server side transports. Mainly for search-ability.

