### PR TITLE
[Blazor] [Fixes #11847] Renderer.DispatchEventAsync throws null reference exception if event handler throws synchronously

### DIFF
--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -235,6 +235,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             catch (Exception e)
             {
                 HandleException(e);
+                return Task.CompletedTask;
             }
             finally
             {

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -456,7 +456,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task CanDispatchEventsToTopLevelComponents()
+        public void CanDispatchEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -485,7 +485,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task DispatchEventHandlesSynchronousExceptionsFromEventHandlers()
+        public void DispatchEventHandlesSynchronousExceptionsFromEventHandlers()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer {
@@ -517,7 +517,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task CanDispatchTypedEventsToTopLevelComponents()
+        public void CanDispatchTypedEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -546,7 +546,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task CanDispatchActionEventsToTopLevelComponents()
+        public void CanDispatchActionEventsToTopLevelComponents()
         {
             // Arrange: Render a component with an event handler
             var renderer = new TestRenderer();
@@ -575,7 +575,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task CanDispatchEventsToNestedComponents()
+        public void CanDispatchEventsToNestedComponents()
         {
             UIEventArgs receivedArgs = null;
 

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -482,8 +482,6 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderTask = renderer.DispatchEventAsync(eventHandlerId, eventArgs);
             Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Same(eventArgs, receivedArgs);
-
-            await renderTask; // Does not throw
         }
 
         [Fact]
@@ -516,8 +514,6 @@ namespace Microsoft.AspNetCore.Components.Test
 
             var exception = Assert.Single(renderer.HandledExceptions);
             Assert.Equal("Error", exception.Message);
-
-            await renderTask; // Does not throw
         }
 
         [Fact]
@@ -547,8 +543,6 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderTask = renderer.DispatchEventAsync(eventHandlerId, eventArgs);
             Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Same(eventArgs, receivedArgs);
-
-            await renderTask; // does not throw
         }
 
         [Fact]
@@ -578,8 +572,6 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderTask = renderer.DispatchEventAsync(eventHandlerId, eventArgs);
             Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.NotNull(receivedArgs);
-
-            await renderTask; // does not throw
         }
 
         [Fact]
@@ -620,8 +612,6 @@ namespace Microsoft.AspNetCore.Components.Test
             var renderTask = renderer.DispatchEventAsync(eventHandlerId, eventArgs);
             Assert.True(renderTask.IsCompletedSuccessfully);
             Assert.Same(eventArgs, receivedArgs);
-
-            await renderTask; // does not throw
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Ignitor;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
@@ -19,6 +19,8 @@
 <button id="triggerjsinterop-success" @onclick="@TriggerJSInteropSuccess">Trigger successfull JS interop callback</button>
 <button id="triggerjsinterop-failure" @onclick="@TriggerJSInteropFailure">Trigger error JS interop callback</button>
 
+<button id="event-handler-throw-sync" @onclick="@TriggerSyncException">Trigger sync exception</button>
+
 <button id="thecounter" @onclick="@IncrementCount">Click me</button>
 
 @code
@@ -32,6 +34,8 @@
     {
         currentCount++;
     }
+
+    void TriggerSyncException() => throw new Exception("Handler threw an exception");
 
     async Task TriggerJSInterop()
     {


### PR DESCRIPTION
* Returns after handling the exception.
* Adds a unit test and an E2E test to validate expected behavior.