### PR TITLE
Don't release SemaphoreSlim when it is canceled

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp3.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp3.0.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Components
     public abstract partial class Dispatcher
     {
         protected Dispatcher() { }
+        public void AssertAccess() { }
         public abstract bool CheckAccess();
         public static Microsoft.AspNetCore.Components.Dispatcher CreateDefault() { throw null; }
         public abstract System.Threading.Tasks.Task InvokeAsync(System.Action workItem);

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Components
     public abstract partial class Dispatcher
     {
         protected Dispatcher() { }
+        public void AssertAccess() { }
         public abstract bool CheckAccess();
         public static Microsoft.AspNetCore.Components.Dispatcher CreateDefault() { throw null; }
         public abstract System.Threading.Tasks.Task InvokeAsync(System.Action workItem);

--- a/src/Components/Components/src/Dispatcher.cs
+++ b/src/Components/Components/src/Dispatcher.cs
@@ -24,6 +24,20 @@ namespace Microsoft.AspNetCore.Components
         internal event UnhandledExceptionEventHandler UnhandledException;
 
         /// <summary>
+        /// Validates that the currently executing code is running inside the dispatcher.
+        /// </summary>
+        public void AssertAccess()
+        {
+            if (!CheckAccess())
+            {
+                throw new InvalidOperationException(
+                    "The current thread is not associated with the Dispatcher. " +
+                    "Use InvokeAsync() to switch execution to the Dispatcher when " +
+                    "triggering rendering or component state.");
+            }
+        }
+
+        /// <summary>
         /// Returns a value that determines whether using the dispatcher to invoke a work item is required
         /// from the current context.
         /// </summary>

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -399,7 +399,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
         private void ProcessRenderQueue()
         {
-            EnsureSynchronizationContext();
+            Dispatcher.AssertAccess();
 
             if (_isBatchInProgress)
             {

--- a/src/Components/Components/src/Rendering/Renderer.cs
+++ b/src/Components/Components/src/Rendering/Renderer.cs
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// </returns>
         public virtual Task DispatchEventAsync(ulong eventHandlerId, EventFieldInfo fieldInfo, EventArgs eventArgs)
         {
-            EnsureSynchronizationContext();
+            Dispatcher.AssertAccess();
 
             if (!_eventBindings.TryGetValue(eventHandlerId, out var callback))
             {
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// <param name="renderFragment">A <see cref="RenderFragment"/> that will supply the updated UI contents.</param>
         internal void AddToRenderQueue(int componentId, RenderFragment renderFragment)
         {
-            EnsureSynchronizationContext();
+            Dispatcher.AssertAccess();
 
             var componentState = GetOptionalComponentState(componentId);
             if (componentState == null)
@@ -372,21 +372,6 @@ namespace Microsoft.AspNetCore.Components.Rendering
             }
 
             return eventHandlerId;
-        }
-
-        private void EnsureSynchronizationContext()
-        {
-            // Render operations are not thread-safe, so they need to be serialized by the dispatcher.
-            // Plus, any other logic that mutates state accessed during rendering also
-            // needs not to run concurrently with rendering so should be dispatched to
-            // the renderer's sync context.
-            if (!Dispatcher.CheckAccess())
-            {
-                throw new InvalidOperationException(
-                    "The current thread is not associated with the Dispatcher. " +
-                    "Use Invoke() or InvokeAsync() to switch execution to the Dispatcher when " +
-                    "triggering rendering or modifying any state accessed during rendering.");
-            }
         }
 
         private ComponentState GetRequiredComponentState(int componentId)

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -324,7 +324,6 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             AssertInitialized();
             AssertNotDisposed();
-            Renderer.Dispatcher.AssertAccess();
 
             try
             {

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 {
     internal class CircuitHost : IAsyncDisposable
     {
-        private readonly SemaphoreSlim HandlerLock = new SemaphoreSlim(1);
         private readonly IServiceScope _scope;
         private readonly CircuitOptions _options;
         private readonly CircuitHandler[] _circuitHandlers;
@@ -187,35 +186,28 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             Log.CircuitOpened(_logger, Circuit.Id);
 
-            await HandlerLock.WaitAsync(cancellationToken);
+            Renderer.Dispatcher.AssertAccess();
 
-            try
+            List<Exception> exceptions = null;
+
+            for (var i = 0; i < _circuitHandlers.Length; i++)
             {
-                List<Exception> exceptions = null;
-
-                for (var i = 0; i < _circuitHandlers.Length; i++)
+                var circuitHandler = _circuitHandlers[i];
+                try
                 {
-                    var circuitHandler = _circuitHandlers[i];
-                    try
-                    {
-                        await circuitHandler.OnCircuitOpenedAsync(Circuit, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnCircuitOpenedAsync), ex);
-                        exceptions ??= new List<Exception>();
-                        exceptions.Add(ex);
-                    }
+                    await circuitHandler.OnCircuitOpenedAsync(Circuit, cancellationToken);
                 }
-
-                if (exceptions != null)
+                catch (Exception ex)
                 {
-                    throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
+                    Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnCircuitOpenedAsync), ex);
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(ex);
                 }
             }
-            finally
+
+            if (exceptions != null)
             {
-                HandlerLock.Release();
+                throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
             }
         }
 
@@ -223,35 +215,28 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             Log.ConnectionUp(_logger, Circuit.Id, Client.ConnectionId);
 
-            await HandlerLock.WaitAsync(cancellationToken);
+            Renderer.Dispatcher.AssertAccess();
+            
+            List<Exception> exceptions = null;
 
-            try
+            for (var i = 0; i < _circuitHandlers.Length; i++)
             {
-                List<Exception> exceptions = null;
-
-                for (var i = 0; i < _circuitHandlers.Length; i++)
+                var circuitHandler = _circuitHandlers[i];
+                try
                 {
-                    var circuitHandler = _circuitHandlers[i];
-                    try
-                    {
-                        await circuitHandler.OnConnectionUpAsync(Circuit, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnConnectionUpAsync), ex);
-                        exceptions ??= new List<Exception>();
-                        exceptions.Add(ex);
-                    }
+                    await circuitHandler.OnConnectionUpAsync(Circuit, cancellationToken);
                 }
-
-                if (exceptions != null)
+                catch (Exception ex)
                 {
-                    throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
+                    Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnConnectionUpAsync), ex);
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(ex);
                 }
             }
-            finally
+
+            if (exceptions != null)
             {
-                HandlerLock.Release();
+                throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
             }
         }
 
