### PR TITLE
Limit max handshake size

### DIFF
--- a/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             _pipe.AddReadResult(new ValueTask<ReadResult>(_handshakeRequestResult));
 
-            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, null, _successHubProtocolResolver,
+            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, _successHubProtocolResolver,
                 _userIdProvider, enableDetailedErrors: true);
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             _pipe.AddReadResult(new ValueTask<ReadResult>(_handshakeRequestResult));
 
-            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, null, _failureHubProtocolResolver,
+            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, _failureHubProtocolResolver,
                 _userIdProvider, enableDetailedErrors: true);
         }
     }

--- a/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             _pipe.AddReadResult(new ValueTask<ReadResult>(_handshakeRequestResult));
 
-            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, _successHubProtocolResolver,
+            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, null, _successHubProtocolResolver,
                 _userIdProvider, enableDetailedErrors: true);
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             _pipe.AddReadResult(new ValueTask<ReadResult>(_handshakeRequestResult));
 
-            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, _failureHubProtocolResolver,
+            await _hubConnectionContext.HandshakeAsync(TimeSpan.FromSeconds(5), _supportedProtocols, null, _failureHubProtocolResolver,
                 _userIdProvider, enableDetailedErrors: true);
         }
     }

--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp3.0.cs
@@ -144,6 +144,7 @@ namespace Microsoft.AspNetCore.SignalR
         public HubConnectionContextOptions() { }
         public System.TimeSpan ClientTimeoutInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.TimeSpan KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public long? MaximumReceiveMessageSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int StreamBufferCapacity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class HubConnectionHandler<THub> : Microsoft.AspNetCore.Connections.ConnectionHandler where THub : Microsoft.AspNetCore.SignalR.Hub

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -24,5 +24,10 @@ namespace Microsoft.AspNetCore.SignalR
         /// Gets or sets the max buffer size for client upload streams.
         /// </summary>
         public int StreamBufferCapacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum message size the client can send.
+        /// </summary>
+        public long? MaximumReceiveMessageSize { get; set; }
     }
 }

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.SignalR
             var connectionContext = new HubConnectionContext(connection, contextOptions, _loggerFactory);
 
             var resolvedSupportedProtocols = (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList();
-            if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))
+            if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _maximumMessageSize, _protocolResolver, _userIdProvider, _enableDetailedErrors))
             {
                 return;
             }

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -89,6 +89,7 @@ namespace Microsoft.AspNetCore.SignalR
                 KeepAliveInterval = _hubOptions.KeepAliveInterval ?? _globalHubOptions.KeepAliveInterval ?? HubOptionsSetup.DefaultKeepAliveInterval,
                 ClientTimeoutInterval = _hubOptions.ClientTimeoutInterval ?? _globalHubOptions.ClientTimeoutInterval ?? HubOptionsSetup.DefaultClientTimeoutInterval,
                 StreamBufferCapacity = _hubOptions.StreamBufferCapacity ?? _globalHubOptions.StreamBufferCapacity ?? HubOptionsSetup.DefaultStreamBufferCapacity,
+                MaximumReceiveMessageSize = _maximumMessageSize,
             };
 
             Log.ConnectedStarting(_logger);
@@ -96,7 +97,7 @@ namespace Microsoft.AspNetCore.SignalR
             var connectionContext = new HubConnectionContext(connection, contextOptions, _loggerFactory);
 
             var resolvedSupportedProtocols = (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList();
-            if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _maximumMessageSize, _protocolResolver, _userIdProvider, _enableDetailedErrors))
+            if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))
             {
                 return;
             }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -332,6 +332,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                                                             sendHandshakeRequestMessage: true,
                                                             expectedHandshakeResponseMessage: false);
 
+                    var message = await client.ReadAsync(isHandshake: true).OrTimeout();
+
+                    Assert.Equal("Handshake was canceled.", ((HandshakeResponseMessage)message).Error);
+
                     // Connection closes
                     await connectionHandlerTask.OrTimeout();
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -311,6 +311,36 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        public async Task ConnectionClosedWhenHandshakeLargerThanMaxMessageSize()
+        {
+            using (StartVerifiableLog())
+            {
+                var connectionHandler = HubConnectionHandlerTestUtils.GetHubConnectionHandler(typeof(HubT), loggerFactory: LoggerFactory,
+                    builder =>
+                    {
+                        builder.AddSignalR(o =>
+                        {
+                            o.MaximumReceiveMessageSize = 1;
+                        });
+                    });
+
+                using (var client = new TestClient())
+                {
+                    client.SupportedFormats = TransferFormat.Text;
+
+                    var connectionHandlerTask = await client.ConnectAsync(connectionHandler,
+                                                            sendHandshakeRequestMessage: true,
+                                                            expectedHandshakeResponseMessage: false);
+
+                    // Connection closes
+                    await connectionHandlerTask.OrTimeout();
+
+                    client.Dispose();
+                }
+            }
+        }
+
+        [Fact]
         public async Task SendingHandshakeRequestInChunksWorks()
         {
             using (StartVerifiableLog())


### PR DESCRIPTION
Now that pipes don't block forever while applying backpressure, we need to limit the maximum message size.
