### PR TITLE
Blazor API Review: Built-in components

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/App.razor
+++ b/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/App.razor
@@ -1,5 +1,5 @@
 ﻿<Router AppAssembly="typeof(Program).Assembly">
-    <NotFoundContent>
+    <NotFound>
         <p>Sorry, there's nothing at this address.</p>
-    </NotFoundContent>
+    </NotFound>
 </Router>

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -301,9 +301,9 @@ namespace Microsoft.AspNetCore.Components
     {
         public PageDisplay() { }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment AuthorizingContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Components.RenderFragment Authorizing { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> NotAuthorizedContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> NotAuthorized { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public System.Type Page { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
@@ -651,11 +651,11 @@ namespace Microsoft.AspNetCore.Components.Routing
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public System.Reflection.Assembly AppAssembly { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment AuthorizingContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Components.RenderFragment Authorizing { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> NotAuthorizedContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.AuthenticationState> NotAuthorized { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment NotFoundContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Components.RenderFragment NotFound { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
         public void Dispose() { }
         System.Threading.Tasks.Task Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync() { throw null; }

--- a/src/Components/Components/src/Auth/AuthorizeViewCore.cs
+++ b/src/Components/Components/src/Auth/AuthorizeViewCore.cs
@@ -58,8 +58,8 @@ namespace Microsoft.AspNetCore.Components
             }
             else if (isAuthorized)
             {
-                var authorizedContent = Authorized ?? ChildContent;
-                builder.AddContent(1, authorizedContent?.Invoke(currentAuthenticationState));
+                var authorized = Authorized ?? ChildContent;
+                builder.AddContent(1, authorized?.Invoke(currentAuthenticationState));
             }
             else
             {

--- a/src/Components/Components/src/PageDisplay.cs
+++ b/src/Components/Components/src/PageDisplay.cs
@@ -36,13 +36,13 @@ namespace Microsoft.AspNetCore.Components
         /// The content that will be displayed if the user is not authorized.
         /// </summary>
         [Parameter]
-        public RenderFragment<AuthenticationState> NotAuthorizedContent { get; set; }
+        public RenderFragment<AuthenticationState> NotAuthorized { get; set; }
 
         /// <summary>
         /// The content that will be displayed while asynchronous authorization is in progress.
         /// </summary>
         [Parameter]
-        public RenderFragment AuthorizingContent { get; set; }
+        public RenderFragment Authorizing { get; set; }
 
         /// <inheritdoc />
         public void Attach(RenderHandle renderHandle)
@@ -109,14 +109,14 @@ namespace Microsoft.AspNetCore.Components
             }
 
             // Some authorization data exists, so we do need to wrap the fragment
-            RenderFragment<AuthenticationState> authorizedContent = context => pageFragment;
+            RenderFragment<AuthenticationState> authorized = context => pageFragment;
             return builder =>
             {
                 builder.OpenComponent<AuthorizeViewWithSuppliedData>(0);
                 builder.AddAttribute(1, nameof(AuthorizeViewWithSuppliedData.AuthorizeDataParam), authorizeData);
-                builder.AddAttribute(2, nameof(AuthorizeViewWithSuppliedData.Authorized), authorizedContent);
-                builder.AddAttribute(3, nameof(AuthorizeViewWithSuppliedData.NotAuthorized), NotAuthorizedContent ?? DefaultNotAuthorizedContent);
-                builder.AddAttribute(4, nameof(AuthorizeViewWithSuppliedData.Authorizing), AuthorizingContent);
+                builder.AddAttribute(2, nameof(AuthorizeViewWithSuppliedData.Authorized), authorized);
+                builder.AddAttribute(3, nameof(AuthorizeViewWithSuppliedData.NotAuthorized), NotAuthorized ?? DefaultNotAuthorized);
+                builder.AddAttribute(4, nameof(AuthorizeViewWithSuppliedData.Authorizing), Authorizing);
                 builder.CloseComponent();
             };
         }
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Components
 
         // There has to be some default content. If we render blank by default, developers
         // will find it hard to guess why their UI isn't appearing.
-        private static RenderFragment DefaultNotAuthorizedContent(AuthenticationState authenticationState)
+        private static RenderFragment DefaultNotAuthorized(AuthenticationState authenticationState)
             => builder => builder.AddContent(0, "Not authorized");
     }
 }

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -41,17 +41,17 @@ namespace Microsoft.AspNetCore.Components.Routing
         /// <summary>
         /// Gets or sets the type of the component that should be used as a fallback when no match is found for the requested route.
         /// </summary>
-        [Parameter] public RenderFragment NotFoundContent { get; set; }
+        [Parameter] public RenderFragment NotFound { get; set; }
 
         /// <summary>
         /// The content that will be displayed if the user is not authorized.
         /// </summary>
-        [Parameter] public RenderFragment<AuthenticationState> NotAuthorizedContent { get; set; }
+        [Parameter] public RenderFragment<AuthenticationState> NotAuthorized { get; set; }
 
         /// <summary>
         /// The content that will be displayed while asynchronous authorization is in progress.
         /// </summary>
-        [Parameter] public RenderFragment AuthorizingContent { get; set; }
+        [Parameter] public RenderFragment Authorizing { get; set; }
 
         private RouteTable Routes { get; set; }
 
@@ -94,8 +94,8 @@ namespace Microsoft.AspNetCore.Components.Routing
             builder.OpenComponent(0, typeof(PageDisplay));
             builder.AddAttribute(1, nameof(PageDisplay.Page), handler);
             builder.AddAttribute(2, nameof(PageDisplay.PageParameters), parameters);
-            builder.AddAttribute(3, nameof(PageDisplay.NotAuthorizedContent), NotAuthorizedContent);
-            builder.AddAttribute(4, nameof(PageDisplay.AuthorizingContent), AuthorizingContent);
+            builder.AddAttribute(3, nameof(PageDisplay.NotAuthorized), NotAuthorized);
+            builder.AddAttribute(4, nameof(PageDisplay.Authorizing), Authorizing);
             builder.CloseComponent();
         }
 
@@ -120,14 +120,14 @@ namespace Microsoft.AspNetCore.Components.Routing
             }
             else
             {
-                if (!isNavigationIntercepted && NotFoundContent != null)
+                if (!isNavigationIntercepted && NotFound != null)
                 {
-                    Log.DisplayingNotFoundContent(_logger, locationPath, _baseUri);
+                    Log.DisplayingNotFound(_logger, locationPath, _baseUri);
 
                     // We did not find a Component that matches the route.
-                    // Only show the NotFoundContent if the application developer programatically got us here i.e we did not
+                    // Only show the NotFound if the application developer programatically got us here i.e we did not
                     // intercept the navigation. In all other cases, force a browser navigation since this could be non-Blazor content.
-                    _renderHandle.Render(NotFoundContent);
+                    _renderHandle.Render(NotFound);
                 }
                 else
                 {
@@ -159,8 +159,8 @@ namespace Microsoft.AspNetCore.Components.Routing
 
         private static class Log
         {
-            private static readonly Action<ILogger, string, string, Exception> _displayingNotFoundContent =
-                LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(1, "DisplayingNotFoundContent"), $"Displaying {nameof(NotFoundContent)} because path '{{Path}}' with base URI '{{BaseUri}}' does not match any component route");
+            private static readonly Action<ILogger, string, string, Exception> _displayingNotFound =
+                LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(1, "DisplayingNotFound"), $"Displaying {nameof(NotFound)} because path '{{Path}}' with base URI '{{BaseUri}}' does not match any component route");
 
             private static readonly Action<ILogger, Type, string, string, Exception> _navigatingToComponent =
                 LoggerMessage.Define<Type, string, string>(LogLevel.Debug, new EventId(2, "NavigatingToComponent"), "Navigating to component {ComponentType} in response to path '{Path}' with base URI '{BaseUri}'");
@@ -168,9 +168,9 @@ namespace Microsoft.AspNetCore.Components.Routing
             private static readonly Action<ILogger, string, string, string, Exception> _navigatingToExternalUri =
                 LoggerMessage.Define<string, string, string>(LogLevel.Debug, new EventId(3, "NavigatingToExternalUri"), "Navigating to non-component URI '{ExternalUri}' in response to path '{Path}' with base URI '{BaseUri}'");
 
-            internal static void DisplayingNotFoundContent(ILogger logger, string path, string baseUri)
+            internal static void DisplayingNotFound(ILogger logger, string path, string baseUri)
             {
-                _displayingNotFoundContent(logger, path, baseUri, null);
+                _displayingNotFound(logger, path, baseUri, null);
             }
 
             internal static void NavigatingToComponent(ILogger logger, Type componentType, string path, string baseUri)

--- a/src/Components/Components/test/Auth/AuthorizeViewTest.cs
+++ b/src/Components/Components/test/Auth/AuthorizeViewTest.cs
@@ -53,13 +53,13 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
-        public void RendersNotAuthorizedContentIfNotAuthorized()
+        public void RendersNotAuthorizedIfNotAuthorized()
         {
             // Arrange
             var authorizationService = new TestAuthorizationService();
             var renderer = CreateTestRenderer(authorizationService);
             var rootComponent = WrapInAuthorizeView(
-                notAuthorizedContent:
+                notAuthorized:
                     context => builder => builder.AddContent(0, $"You are not authorized, even though we know you are {context.User.Identity.Name}"));
             rootComponent.AuthenticationState = CreateAuthenticationState("Nellie");
 
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
-        public void RendersNothingIfAuthorizedButNoChildContentOrAuthorizedContentProvided()
+        public void RendersNothingIfAuthorizedButNoChildContentOrAuthorizedProvided()
         {
             // Arrange
             var authorizationService = new TestAuthorizationService();
@@ -152,14 +152,14 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
-        public void RendersAuthorizedContentIfAuthorized()
+        public void RendersAuthorizedIfAuthorized()
         {
             // Arrange
             var authorizationService = new TestAuthorizationService();
             authorizationService.NextResult = AuthorizationResult.Success();
             var renderer = CreateTestRenderer(authorizationService);
             var rootComponent = WrapInAuthorizeView(
-                authorizedContent: context => builder =>
+                authorized: context => builder =>
                     builder.AddContent(0, $"You are authenticated as {context.User.Identity.Name}"));
             rootComponent.AuthenticationState = CreateAuthenticationState("Nellie");
 
@@ -235,13 +235,13 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
-        public void ThrowsIfBothChildContentAndAuthorizedContentProvided()
+        public void ThrowsIfBothChildContentAndAuthorizedProvided()
         {
             // Arrange
             var authorizationService = new TestAuthorizationService();
             var renderer = CreateTestRenderer(authorizationService);
             var rootComponent = WrapInAuthorizeView(
-                authorizedContent: context => builder => { },
+                authorized: context => builder => { },
                 childContent: context => builder => { });
 
             // Act/Assert
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.Components
             var renderer = CreateTestRenderer(authorizationService);
             renderer.OnUpdateDisplayComplete = () => { @event.Set(); };
             var rootComponent = WrapInAuthorizeView(
-                notAuthorizedContent:
+                notAuthorized:
                     context => builder => builder.AddContent(0, "You are not authorized"));
             var authTcs = new TaskCompletionSource<AuthenticationState>();
             rootComponent.AuthenticationState = authTcs.Task;
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.Components
         }
 
         [Fact]
-        public void RendersAuthorizingContentUntilAuthorizationCompleted()
+        public void RendersAuthorizingUntilAuthorizationCompleted()
         {
             // Arrange
             var @event = new ManualResetEventSlim();
@@ -302,8 +302,8 @@ namespace Microsoft.AspNetCore.Components
             var renderer = CreateTestRenderer(authorizationService);
             renderer.OnUpdateDisplayComplete = () => { @event.Set(); };
             var rootComponent = WrapInAuthorizeView(
-                authorizingContent: builder => builder.AddContent(0, "Auth pending..."),
-                authorizedContent: context => builder => builder.AddContent(0, $"Hello, {context.User.Identity.Name}!"));
+                authorizing: builder => builder.AddContent(0, "Auth pending..."),
+                authorized: context => builder => builder.AddContent(0, $"Hello, {context.User.Identity.Name}!"));
             var authTcs = new TaskCompletionSource<AuthenticationState>();
             rootComponent.AuthenticationState = authTcs.Task;
 
@@ -447,9 +447,9 @@ namespace Microsoft.AspNetCore.Components
 
         private static TestAuthStateProviderComponent WrapInAuthorizeView(
             RenderFragment<AuthenticationState> childContent = null,
-            RenderFragment<AuthenticationState> authorizedContent = null,
-            RenderFragment<AuthenticationState> notAuthorizedContent = null,
-            RenderFragment authorizingContent = null,
+            RenderFragment<AuthenticationState> authorized = null,
+            RenderFragment<AuthenticationState> notAuthorized = null,
+            RenderFragment authorizing = null,
             string policy = null,
             string roles = null,
             object resource = null)
@@ -458,9 +458,9 @@ namespace Microsoft.AspNetCore.Components
             {
                 builder.OpenComponent<AuthorizeView>(0);
                 builder.AddAttribute(1, nameof(AuthorizeView.ChildContent), childContent);
-                builder.AddAttribute(2, nameof(AuthorizeView.Authorized), authorizedContent);
-                builder.AddAttribute(3, nameof(AuthorizeView.NotAuthorized), notAuthorizedContent);
-                builder.AddAttribute(4, nameof(AuthorizeView.Authorizing), authorizingContent);
+                builder.AddAttribute(2, nameof(AuthorizeView.Authorized), authorized);
+                builder.AddAttribute(3, nameof(AuthorizeView.NotAuthorized), notAuthorized);
+                builder.AddAttribute(4, nameof(AuthorizeView.Authorizing), authorizing);
                 builder.AddAttribute(5, nameof(AuthorizeView.Policy), policy);
                 builder.AddAttribute(6, nameof(AuthorizeView.Roles), roles);
                 builder.AddAttribute(7, nameof(AuthorizeView.Resource), resource);

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
@@ -10,12 +10,12 @@
 
 <CascadingAuthenticationState>
     <Router AppAssembly=typeof(BasicTestApp.Program).Assembly>
-        <AuthorizingContent>Authorizing...</AuthorizingContent>
-        <NotAuthorizedContent>
+        <Authorizing>Authorizing...</Authorizing>
+        <NotAuthorized>
             <div id="auth-failure">
                 Sorry, @(context.User.Identity.Name ?? "anonymous"), you're not authorized.
             </div>
-        </NotAuthorizedContent>
+        </NotAuthorized>
     </Router>
 </CascadingAuthenticationState>
 

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -58,7 +58,6 @@
         <option value="BasicTestApp.RenderFragmentToggler">Render fragment renderer</option>
         <option value="BasicTestApp.ReorderingFocusComponent">Reordering focus retention</option>
         <option value="BasicTestApp.RouterTest.TestRouter">Router</option>
-        <option value="BasicTestApp.RouterTest.TestRouterWithoutNotFoundContent">Router without NotFoundContent</option>
         <option value="BasicTestApp.RouterTest.UriHelperComponent">UriHelper Test</option>
         <option value="BasicTestApp.SvgComponent">SVG</option>
         <option value="BasicTestApp.SvgWithChildComponent">SVG with child component</option>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouter.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouter.razor
@@ -1,6 +1,6 @@
 @using Microsoft.AspNetCore.Components.Routing
 <Router AppAssembly=typeof(BasicTestApp.Program).Assembly>
-    <NotFoundContent>
+    <NotFound>
         <div id="test-info">Oops, that component wasn't found!</div>
-    </NotFoundContent>
+    </NotFound>
 </Router>

--- a/src/Mvc/test/WebSites/BasicWebSite/RazorComponents/RouterContainer.razor
+++ b/src/Mvc/test/WebSites/BasicWebSite/RazorComponents/RouterContainer.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 Router component
 <Router AppAssembly="System.Reflection.Assembly.GetAssembly(typeof(RouterContainer))">
-    <NotFoundContent>
+    <NotFound>
         <p>Route not found</p>
-    </NotFoundContent>
+    </NotFound>
 </Router>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
@@ -1,7 +1,7 @@
 ﻿<CascadingAuthenticationState>
     <Router AppAssembly="typeof(Startup).Assembly">
-        <NotFoundContent>
+        <NotFound>
             <p>Sorry, there's nothing at this address.</p>
-        </NotFoundContent>
+        </NotFound>
     </Router>
 </CascadingAuthenticationState>


### PR DESCRIPTION
Fixes: #12548

Renaming properties to drop 'Content' as a suffix. We haven't been
consistent in using this, and we're removing it instead of adding it
elsewhere.