### PR TITLE
Set transport handlers earlier in Typescript client

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -281,9 +281,6 @@ export class HttpConnection implements IConnection {
                 this.features.inherentKeepAlive = true;
             }
 
-            this.transport!.onreceive = this.onreceive;
-            this.transport!.onclose = (e) => this.stopConnection(e);
-
             if (this.connectionState === ConnectionState.Connecting) {
                 // Ensure the connection transitions to the connected state prior to completing this.startInternalPromise.
                 // start() will handle the case when stop was called and startInternal exits still in the disconnecting state.
@@ -344,6 +341,8 @@ export class HttpConnection implements IConnection {
         if (this.isITransport(requestedTransport)) {
             this.logger.log(LogLevel.Debug, "Connection was provided an instance of ITransport, using that directly.");
             this.transport = requestedTransport;
+            this.transport.onreceive = this.onreceive;
+            this.transport.onclose = (e) => this.stopConnection(e);
             await this.transport.connect(connectUrl, requestedTransferFormat);
 
             return;
@@ -367,6 +366,8 @@ export class HttpConnection implements IConnection {
                     connectUrl = this.createConnectUrl(url, negotiateResponse.connectionId);
                 }
                 try {
+                    this.transport!.onreceive = this.onreceive;
+                    this.transport!.onclose = (e) => this.stopConnection(e);
                     await this.transport!.connect(connectUrl, requestedTransferFormat);
                     return;
                 } catch (ex) {

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -230,7 +230,7 @@ export class HttpConnection implements IConnection {
                     this.transport = this.constructTransport(HttpTransportType.WebSockets);
                     // We should just call connect directly in this case.
                     // No fallback or negotiate in this case.
-                    await this.transport!.connect(url, transferFormat);
+                    await this.startTransport(url, transferFormat);
                 } else {
                     throw new Error("Negotiation can only be skipped when using the WebSocket transport directly.");
                 }
@@ -341,9 +341,7 @@ export class HttpConnection implements IConnection {
         if (this.isITransport(requestedTransport)) {
             this.logger.log(LogLevel.Debug, "Connection was provided an instance of ITransport, using that directly.");
             this.transport = requestedTransport;
-            this.transport.onreceive = this.onreceive;
-            this.transport.onclose = (e) => this.stopConnection(e);
-            await this.transport.connect(connectUrl, requestedTransferFormat);
+            await this.startTransport(connectUrl, requestedTransferFormat);
 
             return;
         }
@@ -366,9 +364,7 @@ export class HttpConnection implements IConnection {
                     connectUrl = this.createConnectUrl(url, negotiateResponse.connectionId);
                 }
                 try {
-                    this.transport!.onreceive = this.onreceive;
-                    this.transport!.onclose = (e) => this.stopConnection(e);
-                    await this.transport!.connect(connectUrl, requestedTransferFormat);
+                    await this.startTransport(connectUrl, requestedTransferFormat);
                     return;
                 } catch (ex) {
                     this.logger.log(LogLevel.Error, `Failed to start the transport '${endpoint.transport}': ${ex}`);
@@ -407,6 +403,12 @@ export class HttpConnection implements IConnection {
             default:
                 throw new Error(`Unknown transport: ${transport}.`);
         }
+    }
+
+    private startTransport(url: string, transferFormat: TransferFormat): Promise<void> {
+        this.transport!.onreceive = this.onreceive;
+        this.transport!.onclose = (e) => this.stopConnection(e);
+        return this.transport!.connect(url, transferFormat);
     }
 
     private resolveTransportOrError(endpoint: IAvailableTransport, requestedTransport: HttpTransportType | undefined, requestedTransferFormat: TransferFormat): ITransport | Error {

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -831,6 +831,48 @@ describe("HttpConnection", () => {
         });
     });
 
+    it("transport handlers set before start for custom transports", async () => {
+        await VerifyLogger.run(async (logger) => {
+            const availableTransport = { transport: "Custom", transferFormats: ["Text"] };
+            let handlersSet = false;
+            const transport: ITransport = {
+                connect: (url: string, transferFormat: TransferFormat) => {
+                    if (transport.onreceive && transport.onclose) {
+                        handlersSet = true;
+                    }
+                    return Promise.resolve();
+                },
+                onclose: null,
+                onreceive: null,
+                send: (data: any) => Promise.resolve(),
+                stop: () => {
+                    if (transport.onclose) {
+                        transport.onclose();
+                    }
+                    return Promise.resolve();
+                },
+            };
+
+            const options: IHttpConnectionOptions = {
+                ...commonOptions,
+                httpClient: new TestHttpClient()
+                    .on("POST", () => ({ connectionId: "42", availableTransports: [availableTransport] })),
+                logger,
+                transport,
+            } as IHttpConnectionOptions;
+
+            const connection = new HttpConnection("http://tempuri.org", options);
+            connection.onreceive = () => null;
+            try {
+                await connection.start(TransferFormat.Text);
+            } finally {
+                await connection.stop();
+            }
+
+            expect(handlersSet).toBe(true);
+        });
+    });
+
     describe(".constructor", () => {
         it("throws if no Url is provided", async () => {
             // Force TypeScript to let us call the constructor incorrectly :)


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2817

We were setting the handlers after start so there were a couple races.

One where data could be received from the server before the handlers were set and so they would be missed.
And another where stop could be called and cause a null ref on `this.transport!.onreceive = this.onreceive;` if it happened at the "right" time.