### PR TITLE
Test PageActionInvoker logs and fix declaring type name for handler in logs

### DIFF
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerTest.cs
@@ -1488,20 +1488,22 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             var controllerName = $"{typeof(ControllerActionInvokerTest).FullName}+{nameof(TestController)} ({typeof(ControllerActionInvokerTest).Assembly.GetName().Name})";
             var actionName = $"{typeof(ControllerActionInvokerTest).FullName}+{nameof(TestController)}.{nameof(TestController.ActionMethod)} ({typeof(ControllerActionInvokerTest).Assembly.GetName().Name})";
             var actionResultName = $"{typeof(CommonResourceInvokerTest).FullName}+{nameof(TestResult)}";
-            Assert.Equal(13, messages.Count);
-            Assert.Equal($"Route matched with {{}}. Executing controller action with signature {actionSignature} on controller {controllerName}.", messages[0]);
-            Assert.Equal("Execution plan of authorization filters (in the following order): None", messages[1]);
-            Assert.Equal("Execution plan of resource filters (in the following order): None", messages[2]);
-            Assert.Equal("Execution plan of action filters (in the following order): None", messages[3]);
-            Assert.Equal("Execution plan of exception filters (in the following order): None", messages[4]);
-            Assert.Equal("Execution plan of result filters (in the following order): None", messages[5]);
-            Assert.Equal($"Executing controller factory for controller {controllerName}", messages[6]);
-            Assert.Equal($"Executed controller factory for controller {controllerName}", messages[7]);
-            Assert.Equal($"Executing action method {actionName} - Validation state: Valid", messages[8]);
-            Assert.StartsWith($"Executed action method {actionName}, returned result {actionResultName} in ", messages[9]);
-            Assert.Equal($"Before executing action result {actionResultName}.", messages[10]);
-            Assert.Equal($"After executing action result {actionResultName}.", messages[11]);
-            Assert.StartsWith($"Executed action {actionName} in ", messages[12]);
+
+            Assert.Collection(
+                messages,
+                m => Assert.Equal($"Route matched with {{}}. Executing controller action with signature {actionSignature} on controller {controllerName}.", m),
+                m => Assert.Equal("Execution plan of authorization filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of resource filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of action filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of exception filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of result filters (in the following order): None", m),
+                m => Assert.Equal($"Executing controller factory for controller {controllerName}", m),
+                m => Assert.Equal($"Executed controller factory for controller {controllerName}", m),
+                m => Assert.Equal($"Executing action method {actionName} - Validation state: Valid", m),
+                m => Assert.StartsWith($"Executed action method {actionName}, returned result {actionResultName} in ", m),
+                m => Assert.Equal($"Before executing action result {actionResultName}.", m),
+                m => Assert.Equal($"After executing action result {actionResultName}.", m),
+                m => Assert.StartsWith($"Executed action {actionName} in ", m));
         }
 
         #endregion

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerTest.cs
@@ -1484,23 +1484,24 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
             // Assert
             var messages = testSink.Writes.Select(write => write.State.ToString()).ToList();
+            var actionSignature = $"{typeof(IActionResult).FullName} {nameof(TestController.ActionMethod)}()";
             var controllerName = $"{typeof(ControllerActionInvokerTest).FullName}+{nameof(TestController)} ({typeof(ControllerActionInvokerTest).Assembly.GetName().Name})";
             var actionName = $"{typeof(ControllerActionInvokerTest).FullName}+{nameof(TestController)}.{nameof(TestController.ActionMethod)} ({typeof(ControllerActionInvokerTest).Assembly.GetName().Name})";
             var actionResultName = $"{typeof(CommonResourceInvokerTest).FullName}+{nameof(TestResult)}";
             Assert.Equal(13, messages.Count);
