### PR TITLE
IIS - Skip setting a header if the value is empty

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -376,6 +376,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 var knownHeaderIndex = HttpApiTypes.HTTP_RESPONSE_HEADER_ID.IndexOfKnownHeader(headerPair.Key);
                 for (var i = 0; i < headerValues.Count; i++)
                 {
+                    if(string.IsNullOrEmpty(headerValues.ToString()))
+                    {
+                        throw new ArgumentException($"{headerPair.Key} header should be non-empty string");
+                    }
+
                     var isFirst = i == 0;
                     var headerValueBytes = Encoding.UTF8.GetBytes(headerValues[i]);
                     fixed (byte* pHeaderValue = headerValueBytes)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -373,12 +373,18 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             foreach (var headerPair in HttpResponseHeaders)
             {
                 var headerValues = headerPair.Value;
+
+                if (headerPair.Value.Count == 0)
+                {
+                    continue;
+                }
+
                 var knownHeaderIndex = HttpApiTypes.HTTP_RESPONSE_HEADER_ID.IndexOfKnownHeader(headerPair.Key);
                 for (var i = 0; i < headerValues.Count; i++)
                 {
-                    if(string.IsNullOrEmpty(headerValues.ToString()))
+                    if (string.IsNullOrEmpty(headerValues[i]))
                     {
-                        throw new ArgumentException($"{headerPair.Key} header should be non-empty string");
+                        continue;
                     }
 
                     var isFirst = i == 0;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResponseHeaderTests.cs
@@ -23,6 +23,15 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         }
 
         [ConditionalFact]
+        public async Task AddEmptyHeaderSkipped()
+        {
+            var response = await _fixture.Client.GetAsync("ResponseEmptyHeaders");
+            var responseText = await response.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(response.Headers.TryGetValues("EmptyHeader", out var headerValues));
+        }
+
+        [ConditionalFact]
         public async Task AddResponseHeaders_HeaderValuesAreSetCorrectly()
         {
             var response = await _fixture.Client.GetAsync("ResponseHeaders");

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -379,6 +379,12 @@ namespace TestSite
             await ctx.Response.WriteAsync("Request Complete");
         }
 
+        private async Task ResponseEmptyHeaders(HttpContext ctx)
+        {
+            ctx.Response.Headers["EmptyHeader"] = "";
+            await ctx.Response.WriteAsync("EmptyHeaderShouldBeSkipped");
+        }
+
         private async Task ResponseInvalidOrdering(HttpContext ctx)
         {
             if (ctx.Request.Path.Equals("/SetStatusCodeAfterWrite"))


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Check if a response header is null or empty before setting it
 - If null or empty throw Argument exception with name of header being set

Addresses #11032 (in this specific format)
Fix based on @anurse comment. I haven't seen any other tests for this class, and not sure if this issue meets the bar for requiring test coverage. I can add a test if someone points me in the right direction for where it should live :)