### PR TITLE
Increase Http2 Header limit size to the MaxFrameSize

### DIFF
--- a/src/Servers/Kestrel/Core/src/Http2Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http2Limits.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         private int _maxStreamsPerConnection = 100;
         private int _headerTableSize = (int)Http2PeerSettings.DefaultHeaderTableSize;
         private int _maxFrameSize = (int)Http2PeerSettings.DefaultMaxFrameSize;
-        private int _maxRequestHeaderFieldSize = 8192;
+        private int _maxRequestHeaderFieldSize = (int)Http2PeerSettings.DefaultMaxFrameSize;
         private int _initialConnectionWindowSize = 1024 * 128; // Larger than the default 64kb, and larger than any one single stream.
         private int _initialStreamWindowSize = 1024 * 96; // Larger than the default 64kb
 
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <summary>
         /// Indicates the size of the maximum allowed size of a request header field sequence. This limit applies to both name and value sequences in their compressed and uncompressed representations.
         /// <para>
-        /// Value must be greater than 0, defaults to 8192
+        /// Value must be greater than 0, defaults to 2^14 (16,384)
         /// </para>
         /// </summary>
         public int MaxRequestHeaderFieldSize

--- a/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void MaxRequestHeadersTotalSizeDefault()
         {
-            Assert.Equal(1 << 14, (new KestrelServerLimits()).MaxRequestHeadersTotalSize);
+            Assert.Equal(32 * 1024, (new KestrelServerLimits()).MaxRequestHeadersTotalSize);
         }
 
         [Theory]
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void Http2MaxRequestHeaderFieldSizeDefault()
         {
-            Assert.Equal(32, new KestrelServerLimits().Http2.MaxRequestHeaderFieldSize);
+            Assert.Equal(16 * 1024, new KestrelServerLimits().Http2.MaxRequestHeaderFieldSize);
         }
 
         [Theory]

--- a/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void MaxRequestHeadersTotalSizeDefault()
         {
-            Assert.Equal(32 * 1024, (new KestrelServerLimits()).MaxRequestHeadersTotalSize);
+            Assert.Equal(1 << 14, (new KestrelServerLimits()).MaxRequestHeadersTotalSize);
         }
 
         [Theory]
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void Http2MaxRequestHeaderFieldSizeDefault()
         {
-            Assert.Equal(8192, new KestrelServerLimits().Http2.MaxRequestHeaderFieldSize);
+            Assert.Equal(32, new KestrelServerLimits().Http2.MaxRequestHeaderFieldSize);
         }
 
         [Theory]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, IHttpHeadersHandler
     {
-        protected static readonly int MaxRequestHeaderFieldSize = 8192;
+        protected static readonly int MaxRequestHeaderFieldSize = 16 * 1024;
         protected static readonly string _4kHeaderValue = new string('a', 4096);
 
         protected static readonly IEnumerable<KeyValuePair<string, string>> _browserRequestHeaders = new[]


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/12213

Increased the limit to the default max frame size.