### PR TITLE
Fix endpoint routing statefulness.

### DIFF
--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Routing
             {
                 Log.MatchSkipped(_logger, endpoint);
 
-                // Someone else set the endpoint, we'll let them handle the unsetting.
+                // Someone else set the endpoint, we'll let them handle the clearing of the endpoint.
                 return _next(httpContext);
             }
 
@@ -88,7 +88,6 @@ namespace Microsoft.AspNetCore.Routing
 
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private async Task SetRoutingAndContinue(HttpContext httpContext)
         {
             // If there was no mutation of the endpoint then log failure
@@ -115,8 +114,7 @@ namespace Microsoft.AspNetCore.Routing
             }
             finally
             {
-                // We unset the endpoint after calling through to the next middleware. This enables any future calls into
-                // endpoint routing don't no-op from there already being an endpoint set.
+                // This allows a second call in a single request (such as from the ErrorHandlerMiddleware) to perform routing again.
                 httpContext.SetEndpoint(endpoint: null);
             }
         }

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.Extensions.Logging;
 
@@ -116,6 +116,9 @@ namespace Microsoft.AspNetCore.Routing
             {
                 // This allows a second call in a single request (such as from the ErrorHandlerMiddleware) to perform routing again.
                 httpContext.SetEndpoint(endpoint: null);
+
+                var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
+                routeValuesFeature?.RouteValues?.Clear();
             }
         }
 

--- a/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         [Fact]
-        public async Task UseRouting_ServicesRegistered_Match_DoesNotSetsFeature()
+        public async Task UseRouting_ServicesRegistered_Match_DoesNotSetFeature()
         {
             // Arrange
             var endpoint = new RouteEndpoint(
@@ -104,7 +104,6 @@ namespace Microsoft.AspNetCore.Builder
             // Assert
             var feature = httpContext.Features.Get<IEndpointFeature>();
             Assert.NotNull(feature);
-            Assert.Same(endpoint, httpContext.GetEndpoint());
         }
 
         [Fact]


### PR DESCRIPTION
- In the case that other middleware change the path of an `HttpContext` and cause middleware to re-invoke we used to short-circuit on second time through the middleware pipeline, now we allow routing to occur.
- Added unit tests to validate the clearing of state.

#11233