### PR TITLE
Ensure SystemTextJsonHelper always HTML encodes output.

### DIFF
--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -2205,7 +2205,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     }
     public partial class SystemTextJsonOutputFormatter : Microsoft.AspNetCore.Mvc.Formatters.TextOutputFormatter
     {
-        public SystemTextJsonOutputFormatter(Microsoft.AspNetCore.Mvc.JsonOptions options) { }
+        public SystemTextJsonOutputFormatter(System.Text.Json.JsonSerializerOptions jsonSerializerOptions) { }
         public System.Text.Json.JsonSerializerOptions SerializerOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public sealed override System.Threading.Tasks.Task WriteResponseBodyAsync(Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context, System.Text.Encoding selectedEncoding) { throw null; }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/JsonSerializerOptionsCopyConstructor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/JsonSerializerOptionsCopyConstructor.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Encodings.Web;
+
+namespace System.Text.Json
+{
+    internal static class JsonSerializerOptionsCopyConstructor
+    {
+        public static JsonSerializerOptions Copy(this JsonSerializerOptions serializerOptions, JavaScriptEncoder encoder)
+        {
+            var copiedOptions = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = serializerOptions.AllowTrailingCommas,
+                DefaultBufferSize = serializerOptions.DefaultBufferSize,
+                DictionaryKeyPolicy = serializerOptions.DictionaryKeyPolicy,
+                IgnoreNullValues = serializerOptions.IgnoreNullValues,
+                IgnoreReadOnlyProperties = serializerOptions.IgnoreReadOnlyProperties,
+                MaxDepth = serializerOptions.MaxDepth,
+                PropertyNameCaseInsensitive = serializerOptions.PropertyNameCaseInsensitive,
+                PropertyNamingPolicy = serializerOptions.PropertyNamingPolicy,
+                ReadCommentHandling = serializerOptions.ReadCommentHandling,
+                WriteIndented = serializerOptions.WriteIndented
+            };
+
+            for (var i = 0; i < serializerOptions.Converters.Count; i++)
+            {
+                copiedOptions.Converters.Add(serializerOptions.Converters[i]);
+            }
+
+            copiedOptions.Encoder = encoder;
+
+            return copiedOptions;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -87,7 +87,9 @@ namespace Microsoft.AspNetCore.Mvc
             options.OutputFormatters.Add(new HttpNoContentOutputFormatter());
             options.OutputFormatters.Add(new StringOutputFormatter());
             options.OutputFormatters.Add(new StreamOutputFormatter());
-            options.OutputFormatters.Add(new SystemTextJsonOutputFormatter(_jsonOptions.Value));
+
+            var jsonOutputFormatter = SystemTextJsonOutputFormatter.CreateFormatter(_jsonOptions.Value);
+            options.OutputFormatters.Add(jsonOutputFormatter);
 
             // Set up ValueProviders
             options.ValueProviderFactories.Add(new FormValueProviderFactory());

--- a/src/Mvc/Mvc.Core/src/JsonOptions.cs
+++ b/src/Mvc/Mvc.Core/src/JsonOptions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -27,9 +26,6 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Use camel casing for properties
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-
-            // Does not encode all non-ASCII characters which matches Json.NET"s behavior.
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         };
     }
 }

--- a/src/Mvc/Mvc.Core/src/JsonOptions.cs
+++ b/src/Mvc/Mvc.Core/src/JsonOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -26,6 +27,9 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Use camel casing for properties
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+
+            // Does not encode all non-ASCII characters which matches Json.NET"s behavior.
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         };
     }
 }

