### PR TITLE
Make server-side Blazor template logout use POST. Fixes #11981

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Areas/Identity/Pages/Account/LogOut.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Areas/Identity/Pages/Account/LogOut.cshtml
@@ -1,8 +1,9 @@
 ﻿@page
 @using Microsoft.AspNetCore.Identity
+@attribute [IgnoreAntiforgeryToken]
 @inject SignInManager<IdentityUser> SignInManager
 @functions {
-    public async Task<IActionResult> OnGet()
+    public async Task<IActionResult> OnPost()
     {
         if (SignInManager.IsSignedIn(User))
         {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/LoginDisplay.IndividualLocalAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/LoginDisplay.IndividualLocalAuth.razor
@@ -1,7 +1,9 @@
 ﻿<AuthorizeView>
     <Authorized>
         <a href="Identity/Account/Manage">Hello, @context.User.Identity.Name!</a>
-        <a href="Identity/Account/LogOut">Log out</a>
+        <form method="post" action="Identity/Account/LogOut">
+            <button type="submit" class="nav-link btn btn-link">Log out</button>
+        </form>
     </Authorized>
     <NotAuthorized>
         <a href="Identity/Account/Register">Register</a>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -4,7 +4,7 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-a {
+a, .btn-link {
     color: #0366d6;
 }
 


### PR DESCRIPTION
Pretty trivial template change to avoid CSRF on logout endpoint as discussed with @GrabYourPitchforks.

It would be good to get it into preview 8 for extra verification that this works everywhere.