### PR TITLE
Complete the reader in Dispose

### DIFF
--- a/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
+++ b/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
@@ -87,7 +87,6 @@ namespace Microsoft.AspNetCore.TestHost
 
             if (result.Buffer.IsEmpty && result.IsCompleted)
             {
-                _pipe.Reader.Complete();
                 _readComplete();
                 _readerComplete = true;
                 return 0;
@@ -128,7 +127,6 @@ namespace Microsoft.AspNetCore.TestHost
             _aborted = true;
             _abortException = innerException;
             _pipe.Reader.CancelPendingRead();
-            _pipe.Reader.Complete();
         }
 
         private void CheckAborted()
@@ -145,6 +143,9 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 _abortRequest();
             }
+
+            _pipe.Reader.Complete();
+
             base.Dispose(disposing);
         }
     }

--- a/src/Hosting/TestHost/test/RequestLifetimeTests.cs
+++ b/src/Hosting/TestHost/test/RequestLifetimeTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.TestHost
             });
 
             var client = host.GetTestServer().CreateClient();
-            var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
+            using var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
             responseReceived.SetResult(0);
             response.EnsureSuccessStatusCode();
             var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());


### PR DESCRIPTION
- This should avoid issues about completing while still reading.
- Dispose the HttpResponseMessage in some tests that use ResponseHeadersRead);

Fixes a couple of flaky tests:
- Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2799
- Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2759
- Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2794