### PR TITLE
Catch all exceptions from Exit shutdown

### DIFF
--- a/src/Hosting/Hosting/src/WebHostExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostExtensions.cs
@@ -135,18 +135,18 @@ namespace Microsoft.AspNetCore.Hosting
         {
             void Shutdown()
             {
-                if (!cts.IsCancellationRequested)
+                try
                 {
-                    if (!string.IsNullOrEmpty(shutdownMessage))
+                    if (!cts.IsCancellationRequested)
                     {
-                        Console.WriteLine(shutdownMessage);
-                    }
-                    try
-                    {
+                        if (!string.IsNullOrEmpty(shutdownMessage))
+                        {
+                            Console.WriteLine(shutdownMessage);
+                        }
                         cts.Cancel();
                     }
-                    catch (ObjectDisposedException) { }
                 }
+                catch (Exception) { }
 
                 // Wait on the given reset event
                 resetEvent.Wait();

--- a/src/Hosting/Hosting/src/WebHostExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostExtensions.cs
@@ -146,6 +146,9 @@ namespace Microsoft.AspNetCore.Hosting
                         cts.Cancel();
                     }
                 }
+                // When hosting with IIS in-process, we detach the Console handle on main thread exit.
+                // Console.WriteLine may throw here as we are logging to console on ProcessExit.
+                // We catch and ignore all exceptions here. Do not log to Console in thie exception handler.
                 catch (Exception) { }
 
                 // Wait on the given reset event


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/7367 in 2.2.

If we fail to log to console due to an invalid handle, catch the exception no matter what.

Writing a test for this is really hard as I would need to muck with Console.* to make it throw.



## Impact
This bug is to fix an issue with hosting aspnetcore in IIS In-process. On process shutdown, hosting tries to log to Console OnProcessExit. When hosting inprocess, once the main thread returns, we restore the original handle which the app originally had, making the old handle invalid. However, OnProcessExit runs after the main thread returns, which causes a race condition between the handle being invalid and the log to console. As this is on a background thread, it crashes the application.

## Workaround
There are no work arounds. Once an event is added to AppDomain.ProcessExit, I don't believe it can be removed without the original event which is internal.

## Risk
Very low. This only affects one call to Console.WriteLine and a cts.Cancel to catch all exceptions on process exit rather than only catching around the cts for an ODE.

cc @NickCraver