### PR TITLE
Use target architecture for building ANCM symbol packages.

### DIFF
--- a/src/Servers/IIS/build/assets.props
+++ b/src/Servers/IIS/build/assets.props
@@ -4,8 +4,8 @@
         <BuildIisNativeProjects Condition="'$(SolutionName)' == 'IISIntegration'">true</BuildIisNativeProjects>
         <PackNativeAssets Condition="'$(BuildIisNativeProjects)' == 'true'">true</PackNativeAssets>
         <PackNativeAssets Condition="'$(BuildIisNativeProjects)' != 'true'">false</PackNativeAssets>
-        <NativePlatform Condition="'$(Platform)' == 'AnyCPU'">x64</NativePlatform>
-        <NativePlatform Condition="'$(NativePlatform)' == ''">$(Platform)</NativePlatform>
+        <NativePlatform Condition="'$(TargetArchitecture)' == 'AnyCPU'">x64</NativePlatform>
+        <NativePlatform Condition="'$(NativePlatform)' == ''">$(TargetArchitecture)</NativePlatform>
         <NativeVCPlatform Condition="'$(NativePlatform)' == 'x86'">Win32</NativeVCPlatform>
         <NativeVCPlatform Condition="'$(NativeVCPlatform)' == ''">$(NativePlatform)</NativeVCPlatform>
     </PropertyGroup>


### PR DESCRIPTION
Infrastructure change to make sure ANCM symbols are built for x86.