### PR TITLE
Reduce truncation of information in the runningProcesses*.txt files

### DIFF
--- a/eng/scripts/dump_process.ps1
+++ b/eng/scripts/dump_process.ps1
@@ -3,10 +3,14 @@ $local:timestamp = $(get-date -f MM-dd-HH-mm)
 
 while ($true) {
     $local:file = "artifacts/log/runningProcesses.$timestamp.txt"
+    if (Test-Path $file) {Move-Item -Force $file "$file.bak"}
+
     $local:temp = Get-Process |Out-String -Width 300
     $temp.Split([Environment]::NewLine).TrimEnd() |? Length -gt 0 |Out-File -Width 300 $file
 
     $file = "artifacts/log/runningProcessesCommandLine.$timestamp.txt"
+    if (Test-Path $file) {Move-Item -Force $file "$file.bak"}
+
     $temp = Get-CimInstance Win32_Process |Format-Table -AutoSize Name, ProcessId, CommandLine |Out-String -Width 800
     $temp.Split([Environment]::NewLine).TrimEnd() |? Length -gt 0 |Out-File -Width 800 $file
 

--- a/eng/scripts/dump_process.ps1
+++ b/eng/scripts/dump_process.ps1
@@ -2,8 +2,13 @@ Set-Location $args[0]
 $local:timestamp = $(get-date -f MM-dd-HH-mm)
 
 while ($true) {
-    Get-Process |Out-File -Width 300 artifacts/log/runningProcesses.$timestamp.txt
-    Get-CimInstance Win32_Process |select name, processid, commandline |Out-File -Width 800 artifacts/log/runningProcessesCommandLine.$timestamp.txt
+    $local:file = "artifacts/log/runningProcesses.$timestamp.txt"
+    $local:temp = Get-Process |Out-String -Width 300
+    $temp.Split([Environment]::NewLine).TrimEnd() |? Length -gt 0 |Out-File -Width 300 $file
+
+    $file = "artifacts/log/runningProcessesCommandLine.$timestamp.txt"
+    $temp = Get-CimInstance Win32_Process |Format-Table -AutoSize Name, ProcessId, CommandLine |Out-String -Width 800
+    $temp.Split([Environment]::NewLine).TrimEnd() |? Length -gt 0 |Out-File -Width 800 $file
 
     Start-Sleep -Seconds 120
 }

--- a/eng/scripts/dump_process.ps1
+++ b/eng/scripts/dump_process.ps1
@@ -1,9 +1,9 @@
 Set-Location $args[0]
-
-$timestamp = $(get-date -f MM-dd-HH-mm)
+$local:timestamp = $(get-date -f MM-dd-HH-mm)
 
 while ($true) {
     Get-Process |Out-File -Width 300 artifacts/log/runningProcesses.$timestamp.txt
     Get-CimInstance Win32_Process |select name, processid, commandline |Out-File -Width 800 artifacts/log/runningProcessesCommandLine.$timestamp.txt
-    Start-Sleep -Seconds 300
+
+    Start-Sleep -Seconds 120
 }

--- a/eng/scripts/dump_process.ps1
+++ b/eng/scripts/dump_process.ps1
@@ -3,7 +3,7 @@ Set-Location $args[0]
 $timestamp = $(get-date -f MM-dd-HH-mm)
 
 while ($true) {
-    Get-Process > artifacts/log/runningProcesses.$timestamp.txt
-    Get-WmiObject Win32_Process | select name, processid, commandline > artifacts/log/runningProcessesCommandLine.$timestamp.txt
+    Get-Process |Out-File -Width 300 artifacts/log/runningProcesses.$timestamp.txt
+    Get-CimInstance Win32_Process |select name, processid, commandline |Out-File -Width 800 artifacts/log/runningProcessesCommandLine.$timestamp.txt
     Start-Sleep -Seconds 300
 }

--- a/eng/scripts/dump_process.ps1
+++ b/eng/scripts/dump_process.ps1
@@ -1,14 +1,13 @@
 Set-Location $args[0]
-$local:timestamp = $(get-date -f MM-dd-HH-mm)
 
 while ($true) {
-    $local:file = "artifacts/log/runningProcesses.$timestamp.txt"
+    $local:file = "artifacts/log/runningProcesses.txt"
     if (Test-Path $file) {Move-Item -Force $file "$file.bak"}
 
     $local:temp = Get-Process |Out-String -Width 300
     $temp.Split([Environment]::NewLine).TrimEnd() |? Length -gt 0 |Out-File -Width 300 $file
 
-    $file = "artifacts/log/runningProcessesCommandLine.$timestamp.txt"
+    $file = "artifacts/log/runningProcessesCommandLine.txt"
     if (Test-Path $file) {Move-Item -Force $file "$file.bak"}
 
     $temp = Get-CimInstance Win32_Process |Format-Table -AutoSize Name, ProcessId, CommandLine |Out-String -Width 800


### PR DESCRIPTION
- move from deprecated `Get-WmiObject` to `Get-CimInstance`