### PR TITLE
SPA template precedence

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
@@ -6,6 +6,7 @@
     "SPA"
   ],
   "groupIdentity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.Angular",
+  "precedence": "5000",
   "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.Angular.CSharp.3.0",
   "name": "ASP.NET Core with Angular",
   "preferNameDirectory": true,

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
@@ -6,6 +6,7 @@
     "SPA"
   ],
   "groupIdentity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.React",
+  "precedence": "5000",
   "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.React.CSharp.3.0",
   "name": "ASP.NET Core with React.js",
   "preferNameDirectory": true,
@@ -189,7 +190,6 @@
       "binding": "HostIdentifier"
     }
   },
-
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
@@ -6,6 +6,7 @@
     "SPA"
   ],
   "groupIdentity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.ReactRedux",
+  "precedence": "5000",
   "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.ReactRedux.CSharp.3.0",
   "name": "ASP.NET Core with React.js and Redux",
   "preferNameDirectory": true,


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/12773.

**Description**
Calling `dotnet new angular` fails to find the project template.

Expected Result:
An Angular project is created.

Actual Result:
![image](https://user-images.githubusercontent.com/14987221/62251633-3d3e9c80-b3a5-11e9-80c9-7293968208b8.png)


**Customer impact**
Customers who have ASPNETCore 3.0 and (2.2|2.1) are not able to create an Angular project. This can be worked around by doing `dotnet new angular -f netcoreapp3.0` explicitly, but it's not at all clear that that's the solution given the message.

**Regression?**
Yes. previous preview versions could successfully create a projects, but a change in how VS initializes the template cache exposed our lack of precedence values.

**Risk**
Low. This is a change only to the template config and mirrors exactly what we do for non-SPA templates.