### PR TITLE
Update user on reconnect. Fixes #12051

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits
@@ -11,6 +12,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             HttpContext httpContext,
             CircuitClientProxy client,
             string uriAbsolute,
-            string baseUriAbsolute);
+            string baseUriAbsolute,
+            ClaimsPrincipal user);
     }
 }

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -107,6 +108,16 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
                 return result;
             });
+        }
+
+        public void SetCircuitUser(ClaimsPrincipal user)
+        {
+            var authenticationStateProvider = Services.GetService<AuthenticationStateProvider>() as IHostEnvironmentAuthenticationStateProvider;
+            if (authenticationStateProvider != null)
+            {
+                var authenticationState = new AuthenticationState(user);
+                authenticationStateProvider.SetAuthenticationState(Task.FromResult(authenticationState));
+            }
         }
 
         internal void InitializeCircuitAfterPrerender(UnhandledExceptionEventHandler unhandledException)

--- a/src/Components/Server/src/Circuits/CircuitPrerenderer.cs
+++ b/src/Components/Server/src/Circuits/CircuitPrerenderer.cs
@@ -132,7 +132,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     context,
                     client: new CircuitClientProxy(), // This creates an "offline" client.
                     GetFullUri(context.Request),
-                    GetFullBaseUri(context.Request));
+                    GetFullBaseUri(context.Request),
+                    context.User);
 
                 result.UnhandledException += CircuitHost_UnhandledException;
                 context.Response.OnCompleted(() =>

--- a/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Rendering;
@@ -13,7 +14,6 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
-using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits
 {

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -97,7 +97,8 @@ namespace Microsoft.AspNetCore.Components.Server
                 Context.GetHttpContext(),
                 circuitClient,
                 uriAbsolute,
-                baseUriAbsolute);
+                baseUriAbsolute,
+                Context.User);
 
             circuitHost.UnhandledException += CircuitHost_UnhandledException;
 
@@ -125,6 +126,7 @@ namespace Microsoft.AspNetCore.Components.Server
                 CircuitHost = circuitHost;
 
                 circuitHost.InitializeCircuitAfterPrerender(CircuitHost_UnhandledException);
+                circuitHost.SetCircuitUser(Context.User);
                 circuitHost.SendPendingBatches();
                 return true;
             }

--- a/src/Components/Server/test/Circuits/CircuitPrerendererTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitPrerendererTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -190,7 +191,7 @@ namespace Microsoft.AspNetCore.Components.Server.Tests.Circuits
                 _circuitIdFactory = circuitIdFactory ?? (() => Guid.NewGuid().ToString());
             }
 
