### PR TITLE
Clarify IUriHelper GetAbsoluteUrl behavior. Fixes #9717

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -55,6 +55,26 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal("Hello from interop call", () => Browser.FindElement(By.Id("val-set-by-interop")).GetAttribute("value"));
         }
 
+        [Fact]
+        public void CanReadUrlHashOnlyOnceConnected()
+        {
+            var urlWithoutHash = "prerendered/show-uri?my=query&another=value";
+            var url = $"{urlWithoutHash}#some/hash?tokens";
+
+            // The server doesn't receive the hash part of the URL, so you can't
+            // read it during prerendering
+            Navigate(url);
+            Browser.Equal(
+                _serverFixture.RootUri + urlWithoutHash,
+                () => Browser.FindElement(By.TagName("strong")).Text);
+
+            // Once connected, you do have access to the full URL
+            BeginInteractivity();
+            Browser.Equal(
+                _serverFixture.RootUri + url,
+                () => Browser.FindElement(By.TagName("strong")).Text);
+        }
+
         private void BeginInteractivity()
         {
             Browser.FindElement(By.Id("load-boot-script")).Click();

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -389,6 +389,19 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void UriHelperCanReadAbsoluteUriIncludingHash()
+        {
+            var app = MountTestComponent<UriHelperComponent>();
+            Browser.Equal(Browser.Url, () => app.FindElement(By.Id("test-info")).Text);
+
+            var uri = "/mytestpath?my=query&another#some/hash?tokens";
+            var expectedAbsoluteUri = $"{_serverFixture.RootUri}subdir{uri}";
+
+            SetUrlViaPushState(uri);
+            Browser.Equal(expectedAbsoluteUri, () => app.FindElement(By.Id("test-info")).Text);
+        }
+
+        [Fact]
         public void CanArriveAtRouteWithExtension()
         {
             // This is an odd test, but it's primarily here to verify routing for routeablecomponentfrompackage isn't available due to

--- a/src/Components/test/testassets/BasicTestApp/ShowUriComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ShowUriComponent.razor
@@ -1,0 +1,3 @@
+@page "/show-uri"
+@inject IUriHelper UriHelper
+The current URL is <strong>@UriHelper.GetAbsoluteUri()</strong>


### PR DESCRIPTION
In #9717, there's the suggestion of a bug because `uriHelper.GetAbsoluteUri` didn't return the hash part of the URL. However I've confirmed there's no bug:

 * During prerendering, the server doesn't receive the hash part of the URL, so it's expected to be absent
 * Once connected, `GetAbsoluteUri` *does* return the URL including hash

So this is behaving as expected. To make this super clear, this PR adds E2E tests to show how it works:

 * When prerendering
 * When initially starting up an interactive circuit (or client-side Blazor instance)
 * When navigating within an interactive circuit (or in client-side Blazor)