### PR TITLE
Add helper methods on ControllerBase to return ProblemDetails

### DIFF
--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -445,6 +445,8 @@ namespace Microsoft.AspNetCore.Mvc
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.PhysicalFileResult PhysicalFile(string physicalPath, string contentType, string fileDownloadName, System.DateTimeOffset? lastModified, Microsoft.Net.Http.Headers.EntityTagHeaderValue entityTag, bool enableRangeProcessing) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
+        public virtual Microsoft.AspNetCore.Mvc.ObjectResult Problem(string detail = null, string instance = null, string title = null, string type = null) { throw null; }
+        [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.RedirectResult Redirect(string url) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.RedirectResult RedirectPermanent(string url) { throw null; }
@@ -586,6 +588,8 @@ namespace Microsoft.AspNetCore.Mvc
         public virtual Microsoft.AspNetCore.Mvc.ActionResult ValidationProblem([Microsoft.AspNetCore.Mvc.Infrastructure.ActionResultObjectValueAttribute]Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary modelStateDictionary) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.ActionResult ValidationProblem([Microsoft.AspNetCore.Mvc.Infrastructure.ActionResultObjectValueAttribute]Microsoft.AspNetCore.Mvc.ValidationProblemDetails descriptor) { throw null; }
+        [Microsoft.AspNetCore.Mvc.NonActionAttribute]
+        public virtual Microsoft.AspNetCore.Mvc.ActionResult ValidationProblem(string detail, string instance = null, string title = null, string type = null, [Microsoft.AspNetCore.Mvc.Infrastructure.ActionResultObjectValueAttribute]Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary modelStateDictionary = null) { throw null; }
     }
     public partial class ControllerContext : Microsoft.AspNetCore.Mvc.ActionContext
     {

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -271,6 +271,7 @@ namespace Microsoft.AspNetCore.Mvc
         public Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinderFactory ModelBinderFactory { get { throw null; } set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary ModelState { get { throw null; } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IObjectModelValidator ObjectValidator { get { throw null; } set { } }
+        public Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory ProblemDetailsFactory { get { throw null; } set { } }
         public Microsoft.AspNetCore.Http.HttpRequest Request { get { throw null; } }
         public Microsoft.AspNetCore.Http.HttpResponse Response { get { throw null; } }
         public Microsoft.AspNetCore.Routing.RouteData RouteData { get { throw null; } }
@@ -445,7 +446,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.PhysicalFileResult PhysicalFile(string physicalPath, string contentType, string fileDownloadName, System.DateTimeOffset? lastModified, Microsoft.Net.Http.Headers.EntityTagHeaderValue entityTag, bool enableRangeProcessing) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
-        public virtual Microsoft.AspNetCore.Mvc.ObjectResult Problem(string detail = null, string instance = null, string title = null, string type = null) { throw null; }
+        public virtual Microsoft.AspNetCore.Mvc.ObjectResult Problem(string detail = null, string instance = null, int? statusCode = default(int?), string title = null, string type = null) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.RedirectResult Redirect(string url) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
@@ -589,7 +590,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
         public virtual Microsoft.AspNetCore.Mvc.ActionResult ValidationProblem([Microsoft.AspNetCore.Mvc.Infrastructure.ActionResultObjectValueAttribute]Microsoft.AspNetCore.Mvc.ValidationProblemDetails descriptor) { throw null; }
         [Microsoft.AspNetCore.Mvc.NonActionAttribute]
-        public virtual Microsoft.AspNetCore.Mvc.ActionResult ValidationProblem(string detail, string instance = null, string title = null, string type = null, [Microsoft.AspNetCore.Mvc.Infrastructure.ActionResultObjectValueAttribute]Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary modelStateDictionary = null) { throw null; }
+        public virtual Microsoft.AspNetCore.Mvc.ActionResult ValidationProblem(string detail = null, string instance = null, int? statusCode = default(int?), string title = null, string type = null, [Microsoft.AspNetCore.Mvc.Infrastructure.ActionResultObjectValueAttribute]Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary modelStateDictionary = null) { throw null; }
     }
     public partial class ControllerContext : Microsoft.AspNetCore.Mvc.ActionContext
     {
@@ -2441,6 +2442,12 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             public System.DateTimeOffset LastModified { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
             public long Length { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         }
+    }
+    public abstract partial class ProblemDetailsFactory
+    {
+        protected ProblemDetailsFactory() { }
+        public abstract Microsoft.AspNetCore.Mvc.ProblemDetails CreateProblemDetails(Microsoft.AspNetCore.Http.HttpContext httpContext, int? statusCode = default(int?), string title = null, string type = null, string detail = null, string instance = null);
+        public abstract Microsoft.AspNetCore.Mvc.ValidationProblemDetails CreateValidationProblemDetails(Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary modelStateDictionary, int? statusCode = default(int?), string title = null, string type = null, string detail = null, string instance = null);
     }
     public partial class RedirectResultExecutor : Microsoft.AspNetCore.Mvc.Infrastructure.IActionResultExecutor<Microsoft.AspNetCore.Mvc.RedirectResult>
     {

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -150,8 +150,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<ApiBehaviorOptions>, ApiBehaviorOptionsSetup>());
             services.TryAddEnumerable(
-                ServiceDescriptor.Transient<IPostConfigureOptions<ApiBehaviorOptions>, ApiBehaviorOptionsSetup>());
-            services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<RouteOptions>, MvcCoreRouteOptionsSetup>());
 
             //

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -258,6 +258,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IActionResultExecutor<ContentResult>, ContentResultExecutor>();
             services.TryAddSingleton<IActionResultExecutor<JsonResult>, SystemTextJsonResultExecutor>();
             services.TryAddSingleton<IClientErrorFactory, ProblemDetailsClientErrorFactory>();
+            services.TryAddSingleton<ProblemDetailsFactory, DefaultProblemDetailsFactory>();
 
             //
             // Route Handlers

--- a/src/Mvc/Mvc.Core/src/Infrastructure/DefaultProblemDetailsFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/DefaultProblemDetailsFactory.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    internal sealed class DefaultProblemDetailsFactory : ProblemDetailsFactory
+    {
+        private readonly ApiBehaviorOptions _options;
+
+        public DefaultProblemDetailsFactory(IOptions<ApiBehaviorOptions> options)
+        {
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public override ProblemDetails CreateProblemDetails(
+            HttpContext httpContext,
+            int? statusCode = null,
+            string title = null,
+            string type = null,
+            string detail = null,
+            string instance = null)
+        {
+            statusCode ??= 500;
+
+            var problemDetails = new ProblemDetails
+            {
+                Status = statusCode,
+                Title = title,
+                Type = type,
+                Detail = detail,
+                Instance = instance,
+            };
+
+            ApplyProblemDetailsDefaults(httpContext, problemDetails, statusCode.Value);
+
+            return problemDetails;
+        }
+
+        public override ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext,
+            ModelStateDictionary modelStateDictionary,
+            int? statusCode = null,
+            string title = null,
+            string type = null,
+            string detail = null,
+            string instance = null)
+        {
+            if (modelStateDictionary == null)
+            {
+                throw new ArgumentNullException(nameof(modelStateDictionary));
+            }
+
+            statusCode ??= 400;
+
+            var problemDetails = new ValidationProblemDetails(modelStateDictionary)
+            {
+                Status = statusCode,
+                Type = type,
+                Detail = detail,
+                Instance = instance,
+            };
+
+            if (title != null)
+            {
+                // For validation problem details, don't overwrite the default title with null.
+                problemDetails.Title = title;
+            }
+
+            ApplyProblemDetailsDefaults(httpContext, problemDetails, statusCode.Value);
+
+            return problemDetails;
+        }
+
+        private void ApplyProblemDetailsDefaults(HttpContext httpContext, ProblemDetails problemDetails, int statusCode)
+        {
+            problemDetails.Status ??= statusCode;
+
+            if (_options.ClientErrorMapping.TryGetValue(statusCode, out var clientErrorData))
+            {
+                problemDetails.Title ??= clientErrorData.Title;
+                problemDetails.Type ??= clientErrorData.Link;
+            }
+
+            var traceId = Activity.Current?.Id ?? httpContext?.TraceIdentifier;
+            if (traceId != null)
+            {
+                problemDetails.Extensions["traceId"] = traceId;
+            }
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ProblemDetailsFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ProblemDetailsFactory.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    /// <summary>
+    /// Factory to produce <see cref="ProblemDetails" /> and <see cref="ValidationProblemDetails" />.
+    /// </summary>
+    public abstract class ProblemDetailsFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="ProblemDetails" /> instance that configures defaults based on values specified in <see cref="ApiBehaviorOptions" />.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext" />.</param>
+        /// <param name="statusCode">The value for <see cref="ProblemDetails.Status"/>.</param>
+        /// <param name="title">The value for <see cref="ProblemDetails.Title" />.</param>
+        /// <param name="type">The value for <see cref="ProblemDetails.Type" />.</param>
+        /// <param name="detail">The value for <see cref="ProblemDetails.Detail" />.</param>
+        /// <param name="instance">The value for <see cref="ProblemDetails.Instance" />.</param>
+        /// <returns>The <see cref="ProblemDetails"/> instance.</returns>
+        public abstract ProblemDetails CreateProblemDetails(
+            HttpContext httpContext,
+            int? statusCode = null,
+            string title = null,
+            string type = null,
+            string detail = null,
+            string instance = null);
+
+        /// <summary>
+        /// Creates a <see cref="ValidationProblemDetails" /> instance that configures defaults based on values specified in <see cref="ApiBehaviorOptions" />.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext" />.</param>
+        /// <param name="modelStateDictionary">The <see cref="ModelStateDictionary" />.</param>
+        /// <param name="statusCode">The value for <see cref="ProblemDetails.Status"/>.</param>
+        /// <param name="title">The value for <see cref="ProblemDetails.Title" />.</param>
+        /// <param name="type">The value for <see cref="ProblemDetails.Type" />.</param>
+        /// <param name="detail">The value for <see cref="ProblemDetails.Detail" />.</param>
+        /// <param name="instance">The value for <see cref="ProblemDetails.Instance" />.</param>
+        /// <returns>The <see cref="ValidationProblemDetails"/> instance.</returns>
+        public abstract ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext,
+            ModelStateDictionary modelStateDictionary,
+            int? statusCode = null,
+            string title = null,
+            string type = null,
+            string detail = null,
+            string instance = null);
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Resources.resx
+++ b/src/Mvc/Mvc.Core/src/Resources.resx
@@ -510,4 +510,7 @@
   <data name="UnexpectedJsonEnd" xml:space="preserve">
     <value>Unexcepted end when reading JSON.</value>
   </data>
+  <data name="ApiConventions_Title_500" xml:space="preserve">
+    <value>An error occured while processing your request.</value>
+  </data>
 </root>

--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Routing;
@@ -2292,56 +2293,20 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         }
 
         [Fact]
-        public void ValidationProblemDetails_UsesErrorDataConfiguredInApiBehaviorOptions()
-        {
-            // Arrange
-            var title = "Custom title";
-            var link = "http://custom-link";
-            var serviceProvider = new ServiceCollection()
-                .AddOptions()
-                .AddTransient<IConfigureOptions<ApiBehaviorOptions>, ApiBehaviorOptionsSetup>()
-                .Configure<ApiBehaviorOptions>(o => o.ClientErrorMapping[400] = new ClientErrorData { Link = link, Title = title })
-                .BuildServiceProvider();
-
-            var context = new ControllerContext(new ActionContext(
-                new DefaultHttpContext { RequestServices = serviceProvider },
-                new RouteData(),
-                new ControllerActionDescriptor()));
-
-            var controller = new TestableController
-            {
-                ControllerContext = context,
-            };
-
-            // Act
-            var actionResult = controller.ValidationProblem();
-
-            // Assert
-            var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult);
-            var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequestResult.Value);
-            // ValidationProblemDetails uses the default value to be consistent with the filter.
-            Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
-            Assert.Equal(link, problemDetails.Type);
-        }
-
-        [Fact]
         public void ValidationProblemDetails_Works()
         {
             // Arrange
-            var serviceProvider = new ServiceCollection()
-                .AddOptions()
-                .AddTransient<IConfigureOptions<ApiBehaviorOptions>, ApiBehaviorOptionsSetup>()
-                .BuildServiceProvider();
-
             var context = new ControllerContext(new ActionContext(
-                new DefaultHttpContext { RequestServices = serviceProvider },
+                new DefaultHttpContext { TraceIdentifier = "some-trace" },
                 new RouteData(),
                 new ControllerActionDescriptor()));
 
             context.ModelState.AddModelError("key1", "error1");
 
+            var options = GetApiBehaviorOptions();
             var controller = new TestableController
             {
+                ProblemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(options)),
                 ControllerContext = context,
             };
 