-            public override CircuitHost CreateCircuitHost(HttpContext httpContext, CircuitClientProxy client, string uriAbsolute, string baseUriAbsolute)
+            public override CircuitHost CreateCircuitHost(HttpContext httpContext, CircuitClientProxy client, string uriAbsolute, string baseUriAbsolute, ClaimsPrincipal user)
             {
                 var serviceCollection = new ServiceCollection();
                 serviceCollection.AddScoped<IUriHelper>(_ =>
@@ -209,7 +210,7 @@ namespace Microsoft.AspNetCore.Components.Server.Tests.Circuits
             public Mock<IServiceScope> MockServiceScope { get; }
                 = new Mock<IServiceScope>();
 
-            public override CircuitHost CreateCircuitHost(HttpContext httpContext, CircuitClientProxy client, string uriAbsolute, string baseUriAbsolute)
+            public override CircuitHost CreateCircuitHost(HttpContext httpContext, CircuitClientProxy client, string uriAbsolute, string baseUriAbsolute, ClaimsPrincipal user)
             {
                 return TestCircuitHost.Create(Guid.NewGuid().ToString(), MockServiceScope.Object);
             }

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Equal(expectedUri, response.Headers.Location);
         }
 
+        [Theory]
         [InlineData(null, null)]
         [InlineData(null, "Bert")]
         [InlineData("Bert", null)]

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
@@ -14,16 +15,15 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
-    public class PrerenderingTest : ServerTestBase<AspNetSiteServerFixture>
+    [Collection("auth")] // Because auth uses cookies, this can't run in parallel with other auth tests
+    public class PrerenderingTest : BasicTestAppTestBase
     {
         public PrerenderingTest(
             BrowserFixture browserFixture,
-            AspNetSiteServerFixture serverFixture,
+            ToggleExecutionModeServerFixture<Program> serverFixture,
             ITestOutputHelper output)
-            : base(browserFixture, serverFixture, output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
         {
-            _serverFixture.Environment = AspNetEnvironment.Development;
-            _serverFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
         }
 
         [Fact]
@@ -95,6 +95,23 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedUri = new Uri(_serverFixture.RootUri, expectedRedirectionLocation);
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             Assert.Equal(expectedUri, response.Headers.Location);
+        }
+
+        [InlineData(null, null)]
+        [InlineData(null, "Bert")]
+        [InlineData("Bert", null)]
+        [InlineData("Bert", "Treb")]
+        public void CanAccessAuthenticationStateDuringStaticPrerendering(string initialUsername, string interactiveUsername)
+        {
+            // See that the authentication state is usable during the initial prerendering
+            SignInAs(initialUsername, null);
+            Navigate("/prerendered/prerendered-transition");
+            Browser.Equal($"Hello, {initialUsername ?? "anonymous"}!", () => Browser.FindElement(By.TagName("h1")).Text);
+
+            // See that during connection, we update to whatever the latest authentication state now is
+            SignInAs(interactiveUsername, null, useSeparateTab: true);
+            BeginInteractivity();
+            Browser.Equal($"Hello, {interactiveUsername ?? "anonymous"}!", () => Browser.FindElement(By.TagName("h1")).Text);
         }
 
         private void BeginInteractivity()

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicTestApp;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.Components.E2ETest.Tests;
+using Microsoft.AspNetCore.E2ETesting;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
+{
+    public class ServerAuthTest : AuthTest
+    {
+        public ServerAuthTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+    }
+}

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.E2ETest.Tests;
 using Microsoft.AspNetCore.E2ETesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
@@ -14,6 +18,48 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public ServerAuthTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
             : base(browserFixture, serverFixture.WithServerExecution(), output)
         {
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "Someone")]
+        [InlineData("Someone", null)]
+        [InlineData("Someone", "Someone")]
+        public void UpdatesAuthenticationStateWhenReconnecting(
+            string usernameBefore, string usernameAfter)
+        {
+            // Establish state before disconnection
+            SignInAs(usernameBefore, usernameBefore == null ? null : "TestRole");
+            var appElement = MountAndNavigateToAuthTest(AuthorizeViewCases);
+            AssertState(usernameBefore);
+
+            // Change authentication state and force reconnection
+            SignInAs(usernameAfter, usernameAfter == null ? null : "TestRole", useSeparateTab: true);
+            PerformReconnection();
+            AssertState(usernameAfter);
+
+            void AssertState(string username)
+            {
+                if (username == null)
+                {
+                    Browser.Equal("You're not authorized, anonymous", () =>
+                        appElement.FindElement(By.CssSelector("#authorize-role .not-authorized")).Text);
+                }
+                else
+                {
+                    Browser.Equal($"Welcome, {username}!", () =>
+                        appElement.FindElement(By.CssSelector("#authorize-role .authorized")).Text);
+                }
+            }
+        }
+
+        private void PerformReconnection()
+        {
+            ((IJavaScriptExecutor)Browser).ExecuteScript("Blazor._internal.forceCloseConnection()");
+
+            // Wait until the reconnection dialog has been shown but is now hidden
+            new WebDriverWait(Browser, TimeSpan.FromSeconds(10))
+                .Until(driver => driver.FindElement(By.Id("components-reconnect-modal"))?.GetCssValue("display") == "none");
         }
     }
 }

--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -83,12 +83,4 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
         }
     }
-
-    public class ServerAuthTest : AuthTest
-    {
-        public ServerAuthTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
-            : base(browserFixture, serverFixture.WithServerExecution(), output)
-        {
-        }
-    }
 }

--- a/src/Components/test/E2ETest/Tests/AuthTest.cs
+++ b/src/Components/test/E2ETest/Tests/AuthTest.cs
@@ -15,12 +15,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
     public class AuthTest : BasicTestAppTestBase
     {
         // These strings correspond to the links in BasicTestApp\AuthTest\Links.razor
-        const string CascadingAuthenticationStateLink = "Cascading authentication state";
-        const string AuthorizeViewCases = "AuthorizeView cases";
-        const string PageAllowingAnonymous = "Page allowing anonymous";
-        const string PageRequiringAuthorization = "Page requiring any authentication";
-        const string PageRequiringPolicy = "Page requiring policy";
-        const string PageRequiringRole = "Page requiring role";
+        protected const string CascadingAuthenticationStateLink = "Cascading authentication state";
+        protected const string AuthorizeViewCases = "AuthorizeView cases";
+        protected const string PageAllowingAnonymous = "Page allowing anonymous";
+        protected const string PageRequiringAuthorization = "Page requiring any authentication";
+        protected const string PageRequiringPolicy = "Page requiring policy";
+        protected const string PageRequiringRole = "Page requiring role";
 
         public AuthTest(
             BrowserFixture browserFixture,
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 appElement.FindElement(By.CssSelector("#auth-failure")).Text);
         }
 
