### PR TITLE
Change non-public [Parameter] warning severities to error.

### DIFF
--- a/src/Components/Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Components/Analyzers/src/DiagnosticDescriptors.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
             new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Title), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Format), Resources.ResourceManager, typeof(Resources)),
             "Encapsulation",
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Description), Resources.ResourceManager, typeof(Resources)));
 
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
             new LocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title), Resources.ResourceManager, typeof(Resources)),
             new LocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Format), Resources.ResourceManager, typeof(Resources)),
             "Encapsulation",
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: new LocalizableResourceString(nameof(Resources.ComponentParametersShouldBePublic_Description), Resources.ResourceManager, typeof(Resources)));
 

--- a/src/Components/Analyzers/test/ComponentParameterSettersShouldBePublicTest.cs
+++ b/src/Components/Analyzers/test/ComponentParameterSettersShouldBePublicTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParameterSettersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty1' should have a public setter.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 7, 39)
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParameterSettersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty2' should have a public setter.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 8, 39)
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParameterSettersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty3' should have a public setter.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 9, 39)

--- a/src/Components/Analyzers/test/ComponentParametersShouldBePublicCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/ComponentParametersShouldBePublicCodeFixProviderTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                 {
                     Id = DiagnosticDescriptors.ComponentParametersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.BadProperty1' should be public.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 8, 40)
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                 {
                     Id = DiagnosticDescriptors.ComponentParameterSettersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty1' should have a public setter.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 8, 39)
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                 {
                     Id = DiagnosticDescriptors.ComponentParameterSettersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty2' should have a public setter.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 9, 39)
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test
                 {
                     Id = DiagnosticDescriptors.ComponentParameterSettersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty3' should have a public setter.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 10, 39)

--- a/src/Components/Analyzers/test/ComponentParametersShouldBePublicTest.cs
+++ b/src/Components/Analyzers/test/ComponentParametersShouldBePublicTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParametersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty1' should be public.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 7, 32)
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParametersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty2' should be public.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 8, 40)
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParametersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty3' should be public.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 9, 42)
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Id = DiagnosticDescriptors.ComponentParametersShouldBePublic.Id,
                     Message = "Component parameter 'ConsoleApplication1.TypeName.MyProperty4' should be public.",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[]
                     {
                         new DiagnosticResultLocation("Test0.cs", 10, 41)


### PR DESCRIPTION
- In preview8 we warned users for non-public `[Parameter]`s and `[Parameter]` setters. For preview9 this is now an error because things will not work as they expect.
- Updated existing tests to reflect the new error expectation.

#12294