### PR TITLE
Support more types of redirection during prerendering. Fixes #11591

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteUriHelper.cs
+++ b/src/Components/Server/src/Circuits/RemoteUriHelper.cs
@@ -88,8 +88,10 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             if (_jsRuntime == null)
             {
-                throw new NavigationException(uri);
+                var absoluteUriString = ToAbsoluteUri(uri).ToString();
+                throw new NavigationException(absoluteUriString);
             }
+
             _jsRuntime.InvokeAsync<object>(Interop.NavigateTo, uri, forceLoad);
         }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -79,14 +79,22 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 () => Browser.FindElement(By.TagName("strong")).Text);
         }
 
-        [Fact]
-        public async Task CanRedirectDuringPrerendering()
+        [Theory]
+        [InlineData("base/relative", "prerendered/base/relative")]
+        [InlineData("/root/relative", "/root/relative")]
+        [InlineData("http://absolute/url", "http://absolute/url")]
+        public async Task CanRedirectDuringPrerendering(string destinationParam, string expectedRedirectionLocation)
         {
-            var targetUri = new Uri(_serverFixture.RootUri, "prerendered/prerendered-redirection?destination=prerendered-transition");
+            var requestUri = new Uri(
+                _serverFixture.RootUri,
+                "prerendered/prerendered-redirection?destination=" + destinationParam);
+
             var httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
-            var response = await httpClient.GetAsync(targetUri);
+            var response = await httpClient.GetAsync(requestUri);
+
+            var expectedUri = new Uri(_serverFixture.RootUri, expectedRedirectionLocation);
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-            Assert.Equal("prerendered-transition", response.Headers.Location.ToString());
+            Assert.Equal(expectedUri, response.Headers.Location);
         }
 
         private void BeginInteractivity()

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
@@ -73,6 +77,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal(
                 _serverFixture.RootUri + url,
                 () => Browser.FindElement(By.TagName("strong")).Text);
+        }
+
+        [Fact]
+        public async Task CanRedirectDuringPrerendering()
+        {
+            var targetUri = new Uri(_serverFixture.RootUri, "prerendered/prerendered-redirection?destination=prerendered-transition");
+            var httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+            var response = await httpClient.GetAsync(targetUri);
+            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+            Assert.Equal("prerendered-transition", response.Headers.Location.ToString());
         }
 
         private void BeginInteractivity()

--- a/src/Components/test/testassets/BasicTestApp/PrerenderedRedirection.razor
+++ b/src/Components/test/testassets/BasicTestApp/PrerenderedRedirection.razor
@@ -1,0 +1,16 @@
+@page "/prerendered-redirection"
+@inject IUriHelper UriHelper
+
+@{
+    throw new InvalidOperationException("The rendering logic should never be executed");
+}
+
+@code {
+    protected override Task OnInitializedAsync()
+    {
+        var uri = UriHelper.GetAbsoluteUri();
+        var destination = uri.Substring(uri.IndexOf("?destination=") + 13);
+        UriHelper.NavigateTo(destination);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             await response.AssertStatusCodeAsync(HttpStatusCode.Redirect);
-            Assert.Equal("/navigation-redirect", response.Headers.Location.ToString());
+            Assert.Equal("http://localhost/navigation-redirect", response.Headers.Location.ToString());
         }
 
         [Fact]
@@ -100,9 +100,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await client.GetAsync("http://localhost/components/Navigation/false");
 
             // Assert
-            // Assert
             await response.AssertStatusCodeAsync(HttpStatusCode.Redirect);
-            Assert.Equal("/navigation-redirect", response.Headers.Location.ToString());
+            Assert.Equal("http://localhost/navigation-redirect", response.Headers.Location.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
This addresses the main problem raised in #11591, which was that URLs were not being resolved relative to the base.

The other two problems raised in #11591 no longer reproed for me:

 * Exception getting logged to console (we have cleaned up a bunch of stuff in this area)
 * Redirection being delayed by 1 second (no idea what fixed this, or whether it really was an issue originally)