### PR TITLE
Log timeouts in Identity functional tests

### DIFF
--- a/src/Identity/test/Identity.FunctionalTests/xunit.runner.json
+++ b/src/Identity/test/Identity.FunctionalTests/xunit.runner.json
@@ -1,3 +1,5 @@
 {
-  "shadowCopy": false
+  "shadowCopy": false,
+  "longRunningTestSeconds": 60,
+  "diagnosticMessages": true
 }


### PR DESCRIPTION
This might help us debug the identity functional test hangs.

FYI @dougbu @anurse. I'm only turning the logs on for this specific test assembly for now. I'm not sure if we can turn this on globally since in the documentation, it specifically says that there is no merging of different json files: https://xunit.net/docs/configuring-with-json. I'd imagine we'll need a custom target that runs before tests to create/append the configuration with global settings. Could explore this as a followup but I don't really have bandwidth for this right now.