### PR TITLE
Clear unused routing params. Fixes #7419

### DIFF
--- a/src/Components/Blazor/testassets/StandaloneApp/Pages/FetchData.razor
+++ b/src/Components/Blazor/testassets/StandaloneApp/Pages/FetchData.razor
@@ -34,36 +34,32 @@ else
         </tbody>
     </table>
     <p>
-        <a href="fetchdata/@StartDate.AddDays(-5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-left">
+        <a href="fetchdata/@startDate.AddDays(-5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-left">
             ◀ Previous
         </a>
-        <a href="fetchdata/@StartDate.AddDays(5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-right">
+        <a href="fetchdata/@startDate.AddDays(5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-right">
             Next ▶
         </a>
     </p>
 }
 
 @code {
-    [Parameter] public DateTime StartDate { get; set; }
+    [Parameter] public DateTime? StartDate { get; set; }
 
     WeatherForecast[] forecasts;
-
-    public override Task SetParametersAsync(ParameterCollection parameters)
-    {
-        StartDate = DateTime.Now;
-        return base.SetParametersAsync(parameters);
-    }
+    DateTime startDate;
 
     protected override async Task OnParametersSetAsync()
     {
+        startDate = StartDate.GetValueOrDefault(DateTime.Now);
         forecasts = await Http.GetJsonAsync<WeatherForecast[]>(
-            $"sample-data/weather.json?date={StartDate.ToString("yyyy-MM-dd")}");
+            $"sample-data/weather.json?date={startDate.ToString("yyyy-MM-dd")}");
 
         // Because StandaloneApp doesn't really have a server endpoint to get dynamic data from,
         // fake the DateFormatted values here. This would not apply in a real app.
         for (var i = 0; i < forecasts.Length; i++)
         {
-            forecasts[i].DateFormatted = StartDate.AddDays(i).ToShortDateString();
+            forecasts[i].DateFormatted = startDate.AddDays(i).ToShortDateString();
         }
     }
 

--- a/src/Components/Components/src/Reflection/MemberAssignment.cs
+++ b/src/Components/Components/src/Reflection/MemberAssignment.cs
@@ -51,7 +51,16 @@ namespace Microsoft.AspNetCore.Components.Reflection
             }
 
             public void SetValue(object target, object value)
-                => _setterDelegate((TTarget)target, (TValue)value);
+            {
+                if (value == null)
+                {
+                    _setterDelegate((TTarget)target, default);
+                }
+                else
+                {
+                    _setterDelegate((TTarget)target, (TValue)value);
+                }
+            }
         }
     }
 }

--- a/src/Components/Components/src/Routing/RouteEntry.cs
+++ b/src/Components/Components/src/Routing/RouteEntry.cs
@@ -8,13 +8,16 @@ namespace Microsoft.AspNetCore.Components.Routing
 {
     internal class RouteEntry
     {
-        public RouteEntry(RouteTemplate template, Type handler)
+        public RouteEntry(RouteTemplate template, Type handler, string[] unusedRouteParameterNames)
         {
             Template = template;
+            UnusedRouteParameterNames = unusedRouteParameterNames;
             Handler = handler;
         }
 
         public RouteTemplate Template { get; }
+
+        public string[] UnusedRouteParameterNames { get; }
 
         public Type Handler { get; }
 
@@ -42,6 +45,18 @@ namespace Microsoft.AspNetCore.Components.Routing
                         parameters ??= new Dictionary<string, object>(StringComparer.Ordinal);
                         parameters[segment.Value] = matchedParameterValue;
                     }
+                }
+            }
+
+            // In addition to extracting parameter values from the URL, each route entry
+            // also knows which other parameters should be supplied with null values. These
+            // are parameters supplied by other route entries matching the same handler.
+            if (UnusedRouteParameterNames.Length > 0)
+            {
+                parameters ??= new Dictionary<string, object>(StringComparer.Ordinal);
+                for (var i = 0; i < UnusedRouteParameterNames.Length; i++)
+                {
+                    parameters[UnusedRouteParameterNames[i]] = null;
                 }
             }
 

