### PR TITLE
Fix XML escaping

### DIFF
--- a/src/Mvc/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Mvc/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup Condition=" '$(OpenApiGenerateDocuments)' == '' ">
     <OpenApiGenerateDocuments
-        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.TrimStart('vV'))' &lt; '2.1' ">false</OpenApiGenerateDocuments>
+        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.TrimStart(&quot;vV&quot;))' &lt; '2.1' ">false</OpenApiGenerateDocuments>
     <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' ">true</OpenApiGenerateDocuments>
   </PropertyGroup>
   <PropertyGroup>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <Target Name="OpenApiGetDocuments" Returns="@(_OpenApiProjectDocuments)">
-    <Error Text="OpenAPI document generation is disabled. Add '<OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>' to the project."
+    <Error Text="OpenAPI document generation is disabled. Add '&lt;OpenApiGenerateDocuments>true&lt;/OpenApiGenerateDocuments>' to the project."
         Condition=" '$(OpenApiGenerateDocuments)' != 'true' " />
 
     <ReadLinesFromFile File="$(_OpenApiDocumentsCache)">
@@ -32,7 +32,7 @@
       Inputs="$(TargetPath)"
       Outputs="$(_OpenApiDocumentsCache)">
     <Error Text="OpenAPI document generation is not supported when targeting netcoreapp2.0 or earlier. Disable the feature or move to a later target framework."
-        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.TrimStart('vV'))' &lt; '2.1' " />
+        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.TrimStart(&quot;vV&quot;))' &lt; '2.1' " />
 
     <PropertyGroup>
       <_Command>dotnet "$(MSBuildThisFileDirectory)/../tools/dotnet-getdocument.dll" --assembly "$(TargetPath)"</_Command>


### PR DESCRIPTION
#### Description
Six characters in a Service Reference .targets file are invalid and must be escaped. `msbuild` cannot load this file due to unescaped '<' characters. Once those are fixed, `msbuild` is unable to evaluate two conditions due to nested unescaped single-quote characters.

#### Customer impact
Customers will be unable to build their projects after upgrading their projects to use the latest Microsoft.Extensions.ApiDescription.Server.nupkg package.

We added new warnings and errors to this package in 3.0.0-preview8 (helping customers avoid silent failures) and would like customers to give us feedback on the improved experience.

#### Regression?
Yes, did not have this issue in the '3.0.0-preview7' release.

#### Risk
Very low.