### PR TITLE
Update gRPC template dependency for preview 8 and link to macOS docs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -221,7 +221,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>0.1.22-pre2</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>0.1.22-pre3</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0-preview3.4</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0-preview3.4</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0-preview3.4</IdentityServer4PackageVersion>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
@@ -16,7 +16,7 @@ namespace GrpcService_CSharp
         }
 
         // Additional configuration is required to successfully run gRPC on macOS.
-        // For instructions on how to configure Kestrel and gRPC clients for macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+        // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
@@ -16,7 +16,7 @@ namespace GrpcService_CSharp
         }
 
         // Additional configuration is required to successfully run gRPC on macOS.
-        // For instructions on how to configure Kestrel and gRPC clients to run on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+        // For instructions on how to configure Kestrel and gRPC clients for macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
@@ -15,6 +15,8 @@ namespace GrpcService_CSharp
             CreateHostBuilder(args).Build().Run();
         }
 
+        // Additional configuration is required to successfully run gRPC on macOS.
+        // For instructions on how to configure Kestrel and gRPC clients to run on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>


### PR DESCRIPTION
* Update gRPC template to use new `Grpc.AspNetCore` dependency. This is **required** for preview 8. There are breaking changes in ASP.NET Core that are fixed in the latest dependency.
* Also includes a template update to link to documentation for developers running on macOS. Addresses https://github.com/aspnet/AspNetCore.Docs/issues/13544