--- a/src/Components/Components/test/ParameterCollectionAssignmentExtensionsTest.cs
+++ b/src/Components/Components/test/ParameterCollectionAssignmentExtensionsTest.cs
@@ -358,6 +358,24 @@ namespace Microsoft.AspNetCore.Components.Test
                 ex.Message);
         }
 
+        [Fact]
+        public void SupplyingNullWritesDefaultForType()
+        {
+            // Arrange
+            var parameterCollection = new ParameterCollectionBuilder
+            {
+                { nameof(HasInstanceProperties.IntProp), null },
+                { nameof(HasInstanceProperties.StringProp), null },
+            }.Build();
+            var target = new HasInstanceProperties { IntProp = 123, StringProp = "Hello" };
+
+            // Act
+            parameterCollection.SetParameterProperties(target);
+
+            // Assert
+            Assert.Equal(0, target.IntProp);
+            Assert.Null(target.StringProp);
+        }
 
         class HasInstanceProperties
         {

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -226,10 +226,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             AssertHighlightedLinks("With parameters", "With more parameters");
 
             // Can remove parameters while remaining on same page
-            // WARNING: This only works because the WithParameters component overrides SetParametersAsync
-            // and explicitly resets its parameters to default when each new set of parameters arrives.
-            // Without that, the page would retain the old value.
-            // See https://github.com/aspnet/AspNetCore/issues/6864 where we reverted the logic to auto-reset.
             app.FindElement(By.LinkText("With parameters")).Click();
             Browser.Equal("Your full name is Abc .", () => app.FindElement(By.Id("test-info")).Text);
             AssertHighlightedLinks("With parameters");

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithParameters.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithParameters.razor
@@ -8,12 +8,4 @@
     [Parameter] public string FirstName { get; set; }
 
     [Parameter] public string LastName { get ; set; }
-
-    public override Task SetParametersAsync(ParameterCollection parameters)
-    {
-        // Manually reset parameters to defaults so we don't retain any from an earlier URL
-        FirstName = default;
-        LastName = default;
-        return base.SetParametersAsync(parameters);
-    }
 }

--- a/src/Components/test/testassets/ComponentsApp.App/Pages/FetchData.razor
+++ b/src/Components/test/testassets/ComponentsApp.App/Pages/FetchData.razor
@@ -34,28 +34,24 @@ else
         </tbody>
     </table>
     <p>
-        <a href="fetchdata/@StartDate.AddDays(-5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-left">
+        <a href="fetchdata/@startDate.AddDays(-5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-left">
             ◀ Previous
         </a>
-        <a href="fetchdata/@StartDate.AddDays(5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-right">
+        <a href="fetchdata/@startDate.AddDays(5).ToString("yyyy-MM-dd")" class="btn btn-secondary float-right">
             Next ▶
         </a>
     </p>
 }
 
 @code {
-    [Parameter] public DateTime StartDate { get; set; }
+    [Parameter] public DateTime? StartDate { get; set; }
 
     WeatherForecast[] forecasts;
-
-    public override Task SetParametersAsync(ParameterCollection parameters)
-    {
-        StartDate = DateTime.Now;
-        return base.SetParametersAsync(parameters);
-    }
+    DateTime startDate;
 
     protected override async Task OnParametersSetAsync()
     {
-        forecasts = await ForecastService.GetForecastAsync(StartDate);
+        startDate = StartDate.GetValueOrDefault(DateTime.Now);
+        forecasts = await ForecastService.GetForecastAsync(startDate);
     }
 }


### PR DESCRIPTION
This implements the plan described in #7419, i.e., that when routing, we always supply *all* the possible route parameters for the target component (supplying `default` for any not in the matched URL).

~~**Still to do:** Run all the other E2E tests to be sure this doesn't break anything.~~ Done that