@@ -2354,7 +2319,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.Equal(400, problemDetails.Status);
             Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
             Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
-            Assert.NotNull(problemDetails.Extensions["traceId"]);
+            Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
             Assert.Equal(new[] { "error1" }, problemDetails.Errors["key1"]);
         }
 
@@ -2364,30 +2329,22 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             // Arrange
             var detail = "My detail";
             var title = "Custom title";
-            var link = "http://custom-link";
-            var serviceProvider = new ServiceCollection()
-                .AddOptions()
-                .Configure<ApiBehaviorOptions>(o => o.ClientErrorMapping[400] = new ClientErrorData { Link = link, Title = "Original Title" })
-                .BuildServiceProvider();
-
-            var context = new ControllerContext(new ActionContext(
-                new DefaultHttpContext { RequestServices = serviceProvider },
-                new RouteData(),
-                new ControllerActionDescriptor()));
+            var type = "http://custom-link";
+            var options = GetApiBehaviorOptions();
 
             var controller = new TestableController
             {
-                ControllerContext = context,
+                ProblemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(options)),
             };
 
             // Act
-            var actionResult = controller.ValidationProblem(detail, title: title);
+            var actionResult = controller.ValidationProblem(detail: detail, title: title, type: type);
 
             // Assert
             var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult);
             var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequestResult.Value);
             Assert.Equal(title, problemDetails.Title);