-        IWebElement MountAndNavigateToAuthTest(string authLinkText)
+        protected IWebElement MountAndNavigateToAuthTest(string authLinkText)
         {
             Navigate(ServerPathBase);
             var appElement = MountTestComponent<BasicTestApp.AuthTest.AuthRouter>();

--- a/src/Components/test/E2ETest/Tests/AuthTest.cs
+++ b/src/Components/test/E2ETest/Tests/AuthTest.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 {
+    [Collection("auth")] // Because auth uses cookies, this can't run in parallel with other auth tests
     public class AuthTest : BasicTestAppTestBase
     {
         // These strings correspond to the links in BasicTestApp\AuthTest\Links.razor
@@ -191,16 +192,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             WaitUntilExists(By.Id("auth-links"));
             appElement.FindElement(By.LinkText(authLinkText)).Click();
             return appElement;
-        }
-
-        void SignInAs(string usernameOrNull, string rolesOrNull)
-        {
-            const string authenticationPageUrl = "/Authentication";
-            var baseRelativeUri = usernameOrNull == null
-                ? $"{authenticationPageUrl}?signout=true"
-                : $"{authenticationPageUrl}?username={usernameOrNull}&roles={rolesOrNull}";
-            Navigate(baseRelativeUri);
-            WaitUntilExists(By.CssSelector("h1#authentication"));
         }
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/PrerenderedToInteractiveTransition.razor
+++ b/src/Components/test/testassets/BasicTestApp/PrerenderedToInteractiveTransition.razor
@@ -3,7 +3,10 @@
 @inject IComponentContext ComponentContext
 
 <CascadingAuthenticationState>
-    <h1>Hello</h1>
+    <AuthorizeView>
+        <Authorized><h1>Hello, @context.User.Identity.Name!</h1></Authorized>
+        <NotAuthorized><h1>Hello, anonymous!</h1></NotAuthorized>
+    </AuthorizeView>
 
     <p>
         Current state:


### PR DESCRIPTION
This address the issue in #12051, which is that Windows authentication becomes broken if you reconnect. Previously it continued trying to use the circuit's original `ClaimsPrincipal` which becomes invalid once the SignalR connection drops, because SignalR disposes the `WindowsPrincipal`.

The fix is to update the circuit's authentication state to match whatever SignalR gives us each time the user connects. This means we have the same level of Windows Authentication support that SignalR itself does:

 * For as long as there is an active SignalR connection (including if it's a *reconnection*, and including across a series of separate HTTP requests that constitute a long-polling connection), we use the `ClaimsPrincipal` from `hubContext.User`. This has some limitations with Windows Authentication (because they clone the principal) but it's the same limitations that SignalR itself has.
 * During any period where there isn't an active SignalR connection, then for most types of auth it makes no difference (you keep using the circuit's previous principal), but for Windows authentication it becomes invalid to do things like evaluate roles during that period. There's nothing we can do to improve this short of some new features deep in the IIS-integration part of the stack.

**Important** This also changes how other auth types work with server-side Blazor. Now, whenever you reconnect, we will update the circuit to the latest `ClaimsPrincipal` for the connection. This means you will observe any changes to roles, etc. If you're using cookie auth and the user has logged out or their cookie expired, then on reconnection they will become logged out, etc. If they logged in as a different person entirely, then on reconnection the circuit becomes that new user. This is consistent with how Blazor's authentication system was originally designed to support changing the authentication state arbitrarily during the lifetime of the circuit: all the UI will update to reflect the new state, declarative authentication for the current route will be re-evaluated, etc.

@blowdart @GrabYourPitchforks I'm not expecting you to review the code (but feel free to if you want). I'm including you on the list of reviewers to make sure you're up-to-date on where this all ended up. Please let me know if you have any thoughts about it!