### PR TITLE
Only use read Pipe when running on Http2. 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -120,13 +120,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public string ConnectionId => _context.ConnectionId;
 
-        public PipeReader Input
-        {
-            get
-            {
-                return _input.Reader;
-            }
-        }
+        public PipeReader Input => _input.Reader;
 
         public IKestrelTrace Log => _context.ServiceContext.Log;
         public IFeatureCollection ConnectionFeatures => _context.ConnectionFeatures;
@@ -988,7 +982,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         }
 
         private void AbortStream(int streamId, IOException error)
-        {
+        {I
             if (_streams.TryGetValue(streamId, out var stream))
             {
                 stream.DecrementActiveClientStreamCount();
@@ -1323,14 +1317,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     }
                 }
             }
-            catch (OperationCanceledException ex)
-            {
-                // Propagate the exception if it's ConnectionAbortedException		
-                error = ex as ConnectionAbortedException;
-            }
             catch (Exception ex)
             {
-                // Don't rethrow the exception. It should be handled by the Pipeline consumer.		
+                // Don't rethrow the exception. It should be handled by the Pipeline consumer.
                 error = ex;
             }
             finally

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -982,7 +982,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         }
 
         private void AbortStream(int streamId, IOException error)
-        {I
+        {
             if (_streams.TryGetValue(streamId, out var stream))
             {
                 stream.DecrementActiveClientStreamCount();

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1323,6 +1323,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     }
                 }
             }
+            catch (OperationCanceledException ex)
+            {
+                // Propagate the exception if it's ConnectionAbortedException		
+                error = ex as ConnectionAbortedException;
+            }
+            catch (Exception ex)
+            {
+                // Don't rethrow the exception. It should be handled by the Pipeline consumer.		
+                error = ex;
+            }
             finally
             {
                 await _context.Transport.Input.CompleteAsync();

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/DuplexPipeStreamAdapter.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -15,11 +14,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     /// <typeparam name="TStream"></typeparam>
     internal class DuplexPipeStreamAdapter<TStream> : DuplexPipeStream, IDuplexPipe where TStream : Stream
     {
-        private readonly Pipe _input;
-        private Task _inputTask;
         private bool _disposed;
         private readonly object _disposeLock = new object();
-        private readonly int _minAllocBufferSize;
 
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, Func<Stream, TStream> createStream) :
             this(duplexPipe, new StreamPipeReaderOptions(leaveOpen: true), new StreamPipeWriterOptions(leaveOpen: true), createStream)
@@ -27,38 +23,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         }
 
         public DuplexPipeStreamAdapter(IDuplexPipe duplexPipe, StreamPipeReaderOptions readerOptions, StreamPipeWriterOptions writerOptions, Func<Stream, TStream> createStream) :
-            base(duplexPipe.Input, duplexPipe.Output, throwOnCancelled: true)
+            base(duplexPipe.Input, duplexPipe.Output)
         {
-            Stream = createStream(this);
-
-            var inputOptions = new PipeOptions(pool: readerOptions.Pool,
-                readerScheduler: PipeScheduler.ThreadPool,
-                writerScheduler: PipeScheduler.Inline,
-                pauseWriterThreshold: 1,
-                resumeWriterThreshold: 1,
-                minimumSegmentSize: readerOptions.Pool.GetMinimumSegmentSize(),
-                useSynchronizationContext: false);
-
-            _minAllocBufferSize = writerOptions.MinimumBufferSize;
-
-            _input = new Pipe(inputOptions);
-            Output = PipeWriter.Create(Stream, writerOptions);
+            var stream = createStream(this);
+            Stream = stream;
+            Input = PipeReader.Create(stream, readerOptions);
+            Output = PipeWriter.Create(stream, writerOptions);
         }
 
         public TStream Stream { get; }
 
-        public PipeReader Input
-        {
-            get
-            {
-                if (_inputTask == null)
-                {
-                    _inputTask = ReadInputAsync();
-                }
-
-                return _input.Reader;
-            }
-        }
+        public PipeReader Input { get; }
 
         public PipeWriter Output { get; }
 
@@ -73,64 +48,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 _disposed = true;
             }
 