-            Assert.Equal(link, problemDetails.Type);
+            Assert.Equal(type, problemDetails.Type);
             Assert.Equal(detail, problemDetails.Detail);
         }
 
@@ -2395,18 +2352,16 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         public void ProblemDetails_Works()
         {
             // Arrange
-            var serviceProvider = new ServiceCollection()
-                .AddOptions()
-                .AddTransient<IConfigureOptions<ApiBehaviorOptions>, ApiBehaviorOptionsSetup>()
-                .BuildServiceProvider();
-
             var context = new ControllerContext(new ActionContext(
-                new DefaultHttpContext { RequestServices = serviceProvider },
+                new DefaultHttpContext { TraceIdentifier = "some-trace" },
                 new RouteData(),
                 new ControllerActionDescriptor()));
 
+            var options = GetApiBehaviorOptions();
+
             var controller = new TestableController
             {
+                ProblemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(options)),
                 ControllerContext = context,
             };
 
@@ -2419,7 +2374,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.Equal(500, problemDetails.Status);
             Assert.Equal("An error occured while processing your request.", problemDetails.Title);
             Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.6.1", problemDetails.Type);
-            Assert.NotNull(problemDetails.Extensions["traceId"]);
+            Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
         }
 
         [Fact]
@@ -2428,19 +2383,11 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             // Arrange
             var title = "The website is down.";
             var detail = "Try again in a few minutes.";