--- a/src/Mvc/Mvc.Core/test/CreatedAtActionResultTests.cs
+++ b/src/Mvc/Mvc.Core/test/CreatedAtActionResultTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = Options.Create(new MvcOptions());
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new SystemTextJsonOutputFormatter(new JsonOptions()));
+            options.Value.OutputFormatters.Add(SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions()));
 
             var services = new ServiceCollection();
             services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(

--- a/src/Mvc/Mvc.Core/test/CreatedAtRouteResultTests.cs
+++ b/src/Mvc/Mvc.Core/test/CreatedAtRouteResultTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = Options.Create(new MvcOptions());
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new SystemTextJsonOutputFormatter(new JsonOptions()));
+            options.Value.OutputFormatters.Add(SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions()));
 
             var services = new ServiceCollection();
             services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(

--- a/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
+++ b/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = Options.Create(new MvcOptions());
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new SystemTextJsonOutputFormatter(new JsonOptions()));
+            options.Value.OutputFormatters.Add(SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions()));
 
             var services = new ServiceCollection();
             services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(

--- a/src/Mvc/Mvc.Core/test/Formatters/FormatFilterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/FormatFilterTest.cs
@@ -465,7 +465,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 // Set up default output formatters.
                 MvcOptions.OutputFormatters.Add(new HttpNoContentOutputFormatter());
                 MvcOptions.OutputFormatters.Add(new StringOutputFormatter());
-                MvcOptions.OutputFormatters.Add(new SystemTextJsonOutputFormatter(new JsonOptions()));
+                MvcOptions.OutputFormatters.Add(SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions()));
 
                 // Set up default mapping for json extensions to content type
                 MvcOptions.FormatterMappings.SetMediaTypeMappingForFormat(

--- a/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
@@ -1,22 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.IO;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
-using Microsoft.Net.Http.Headers;
-using Xunit;
-
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
     public class SystemTextJsonOutputFormatterTest : JsonOutputFormatterTestBase
     {
         protected override TextOutputFormatter GetOutputFormatter()
         {
-            return new SystemTextJsonOutputFormatter(new JsonOptions());
+            return SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions());
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
@@ -18,39 +18,5 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             return new SystemTextJsonOutputFormatter(new JsonOptions());
         }
-
-        [Theory]
-        [MemberData(nameof(WriteCorrectCharacterEncoding))]
-        public async Task WriteToStreamAsync_UsesCorrectCharacterEncoding(
-           string content,
-           string encodingAsString,
-           bool isDefaultEncoding)
-        {
-            // Arrange
-            var formatter = GetOutputFormatter();
-            var expectedContent = "\"" + JavaScriptEncoder.Default.Encode(content) + "\"";
-            var mediaType = MediaTypeHeaderValue.Parse(string.Format("application/json; charset={0}", encodingAsString));
-            var encoding = CreateOrGetSupportedEncoding(formatter, encodingAsString, isDefaultEncoding);
-
-
-            var body = new MemoryStream();
-            var actionContext = GetActionContext(mediaType, body);
-
-            var outputFormatterContext = new OutputFormatterWriteContext(
-                actionContext.HttpContext,
-                new TestHttpResponseStreamWriterFactory().CreateWriter,
-                typeof(string),
-                content)
-            {
-                ContentType = new StringSegment(mediaType.ToString()),
-            };
-
-            // Act
-            await formatter.WriteResponseBodyAsync(outputFormatterContext, Encoding.GetEncoding(encodingAsString));
-
-            // Assert
-            var actualContent = encoding.GetString(body.ToArray());
-            Assert.Equal(expectedContent, actualContent, StringComparer.OrdinalIgnoreCase);
-        }
     }
 }

--- a/src/Mvc/Mvc.Core/test/HttpNotFoundObjectResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/HttpNotFoundObjectResultTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = Options.Create(new MvcOptions());
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new SystemTextJsonOutputFormatter(new JsonOptions()));
+            options.Value.OutputFormatters.Add(SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions()));
 
             var services = new ServiceCollection();
             services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(

--- a/src/Mvc/Mvc.Core/test/HttpOkObjectResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/HttpOkObjectResultTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = Options.Create(new MvcOptions());
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new SystemTextJsonOutputFormatter(new JsonOptions()));
+            options.Value.OutputFormatters.Add(SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions()));
 
             var services = new ServiceCollection();
             services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/SystemTextJsonHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/SystemTextJsonHelper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         public SystemTextJsonHelper(IOptions<JsonOptions> options)
         {
-            _htmlSafeJsonSerializerOptions = CreateHtmlSafeSerializerOptions(options.Value.JsonSerializerOptions);
+            _htmlSafeJsonSerializerOptions = GetHtmlSafeSerializerOptions(options.Value.JsonSerializerOptions);
         }
 
         /// <inheritdoc />
@@ -27,31 +27,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             return new HtmlString(json);
         }
 
