### PR TITLE
Revert "Make RemoteUriHelper internal"

### DIFF
--- a/src/Components/Server/ref/Microsoft.AspNetCore.Components.Server.netcoreapp3.0.cs
+++ b/src/Components/Server/ref/Microsoft.AspNetCore.Components.Server.netcoreapp3.0.cs
@@ -69,6 +69,15 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         public virtual System.Threading.Tasks.Task OnConnectionDownAsync(Microsoft.AspNetCore.Components.Server.Circuits.Circuit circuit, System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task OnConnectionUpAsync(Microsoft.AspNetCore.Components.Server.Circuits.Circuit circuit, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
+    public partial class RemoteUriHelper : Microsoft.AspNetCore.Components.UriHelperBase
+    {
+        public RemoteUriHelper(Microsoft.Extensions.Logging.ILogger<Microsoft.AspNetCore.Components.Server.Circuits.RemoteUriHelper> logger) { }
+        public bool HasAttachedJSRuntime { get { throw null; } }
+        public override void InitializeState(string uriAbsolute, string baseUriAbsolute) { }
+        protected override void NavigateToCore(string uri, bool forceLoad) { }
+        [Microsoft.JSInterop.JSInvokableAttribute("NotifyLocationChanged")]
+        public static void NotifyLocationChanged(string uriAbsolute, bool isInterceptedLink) { }
+    }
 }
 namespace Microsoft.AspNetCore.Components.Web.Rendering
 {

--- a/src/Components/Server/src/Circuits/RemoteUriHelper.cs
+++ b/src/Components/Server/src/Circuits/RemoteUriHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
     /// <summary>
     /// A Server-Side Components implementation of <see cref="IUriHelper"/>.
     /// </summary>
-    internal class RemoteUriHelper : UriHelperBase
+    public class RemoteUriHelper : UriHelperBase
     {
         private readonly ILogger<RemoteUriHelper> _logger;
         private IJSRuntime _jsRuntime;


### PR DESCRIPTION
This reverts commit e23bc822cf5f56d6cf35617e7474bbaab36eaf78.

This change breaks server-side Blazor. It was able to get through because the E2E tests aren't running and the template test was marked flaky.