### PR TITLE
Avoid unobserved tasks in WebSocketsTransport

### DIFF
--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.Log.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.Log.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 LoggerMessage.Define(LogLevel.Information, new EventId(16, "ClosingWebSocket"), "Closing WebSocket.");
 
             private static readonly Action<ILogger, Exception> _closingWebSocketFailed =
-                LoggerMessage.Define(LogLevel.Information, new EventId(17, "ClosingWebSocketFailed"), "Closing webSocket failed.");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(17, "ClosingWebSocketFailed"), "Closing webSocket failed.");
 
             private static readonly Action<ILogger, Exception> _cancelMessage =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(18, "CancelMessage"), "Canceled passing message to application.");

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -156,6 +156,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
                 if (trigger == receiving)
                 {
+                    // Observe exception if there is one to avoid unobserved tasks
+                    _ = receiving.Exception;
+
                     // We're waiting for the application to finish and there are 2 things it could be doing
                     // 1. Waiting for application data
                     // 2. Waiting for a websocket send to complete
@@ -176,6 +179,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                         }
                         else
                         {
+                            // Observe exception if there is one to avoid unobserved tasks
+                            _ = sending.Exception;
+
                             // Cancel the timeout
                             delayCts.Cancel();
                         }
@@ -183,6 +189,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 }
                 else
                 {
+                    // Observe exception if there is one to avoid unobserved tasks
+                    _ = sending.Exception;
+
                     // We're waiting on the websocket to close and there are 2 things it could be doing
                     // 1. Waiting for websocket data
                     // 2. Waiting on a flush to complete (backpressure being applied)
@@ -269,10 +278,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 if (!_aborted)
                 {
                     _application.Output.Complete(ex);
-
-                    // We re-throw here so we can communicate that there was an error when sending
-                    // the close frame
-                    throw;
                 }
             }
             finally

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -352,8 +352,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             {
                 if (WebSocketCanSend(socket))
                 {
-                    // We're done sending, send the close frame to the client if the websocket is still open
-                    await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    try
+                    {
+                        // We're done sending, send the close frame to the client if the websocket is still open
+                        await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.ClosingWebSocketFailed(_logger, ex);
+                    }
                 }
 
                 _application.Input.Complete();

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -156,9 +156,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
                 if (trigger == receiving)
                 {
-                    // Observe exception if there is one to avoid unobserved tasks
-                    _ = receiving.Exception;
-
                     // We're waiting for the application to finish and there are 2 things it could be doing
                     // 1. Waiting for application data
                     // 2. Waiting for a websocket send to complete
@@ -179,9 +176,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                         }
                         else
                         {
-                            // Observe exception if there is one to avoid unobserved tasks
-                            _ = sending.Exception;
-
                             // Cancel the timeout
                             delayCts.Cancel();
                         }
@@ -189,9 +183,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 }
                 else
                 {
-                    // Observe exception if there is one to avoid unobserved tasks
-                    _ = sending.Exception;
-
                     // We're waiting on the websocket to close and there are 2 things it could be doing
                     // 1. Waiting for websocket data
                     // 2. Waiting on a flush to complete (backpressure being applied)

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -77,6 +77,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
 
             if (trigger == receiving)
             {
+                // Observe exception if there is one to avoid unobserved tasks
+                _ = receiving.Exception;
+
                 Log.WaitingForSend(_logger);
 
                 // We're waiting for the application to finish and there are 2 things it could be doing
@@ -102,12 +105,18 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
                     }
                     else
                     {
+                        // Observe exception if there is one to avoid unobserved tasks
+                        _ = sending.Exception;
+
                         delayCts.Cancel();
                     }
                 }
             }
             else
             {
+                // Observe exception if there is one to avoid unobserved tasks
+                _ = sending.Exception;
+
                 Log.WaitingForClose(_logger);
 
                 // We're waiting on the websocket to close and there are 2 things it could be doing
@@ -130,6 +139,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
                     }
                     else
                     {
+                        // Observe exception if there is one to avoid unobserved tasks
+                        _ = receiving.Exception;
+
                         delayCts.Cancel();
                     }
                 }
@@ -189,10 +201,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
                 if (!_aborted && !token.IsCancellationRequested)
                 {
                     _application.Output.Complete(ex);
-
-                    // We re-throw here so we can communicate that there was an error when sending
-                    // the close frame
-                    throw;
                 }
             }
             finally

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -278,8 +278,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
                 // Send the close frame before calling into user code
                 if (WebSocketCanSend(socket))
                 {
-                    // We're done sending, send the close frame to the client if the websocket is still open
-                    await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    try
+                    {
+                        // We're done sending, send the close frame to the client if the websocket is still open
+                        await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.ClosingWebSocketFailed(_logger, ex);
+                    }
                 }
 
                 _application.Input.Complete();

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -77,9 +77,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
 
             if (trigger == receiving)
             {
-                // Observe exception if there is one to avoid unobserved tasks
-                _ = receiving.Exception;
-
                 Log.WaitingForSend(_logger);
 
                 // We're waiting for the application to finish and there are 2 things it could be doing
@@ -105,18 +102,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
                     }
                     else
                     {
-                        // Observe exception if there is one to avoid unobserved tasks
-                        _ = sending.Exception;
-
                         delayCts.Cancel();
                     }
                 }
             }
             else
             {
-                // Observe exception if there is one to avoid unobserved tasks
-                _ = sending.Exception;
-
                 Log.WaitingForClose(_logger);
 
                 // We're waiting on the websocket to close and there are 2 things it could be doing
@@ -139,9 +130,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
                     }
                     else
                     {
-                        // Observe exception if there is one to avoid unobserved tasks
-                        _ = receiving.Exception;
-
                         delayCts.Cancel();
                     }
                 }

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsTransport.Log.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsTransport.Log.cs
@@ -53,6 +53,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
             private static readonly Action<ILogger, Exception> _closedPrematurely =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(14, "ClosedPrematurely"), "Socket connection closed prematurely.");
 
+            private static readonly Action<ILogger, Exception> _closingWebSocketFailed =
+                LoggerMessage.Define(LogLevel.Debug, new EventId(15, "ClosingWebSocketFailed"), "Closing webSocket failed.");
+
             public static void SocketOpened(ILogger logger, string subProtocol)
             {
                 _socketOpened(logger, subProtocol, null);
@@ -121,6 +124,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal.Transports
             public static void ClosedPrematurely(ILogger logger, Exception ex)
             {
                 _closedPrematurely(logger, ex);
+            }
+
+            public static void ClosingWebSocketFailed(ILogger logger, Exception ex)
+            {
+                _closingWebSocketFailed(logger, ex);
             }
         }
     }


### PR DESCRIPTION
Fixing an instance of unobserved tasks that was causing clients in UWP apps to crash.
Not sure if this 100% fixes https://github.com/aspnet/AspNetCore/issues/12193 as one of the stack traces showed `HubConnection.ReceiveLoop` causing a crash (which looks impossible IMO).