### PR TITLE
Templating test reliability

### DIFF
--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -29,7 +29,6 @@ namespace Templates.Test
         [Theory]
         [InlineData(null)]
         [InlineData("F#")]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2267", FlakyOn.All)]
         public async Task MvcTemplate_NoAuthImplAsync(string languageOverride)
         {
             Project = await ProjectFactory.GetOrCreateProject("mvcnoauth" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);
@@ -99,7 +98,6 @@ namespace Templates.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2267", FlakyOn.All)]
         public async Task MvcTemplate_IndividualAuthImplAsync(bool useLocalDB)
         {
             Project = await ProjectFactory.GetOrCreateProject("mvcindividual" + (useLocalDB ? "uld" : ""), Output);

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -27,7 +27,6 @@ namespace Templates.Test
         public ITestOutputHelper Output { get; }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2327", FlakyOn.All)]
         public async Task RazorPagesTemplate_NoAuthImplAsync()
         {
             Project = await ProjectFactory.GetOrCreateProject("razorpagesnoauth", Output);
@@ -96,7 +95,6 @@ namespace Templates.Test
         }
 
         [Theory]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2335", FlakyOn.All)]
         [InlineData(false)]
         [InlineData(true)]
         public async Task RazorPagesTemplate_IndividualAuthImplAsync(bool useLocalDB)


### PR DESCRIPTION
I'm using this as sort of a catch-all for templating fixes and reliability improvements. Firstly I removed all the Flaky attributes (which universally pointed to closed issue anyway). Secondly I made a change to avoid one type of templating test failure I see a lot, especially on retries. It would seem that we're getting [GUID substring collision](https://devblogs.microsoft.com/oldnewthing/20080627-00/?p=21823). Therefore we'll use `Path.GetRandomFileName`, which should be plenty unique for our purposes. I'm going to retry this PR several times to see if we get any failures and try to address them if any are found.