-        private static JsonSerializerOptions CreateHtmlSafeSerializerOptions(JsonSerializerOptions serializerOptions)
+        private static JsonSerializerOptions GetHtmlSafeSerializerOptions(JsonSerializerOptions serializerOptions)
         {
-            var htmlSafeOptions = new JsonSerializerOptions
+            if (serializerOptions.Encoder is null || serializerOptions.Encoder == JavaScriptEncoder.Default)
             {
-                AllowTrailingCommas = serializerOptions.AllowTrailingCommas,
-                DefaultBufferSize = serializerOptions.DefaultBufferSize,
-                DictionaryKeyPolicy = serializerOptions.DictionaryKeyPolicy,
-                IgnoreNullValues = serializerOptions.IgnoreNullValues,
-                IgnoreReadOnlyProperties = serializerOptions.IgnoreReadOnlyProperties,
-                MaxDepth = serializerOptions.MaxDepth,
-                PropertyNameCaseInsensitive = serializerOptions.PropertyNameCaseInsensitive,
-                PropertyNamingPolicy = serializerOptions.PropertyNamingPolicy,
-                ReadCommentHandling = serializerOptions.ReadCommentHandling,
-                WriteIndented = serializerOptions.WriteIndented
-            };
-
-            // Use the HTML safe encoder
-            htmlSafeOptions.Encoder = JavaScriptEncoder.Default;
-
-            for (var i = 0; i < serializerOptions.Converters.Count; i++)
-            {
-                htmlSafeOptions.Converters.Add(serializerOptions.Converters[i]);
+                return serializerOptions;
             }
 
-            return htmlSafeOptions;
+            return serializerOptions.Copy(JavaScriptEncoder.Default);
         }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/SystemTextJsonHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/SystemTextJsonHelper.cs
@@ -2,6 +2,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.Options;
@@ -10,11 +11,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 {
     internal class SystemTextJsonHelper : IJsonHelper
     {
-        private readonly JsonOptions _options;
+        private readonly JsonSerializerOptions _htmlSafeJsonSerializerOptions;
 
         public SystemTextJsonHelper(IOptions<JsonOptions> options)
         {
-            _options = options.Value;
+            _htmlSafeJsonSerializerOptions = CreateHtmlSafeSerializerOptions(options.Value.JsonSerializerOptions);
         }
 
         /// <inheritdoc />
@@ -22,8 +23,35 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // JsonSerializer always encodes non-ASCII chars, so we do not need
             // to do anything special with the SerializerOptions
-            var json = JsonSerializer.Serialize(value, _options.JsonSerializerOptions);
+            var json = JsonSerializer.Serialize(value, _htmlSafeJsonSerializerOptions);
             return new HtmlString(json);
+        }
+
+        private static JsonSerializerOptions CreateHtmlSafeSerializerOptions(JsonSerializerOptions serializerOptions)
+        {
+            var htmlSafeOptions = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = serializerOptions.AllowTrailingCommas,
+                DefaultBufferSize = serializerOptions.DefaultBufferSize,
+                DictionaryKeyPolicy = serializerOptions.DictionaryKeyPolicy,
+                IgnoreNullValues = serializerOptions.IgnoreNullValues,
+                IgnoreReadOnlyProperties = serializerOptions.IgnoreReadOnlyProperties,
+                MaxDepth = serializerOptions.MaxDepth,
+                PropertyNameCaseInsensitive = serializerOptions.PropertyNameCaseInsensitive,
+                PropertyNamingPolicy = serializerOptions.PropertyNamingPolicy,
+                ReadCommentHandling = serializerOptions.ReadCommentHandling,
+                WriteIndented = serializerOptions.WriteIndented
+            };
+
+            // Use the HTML safe encoder
+            htmlSafeOptions.Encoder = JavaScriptEncoder.Default;
+
+            for (var i = 0; i < serializerOptions.Converters.Count; i++)
+            {
+                htmlSafeOptions.Converters.Add(serializerOptions.Converters[i]);
+            }
+
+            return htmlSafeOptions;
         }
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/test/Rendering/JsonHelperTestBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Rendering/JsonHelperTestBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
             // Assert
             var htmlString = Assert.IsType<HtmlString>(result);
-            Assert.Equal(expectedOutput, htmlString.ToString());
+            Assert.Equal(expectedOutput, htmlString.ToString(), ignoreCase: true);
         }
 
         [Fact]
@@ -71,14 +71,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             {
                 HTML = $"Hello pingüino"
             };
-            var expectedOutput = "{\"html\":\"Hello ping\\u00fcino\"}";
+            var expectedOutput = "{\"html\":\"Hello pingüino\"}";
 
             // Act
             var result = helper.Serialize(obj);
 
             // Assert
             var htmlString = Assert.IsType<HtmlString>(result);