-            _input.Reader.Complete();
-            Output.Complete();
-
-            CancelPendingRead();
-
-            if (_inputTask != null)
-            {
-                await _inputTask;
-            }
+            await Input.CompleteAsync();
+            await Output.CompleteAsync();
         }
 
         protected override void Dispose(bool disposing)
         {
             throw new NotSupportedException();
-        }
-
-        private async Task ReadInputAsync()
-        {
-            Exception error = null;
-            try
-            {
-                while (true)
-                {
-                    var outputBuffer = _input.Writer.GetMemory(_minAllocBufferSize);
-
-                    var bytesRead = await Stream.ReadAsync(outputBuffer);
-                    _input.Writer.Advance(bytesRead);
-
-                    if (bytesRead == 0)
-                    {
-                        // FIN
-                        break;
-                    }
-
-                    var result = await _input.Writer.FlushAsync();
-
-                    if (result.IsCompleted)
-                    {
-                        // flushResult should not be canceled.
-                        break;
-                    }
-                }
-
-            }
-            catch (OperationCanceledException ex)
-            {
-                // Propagate the exception if it's ConnectionAbortedException	
-                error = ex as ConnectionAbortedException;
-            }
-            catch (Exception ex)
-            {
-                // Don't rethrow the exception. It should be handled by the Pipeline consumer.	
-                error = ex;
-            }
-            finally
-            {
-                _input.Writer.Complete(error);
-            }
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -190,8 +190,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Theory]
-        [Repeat(20)]
-        [InlineData((int)Http2FrameType.DATA)]
         [InlineData((int)Http2FrameType.CONTINUATION)]
         public async Task AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires(int intFinalFrameType)
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -190,6 +190,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Theory]
+        [InlineData((int)Http2FrameType.DATA)]
         [InlineData((int)Http2FrameType.CONTINUATION)]
         public async Task AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires(int intFinalFrameType)
         {


### PR DESCRIPTION
#### Description
Fixes a major perf regression with Http1 connection opening and closing.

#### Customer Impact
Customers could experience a performance regression in connection opening in Kestrel.

#### Regression?
 Yes. Regression from perf in 2.2 and earlier in 3.0 to now.

#### Risk
Low. We are using the StreamPipeReader now, but for Http2, we still write to a Pipe before reading the values such that we can cancel reads appropriately.

Fixes https://github.com/aspnet/Benchmarks/issues/1202
**Before:**

ConnectionClose, https, Windows
```
RequestsPerSecond:           2,949
Max CPU (%):                 39
WorkingSet (MB):             398
Avg. Latency (ms):           4.69
Startup (ms):                365
First Request (ms):          130.45
Latency (ms):                3.69
Total Requests:              44,517
Duration: (ms)               15,100
Socket Errors:               256
Bad Responses:               0
SDK:                         5.0.100-alpha1-013616
Runtime:                     3.0.0-preview8-28373-17
ASP.NET Core:                3.0.0-preview8.19379.2
```
**After:**
```
RequestsPerSecond:           13,967
Max CPU (%):                 33
WorkingSet (MB):             398
Avg. Latency (ms):           0.45
Startup (ms):                384
First Request (ms):          145.79
Latency (ms):                3.69
Total Requests:              210,555
Duration: (ms)               15,080
Socket Errors:               0
Bad Responses:               0
SDK:                         5.0.100-alpha1-013616
Runtime:                     3.0.0-preview8-28373-17
ASP.NET Core:                3.0.0-preview8.19379.2
```

Also note that Http2 perf didn't regress either:
**Before:**
Http2 PlaintextNonPipelined, windows

```
RequestsPerSecond:           378,473
Max CPU (%):                 58
WorkingSet (MB):             685
Avg. Latency (ms):           11.12
Startup (ms):                263
First Request (ms):          196.98
Latency (ms):                0.14
Total Requests:              5,677,089
Duration: (ms)               15,000
Socket Errors:               0
Bad Responses:               0
SDK:                         5.0.100-alpha1-013616
Runtime:                     3.0.0-preview8-28373-17
ASP.NET Core:                3.0.0-preview8.19379.2
```
**After:**
```
RequestsPerSecond:           375,879
Max CPU (%):                 56
WorkingSet (MB):             658
Avg. Latency (ms):           10.16
Startup (ms):                263
First Request (ms):          209.08
Latency (ms):                0.13
Total Requests:              5,638,184
Duration: (ms)               15,000
Socket Errors:               0
Bad Responses:               0
SDK:                         5.0.100-alpha1-013616
Runtime:                     3.0.0-preview8-28373-17
ASP.NET Core:                3.0.0-preview8.19379.2
```
Note, there is a discrepancy between what benchmarks reports for connection close (8k vs 7.6k), however, I believe that difference is due to publishing standalone vs publishing portable. I've consistently seen worse numbers when running a standalone publish (which you do by default uploading your own files).