### PR TITLE
Response Caching: Cache Head with Content-Length

### DIFF
--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
@@ -345,7 +344,9 @@ namespace Microsoft.AspNetCore.ResponseCaching
             {
                 var contentLength = context.HttpContext.Response.ContentLength;
                 var bufferStream = context.ResponseCachingStream.GetBufferStream();
-                if (!contentLength.HasValue || contentLength == bufferStream.Length)
+                if (!contentLength.HasValue || contentLength == bufferStream.Length
+                    || (bufferStream.Length == 0
+                        && string.Equals(context.HttpContext.Request.Method, "HEAD", StringComparison.OrdinalIgnoreCase)))
                 {
                     var response = context.HttpContext.Response;
                     // Add a content-length if required

--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -726,7 +726,6 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [Theory]
         [InlineData("GET")]
         [InlineData("HEAD")]
-        [InlineData("head")]
         public async Task FinalizeCacheBody_DoNotCache_IfContentLengthMismatches(string method)
         {
             var cache = new TestResponseCache();
@@ -754,11 +753,9 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Theory]
-        [InlineData("HEAD", false)]
-        [InlineData("head", false)]
-        [InlineData("HEAD", true)]
-        [InlineData("head", true)]
-        public async Task FinalizeCacheBody_RequestHead_Cache_IfContentLengthPresent_AndBodyAbsentOrOfSameLength(string method, bool includeBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task FinalizeCacheBody_RequestHead_Cache_IfContentLengthPresent_AndBodyAbsentOrOfSameLength(bool includeBody)
         {
             var cache = new TestResponseCache();
             var sink = new TestSink();
@@ -768,7 +765,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             context.ShouldCacheResponse = true;
             middleware.ShimResponseStream(context);
             context.HttpContext.Response.ContentLength = 10;
-            context.HttpContext.Request.Method = method;
+            context.HttpContext.Request.Method = "HEAD";
 
             if (includeBody)
             {

--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -723,8 +723,11 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 LoggedMessage.ResponseCached);
         }
 
-        [Fact]
-        public async Task FinalizeCacheBody_DoNotCache_IfContentLengthMismatches()
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("HEAD")]
+        [InlineData("head")]
+        public async Task FinalizeCacheBody_DoNotCache_IfContentLengthMismatches(string method)
         {
             var cache = new TestResponseCache();
             var sink = new TestSink();
@@ -734,6 +737,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             context.ShouldCacheResponse = true;
             middleware.ShimResponseStream(context);
             context.HttpContext.Response.ContentLength = 9;
+            context.HttpContext.Request.Method = method;
 
             await context.HttpContext.Response.WriteAsync(new string('0', 10));
 
@@ -747,6 +751,41 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             TestUtils.AssertLoggedMessages(
                 sink.Writes,
                 LoggedMessage.ResponseContentLengthMismatchNotCached);
+        }
+
+        [Theory]
+        [InlineData("HEAD", false)]
+        [InlineData("head", false)]
+        [InlineData("HEAD", true)]
+        [InlineData("head", true)]
+        public async Task FinalizeCacheBody_RequestHead_Cache_IfContentLengthPresent_AndBodyAbsentOrOfSameLength(string method, bool includeBody)
+        {
+            var cache = new TestResponseCache();
+            var sink = new TestSink();
+            var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache);
+            var context = TestUtils.CreateTestContext();
+
+            context.ShouldCacheResponse = true;
+            middleware.ShimResponseStream(context);
+            context.HttpContext.Response.ContentLength = 10;
+            context.HttpContext.Request.Method = method;
+
+            if (includeBody)
+            {
+                // A response to HEAD should not include a body, but it may be present
+                await context.HttpContext.Response.WriteAsync(new string('0', 10));
+            }
+
+            context.CachedResponse = new CachedResponse();
+            context.BaseKey = "BaseKey";
+            context.CachedResponseValidFor = TimeSpan.FromSeconds(10);
+
+            middleware.FinalizeCacheBody(context);
+
+            Assert.Equal(1, cache.SetCount);
+            TestUtils.AssertLoggedMessages(
+                sink.Writes,
+                LoggedMessage.ResponseCached);
         }
 
         [Fact]

--- a/src/Middleware/ResponseCaching/test/ResponseCachingTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingTests.cs
@@ -2,13 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Net.Http.Headers;
 using Xunit;
@@ -769,6 +765,24 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                     client.DefaultRequestHeaders.Pragma.Add(new System.Net.Http.Headers.NameValueHeaderValue("From"));
                     client.DefaultRequestHeaders.MaxForwards = 1;
                     var subsequentResponse = await client.GetAsync("");
+
+                    await AssertCachedResponseAsync(initialResponse, subsequentResponse);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ServesCachedContent_IfAvailable_UsingHead_WithContentLength()
+        {
+            var builders = TestUtils.CreateBuildersWithResponseCaching();
+
+            foreach (var builder in builders)
+            {
+                using (var server = new TestServer(builder))
+                {
+                    var client = server.CreateClient();
+                    var initialResponse = await client.SendAsync(TestUtils.CreateRequest("HEAD", "?contentLength=10"));
+                    var subsequentResponse = await client.SendAsync(TestUtils.CreateRequest("HEAD", "?contentLength=10"));
 
                     await AssertCachedResponseAsync(initialResponse, subsequentResponse);
                 }

--- a/src/Middleware/ResponseCaching/test/TestUtils.cs
+++ b/src/Middleware/ResponseCaching/test/TestUtils.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Pipelines;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -23,7 +21,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Xunit;
-using ISystemClock = Microsoft.AspNetCore.ResponseCaching.ISystemClock;
 
 namespace Microsoft.AspNetCore.ResponseCaching.Tests
 {
@@ -60,6 +57,12 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             }
             headers.Date = DateTimeOffset.UtcNow;
             headers.Headers["X-Value"] = guid;
+
+            var contentLength = context.Request.Query["ContentLength"];
+            if (!string.IsNullOrEmpty(contentLength))
+            {
+                headers.ContentLength = long.Parse(contentLength);
+            }
 
             if (context.Request.Method != "HEAD")
             {


### PR DESCRIPTION
 - Cache HEAD requests which include a `Content-Length`
 - Skip caching if it include a body (even if it shouldn't) and it doesn't match the `Content-Length`
 - Cleaned unnecessary `using`s in modified files

Addresses #12491