-            Assert.Contains($"Route matched with {{}}. Executing controller action with signature {typeof(IActionResult).FullName} {nameof(TestController.ActionMethod)}() on controller {controllerName}.", messages);
-            Assert.Contains("Execution plan of authorization filters (in the following order): None", messages);
-            Assert.Contains("Execution plan of resource filters (in the following order): None", messages);
-            Assert.Contains("Execution plan of action filters (in the following order): None", messages);
-            Assert.Contains("Execution plan of exception filters (in the following order): None", messages);
-            Assert.Contains("Execution plan of result filters (in the following order): None", messages);
-            Assert.Contains($"Executing controller factory for controller {controllerName}", messages);
-            Assert.Contains($"Executed controller factory for controller {controllerName}", messages);
-            Assert.Contains($"Executing action method {actionName} - Validation state: Valid", messages);
-            Assert.Contains(messages, m => m.Contains($"Executed action method {actionName}, returned result {actionResultName} in "));
-            Assert.Contains($"Before executing action result {actionResultName}.", messages);
-            Assert.Contains($"After executing action result {actionResultName}.", messages);
-            Assert.Contains(messages, m => m.Contains($"Executed action {actionName} in "));
+            Assert.Equal($"Route matched with {{}}. Executing controller action with signature {actionSignature} on controller {controllerName}.", messages[0]);
+            Assert.Equal("Execution plan of authorization filters (in the following order): None", messages[1]);
+            Assert.Equal("Execution plan of resource filters (in the following order): None", messages[2]);
+            Assert.Equal("Execution plan of action filters (in the following order): None", messages[3]);
+            Assert.Equal("Execution plan of exception filters (in the following order): None", messages[4]);
+            Assert.Equal("Execution plan of result filters (in the following order): None", messages[5]);
+            Assert.Equal($"Executing controller factory for controller {controllerName}", messages[6]);
+            Assert.Equal($"Executed controller factory for controller {controllerName}", messages[7]);
+            Assert.Equal($"Executing action method {actionName} - Validation state: Valid", messages[8]);
+            Assert.StartsWith($"Executed action method {actionName}, returned result {actionResultName} in ", messages[9]);
+            Assert.Equal($"Before executing action result {actionResultName}.", messages[10]);
+            Assert.Equal($"After executing action result {actionResultName}.", messages[11]);
+            Assert.StartsWith($"Executed action {actionName} in ", messages[12]);
         }
 
         #endregion

