### PR TITLE
Always load hostfxr.dll by absolute path

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
@@ -30,13 +30,6 @@ void HostFxrErrorRedirector::HostFxrErrorRedirectorCallback(const WCHAR* message
     m_writeFunction->Append(std::wstring(message) + L"\r\n");
 }
 
-void HostFxr::Load()
-{
-    HMODULE hModule;
-    THROW_LAST_ERROR_IF(!GetModuleHandleEx(0, L"hostfxr.dll", &hModule));
-    Load(hModule);
-}
-
 void HostFxr::Load(HMODULE moduleHandle)
 {
     m_hHostFxrDll = moduleHandle;
@@ -63,9 +56,13 @@ void HostFxr::Load(HMODULE moduleHandle)
 
 void HostFxr::Load(const std::wstring& location)
 {
+    // Make sure to always load hostfxr via an absolute path.
+    // If the process fails to start for whatever reason, a mismatched hostfxr
+    // may be already loaded in the process.
     try
     {
         HMODULE hModule;
+        LOG_INFOF(L"Loading hostfxr from location %s", location.c_str());
         THROW_LAST_ERROR_IF_NULL(hModule = LoadLibraryW(location.c_str()));
         Load(hModule);
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
@@ -32,7 +32,15 @@ void HostFxrErrorRedirector::HostFxrErrorRedirectorCallback(const WCHAR* message
 
 void HostFxr::Load(HMODULE moduleHandle)
 {
+    // A hostfxr may already be loaded here if we tried to start with an
+    // invalid configuration. Release hostfxr before loading it again.
+    if (m_hHostFxrDll != nullptr)
+    {
+        m_hHostFxrDll.release();
+    }
+
     m_hHostFxrDll = moduleHandle;
+
     try
     {
         m_hostfxr_get_native_search_directories_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_get_native_search_directories_fn>(moduleHandle, "hostfxr_get_native_search_directories");

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -60,7 +60,6 @@ public:
     {
     }
 
-    void Load();
     void Load(HMODULE moduleHandle);
     void Load(const std::wstring& location);
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -210,7 +210,7 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
 
             hostFxrResolutionResult->GetArguments(context->m_argc, context->m_argv);
             THROW_IF_FAILED(SetEnvironmentVariablesOnWorkerProcess());
-            context->m_hostFxr.Load();
+            context->m_hostFxr.Load(hostFxrResolutionResult->GetHostFxrLocation());
         }
         else
         {


### PR DESCRIPTION
#### Description
Fixes an issue where applications could be deployed correctly behind IIS and the app would still fail to start. The application must originally be deployed incorrectly, but it is trivial to do through Visual Studio. Specifically, someone first needs to accidentally publish a framework dependent application, which is the default. The reason this doesn't work at the moment is that the 3.0 preview isn't available on Azure yet. Next, they need to recognize that they need to publish standalone, which they do next. After the publish standalone, the application still fails to start with a different error. Finally, the customer restarts their application and the app works successfully without changing any dependencies. 

#### Customer Impact
Customers would hit a horrible user experience when publishing applications to azure in preview8. Also, they wouldn't be able to easily diagnose 

#### Regression?
 Yes. Regression from 2.2 and earlier in 3.0 (preview5) to now. 

#### Risk
Very low. The fix is to always load hostfxr via an absolute path. Also, if hostfxr was already loaded, we release hostfxr first before reloading it.