-            var serviceProvider = new ServiceCollection()
-                .AddOptions()
-                .AddTransient<IConfigureOptions<ApiBehaviorOptions>, ApiBehaviorOptionsSetup>()
-                .BuildServiceProvider();
-
-            var context = new ControllerContext(new ActionContext(
-                new DefaultHttpContext { RequestServices = serviceProvider },
-                new RouteData(),
-                new ControllerActionDescriptor()));
+            var options = GetApiBehaviorOptions();
 
             var controller = new TestableController
             {
-                ControllerContext = context,
+                ProblemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(options)),
             };
 
             // Act
@@ -2453,7 +2400,53 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.Equal(title, problemDetails.Title);
             Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.6.1", problemDetails.Type);
             Assert.Equal(detail, problemDetails.Detail);
-            Assert.NotNull(problemDetails.Extensions["traceId"]);
+        }
+
+        [Fact]
+        public void ProblemDetails_UsesPassedInStatusCode()
+        {
+            // Arrange
+            var options = GetApiBehaviorOptions();
+
+            var controller = new TestableController
+            {
+                ProblemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(options)),
+            };
+
+            // Act
+            var actionResult = controller.Problem(statusCode: 422);
+
+            // Assert
+            var badRequestResult = Assert.IsType<ObjectResult>(actionResult);
+            var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
+            Assert.Equal(422, problemDetails.Status);
+            Assert.Equal("Unprocessable entity.", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc4918#section-11.2", problemDetails.Type);
+        }
+
+        private static ApiBehaviorOptions GetApiBehaviorOptions()
+        {
+            return new ApiBehaviorOptions
+            {
+                ClientErrorMapping =
+                {
+                    [400] = new ClientErrorData
+                    {
+                        Title = "One or more validation errors occurred.",
+                        Link = "https://tools.ietf.org/html/rfc7231#section-6.5.1"
+                    },
+                    [422] = new ClientErrorData
+                    {
+                        Title = "Unprocessable entity.",
+                        Link = "https://tools.ietf.org/html/rfc4918#section-11.2"
+                    },
+                    [500] = new ClientErrorData
+                    {
+                        Title = "An error occured while processing your request.",
+                        Link = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
+                    }
+                }
+            };
         }
 
         public static IEnumerable<object[]> RedirectTestData

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
@@ -13,24 +13,10 @@ namespace Microsoft.Extensions.DependencyInjection
     public class ApiBehaviorOptionsSetupTest
     {
         [Fact]
-        public void Configure_AssignsInvalidModelStateResponseFactory()
-        {
-            // Arrange
-            var optionsSetup = new ApiBehaviorOptionsSetup();
-            var options = new ApiBehaviorOptions();
-
-            // Act
-            optionsSetup.Configure(options);
-
-            // Assert
-            Assert.Same(ApiBehaviorOptionsSetup.DefaultFactory, options.InvalidModelStateResponseFactory);
-        }
-
-        [Fact]
         public void Configure_AddsClientErrorMappings()
         {
             // Arrange
-            var expected = new[] { 400, 401, 403, 404, 406, 409, 415, 422, };
+            var expected = new[] { 400, 401, 403, 404, 406, 409, 415, 422, 500, };
             var optionsSetup = new ApiBehaviorOptionsSetup();
             var options = new ApiBehaviorOptions();
 
@@ -42,39 +28,6 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
-        public void PostConfigure_SetProblemDetailsModelStateResponseFactory()
-        {
-            // Arrange
-            var optionsSetup = new ApiBehaviorOptionsSetup();
-            var options = new ApiBehaviorOptions();
-
-            // Act
-            optionsSetup.Configure(options);
-            optionsSetup.PostConfigure(string.Empty, options);
-
-            // Assert
-            Assert.Same(ApiBehaviorOptionsSetup.ProblemDetailsFactory, options.InvalidModelStateResponseFactory);
-        }
-
-        [Fact]
-        public void PostConfigure_DoesNotSetProblemDetailsFactory_IfValueWasModified()
-        {
-            // Arrange
-            var optionsSetup = new ApiBehaviorOptionsSetup();
-            var options = new ApiBehaviorOptions();
-            Func<ActionContext, IActionResult> expected = _ => null;
-
-            // Act
-            optionsSetup.Configure(options);
-            // This is equivalent to user code updating the value via ConfigureOptions
-            options.InvalidModelStateResponseFactory = expected;
-            optionsSetup.PostConfigure(string.Empty, options);
-
-            // Assert
-            Assert.Same(expected, options.InvalidModelStateResponseFactory);
-        }
-
-        [Fact]
         public void ProblemDetailsInvalidModelStateResponse_ReturnsBadRequestWithProblemDetails()
         {
             // Arrange
@@ -83,8 +36,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
             };
 
+            var factory = GetInvalidModelStateResponseFactory();
+
             // Act
-            var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(actionContext);
+            var result = factory(actionContext);
 
             // Assert
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
@@ -92,6 +47,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
             Assert.Equal(400, problemDetails.Status);
+            Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
         }
 
         [Fact]
@@ -104,9 +61,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
                 };