--- a/src/Mvc/Mvc.RazorPages/src/PageLoggerExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageLoggerExtensions.cs
@@ -150,7 +150,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
         {
             if (logger.IsEnabled(LogLevel.Information))
             {
-                var handlerName = handler.MethodInfo.DeclaringType.FullName + "." + handler.MethodInfo.Name;
+                var declaringTypeName = TypeNameHelper.GetTypeDisplayName(handler.MethodInfo.DeclaringType);
+                var handlerName = declaringTypeName + "." + handler.MethodInfo.Name;
 
                 var validationState = context.ModelState.ValidationState;
                 _handlerMethodExecuting(logger, handlerName, validationState, null);

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionInvokerTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionInvokerTest.cs
@@ -1391,15 +1391,21 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
         #region Logs
 
-        [Fact]
-        public async Task InvokeAction_LogsPageFactory()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task InvokeAction_ForPage_Logs(bool hasPageModel)
         {
             // Arrange
             var testSink = new TestSink();
             var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
             var logger = loggerFactory.CreateLogger("test");
 
-            var actionDescriptor = CreateDescriptorForSimplePage();
+            var actionDescriptor = hasPageModel 
+                ? CreateDescriptorForPageModelPage() 
+                : CreateDescriptorForSimplePage();
+            actionDescriptor.ViewEnginePath = "/Pages/Foo";
+            actionDescriptor.RouteValues.Add("page", "foo");
             var invoker = CreateInvoker(null, actionDescriptor, logger: logger);
 
             // Act
@@ -1408,29 +1414,29 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             // Assert
             var messages = testSink.Writes.Select(write => write.State.ToString()).ToList();
             var pageName = $"{typeof(PageActionInvokerTest).FullName}+{nameof(TestPage)} ({typeof(PageActionInvokerTest).Assembly.GetName().Name})";
-            Assert.Contains($"Executing page factory for page {pageName}", messages);
-            Assert.Contains($"Executed page factory for page {pageName}", messages);
-        }
+            var pagePath = actionDescriptor.ViewEnginePath;
+            var methodFullName = hasPageModel
+                ? $"{typeof(PageActionInvokerTest).FullName}+{nameof(TestPageModel)}.{nameof(TestPageModel.OnGetHandler1)}"
+                : $"{typeof(PageActionInvokerTest).FullName}+{nameof(TestPage)}.{nameof(TestPage.OnGetHandler1)}";
+            var methodName = nameof(TestPage.OnGetHandler1);
+            var resultName = typeof(PageResult).FullName;
+            var factoryType = hasPageModel ? "page model" : "page";
 
-        [Fact]
-        public async Task InvokeAction_LogsPageModelFactory()
-        {
-            // Arrange
-            var testSink = new TestSink();
-            var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
-            var logger = loggerFactory.CreateLogger("test");
+            Assert.Equal(13, messages.Count);
+            Assert.Equal($"Route matched with {{page = \"foo\"}}. Executing page {pagePath}", messages[0]);
+            Assert.Equal("Execution plan of authorization filters (in the following order): None", messages[1]);
+            Assert.Equal("Execution plan of resource filters (in the following order): None", messages[2]);
+            Assert.Equal("Execution plan of action filters (in the following order): None", messages[3]);
+            Assert.Equal("Execution plan of exception filters (in the following order): None", messages[4]);
+            Assert.Equal("Execution plan of result filters (in the following order): None", messages[5]);
+            Assert.Equal($"Executing {factoryType} factory for page {pageName}", messages[6]);
+            Assert.Equal($"Executed {factoryType} factory for page {pageName}", messages[7]);
+            Assert.Equal($"Executing handler method {methodFullName} - ModelState is Valid", messages[8]);
+            Assert.Equal($"Executed handler method {methodName}, returned result {resultName}.", messages[9]);
+            Assert.Equal($"Before executing action result {resultName}.", messages[10]);
+            Assert.Equal($"After executing action result {resultName}.", messages[11]);
+            Assert.StartsWith($"Executed page {pagePath} in ", messages[12]);
 
-            var actionDescriptor = CreateDescriptorForPageModelPage();
-            var invoker = CreateInvoker(null, actionDescriptor, logger: logger);
-
-            // Act
-            await invoker.InvokeAsync();
-
-            // Assert
-            var messages = testSink.Writes.Select(write => write.State.ToString()).ToList();
-            var pageName = $"{typeof(PageActionInvokerTest).FullName}+{nameof(TestPage)} ({typeof(PageActionInvokerTest).Assembly.GetName().Name})";
-            Assert.Contains($"Executing page model factory for page {pageName}", messages);
-            Assert.Contains($"Executed page model factory for page {pageName}", messages);
         }
 
         #endregion

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionInvokerTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionInvokerTest.cs
@@ -1422,21 +1422,21 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             var resultName = typeof(PageResult).FullName;
             var factoryType = hasPageModel ? "page model" : "page";
 
-            Assert.Equal(13, messages.Count);
-            Assert.Equal($"Route matched with {{page = \"foo\"}}. Executing page {pagePath}", messages[0]);
-            Assert.Equal("Execution plan of authorization filters (in the following order): None", messages[1]);
-            Assert.Equal("Execution plan of resource filters (in the following order): None", messages[2]);
-            Assert.Equal("Execution plan of action filters (in the following order): None", messages[3]);
-            Assert.Equal("Execution plan of exception filters (in the following order): None", messages[4]);
-            Assert.Equal("Execution plan of result filters (in the following order): None", messages[5]);
-            Assert.Equal($"Executing {factoryType} factory for page {pageName}", messages[6]);
-            Assert.Equal($"Executed {factoryType} factory for page {pageName}", messages[7]);
-            Assert.Equal($"Executing handler method {methodFullName} - ModelState is Valid", messages[8]);
-            Assert.Equal($"Executed handler method {methodName}, returned result {resultName}.", messages[9]);
-            Assert.Equal($"Before executing action result {resultName}.", messages[10]);
-            Assert.Equal($"After executing action result {resultName}.", messages[11]);
-            Assert.StartsWith($"Executed page {pagePath} in ", messages[12]);
-
+            Assert.Collection(
+                messages,
+                m => Assert.Equal($"Route matched with {{page = \"foo\"}}. Executing page {pagePath}", m),
+                m => Assert.Equal("Execution plan of authorization filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of resource filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of action filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of exception filters (in the following order): None", m),
+                m => Assert.Equal("Execution plan of result filters (in the following order): None", m),
+                m => Assert.Equal($"Executing {factoryType} factory for page {pageName}", m),
+                m => Assert.Equal($"Executed {factoryType} factory for page {pageName}", m),
+                m => Assert.Equal($"Executing handler method {methodFullName} - ModelState is Valid", m),
+                m => Assert.Equal($"Executed handler method {methodName}, returned result {resultName}.", m),
+                m => Assert.Equal($"Before executing action result {resultName}.", m),
+                m => Assert.Equal($"After executing action result {resultName}.", m),
+                m => Assert.StartsWith($"Executed page {pagePath} in ", m));
         }
 
         #endregion


### PR DESCRIPTION
 - Extends test added in #11526 for all the log messages generated by the `PageActionInvoker` on Invoke, similar to what done in #12107 for `ControllerActionInvoker`
 - Updated `ControllerActionInvoker` logs tests to return more meaningful errors on failure.
 - Update the the declaring type name of the executing handler in the logs to use a clean name, similar to what happens for pages and controllers 

/cc @rynowak 