### PR TITLE
HeaderPropagation: reworded registration exception for clarity

### DIFF
--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationMessageHandler.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationMessageHandler.cs
@@ -48,8 +48,8 @@ namespace Microsoft.AspNetCore.HeaderPropagation
             {
                 var message =
                     $"The {nameof(HeaderPropagationValues)}.{nameof(HeaderPropagationValues.Headers)} property has not been " +
-                    $"initialized. Register the header propagation middleware by adding 'app.{nameof(HeaderPropagationApplicationBuilderExtensions.UseHeaderPropagation)}() " +
-                    $"in the 'Configure(...)' method.";
+                    $"initialized. Register the header propagation middleware by adding 'app.{nameof(HeaderPropagationApplicationBuilderExtensions.UseHeaderPropagation)}()' " +
+                    $"in the 'Configure(...)' method. Also, do not use an HttpClient with header propagation outside of an incoming HTTP request.";
                 throw new InvalidOperationException(message);
             }
 

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationMessageHandler.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationMessageHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
                 var message =
                     $"The {nameof(HeaderPropagationValues)}.{nameof(HeaderPropagationValues.Headers)} property has not been " +
                     $"initialized. Register the header propagation middleware by adding 'app.{nameof(HeaderPropagationApplicationBuilderExtensions.UseHeaderPropagation)}()' " +
-                    $"in the 'Configure(...)' method. Also, do not use an HttpClient with header propagation outside of an incoming HTTP request.";
+                    $"in the 'Configure(...)' method. Header propagation can only be used within the context of an HTTP request.";
                 throw new InvalidOperationException(message);
             }
 

--- a/src/Middleware/HeaderPropagation/test/HeaderPropagationIntegrationTest.cs
+++ b/src/Middleware/HeaderPropagation/test/HeaderPropagationIntegrationTest.cs
@@ -64,8 +64,8 @@ namespace Microsoft.AspNetCore.HeaderPropagation.Tests
             Assert.IsType<InvalidOperationException>(captured);
             Assert.Equal(
                 "The HeaderPropagationValues.Headers property has not been initialized. Register the header propagation middleware " +
-                "by adding 'app.UseHeaderPropagation()' in the 'Configure(...)' method. Also, do not use an HttpClient with header " +
-                "propagation outside of an incoming HTTP request.",
+                "by adding 'app.UseHeaderPropagation()' in the 'Configure(...)' method. Header propagation can only be used within " +
+                "the context of an HTTP request.",
                 captured.Message);
         }
 
@@ -81,15 +81,13 @@ namespace Microsoft.AspNetCore.HeaderPropagation.Tests
             });
             var serviceProvider = services.BuildServiceProvider();
 
-            // Act
+            // Act & Assert
             var client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetAsync("http://localhost/"));
-
-            // Assert
             Assert.Equal(
                 "The HeaderPropagationValues.Headers property has not been initialized. Register the header propagation middleware " +
-                "by adding 'app.UseHeaderPropagation()' in the 'Configure(...)' method. Also, do not use an HttpClient with header " +
-                "propagation outside of an incoming HTTP request.",
+                "by adding 'app.UseHeaderPropagation()' in the 'Configure(...)' method. Header propagation can only be used within " +
+                "the context of an HTTP request.",
                 exception.Message);
         }
 


### PR DESCRIPTION
The MessageHandler throws when used outside of a request.
This reword the exception to clarify that this could be another possible cause of it.

Also fixes a missing `'` in the current message.

Related to #12169, but not a final fix

@rynowak I have a couple questions:
- What is the best way to describe an incoming request of the pipeline? Open for suggestions on how to better word this message.
- I guess this is it for now. We could use the `HttpContextAccessor` to distinguish between the two types of errors and have a specific message, but this can add a performance hit if not already registered. Unless we use it only if it is available and fallback to this generic exception message otherwise. However adding a dependency only to have a better error message feels wrong.

/cc @anurse 