### PR TITLE
Add host caution to MVC GetUri extension methods

### DIFF
--- a/src/Mvc/Mvc.Core/src/Routing/ControllerLinkGeneratorExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerLinkGeneratorExtensions.cs
@@ -138,6 +138,14 @@ namespace Microsoft.AspNetCore.Routing
         /// names from <c>RouteOptions</c>.
         /// </param>
         /// <returns>A absolute URI, or <c>null</c> if a URI cannot be created.</returns>
+        /// <remarks>
+        /// <para>
+        /// The value of <paramref name="host" /> should be a trusted value. Relying on the value of the current request
+        /// can allow untrusted input to influence the resulting URI unless the <c>Host</c> header has been validated.
+        /// See the deployment documentation for instructions on how to properly validate the <c>Host</c> header in
+        /// your deployment environment.
+        /// </para>
+        /// </remarks>
         public static string GetUriByAction(
             this LinkGenerator generator,
             HttpContext httpContext,
@@ -189,6 +197,14 @@ namespace Microsoft.AspNetCore.Routing
         /// names from <c>RouteOptions</c>.
         /// </param>
         /// <returns>A absolute URI, or <c>null</c> if a URI cannot be created.</returns>
+        /// <remarks>
+        /// <para>
+        /// The value of <paramref name="host" /> should be a trusted value. Relying on the value of the current request
+        /// can allow untrusted input to influence the resulting URI unless the <c>Host</c> header has been validated.
+        /// See the deployment documentation for instructions on how to properly validate the <c>Host</c> header in
+        /// your deployment environment.
+        /// </para>
+        /// </remarks>
         public static string GetUriByAction(
             this LinkGenerator generator,
             string action,

--- a/src/Mvc/Mvc.Core/src/Routing/PageLinkGeneratorExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/PageLinkGeneratorExtensions.cs
@@ -135,6 +135,13 @@ namespace Microsoft.AspNetCore.Routing
         /// names from <c>RouteOptions</c>.
         /// </param>
         /// <returns>A absolute URI, or <c>null</c> if a URI cannot be created.</returns>
+        /// <para>
+        /// The value of <paramref name="host" /> should be a trusted value. Relying on the value of the current request
+        /// can allow untrusted input to influence the resulting URI unless the <c>Host</c> header has been validated.
+        /// See the deployment documentation for instructions on how to properly validate the <c>Host</c> header in
+        /// your deployment environment.
+        /// </para>
+        /// </remarks>
         public static string GetUriByPage(
             this LinkGenerator generator,
             HttpContext httpContext,
@@ -186,6 +193,13 @@ namespace Microsoft.AspNetCore.Routing
         /// names from <c>RouteOptions</c>.
         /// </param>
         /// <returns>A absolute URI, or <c>null</c> if a URI cannot be created.</returns>
+        /// <para>
+        /// The value of <paramref name="host" /> should be a trusted value. Relying on the value of the current request
+        /// can allow untrusted input to influence the resulting URI unless the <c>Host</c> header has been validated.
+        /// See the deployment documentation for instructions on how to properly validate the <c>Host</c> header in
+        /// your deployment environment.
+        /// </para>
+        /// </remarks>
         public static string GetUriByPage(
             this LinkGenerator generator,
             string page,

--- a/src/Mvc/Mvc.Core/src/Routing/PageLinkGeneratorExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/PageLinkGeneratorExtensions.cs
@@ -135,6 +135,7 @@ namespace Microsoft.AspNetCore.Routing
         /// names from <c>RouteOptions</c>.
         /// </param>
         /// <returns>A absolute URI, or <c>null</c> if a URI cannot be created.</returns>
+        /// <remarks>
         /// <para>
         /// The value of <paramref name="host" /> should be a trusted value. Relying on the value of the current request
         /// can allow untrusted input to influence the resulting URI unless the <c>Host</c> header has been validated.
@@ -193,6 +194,7 @@ namespace Microsoft.AspNetCore.Routing
         /// names from <c>RouteOptions</c>.
         /// </param>
         /// <returns>A absolute URI, or <c>null</c> if a URI cannot be created.</returns>
+        /// <remarks>
         /// <para>
         /// The value of <paramref name="host" /> should be a trusted value. Relying on the value of the current request
         /// can allow untrusted input to influence the resulting URI unless the <c>Host</c> header has been validated.


### PR DESCRIPTION
Caution not added to the extension methods in MVC.