### PR TITLE
Change OSX to macOS in error message

### DIFF
--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -44,7 +44,7 @@ namespace Templates.Test
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     Assert.True(serverProcess.Process.HasExited, "built");
-                    Assert.Contains("System.NotSupportedException: HTTP/2 over TLS is not supported on OSX due to missing ALPN support.",
+                    Assert.Contains("System.NotSupportedException: HTTP/2 over TLS is not supported on macOS due to missing ALPN support.",
                         ErrorMessages.GetFailedProcessMessageOrEmpty("Run built service", Project, serverProcess.Process));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version < new Version(6, 2))
@@ -68,7 +68,7 @@ namespace Templates.Test
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     Assert.True(aspNetProcess.Process.HasExited, "published");
-                    Assert.Contains("System.NotSupportedException: HTTP/2 over TLS is not supported on OSX due to missing ALPN support.",
+                    Assert.Contains("System.NotSupportedException: HTTP/2 over TLS is not supported on macOS due to missing ALPN support.",
                         ErrorMessages.GetFailedProcessMessageOrEmpty("Run published service", Project, aspNetProcess.Process));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version < new Version(6, 2))

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -606,7 +606,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
     <value>The request trailers are not available yet. They may not be available until the full request body is read.</value>
   </data>
   <data name="HTTP2NoTlsOsx" xml:space="preserve">
-    <value>HTTP/2 over TLS is not supported on OSX due to missing ALPN support.</value>
+    <value>HTTP/2 over TLS is not supported on macOS due to missing ALPN support.</value>
   </data>
   <data name="HTTP2NoTlsWin7" xml:space="preserve">
     <value>HTTP/2 over TLS is not supported on Windows 7 due to missing ALPN support.</value>

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 });
             }));
 
-            Assert.Equal("HTTP/2 over TLS is not supported on OSX due to missing ALPN support.", ex.Message);
+            Assert.Equal("HTTP/2 over TLS is not supported on macOS due to missing ALPN support.", ex.Message);
         }
 
 


### PR DESCRIPTION
**Description**

We mix between the names OSX and macOS in class/variable names in code, but documentation commonly refers to the OS as macOS. Changing this exception message designed for end users to use the common name.

**Customer impact**

Consistent language between documentation and product.

**Regression?**

No

**Risk**

Low