### PR TITLE
Add option to disable adding trailing slash

### DIFF
--- a/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
+++ b/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
@@ -119,12 +119,14 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
     public partial class SharedOptions
     {
         public SharedOptions() { }
+        public bool AppendTrailingSlash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Extensions.FileProviders.IFileProvider FileProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Http.PathString RequestPath { get { throw null; } set { } }
     }
     public abstract partial class SharedOptionsBase
     {
         protected SharedOptionsBase(Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions sharedOptions) { }
+        public bool AppendTrailingSlash { get { throw null; } set { } }
         public Microsoft.Extensions.FileProviders.IFileProvider FileProvider { get { throw null; } set { } }
         public Microsoft.AspNetCore.Http.PathString RequestPath { get { throw null; } set { } }
         protected Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions SharedOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
+++ b/src/Middleware/StaticFiles/ref/Microsoft.AspNetCore.StaticFiles.netcoreapp3.0.cs
@@ -119,15 +119,15 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
     public partial class SharedOptions
     {
         public SharedOptions() { }
-        public bool AppendTrailingSlash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Extensions.FileProviders.IFileProvider FileProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool RedirectToAppendTrailingSlash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Http.PathString RequestPath { get { throw null; } set { } }
     }
     public abstract partial class SharedOptionsBase
     {
         protected SharedOptionsBase(Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions sharedOptions) { }
-        public bool AppendTrailingSlash { get { throw null; } set { } }
         public Microsoft.Extensions.FileProviders.IFileProvider FileProvider { get { throw null; } set { } }
+        public bool RedirectToAppendTrailingSlash { get { throw null; } set { } }
         public Microsoft.AspNetCore.Http.PathString RequestPath { get { throw null; } set { } }
         protected Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions SharedOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }

--- a/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
@@ -80,17 +80,12 @@ namespace Microsoft.AspNetCore.StaticFiles
                         {
                             // If the path matches a directory but does not end in a slash, redirect to add the slash.
                             // This prevents relative links from breaking.
-                            if (!Helpers.PathEndsInSlash(context.Request.Path))
+                            if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.AppendTrailingSlash)
                             {
-                                context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
-                                var request = context.Request;
-                                var redirect = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase, request.Path + "/", request.QueryString);
-                                context.Response.Headers[HeaderNames.Location] = redirect;
-                                return Task.CompletedTask;
+                                return Helpers.RedirectToPathWithSlash(context);
                             }
-
                             // Match found, re-write the url. A later middleware will actually serve the file.
-                            context.Request.Path = new PathString(context.Request.Path.Value + defaultFile);
+                            context.Request.Path = new PathString(Helpers.GetPathValueWithSlash(context.Request.Path) + defaultFile);
                             break;
                         }
                     }

--- a/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
@@ -80,9 +80,10 @@ namespace Microsoft.AspNetCore.StaticFiles
                         {
                             // If the path matches a directory but does not end in a slash, redirect to add the slash.
                             // This prevents relative links from breaking.
-                            if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.AppendTrailingSlash)
+                            if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.RedirectToAppendTrailingSlash)
                             {
-                                return Helpers.RedirectToPathWithSlash(context);
+                                Helpers.RedirectToPathWithSlash(context);
+                                return Task.CompletedTask;
                             }
                             // Match found, re-write the url. A later middleware will actually serve the file.
                             context.Request.Path = new PathString(Helpers.GetPathValueWithSlash(context.Request.Path) + defaultFile);

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
@@ -87,13 +87,9 @@ namespace Microsoft.AspNetCore.StaticFiles
             {
                 // If the path matches a directory but does not end in a slash, redirect to add the slash.
                 // This prevents relative links from breaking.
-                if (!Helpers.PathEndsInSlash(context.Request.Path))
+                if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.AppendTrailingSlash)
                 {
-                    context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
-                    var request = context.Request;
-                    var redirect = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase, request.Path + "/", request.QueryString);
-                    context.Response.Headers[HeaderNames.Location] = redirect;
-                    return Task.CompletedTask;
+                    return Helpers.RedirectToPathWithSlash(context);
                 }
 
                 return _formatter.GenerateContentAsync(context, contents);

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
@@ -87,9 +87,10 @@ namespace Microsoft.AspNetCore.StaticFiles
             {
                 // If the path matches a directory but does not end in a slash, redirect to add the slash.
                 // This prevents relative links from breaking.
-                if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.AppendTrailingSlash)
+                if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.RedirectToAppendTrailingSlash)
                 {
-                    return Helpers.RedirectToPathWithSlash(context);
+                    Helpers.RedirectToPathWithSlash(context);
+                    return Task.CompletedTask;
                 }
 
                 return _formatter.GenerateContentAsync(context, contents);

--- a/src/Middleware/StaticFiles/src/Helpers.cs
+++ b/src/Middleware/StaticFiles/src/Helpers.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.StaticFiles
 {
@@ -26,6 +29,24 @@ namespace Microsoft.AspNetCore.StaticFiles
         internal static bool PathEndsInSlash(PathString path)
         {
             return path.Value.EndsWith("/", StringComparison.Ordinal);
+        }
+
+        internal static string GetPathValueWithSlash(PathString path)
+        {
+            if (!PathEndsInSlash(path))
+            {
+                return path.Value + "/";
+            }
+            return path.Value;
+        }
+
+        internal static Task RedirectToPathWithSlash(HttpContext context)
+        {
+            context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
+            var request = context.Request;
+            var redirect = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase, request.Path + "/", request.QueryString);
+            context.Response.Headers[HeaderNames.Location] = redirect;
+            return Task.CompletedTask;
         }
 
         internal static bool TryMatchPath(HttpContext context, PathString matchUrl, bool forDirectory, out PathString subpath)

