### PR TITLE
Send HttpOnly (if applicable) when deleting cookies

### DIFF
--- a/src/Security/Authentication/test/WsFederation/WsFederationTest.cs
+++ b/src/Security/Authentication/test/WsFederation/WsFederationTest.cs
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
             response.EnsureSuccessStatusCode();
 
             var cookie = response.Headers.GetValues(HeaderNames.SetCookie).Single();
-            Assert.Equal(".AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax", cookie);
+            Assert.Equal(".AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly", cookie);
             Assert.Equal("OnRemoteSignOut", response.Headers.GetValues("EventHeader").Single());
             Assert.Equal("", await response.Content.ReadAsStringAsync());
         }

--- a/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
+++ b/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
@@ -289,6 +289,7 @@ namespace Microsoft.AspNetCore.Internal
                     Secure = options.Secure,
                     IsEssential = options.IsEssential,
                     Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    HttpOnly = options.HttpOnly,
                 });
 
             for (int i = 1; i <= chunks; i++)
@@ -305,6 +306,7 @@ namespace Microsoft.AspNetCore.Internal
                         Secure = options.Secure,
                         IsEssential = options.IsEssential,
                         Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                        HttpOnly = options.HttpOnly,
                     });
             }
         }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/12546

Tested with Edge, Chrome, and Firefox. All removed the cookie when requested with the addition of httponly.