@@ -259,35 +244,28 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             Log.ConnectionDown(_logger, Circuit.Id, Client.ConnectionId);
 
-            await HandlerLock.WaitAsync(cancellationToken);
+            Renderer.Dispatcher.AssertAccess();
+            
+            List<Exception> exceptions = null;
 
-            try
+            for (var i = 0; i < _circuitHandlers.Length; i++)
             {
-                List<Exception> exceptions = null;
-
-                for (var i = 0; i < _circuitHandlers.Length; i++)
+                var circuitHandler = _circuitHandlers[i];
+                try
                 {
-                    var circuitHandler = _circuitHandlers[i];
-                    try
-                    {
-                        await circuitHandler.OnConnectionDownAsync(Circuit, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnConnectionDownAsync), ex);
-                        exceptions ??= new List<Exception>();
-                        exceptions.Add(ex);
-                    }
+                    await circuitHandler.OnConnectionDownAsync(Circuit, cancellationToken);
                 }
-
-                if (exceptions != null)
+                catch (Exception ex)
                 {
-                    throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
+                    Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnConnectionDownAsync), ex);
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(ex);
                 }
             }
-            finally
+
+            if (exceptions != null)
             {
-                HandlerLock.Release();
+                throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
             }
         }
 
@@ -295,35 +273,26 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             Log.CircuitClosed(_logger, Circuit.Id);
 
-            await HandlerLock.WaitAsync(cancellationToken);
+            List<Exception> exceptions = null;
 
-            try
+            for (var i = 0; i < _circuitHandlers.Length; i++)
             {
-                List<Exception> exceptions = null;
-
-                for (var i = 0; i < _circuitHandlers.Length; i++)
+                var circuitHandler = _circuitHandlers[i];
+                try
                 {
-                    var circuitHandler = _circuitHandlers[i];
-                    try
-                    {
-                        await circuitHandler.OnCircuitClosedAsync(Circuit, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnCircuitClosedAsync), ex);
-                        exceptions ??= new List<Exception>();
-                        exceptions.Add(ex);
-                    }
+                    await circuitHandler.OnCircuitClosedAsync(Circuit, cancellationToken);
                 }
-
-                if (exceptions != null)
+                catch (Exception ex)
                 {
-                    throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
+                    Log.CircuitHandlerFailed(_logger, circuitHandler, nameof(CircuitHandler.OnCircuitClosedAsync), ex);
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(ex);
                 }
             }
-            finally
+
+            if (exceptions != null)
             {
-                HandlerLock.Release();
+                throw new AggregateException("Encountered exceptions while executing circuit handlers.", exceptions);
             }
         }
 
@@ -355,6 +324,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             AssertInitialized();
             AssertNotDisposed();
+            Renderer.Dispatcher.AssertAccess();
 
             try
             {

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -261,6 +263,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [Flaky("https://github.com/aspnet/AspNetCore/issues/13086", FlakyOn.AzP.Windows)]
         public async Task ContinuesWorkingAfterInvalidAsyncReturnCallback()
         {
             // Arrange

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerComponentRenderingTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             appElement.FindElement(By.Id("run-without-dispatch")).Click();
 
             Browser.Contains(
-                $"{typeof(InvalidOperationException).FullName}: The current thread is not associated with the Dispatcher. Use Invoke() or InvokeAsync() to switch execution to the Dispatcher when triggering rendering or modifying any state accessed during rendering.",
+                $"{typeof(InvalidOperationException).FullName}: The current thread is not associated with the Dispatcher. Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state.",
                 () => result.Text);
         }
     }


### PR DESCRIPTION
Fixes #11686 

We don't want to reuse the semaphoreslim when it is cancelled. So moving it out of try block so it doesn't try to release it.