--- a/src/Middleware/StaticFiles/src/Helpers.cs
+++ b/src/Middleware/StaticFiles/src/Helpers.cs
@@ -15,7 +15,8 @@ namespace Microsoft.AspNetCore.StaticFiles
     {
         internal static IFileProvider ResolveFileProvider(IWebHostEnvironment hostingEnv)
         {
-            if (hostingEnv.WebRootFileProvider == null) {
+            if (hostingEnv.WebRootFileProvider == null)
+            {
                 throw new InvalidOperationException("Missing FileProvider.");
             }
             return hostingEnv.WebRootFileProvider;
@@ -40,13 +41,12 @@ namespace Microsoft.AspNetCore.StaticFiles
             return path.Value;
         }
 
-        internal static Task RedirectToPathWithSlash(HttpContext context)
+        internal static void RedirectToPathWithSlash(HttpContext context)
         {
             context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
             var request = context.Request;
             var redirect = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase, request.Path + "/", request.QueryString);
             context.Response.Headers[HeaderNames.Location] = redirect;
-            return Task.CompletedTask;
         }
 
         internal static bool TryMatchPath(HttpContext context, PathString matchUrl, bool forDirectory, out PathString subpath)

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptions.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptions.cs
@@ -44,8 +44,8 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
         public IFileProvider FileProvider { get; set; }
 
         /// <summary>
-        /// Indicates whether to add trailing slash at the end of path
+        /// Indicates whether to redirect to add a trailing slash at the end of path. Relative resource links may require this.
         /// </summary>
-        public bool AppendTrailingSlash { get; set; } = true;
+        public bool RedirectToAppendTrailingSlash { get; set; } = true;
     }
 }

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptions.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptions.cs
@@ -42,5 +42,10 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
         /// The file system used to locate resources
         /// </summary>
         public IFileProvider FileProvider { get; set; }
+
+        /// <summary>
+        /// Indicates whether to add trailing slash at the end of path
+        /// </summary>
+        public bool AppendTrailingSlash { get; set; } = true;
     }
 }

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
@@ -48,5 +48,14 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
             get { return SharedOptions.FileProvider; }
             set { SharedOptions.FileProvider = value; }
         }
+
+        /// <summary>
+        /// Indicates whether to add trailing slash at the end of path
+        /// </summary>
+        public bool AppendTrailingSlash
+        {
+            get { return SharedOptions.AppendTrailingSlash; }
+            set { SharedOptions.AppendTrailingSlash = value; }
+        }
     }
 }

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
@@ -50,12 +50,12 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
         }
 
         /// <summary>
-        /// Indicates whether to add trailing slash at the end of path
+        /// Indicates whether to redirect to add a trailing slash at the end of path. Relative resource links may require this.
         /// </summary>
-        public bool AppendTrailingSlash
+        public bool RedirectToAppendTrailingSlash
         {
-            get { return SharedOptions.AppendTrailingSlash; }
-            set { SharedOptions.AppendTrailingSlash = value; }
+            get { return SharedOptions.RedirectToAppendTrailingSlash; }
+            set { SharedOptions.RedirectToAppendTrailingSlash = value; }
         }
     }
 }

--- a/src/Middleware/StaticFiles/test/UnitTests/DefaultFilesMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/DefaultFilesMiddlewareTests.cs
@@ -118,10 +118,11 @@ namespace Microsoft.AspNetCore.StaticFiles
         [InlineData("", @"./SubFolder", "/")]
         [InlineData("", @"./SubFolder", "/你好/")]
         [InlineData("", @"./SubFolder", "/你好/世界/")]
-        [InlineData("", @".\", "/SubFolder/",false)]
-        [InlineData("", @".\subFolder", "/", false)]
-        [InlineData("", @".\SubFolder", "/你好/", false)]
-        [InlineData("", @".\SubFolder", "/你好/世界/", false)]
+        [InlineData("", @".", "/SubFolder/", false)]
+        [InlineData("", @"./", "/SubFolder/", false)]
+        [InlineData("", @"./SubFolder", "/", false)]
+        [InlineData("", @"./SubFolder", "/你好/", false)]
+        [InlineData("", @"./SubFolder", "/你好/世界/", false)]
         public async Task FoundDirectoryWithDefaultFile_PathModified_All(string baseUrl, string baseDir, string requestUrl, bool appendTrailingSlash = true)
         {
             await FoundDirectoryWithDefaultFile_PathModified(baseUrl, baseDir, requestUrl, appendTrailingSlash);

--- a/src/Middleware/StaticFiles/test/UnitTests/DefaultFilesMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/DefaultFilesMiddlewareTests.cs
@@ -152,7 +152,8 @@ namespace Microsoft.AspNetCore.StaticFiles
                     app.UseDefaultFiles(new DefaultFilesOptions
                     {
                         RequestPath = new PathString(baseUrl),
-                        FileProvider = fileProvider
+                        FileProvider = fileProvider,
+                        AppendTrailingSlash = appendTrailingSlash
                     });
                     app.Run(context => context.Response.WriteAsync(context.Request.Path.Value));
                 });


### PR DESCRIPTION
Middlewares affected:
- DefaultFilesMiddleware
- DirectoryBrowserMiddleware

Added AppendTrailingSlash property with default value= true in SharedOptions for files middleware. Now users are able to disable redirect to path with trailing slash. Also added some test cases for this option changed to false.

Closes #2449
