### PR TITLE
Check length for pipe test rather than byte content

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResponseBodyTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResponseBodyTests.cs
@@ -21,14 +21,14 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         [RequiresNewHandler]
         public async Task ResponseBodyTest_UnflushedPipe_AutoFlushed()
         {
-            Assert.Equal(new byte[10], await _fixture.Client.GetByteArrayAsync($"/UnflushedResponsePipe"));
+            Assert.Equal(10, (await _fixture.Client.GetByteArrayAsync($"/UnflushedResponsePipe")).Length);
         }
 
         [ConditionalFact]
         [RequiresNewHandler]
         public async Task ResponseBodyTest_FlushedPipeAndThenUnflushedPipe_AutoFlushed()
         {
-            Assert.Equal(new byte[20], await _fixture.Client.GetByteArrayAsync($"/FlushedPipeAndThenUnflushedPipe"));
+            Assert.Equal(20, (await _fixture.Client.GetByteArrayAsync($"/FlushedPipeAndThenUnflushedPipe")).Length);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2879.

I decided it was easier to check the length than clear out the contents or check against a string. If you care about checking the contents, I can fill the memory on the server with data, but what matters in this test is that 10/20 bytes are written.