-            Assert.Equal(expectedOutput, htmlString.ToString());
+            Assert.Equal(expectedOutput, htmlString.ToString(), ignoreCase: true);
         }
 
         [Fact]
@@ -91,6 +91,26 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 HTML = $"Hello &nbsp; &lt;John&gt;"
             };
             var expectedOutput = "{\"html\":\"Hello \\u0026nbsp; \\u0026lt;John\\u0026gt;\"}";
+
+            // Act
+            var result = helper.Serialize(obj);
+
+            // Assert
+            var htmlString = Assert.IsType<HtmlString>(result);
+            Assert.Equal(expectedOutput, htmlString.ToString());
+        }
+
+
+        [Fact]
+        public virtual void Serialize_WithHTMLNonAsciiAndControlChars()
+        {
+            // Arrange
+            var helper = GetJsonHelper();
+            var obj = new
+            {
+                HTML = "<b>Hello \n pingüino</b>"
+            };
+            var expectedOutput = "{\"html\":\"\\u003cb\\u003eHello \\n pingüino\\u003c/b\\u003e\"}";
 
             // Act
             var result = helper.Serialize(obj);

--- a/src/Mvc/Mvc.ViewFeatures/test/Rendering/SystemTextJsonHelperTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Rendering/SystemTextJsonHelperTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text.Json;
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -10,29 +10,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 {
     public class SystemTextJsonHelperTest : JsonHelperTestBase
     {
-        protected override IJsonHelper GetJsonHelper()
+        protected override IJsonHelper GetJsonHelper() => GetJsonHelper(new JsonOptions());
+
+        private static IJsonHelper GetJsonHelper(JsonOptions options)
         {
-            var options = new JsonOptions() { JsonSerializerOptions = { PropertyNamingPolicy = JsonNamingPolicy.CamelCase } };
             return new SystemTextJsonHelper(Options.Create(options));
-        }
-
-        [Fact]
-        public override void Serialize_EscapesHtmlByDefault()
-        {
-            // Arrange
-            var helper = GetJsonHelper();
-            var obj = new
-            {
-                HTML = "<b>John Doe</b>"
-            };
-            var expectedOutput = "{\"html\":\"\\u003Cb\\u003EJohn Doe\\u003C/b\\u003E\"}";
-
-            // Act
-            var result = helper.Serialize(obj);
-
-            // Assert
-            var htmlString = Assert.IsType<HtmlString>(result);
-            Assert.Equal(expectedOutput, htmlString.ToString());
         }
 
         [Fact]
@@ -45,6 +27,57 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 HTML = $"Hello pingüino"
             };
             var expectedOutput = "{\"html\":\"Hello ping\\u00FCino\"}";
+
+            // Act
+            var result = helper.Serialize(obj);
+
+            // Assert
+            var htmlString = Assert.IsType<HtmlString>(result);
+            Assert.Equal(expectedOutput, htmlString.ToString());
+        }
+
+        [Fact]
+        public override void Serialize_WithHTMLNonAsciiAndControlChars()
+        {
+            // Arrange
+            var helper = GetJsonHelper();
+            var obj = new
+            {
+                HTML = "<b>Hello \n pingüino</b>"
+            };
+            var expectedOutput = "{\"html\":\"\\u003Cb\\u003EHello \\n ping\\u00FCino\\u003C/b\\u003E\"}";
+
+            // Act
+            var result = helper.Serialize(obj);
+
+            // Assert
+            var htmlString = Assert.IsType<HtmlString>(result);
+            Assert.Equal(expectedOutput, htmlString.ToString());
+        }
+
+        [Fact]
+        public void Serialize_UsesOptionsConfiguredInTheProvider()
+        {
+            // Arrange
+            // This should use property-casing and indentation, but the result should be HTML-safe
+            var options = new JsonOptions
+            {
+                JsonSerializerOptions =
+                {
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    PropertyNamingPolicy = null,
+                    WriteIndented = true,
+                }
+            };
+            var helper = GetJsonHelper(options);
+            var obj = new
+            {
+                HTML = "<b>John</b>"
+            };
+            var expectedOutput =
+@"{
+  ""HTML"": ""\u003Cb\u003EJohn\u003C/b\u003E""
+}";
 
             // Act
             var result = helper.Serialize(obj);

--- a/src/Mvc/test/Mvc.FunctionalTests/JsonOutputFormatterTestBase.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/JsonOutputFormatterTestBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -11,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FormatterWebSite.Controllers;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -21,13 +21,14 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
     {
         protected JsonOutputFormatterTestBase(MvcTestFixture<TStartup> fixture)
         {
-            var factory = fixture.Factories.FirstOrDefault() ?? fixture.WithWebHostBuilder(ConfigureWebHostBuilder);
-            Client = factory.CreateDefaultClient();
+            Factory = fixture.Factories.FirstOrDefault() ?? fixture.WithWebHostBuilder(ConfigureWebHostBuilder);
+            Client = Factory.CreateDefaultClient();
         }
 
         private static void ConfigureWebHostBuilder(IWebHostBuilder builder) =>
             builder.UseStartup<TStartup>();
 
+        public WebApplicationFactory<TStartup> Factory { get; }
         public HttpClient Client { get; }
 
         [Fact]
@@ -98,6 +99,17 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             Assert.Equal("\"Hello Mr. 🦊\"", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public virtual async Task Formatting_StringValueWithNonAsciiCharacters()
+        {
+            // Act
+            var response = await Client.GetAsync($"/JsonOutputFormatter/{nameof(JsonOutputFormatterController.StringWithNonAsciiContent)}");
+
+            // Assert
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+            Assert.Equal("\"Une bête de cirque\"", await response.Content.ReadAsStringAsync());
         }
 
         [Fact]

--- a/src/Mvc/test/Mvc.FunctionalTests/SystemTextJsonOutputFormatterTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SystemTextJsonOutputFormatterTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         {
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/11459")]
+        [Fact]
         public override Task SerializableErrorIsReturnedInExpectedFormat() => base.SerializableErrorIsReturnedInExpectedFormat();
 
         [Fact]

--- a/src/Mvc/test/Mvc.FunctionalTests/SystemTextJsonOutputFormatterTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SystemTextJsonOutputFormatterTest.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using FormatterWebSite.Controllers;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -27,6 +29,25 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             Assert.Equal("\"Hello Mr. \\uD83E\\uDD8A\"", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Formatting_WithCustomEncoder()
+        {
+            // Arrange
+            static void ConfigureServices(IServiceCollection serviceCollection)
+            {
+                serviceCollection.AddControllers()
+                    .AddJsonOptions(o => o.JsonSerializerOptions.Encoder = JavaScriptEncoder.Default);
+            }
+            var client = Factory.WithWebHostBuilder(c => c.ConfigureServices(ConfigureServices)).CreateClient();
+
+            // Act
+            var response = await client.GetAsync($"/JsonOutputFormatter/{nameof(JsonOutputFormatterController.StringWithNonAsciiContent)}");
+
+            // Assert
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+            Assert.Equal("\"Une b\\u00EAte de cirque\"", await response.Content.ReadAsStringAsync());
         }
 
         [Fact]

--- a/src/Mvc/test/WebSites/FormatterWebSite/Controllers/JsonOutputFormatterController.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Controllers/JsonOutputFormatterController.cs
@@ -21,6 +21,9 @@ namespace FormatterWebSite.Controllers
         public ActionResult<string> StringWithUnicodeResult() => "Hello Mr. 🦊";
 
         [HttpGet]
+        public ActionResult<string> StringWithNonAsciiContent() => "Une bête de cirque";
+
+        [HttpGet]
         public ActionResult<SimpleModel> SimpleModelResult() =>
             new SimpleModel { Id = 10, Name = "Test", StreetName = "Some street" };
 


### PR DESCRIPTION
Ensure JsonSerializer always HTML encodes output.

* Update JsonOptions.JsonSerializerOptions to use encoder scheme that does not encode non-ASCII
  characters by default. This makes the encoding comparable to Json.NET's defaults
* In SystemTextJsonHelper, ensure that the content is always HTML-encoded
* Unskip skipped test

Fixes https://github.com/aspnet/AspNetCore/issues/9946
Fixes https://github.com/aspnet/AspNetCore/issues/11459

------------------------------------------------------------------------------

## Description

System.Text.Json introduced a feature that allows configuring the encoding behavior including preventing encoding HTML content. In one case, MVC needs to guarantee the generated content is always HTML safe. This is important to prevent XSS.

## Regression

The feature was added to System.Text.Json fairly recently and this is a reaction.

## Customer Impact
n/a

## Risk
n/a