+                var factory = GetInvalidModelStateResponseFactory();
 
                 // Act
-                var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(actionContext);
+                var result = factory(actionContext);
 
                 // Assert
                 var badRequest = Assert.IsType<BadRequestObjectResult>(result);
@@ -123,14 +81,26 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
             };
+            var factory = GetInvalidModelStateResponseFactory();
 
             // Act
-            var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(actionContext);
+            var result = factory(actionContext);
 
             // Assert
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
             Assert.Equal("42", problemDetails.Extensions["traceId"]);
+        }
+
+        private static Func<ActionContext, IActionResult> GetInvalidModelStateResponseFactory()
+        {
+            var options = new ApiBehaviorOptions();
+            var setup = new ApiBehaviorOptionsSetup();
+
+            setup.Configure(options);
+
+            var factory = options.InvalidModelStateResponseFactory;
+            return factory;
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Xunit;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -31,15 +32,11 @@ namespace Microsoft.Extensions.DependencyInjection
         public void ProblemDetailsInvalidModelStateResponse_ReturnsBadRequestWithProblemDetails()
         {
             // Arrange
-            var actionContext = new ActionContext
-            {
-                HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
-            };
-
-            var factory = GetInvalidModelStateResponseFactory();
+            var actionContext = GetActionContext();
+            var factory = GetProblemDetailsFactory();
 
             // Act
-            var result = factory(actionContext);
+            var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(factory, actionContext);
 
             // Assert
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
@@ -52,19 +49,38 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        public void ProblemDetailsInvalidModelStateResponse_UsesUserConfiguredLink()
+        {
+            // Arrange
+            var link = "http://mylink";
+            var actionContext = GetActionContext();
+
+            var factory = GetProblemDetailsFactory(options => options.ClientErrorMapping[400].Link = link);
+
+            // Act
+            var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(factory, actionContext);
+
+            // Assert
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(new[] { "application/problem+json", "application/problem+xml" }, badRequest.ContentTypes.OrderBy(c => c));
+
+            var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+            Assert.Equal(400, problemDetails.Status);
+            Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+            Assert.Equal(link, problemDetails.Type);
+        }
+
+        [Fact]
         public void ProblemDetailsInvalidModelStateResponse_SetsTraceId()
         {
             // Arrange
             using (new ActivityReplacer())
             {
-                var actionContext = new ActionContext
-                {
-                    HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
-                };
-                var factory = GetInvalidModelStateResponseFactory();
+                var actionContext = GetActionContext();
+                var factory = GetProblemDetailsFactory();
 
                 // Act
-                var result = factory(actionContext);
+                var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(factory, actionContext);
 
                 // Assert
                 var badRequest = Assert.IsType<BadRequestObjectResult>(result);
@@ -77,14 +93,11 @@ namespace Microsoft.Extensions.DependencyInjection
         public void ProblemDetailsInvalidModelStateResponse_SetsTraceIdFromRequest_IfActivityIsNull()
         {
             // Arrange
-            var actionContext = new ActionContext
-            {
-                HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
-            };
-            var factory = GetInvalidModelStateResponseFactory();
+            var actionContext = GetActionContext();
+            var factory = GetProblemDetailsFactory();
 
             // Act
-            var result = factory(actionContext);
+            var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(factory, actionContext);
 
             // Assert
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
@@ -92,15 +105,26 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.Equal("42", problemDetails.Extensions["traceId"]);
         }
 
-        private static Func<ActionContext, IActionResult> GetInvalidModelStateResponseFactory()
+        private static ProblemDetailsFactory GetProblemDetailsFactory(Action<ApiBehaviorOptions> configure = null)
         {
             var options = new ApiBehaviorOptions();
             var setup = new ApiBehaviorOptionsSetup();
 
             setup.Configure(options);
+            if (configure != null)
+            {
+                configure(options);
+            }
 
-            var factory = options.InvalidModelStateResponseFactory;
-            return factory;
+            return new DefaultProblemDetailsFactory(Options.Options.Create(options));
+        }
+
+        private static ActionContext GetActionContext()
+        {
+            return new ActionContext
+            {
+                HttpContext = new DefaultHttpContext { TraceIdentifier = "42" },
+            };
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreServiceCollectionExtensionsTest.cs
@@ -265,13 +265,6 @@ namespace Microsoft.AspNetCore.Mvc
                         }
                     },
                     {
-                        typeof(IPostConfigureOptions<ApiBehaviorOptions>),
-                        new Type[]
-                        {
-                            typeof(ApiBehaviorOptionsSetup),
-                        }
-                    },
-                    {
                         typeof(IActionConstraintProvider),
                         new Type[]
                         {

--- a/src/Mvc/Mvc.Core/test/Formatters/TranscodingReadStreamTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/TranscodingReadStreamTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;

--- a/src/Mvc/Mvc.Core/test/Formatters/TranscodingReadStreamTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/TranscodingReadStreamTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    public class ProblemDetailsFactoryTest
+    {
+        private readonly ProblemDetailsFactory Factory = GetProblemDetails();
+
+        [Fact]
+        public void CreateProblemDetails_DefaultValues()
+        {
+            // Act
+            var problemDetails = Factory.CreateProblemDetails(GetHttpContext());
+
+            // Assert
+            Assert.Equal(500, problemDetails.Status);
+            Assert.Equal("An error occured while processing your request.", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.6.1", problemDetails.Type);
+            Assert.Null(problemDetails.Instance);
+            Assert.Null(problemDetails.Detail);
+            Assert.Collection(
+                problemDetails.Extensions,
+                kvp =>
+                {
+                    Assert.Equal("traceId", kvp.Key);
+                    Assert.Equal("some-trace", kvp.Value);
+                });
+        }
+
+        [Fact]
+        public void CreateProblemDetails_WithStatusCode()
+        {
+            // Act
+            var problemDetails = Factory.CreateProblemDetails(GetHttpContext(), statusCode: 406);
+
+            // Assert
+            Assert.Equal(406, problemDetails.Status);
+            Assert.Equal("Not Acceptable", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.6", problemDetails.Type);
+            Assert.Null(problemDetails.Instance);
+            Assert.Null(problemDetails.Detail);
+            Assert.Collection(
+                problemDetails.Extensions,
+                kvp =>
+                {
+                    Assert.Equal("traceId", kvp.Key);
+                    Assert.Equal("some-trace", kvp.Value);
+                });
+        }
+
+        [Fact]
+        public void CreateProblemDetails_WithDetailAndTitle()
+        {
+            // Act
+            var title = "Some title";
+            var detail = "some detail";
+            var problemDetails = Factory.CreateProblemDetails(GetHttpContext(), statusCode: 406, title: title, detail: detail);
+
+            // Assert
+            Assert.Equal(406, problemDetails.Status);
+            Assert.Equal(title, problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.6", problemDetails.Type);
+            Assert.Null(problemDetails.Instance);
+            Assert.Equal(detail, problemDetails.Detail);
+            Assert.Collection(
+                problemDetails.Extensions,
+                kvp =>
+                {
+                    Assert.Equal("traceId", kvp.Key);
+                    Assert.Equal("some-trace", kvp.Value);
+                });
+        }
+
+        [Fact]
+        public void CreateValidationProblemDetails_DefaultValues()
+        {
+            // Act
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("some-key", "some-value");
+            var problemDetails = Factory.CreateValidationProblemDetails(GetHttpContext(), modelState);
+
+            // Assert
+            Assert.Equal(400, problemDetails.Status);
+            Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
+            Assert.Null(problemDetails.Instance);
+            Assert.Null(problemDetails.Detail);
+            Assert.Collection(
+                problemDetails.Extensions,
+                kvp =>
+                {
+                    Assert.Equal("traceId", kvp.Key);
+                    Assert.Equal("some-trace", kvp.Value);
+                });
+            Assert.Collection(
+               problemDetails.Errors,
+               kvp =>
+               {
+                   Assert.Equal("some-key", kvp.Key);
+                   Assert.Equal(new[] { "some-value" }, kvp.Value);
+               });
+        }
+
+        [Fact]
+        public void CreateValidationProblemDetails_WithStatusCode()
+        {
+            // Act
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("some-key", "some-value");
+            var problemDetails = Factory.CreateValidationProblemDetails(GetHttpContext(), modelState, 422);
+
+            // Assert
+            Assert.Equal(422, problemDetails.Status);
+            Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc4918#section-11.2", problemDetails.Type);
+            Assert.Null(problemDetails.Instance);
+            Assert.Null(problemDetails.Detail);
+            Assert.Collection(
+                problemDetails.Extensions,
+                kvp =>
+                {
+                    Assert.Equal("traceId", kvp.Key);
+                    Assert.Equal("some-trace", kvp.Value);
+                });
+            Assert.Collection(
+               problemDetails.Errors,
+               kvp =>
+               {
+                   Assert.Equal("some-key", kvp.Key);
+                   Assert.Equal(new[] { "some-value" }, kvp.Value);
+               });
+        }
+
+        [Fact]
+        public void CreateValidationProblemDetails_WithTitleAndInstance()
+        {
+            // Act
+            var title = "Some title";
+            var instance = "some instance";
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("some-key", "some-value");
+            var problemDetails = Factory.CreateValidationProblemDetails(GetHttpContext(), modelState, title: title, instance: instance);
+
+            // Assert
+            Assert.Equal(400, problemDetails.Status);
+            Assert.Equal(title, problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
+            Assert.Equal(instance, problemDetails.Instance);
+            Assert.Null(problemDetails.Detail);
+            Assert.Collection(
+                problemDetails.Extensions,
+                kvp =>
+                {
+                    Assert.Equal("traceId", kvp.Key);
+                    Assert.Equal("some-trace", kvp.Value);
+                });
+            Assert.Collection(
+               problemDetails.Errors,
+               kvp =>
+               {
+                   Assert.Equal("some-key", kvp.Key);
+                   Assert.Equal(new[] { "some-value" }, kvp.Value);
+               });
+        }
+
+        private static DefaultHttpContext GetHttpContext()
+        {
+            return new DefaultHttpContext
+            {
+                TraceIdentifier = "some-trace",
+            };
+        }
+
+        private static ProblemDetailsFactory GetProblemDetails()
+        {
+            var options = new ApiBehaviorOptions();
+            new ApiBehaviorOptionsSetup().Configure(options);
+            return new DefaultProblemDetailsFactory(Options.Create(options));
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetalsClientErrorFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetalsClientErrorFactoryTest.cs
@@ -15,13 +15,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         {
             // Arrange
             var clientError = new UnsupportedMediaTypeResult();
-            var factory = new ProblemDetailsClientErrorFactory(Options.Create(new ApiBehaviorOptions
+            var problemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(new ApiBehaviorOptions
             {
                 ClientErrorMapping =
                 {
                     [405] = new ClientErrorData { Link = "Some link", Title = "Summary" },
                 },
             }));
+            var factory = new ProblemDetailsClientErrorFactory(problemDetailsFactory);
 
             // Act
             var result = factory.GetClientError(GetActionContext(), clientError);
@@ -31,7 +32,6 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             Assert.Equal(new[] { "application/problem+json", "application/problem+xml" }, objectResult.ContentTypes);
             var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
             Assert.Equal(415, problemDetails.Status);
-            Assert.Equal("about:blank", problemDetails.Type);
             Assert.Null(problemDetails.Title);
             Assert.Null(problemDetails.Detail);
             Assert.Null(problemDetails.Instance);
@@ -42,13 +42,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         {
             // Arrange
             var clientError = new UnsupportedMediaTypeResult();
-            var factory = new ProblemDetailsClientErrorFactory(Options.Create(new ApiBehaviorOptions
+            var problemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(new ApiBehaviorOptions
             {
                 ClientErrorMapping =
                 {
                     [415] = new ClientErrorData { Link = "Some link", Title = "Summary" },
                 },
             }));
+            var factory = new ProblemDetailsClientErrorFactory(problemDetailsFactory);
 
             // Act
             var result = factory.GetClientError(GetActionContext(), clientError);
@@ -71,13 +72,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             using (new ActivityReplacer())
             {
                 var clientError = new UnsupportedMediaTypeResult();
-                var factory = new ProblemDetailsClientErrorFactory(Options.Create(new ApiBehaviorOptions
+                var problemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(new ApiBehaviorOptions
                 {
                     ClientErrorMapping =
                 {
-                    [415] = new ClientErrorData { Link = "Some link", Title = "Summary" },
+                    [405] = new ClientErrorData { Link = "Some link", Title = "Summary" },
                 },
                 }));
+                var factory = new ProblemDetailsClientErrorFactory(problemDetailsFactory);
 
                 // Act
                 var result = factory.GetClientError(GetActionContext(), clientError);
@@ -96,13 +98,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         {
             // Arrange
             var clientError = new UnsupportedMediaTypeResult();
-            var factory = new ProblemDetailsClientErrorFactory(Options.Create(new ApiBehaviorOptions
+            var problemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(new ApiBehaviorOptions
             {
                 ClientErrorMapping =
                 {
-                    [415] = new ClientErrorData { Link = "Some link", Title = "Summary" },
+                    [405] = new ClientErrorData { Link = "Some link", Title = "Summary" },
                 },
             }));
+            var factory = new ProblemDetailsClientErrorFactory(problemDetailsFactory);
 
             // Act
             var result = factory.GetClientError(GetActionContext(), clientError);

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiBehaviorTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiBehaviorTest.cs
@@ -56,6 +56,10 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                     {
                         Converters = { new ValidationProblemDetailsConverter() }
                     });
+
+                Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+                Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
+
                 Assert.Collection(
                     problemDetails.Errors.OrderBy(kvp => kvp.Key),
                     kvp =>

--- a/src/Mvc/test/WebSites/BasicWebSite/StartupWithCustomInvalidModelStateFactory.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/StartupWithCustomInvalidModelStateFactory.cs
@@ -24,15 +24,11 @@ namespace BasicWebSite
 
             services.Configure<ApiBehaviorOptions>(options =>
             {
-                var previous = options.InvalidModelStateResponseFactory;
                 options.InvalidModelStateResponseFactory = context =>
                 {
-                    var result = (BadRequestObjectResult)previous(context);
-                    if (context.ActionDescriptor.FilterDescriptors.Any(f => f.Filter is VndErrorAttribute))
-                    {
-                        result.ContentTypes.Clear();
-                        result.ContentTypes.Add("application/vnd.error+json");
-                    }
+                    var result = new BadRequestObjectResult(context.ModelState);
+                    result.ContentTypes.Clear();
+                    result.ContentTypes.Add("application/vnd.error+json");
 
                     return result;
                 };


### PR DESCRIPTION
* Introduce ControllerBase.Problem and ValidationProblem overload
  that accepts optional parameters
* Consistently use ClientErrorData when generating ProblemDetails
* Clean-up InvalidModelStateResponseFactory initialization.

Fixes https://github.com/aspnet/AspNetCore/issues/8537

---------------------------------------------------------

## Description

Add APIs to return a `ProblemDetails` instance from a `ControllerBase`. Fixes bugs where instances of `ProblemDetails` created in different parts of MVC had different (missing) content.

## Customer Impact
This is a new API so customers aren't impacted until they use it.

## Regression?
No

## Risk
Low. 


