### PR TITLE
Crankier server

### DIFF
--- a/src/SignalR/perf/benchmarkapps/Crankier/Commands/Defaults.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Commands/Defaults.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
 {
@@ -11,5 +12,6 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
         public static readonly int NumberOfConnections = 10_000;
         public static readonly int SendDurationInSeconds = 300;
         public static readonly HttpTransportType TransportType = HttpTransportType.WebSockets;
+        public static readonly LogLevel LogLevel = LogLevel.None;
     }
 }

--- a/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
                 .UseConfiguration(config)
                 .ConfigureLogging(loggerFactory =>
                 {
-                    loggerFactory.AddConsole().SetMinimumLevel(logLevel);   
+                    loggerFactory.AddConsole().SetMinimumLevel(logLevel);
                 })
                 .UseKestrel()
                 .UseStartup<Startup>();

--- a/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.SignalR.Crankier.Server;
 
 namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
 {

--- a/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.Extensions.CommandLineUtils;
+using static Microsoft.AspNetCore.SignalR.Crankier.Commands.CommandLineUtilities;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
+{
+    internal class ServerCommand
+    {
+        public static void Register(CommandLineApplication app, params string[] args)
+        {
+            app.Command("server", cmd =>
+            {
+                cmd.OnExecute(() =>
+                {
+                    return Execute();
+                });
+            });
+        }
+
+        private static int Execute(params string[] args)
+        {
+            Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
+
+            var config = new ConfigurationBuilder()
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .AddCommandLine(args)
+                .Build();
+
+            var host = new WebHostBuilder()
+                .UseConfiguration(config)
+                .ConfigureLogging(loggerFactory =>
+                {
+                    if (Enum.TryParse(config["LogLevel"], out LogLevel logLevel))
+                    {
+                        loggerFactory.AddConsole().SetMinimumLevel(logLevel);
+                    }
+                })
+                .UseKestrel()
+                .UseStartup<Startup>();
+
+            host.Build().Run();
+
+            return 0;
+        }
+    }
+}

--- a/src/SignalR/perf/benchmarkapps/Crankier/Crankier.csproj
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Crankier.csproj
@@ -9,6 +9,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.SignalR.Client" />
     <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
+    <Reference Include="Microsoft.AspNetCore.SignalR" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
+    <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/SignalR/perf/benchmarkapps/Crankier/Program.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Program.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
             LocalCommand.Register(app);
             AgentCommand.Register(app);
             WorkerCommand.Register(app);
+            ServerCommand.Register(app, args);
 
             app.Command("help", cmd =>
             {

--- a/src/SignalR/perf/benchmarkapps/Crankier/Program.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Program.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
             LocalCommand.Register(app);
             AgentCommand.Register(app);
             WorkerCommand.Register(app);
-            ServerCommand.Register(app, args);
+            ServerCommand.Register(app);
 
             app.Command("help", cmd =>
             {

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounter.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounter.cs
@@ -29,10 +29,11 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
             }
         }
 
-        public void Receive(string a) {
+        public void Receive(string payload)
+        {
             lock (_lock)
             {
-                _receivedCount += a.Length;
+                _receivedCount += payload.Length;
             }
         }
 

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounter.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNetCore.SignalR.Crankier.Server

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounter.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounter.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Microsoft.AspNetCore.SignalR.Crankier.Server
+{
+    public class ConnectionCounter
+    {
+        private int _totalConnectedCount;
+        private int _peakConnectedCount;
+        private int _totalDisconnectedCount;
+        private int _receivedCount;
+
+        private readonly object _lock = new object();
+
+        public ConnectionSummary Summary
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return new ConnectionSummary
+                    {
+                        CurrentConnections = _totalConnectedCount - _totalDisconnectedCount,
+                        PeakConnections = _peakConnectedCount,
+                        TotalConnected = _totalConnectedCount,
+                        TotalDisconnected = _totalDisconnectedCount,
+                        ReceivedCount = _receivedCount
+                    };
+                }
+            }
+        }
+
+        public void Receive(string a) {
+            lock (_lock)
+            {
+                _receivedCount += a.Length;
+            }
+        }
+
+        public void Connected()
+        {
+            lock (_lock)
+            {
+                _totalConnectedCount++;
+                _peakConnectedCount = Math.Max(_totalConnectedCount - _totalDisconnectedCount, _peakConnectedCount);
+            }
+        }
+
+        public void Disconnected()
+        {
+            lock (_lock)
+            {
+                _totalDisconnectedCount++;
+            }
+        }
+    }
+}

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounterHostedService.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounterHostedService.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounterHostedService.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounterHostedService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.SignalR.Crankier.Server
+{
+    public class ConnectionCounterHostedService : IHostedService, IDisposable
+    {
+        private Stopwatch _timeSinceFirstConnection;
+        private readonly ConnectionCounter _counter;
+        private ConnectionSummary _lastSummary;
+        private Timer _timer;
+
+        public ConnectionCounterHostedService(ConnectionCounter counter)
+        {
+            _counter = counter;
+            _timeSinceFirstConnection = new Stopwatch();
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            
+            return Task.CompletedTask;
+        }
+
+        private void DoWork(object state)
+        {
+            var summary = _counter.Summary;
+
+            if (summary.PeakConnections > 0)
+            {
+                if (_timeSinceFirstConnection.ElapsedTicks == 0)
+                    _timeSinceFirstConnection.Start();
+
+                var elapsed = _timeSinceFirstConnection.Elapsed;
+
+                if (_lastSummary != null)
+                    Console.WriteLine(@"[{0:hh\:mm\:ss}] Current: {1}, peak: {2}, connected: {3}, disconnected: {4}, rate: {5}/s",
+                        elapsed,
+                        summary.CurrentConnections,
+                        summary.PeakConnections,
+                        summary.TotalConnected - _lastSummary.TotalConnected,
+                        summary.TotalDisconnected - _lastSummary.TotalDisconnected,
+                        summary.CurrentConnections - _lastSummary.CurrentConnections
+                        );
+
+                _lastSummary = summary;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _timer?.Change(Timeout.Infinite, 0);
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+    }
+}

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounterHostedService.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionCounterHostedService.cs
@@ -37,11 +37,14 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
             if (summary.PeakConnections > 0)
             {
                 if (_timeSinceFirstConnection.ElapsedTicks == 0)
+                {
                     _timeSinceFirstConnection.Start();
+                }
 
                 var elapsed = _timeSinceFirstConnection.Elapsed;
 
                 if (_lastSummary != null)
+                {
                     Console.WriteLine(@"[{0:hh\:mm\:ss}] Current: {1}, peak: {2}, connected: {3}, disconnected: {4}, rate: {5}/s",
                         elapsed,
                         summary.CurrentConnections,
@@ -50,6 +53,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
                         summary.TotalDisconnected - _lastSummary.TotalDisconnected,
                         summary.CurrentConnections - _lastSummary.CurrentConnections
                         );
+                }
 
                 _lastSummary = summary;
             }

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionSummary.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionSummary.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 {
     public class ConnectionSummary

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionSummary.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/ConnectionSummary.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.AspNetCore.SignalR.Crankier.Server
+{
+    public class ConnectionSummary
+    {
+        public int TotalConnected { get; set; }
+
+        public int TotalDisconnected { get; set; }
+
+        public int PeakConnections { get; set; }
+
+        public int CurrentConnections { get; set; }
+
+        public int ReceivedCount { get; set; }
+    }
+}

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.AspNetCore.SignalR.Crankier
+{
+    public class EchoHub : Hub
+    {
+        public async Task Broadcast(int duration)
+        {
+            var sent = 0;
+            try
+            {
+                var t = new CancellationTokenSource();
+                t.CancelAfter(TimeSpan.FromSeconds(duration));
+                while (!t.IsCancellationRequested && !Context.ConnectionAborted.IsCancellationRequested)
+                {
+                    await Clients.All.SendAsync("send", DateTime.UtcNow);
+                    sent++;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            Console.WriteLine("Broadcast exited: Sent {0} messages", sent);
+        }
+
+        public DateTime Echo(DateTime time)
+        {
+            return time;
+        }
+
+        public Task EchoAll(DateTime time)
+        {
+            return Clients.All.SendAsync("send", time);
+        }
+
+        public void SendPayload(string payload)
+        {
+            // Dump the payload, we don't care
+        }
+
+        public DateTime GetCurrentTime()
+        {
+            return DateTime.UtcNow;
+        }
+    }
+}

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
@@ -6,10 +6,17 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 
-namespace Microsoft.AspNetCore.SignalR.Crankier
+namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 {
     public class EchoHub : Hub
     {
+        private ConnectionCounter _counter;
+
+        public EchoHub(ConnectionCounter counter)
+        {
+            _counter = counter;
+        }
+
         public async Task Broadcast(int duration)
         {
             var sent = 0;
@@ -28,6 +35,17 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                 Console.WriteLine(e);
             }
             Console.WriteLine("Broadcast exited: Sent {0} messages", sent);
+        }
+
+        public override Task OnConnectedAsync()
+        {
+            _counter?.Connected();
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDisconnectedAsync(Exception exception) {
+            _counter?.Disconnected();
+            return Task.CompletedTask;
         }
 
         public DateTime Echo(DateTime time)

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 
         public void SendPayload(string payload)
         {
-            // Dump the payload, we don't care
+            _counter?.Receive(payload);
         }
 
         public DateTime GetCurrentTime()

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/EchoHub.cs
@@ -43,7 +43,8 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
             return Task.CompletedTask;
         }
 
-        public override Task OnDisconnectedAsync(Exception exception) {
+        public override Task OnDisconnectedAsync(Exception exception)
+        {
             _counter?.Disconnected();
             return Task.CompletedTask;
         }

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
@@ -18,10 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 
         public void ConfigureServices(IServiceCollection services)
         {
-            var signalrBuilder = services.AddSignalR(o =>
-            {
-                o.EnableDetailedErrors = true;
-            })
+            var signalrBuilder = services.AddSignalR();
 
             services.AddSingleton<ConnectionCounter>();
 

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
@@ -22,8 +22,6 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
             {
                 o.EnableDetailedErrors = true;
             })
-            // TODO: Json vs NewtonsoftJson option
-            .AddMessagePackProtocol();
 
             services.AddSingleton<ConnectionCounter>();
 
@@ -36,12 +34,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapHub<EchoHub>("/echo", o =>
-                {
-                    // Remove backpressure for benchmarking
-                    o.TransportMaxBufferSize = 0;
-                    o.ApplicationMaxBufferSize = 0;
-                });
+                endpoints.MapHub<EchoHub>("/echo");
             });
         }
     }

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.AspNetCore.SignalR.Crankier
+namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 {
     public class Startup
     {
@@ -24,6 +24,10 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
             })
             // TODO: Json vs NewtonsoftJson option
             .AddMessagePackProtocol();
+
+            services.AddSingleton<ConnectionCounter>();
+
+            services.AddHostedService<ConnectionCounterHostedService>();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
@@ -18,7 +18,8 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Server
 
         public void ConfigureServices(IServiceCollection services)
         {
-            var signalrBuilder = services.AddSignalR();
+            var signalrBuilder = services.AddSignalR()
+                .AddMessagePackProtocol();
 
             services.AddSingleton<ConnectionCounter>();
 

--- a/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Server/Startup.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.SignalR.Crankier
+{
+    public class Startup
+    {
+        private readonly IConfiguration _config;
+        public Startup(IConfiguration configuration)
+        {
+            _config = configuration;
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var signalrBuilder = services.AddSignalR(o =>
+            {
+                o.EnableDetailedErrors = true;
+            })
+            // TODO: Json vs NewtonsoftJson option
+            .AddMessagePackProtocol();
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHub<EchoHub>("/echo", o =>
+                {
+                    // Remove backpressure for benchmarking
+                    o.TransportMaxBufferSize = 0;
+                    o.ApplicationMaxBufferSize = 0;
+                });
+            });
+        }
+    }
+}


### PR DESCRIPTION
Alternate solution for #9264, Crankier now includes the server itself, call it using the `server` command, and then point another instance of Crankier at it with the usual `local` command;

```
$ dotnet run -- server

Process ID: 4837
Hosting environment: Production
Content root path: /Users/staffordwilliams/git/aspnetcore/artifacts/bin/Crankier/Debug/netcoreapp3.0/
Now listening on: http://localhost:5000
Application started. Press Ctrl+C to shut down.
[00:00:00] Current: 412, peak: 412, connected: 236, disconnected: 0, rate: 236/s
[00:00:01] Current: 632, peak: 632, connected: 220, disconnected: 0, rate: 220/s
[00:00:02] Current: 851, peak: 851, connected: 219, disconnected: 0, rate: 219/s
[00:00:03] Current: 1087, peak: 1087, connected: 236, disconnected: 0, rate: 236/s
[00:00:04] Current: 1329, peak: 1329, connected: 242, disconnected: 0, rate: 242/s
[00:00:05] Current: 1568, peak: 1568, connected: 239, disconnected: 0, rate: 239/s
[00:00:06] Current: 1772, peak: 1772, connected: 204, disconnected: 0, rate: 204/s
```

Also, rather than spamming based on connection count, a hosted service now periodically echoes the output.