### PR TITLE
Fix form pipe parser

### DIFF
--- a/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/FormPipeReaderInternalsBenchmark.cs
+++ b/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/FormPipeReaderInternalsBenchmark.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNetCore.WebUtilities.Performance
     public class FormPipeReaderInternalsBenchmark
     {
         private byte[] _singleUtf8 = Encoding.UTF8.GetBytes("foo=bar&baz=boo&haha=hehe&lol=temp");
-        private byte[] _firstUtf8 = Encoding.UTF8.GetBytes("foo=bar&baz=boo");
-        private byte[] _secondUtf8 = Encoding.UTF8.GetBytes("&haha=hehe&lol=temp");
+        private byte[] _firstUtf8 = Encoding.UTF8.GetBytes("foo=bar&baz=bo");
+        private byte[] _secondUtf8 = Encoding.UTF8.GetBytes("o&haha=hehe&lol=temp");
         private FormPipeReader _formPipeReader;
 
         [IterationSetup]

--- a/src/Http/WebUtilities/test/FormPipeReaderTests.cs
+++ b/src/Http/WebUtilities/test/FormPipeReaderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public async Task ReadFormAsync_EmptyValuedAtEndAllowed()
+        public async Task ReadFormAsync_EmptyValueAtEndAllowed()
         {
             var bodyPipe = await MakePipeReader("foo=");
 
@@ -47,9 +47,30 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public async Task ReadFormAsync_EmptyValuedWithAdditionalEntryAllowed()
+        public async Task ReadFormAsync_EmptyValueWithoutEqualsAtEndAllowed()
+        {
+            var bodyPipe = await MakePipeReader("foo");
+
+            var formCollection = await ReadFormAsync(new FormPipeReader(bodyPipe));
+
+            Assert.Equal("", formCollection["foo"].ToString());
+        }
+
+        [Fact]
+        public async Task ReadFormAsync_EmptyValueWithAdditionalEntryAllowed()
         {
             var bodyPipe = await MakePipeReader("foo=&baz=2");
+
+            var formCollection = await ReadFormAsync(new FormPipeReader(bodyPipe));
+
+            Assert.Equal("", formCollection["foo"].ToString());
+            Assert.Equal("2", formCollection["baz"].ToString());
+        }
+
+        [Fact]
+        public async Task ReadFormAsync_EmptyValueWithoutEqualsWithAdditionalEntryAllowed()
+        {
+            var bodyPipe = await MakePipeReader("foo&baz=2");
 
             var formCollection = await ReadFormAsync(new FormPipeReader(bodyPipe));
 
@@ -172,7 +193,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         [Theory]
         [MemberData(nameof(Encodings))]
-        public void TryParseFormValues_MultiSegmentWorks(Encoding encoding)
+        public void TryParseFormValues_Works(Encoding encoding)
         {
             var readOnlySequence = ReadOnlySequenceFactory.SingleSegmentFactory.CreateWithContent(encoding.GetBytes("foo=bar&baz=boo&t="));
 
@@ -190,9 +211,9 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         [Theory]
         [MemberData(nameof(Encodings))]
-        public void TryParseFormValues_MultiSegmentSplitAcrossSegmentsWorks(Encoding encoding)
+        public void TryParseFormValues_SplitAcrossSegmentsWorks(Encoding encoding)
         {
-            var readOnlySequence = ReadOnlySequenceFactory.SingleSegmentFactory.CreateWithContent(encoding.GetBytes("foo=bar&baz=boo&t="));
+            var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(encoding.GetBytes("foo=bar&baz=boo&t="));
 
             KeyValueAccumulator accumulator = default;
 
@@ -210,7 +231,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         [MemberData(nameof(Encodings))]
         public void TryParseFormValues_MultiSegmentWithArrayPoolAcrossSegmentsWorks(Encoding encoding)
         {
-            var readOnlySequence = ReadOnlySequenceFactory.SingleSegmentFactory.CreateWithContent(encoding.GetBytes("foo=bar&baz=bo" + new string('a', 128)));
+            var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(encoding.GetBytes("foo=bar&baz=bo" + new string('a', 128)));
 
             KeyValueAccumulator accumulator = default;
 
@@ -227,7 +248,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         [MemberData(nameof(Encodings))]
         public void TryParseFormValues_MultiSegmentSplitAcrossSegmentsWithPlusesWorks(Encoding encoding)
         {
-            var readOnlySequence = ReadOnlySequenceFactory.SingleSegmentFactory.CreateWithContent(encoding.GetBytes("+++=+++&++++=++++&+="));
+            var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(encoding.GetBytes("+++=+++&++++=++++&+="));
 
             KeyValueAccumulator accumulator = default;
 
@@ -261,9 +282,9 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         [Theory]
         [MemberData(nameof(Encodings))]
-        public void TryParseFormValues_MultiSegmentSplitAcrossSegmentsThatNeedDecodingWorks(Encoding encoding)
+        public void TryParseFormValues_SplitAcrossSegmentsThatNeedDecodingWorks(Encoding encoding)
         {
-            var readOnlySequence = ReadOnlySequenceFactory.SingleSegmentFactory.CreateWithContent(encoding.GetBytes("\"%-.<>\\^_`{|}~=\"%-.<>\\^_`{|}~&\"%-.<>\\^_`{|}=wow"));
+            var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(encoding.GetBytes("\"%-.<>\\^_`{|}~=\"%-.<>\\^_`{|}~&\"%-.<>\\^_`{|}=wow"));
 
             KeyValueAccumulator accumulator = default;
 
@@ -277,7 +298,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public void TryParseFormValues_MultiSegmentExceedKeyLengthThrows()
+        public void TryParseFormValues_ExceedKeyLengthThrows()
         {
             var readOnlySequence = ReadOnlySequenceFactory.SingleSegmentFactory.CreateWithContent(Encoding.UTF8.GetBytes("foo=bar&baz=boo&t="));
 
@@ -291,7 +312,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public void TryParseFormValues_MultiSegmentExceedKeyLengthThrowsInSplitSegment()
+        public void TryParseFormValues_ExceedKeyLengthThrowsInSplitSegment()
         {
             var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("fo=bar&ba"), Encoding.UTF8.GetBytes("z=boo&t="));
 
@@ -305,9 +326,9 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public void TryParseFormValues_MultiSegmentExceedValueLengthThrows()
+        public void TryParseFormValues_ExceedValueLengthThrows()
         {
-            var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("foo=bar&baz=bo"), Encoding.UTF8.GetBytes("o&t="));
+            var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("foo=bar&baz=boo&t="));
 
             KeyValueAccumulator accumulator = default;
 
@@ -319,7 +340,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public void TryParseFormValues_MultiSegmentExceedValueLengthThrowsInSplitSegment()
+        public void TryParseFormValues_ExceedValueLengthThrowsInSplitSegment()
         {
             var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("foo=ba&baz=bo"), Encoding.UTF8.GetBytes("o&t="));
 
@@ -333,7 +354,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public void TryParseFormValues_MultiSegmentExceedKeLengthThrowsInSplitSegmentEnd()
+        public void TryParseFormValues_ExceedKeyLengthThrowsInSplitSegmentEnd()
         {
             var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("foo=ba&baz=bo"), Encoding.UTF8.GetBytes("o&asdfasdfasd="));
 
@@ -347,7 +368,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public void TryParseFormValues_MultiSegmentExceedValueLengthThrowsInSplitSegmentEnd()
+        public void TryParseFormValues_ExceedValueLengthThrowsInSplitSegmentEnd()
         {
             var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("foo=ba&baz=bo"), Encoding.UTF8.GetBytes("o&t=asdfasdfasd"));
 
@@ -389,12 +410,13 @@ namespace Microsoft.AspNetCore.WebUtilities
                 KeyLengthLimit = 3
             };
 
-            formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: false);
+            formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
 
             IDictionary<string, StringValues> values = accumulator.GetResults();
-            Assert.Single(values);
             Assert.Contains("fo", values);
             Assert.Equal("bar", values["fo"]);
+            Assert.Contains("ba", values);
+            Assert.Equal("", values["ba"]);
         }
 
         [Theory]
@@ -408,12 +430,13 @@ namespace Microsoft.AspNetCore.WebUtilities
                 ValueLengthLimit = 3
             };
 
-            formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: false);
+            formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
 
             IDictionary<string, StringValues> values = accumulator.GetResults();
-            Assert.Single(values);
             Assert.Contains("fo", values);
             Assert.Equal("bar", values["fo"]);
+            Assert.Contains("b", values);
+            Assert.Equal("", values["b"]);
         }
 
         public static TheoryData<ReadOnlySequence<byte>> IncompleteFormKeys =>


### PR DESCRIPTION
#### Description
#12381 
Issue 1) Keys without values were being merged "key1&key2=value2"
Issue 2) Keys without values at the end of a form being dropped (2.2) or throwing (3.0) "key1=value1&key2".
		
#### Customer Impact
Externally posted forms were being mis-parsed in some situations.
		
#### Regression?
Yes, in 2.2 un-parsed trailing data would be discarded, but in 3.0 it throws.
		
#### Risk
Low, we have good unit test coverage here.


Old algorithm: Look for "=", then "&".
New algorithm: Look for "&", then see if it has an optional "="