### PR TITLE
Ensure IFormFile binding for nested properties works

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/12962")]
         public async Task LogsJSInteropCompletionsCallbacksAndContinuesWorkingInAllSituations()
         {
             // Arrange

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp3.0.cs
@@ -2560,6 +2560,17 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     {
         public EmptyModelMetadataProvider() : base (default(Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ICompositeMetadataDetailsProvider)) { }
     }
+    public sealed partial class FormFileValueProvider : Microsoft.AspNetCore.Mvc.ModelBinding.IValueProvider
+    {
+        public FormFileValueProvider(Microsoft.AspNetCore.Http.IFormFileCollection files) { }
+        public bool ContainsPrefix(string prefix) { throw null; }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.ValueProviderResult GetValue(string key) { throw null; }
+    }
+    public sealed partial class FormFileValueProviderFactory : Microsoft.AspNetCore.Mvc.ModelBinding.IValueProviderFactory
+    {
+        public FormFileValueProviderFactory() { }
+        public System.Threading.Tasks.Task CreateValueProviderAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ValueProviderFactoryContext context) { throw null; }
+    }
     public partial class FormValueProvider : Microsoft.AspNetCore.Mvc.ModelBinding.BindingSourceValueProvider, Microsoft.AspNetCore.Mvc.ModelBinding.IEnumerableValueProvider, Microsoft.AspNetCore.Mvc.ModelBinding.IValueProvider
     {
         public FormValueProvider(Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource, Microsoft.AspNetCore.Http.IFormCollection values, System.Globalization.CultureInfo culture) : base (default(Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource)) { }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -96,6 +96,7 @@ namespace Microsoft.AspNetCore.Mvc
             options.ValueProviderFactories.Add(new RouteValueProviderFactory());
             options.ValueProviderFactories.Add(new QueryStringValueProviderFactory());
             options.ValueProviderFactories.Add(new JQueryFormValueProviderFactory());
+            options.ValueProviderFactories.Add(new FormFileValueProviderFactory());
 
             // Set up metadata providers
             ConfigureAdditionalModelMetadataDetailsProviders(options.ModelMetadataDetailsProviders);

--- a/src/Mvc/Mvc.Core/src/ModelBinding/FormFileValueProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/FormFileValueProvider.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    /// <summary>
+    /// An <see cref="IValueProvider"/> adapter for data stored in an <see cref="IFormFileCollection"/>.
+    /// </summary>
+    /// <remarks>
+    /// Unlike most <see cref="IValueProvider"/> instances, <see cref="FormFileValueProvider"/> does not provide any values, but
+    /// specifically responds to <see cref="ContainsPrefix(string)"/> queries. This allows the model binding system to
+    /// recurse in to deeply nested object graphs with only values for form files.
+    /// </remarks>
+    public sealed class FormFileValueProvider : IValueProvider
+    {
+        private readonly IFormFileCollection _files;
+        private PrefixContainer _prefixContainer;
+
+        /// <summary>
+        /// Creates a value provider for <see cref="IFormFileCollection"/>.
+        /// </summary>
+        /// <param name="files">The <see cref="IFormFileCollection"/>.</param>
+        public FormFileValueProvider(IFormFileCollection files)
+        {
+            _files = files ?? throw new ArgumentNullException(nameof(files));
+        }
+
+        private PrefixContainer PrefixContainer
+        {
+            get
+            {
+                _prefixContainer ??= CreatePrefixContainer(_files);
+                return _prefixContainer;
+            }
+        }
+
+        private static PrefixContainer CreatePrefixContainer(IFormFileCollection formFiles)
+        {
+            var fileNames = new List<string>();
+            var count = formFiles.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var file = formFiles[i];
+
+                // If there is an <input type="file" ... /> in the form and is left blank.
+                // This matches the filtering behavior from FormFileModelBinder
+                if (file.Length == 0 && string.IsNullOrEmpty(file.FileName))
+                {
+                    continue;
+                }
+
+                fileNames.Add(file.Name);
+            }
+
+            return new PrefixContainer(fileNames);
+        }
+
+        /// <inheritdoc />
+        public bool ContainsPrefix(string prefix) => PrefixContainer.ContainsPrefix(prefix);
+
+        /// <inheritdoc />
+        public ValueProviderResult GetValue(string key) => ValueProviderResult.None;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/FormFileValueProviderFactory.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/FormFileValueProviderFactory.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    /// <summary>
+    /// A <see cref="IValueProviderFactory"/> for <see cref="FormValueProvider"/>.
+    /// </summary>
+    public sealed class FormFileValueProviderFactory : IValueProviderFactory
+    {
+        /// <inheritdoc />
+        public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var request = context.ActionContext.HttpContext.Request;
+            if (HasMultipartFormContentType(request))
+            {
+                // Allocating a Task only when the body is multipart form.
+                return AddValueProviderAsync(context, request);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static async Task AddValueProviderAsync(ValueProviderFactoryContext context, HttpRequest request)
+        {
+            var formCollection = await request.ReadFormAsync();
+            if (formCollection.Files.Count > 0)
+            {
+                var valueProvider = new FormFileValueProvider(formCollection.Files);
+                context.ValueProviders.Add(valueProvider);
+            }
+        }
+
+        private static bool HasMultipartFormContentType(HttpRequest request)
+        {
+            var contentType = request.ContentType;
+
+            // Content-Type: multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq
+            return contentType != null &&
+                MediaTypeHeaderValue.TryParse(contentType, out var mediaType) &&
+                mediaType.MediaType.Equals("multipart/form-data", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/FormFileValueProviderFactory.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/FormFileValueProviderFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
@@ -22,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             var request = context.ActionContext.HttpContext.Request;
-            if (HasMultipartFormContentType(request))
+            if (request.HasFormContentType)
             {
                 // Allocating a Task only when the body is multipart form.
                 return AddValueProviderAsync(context, request);
@@ -39,16 +38,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 var valueProvider = new FormFileValueProvider(formCollection.Files);
                 context.ValueProviders.Add(valueProvider);
             }
-        }
-
-        private static bool HasMultipartFormContentType(HttpRequest request)
-        {
-            var contentType = request.ContentType;
-
-            // Content-Type: multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq
-            return contentType != null &&
-                MediaTypeHeaderValue.TryParse(contentType, out var mediaType) &&
-                mediaType.MediaType.Equals("multipart/form-data", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/Microsoft.AspNetCore.Mvc.Core.Test.csproj
+++ b/src/Mvc/Mvc.Core/test/Microsoft.AspNetCore.Mvc.Core.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>Microsoft.AspNetCore.Mvc</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.Core/test/ModelBinding/FormFileValueProviderFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/FormFileValueProviderFactoryTest.cs
@@ -14,14 +14,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     public class FormFileValueProviderFactoryTest
     {
-        [Theory]
-        [InlineData("application/json")]
-        [InlineData("application/x-www-form-urlencoded")]
-        public async Task CreateValueProviderAsync_DoesNotAddValueProvider_IfContentTypeIsNotMultipart(string contentType)
+        [Fact]
+        public async Task CreateValueProviderAsync_DoesNotAddValueProvider_IfRequestDoesNotHaveFormContent()
         {
             // Arrange
             var factory = new FormFileValueProviderFactory();
-            var context = CreateContext(contentType);
+            var context = CreateContext("application/json");
 
             // Act
             await factory.CreateValueProviderAsync(context);

--- a/src/Mvc/Mvc.Core/test/ModelBinding/FormFileValueProviderFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/FormFileValueProviderFactoryTest.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    public class FormFileValueProviderFactoryTest
+    {
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/x-www-form-urlencoded")]
+        public async Task CreateValueProviderAsync_DoesNotAddValueProvider_IfContentTypeIsNotMultipart(string contentType)
+        {
+            // Arrange
+            var factory = new FormFileValueProviderFactory();
+            var context = CreateContext(contentType);
+
+            // Act
+            await factory.CreateValueProviderAsync(context);
+
+            // Assert
+            Assert.Empty(context.ValueProviders);
+        }
+
+        [Fact]
+        public async Task CreateValueProviderAsync_DoesNotAddValueProvider_IfFileCollectionIsEmpty()
+        {
+            // Arrange
+            var factory = new FormFileValueProviderFactory();
+            var context = CreateContext("multipart/form-data");
+
+            // Act
+            await factory.CreateValueProviderAsync(context);
+
+            // Assert
+            Assert.Empty(context.ValueProviders);
+        }
+
+        [Fact]
+        public async Task CreateValueProviderAsync_AddsValueProvider()
+        {
+            // Arrange
+            var factory = new FormFileValueProviderFactory();
+            var context = CreateContext("multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq");
+            var files = (FormFileCollection)context.ActionContext.HttpContext.Request.Form.Files;
+            files.Add(new FormFile(Stream.Null, 0, 10, "some-name", "some-name"));
+
+            // Act
+            await factory.CreateValueProviderAsync(context);
+
+            // Assert
+            Assert.Collection(
+                context.ValueProviders,
+                v => Assert.IsType<FormFileValueProvider>(v));
+        }
+
+        private static ValueProviderFactoryContext CreateContext(string contentType)
+        {
+            var context = new DefaultHttpContext();
+            context.Request.ContentType = contentType;
+            context.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), new FormFileCollection());
+            var actionContext = new ActionContext(context, new RouteData(), new ActionDescriptor());
+
+            return new ValueProviderFactoryContext(actionContext);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/FormFileValueProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/FormFileValueProviderTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    public class FormFileValueProviderTest
+    {
+        [Fact]
+        public void ContainsPrefix_ReturnsFalse_IfFileIs0LengthAndFileNameIsEmpty()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = "multipart/form-data";
+            var formFiles = new FormFileCollection();
+            formFiles.Add(new FormFile(Stream.Null, 0, 0, "file", fileName: null));
+            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), formFiles);
+
+            var valueProvider = new FormFileValueProvider(formFiles);
+
+            // Act
+            var result = valueProvider.ContainsPrefix("file");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ContainsPrefix_ReturnsTrue_IfFileExists()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = "multipart/form-data";
+            var formFiles = new FormFileCollection();
+            formFiles.Add(new FormFile(Stream.Null, 0, 10, "file", "file"));
+            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), formFiles);
+
+            var valueProvider = new FormFileValueProvider(formFiles);
+
+            // Act
+            var result = valueProvider.ContainsPrefix("file");
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void GetValue_ReturnsNoneResult()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = "multipart/form-data";
+            var formFiles = new FormFileCollection();
+            formFiles.Add(new FormFile(Stream.Null, 0, 10, "file", "file"));
+            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>(), formFiles);
+
+            var valueProvider = new FormFileValueProvider(formFiles);
+
+            // Act
+            var result = valueProvider.GetValue("file");
+
+            // Assert
+            Assert.Equal(ValueProviderResult.None, result);
+        }
+    }
+}

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/SystemTextJsonHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/SystemTextJsonHelper.cs
@@ -1,5 +1,4 @@
-﻿
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Text.Encodings.Web;

--- a/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
+++ b/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
@@ -82,7 +82,8 @@ namespace Microsoft.AspNetCore.Mvc
                 provider => Assert.IsType<FormValueProviderFactory>(provider),
                 provider => Assert.IsType<RouteValueProviderFactory>(provider),
                 provider => Assert.IsType<QueryStringValueProviderFactory>(provider),
-                provider => Assert.IsType<JQueryFormValueProviderFactory>(provider));
+                provider => Assert.IsType<JQueryFormValueProviderFactory>(provider),
+                provider => Assert.IsType<FormFileValueProviderFactory>(provider));
         }
 
         [Fact]

--- a/src/Mvc/test/Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
@@ -519,7 +519,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Null(modelStateEntry.RawValue);
         }
 
-
         [Fact]
         public async Task BindCollectionProperty_NoData_IsNotBound()
         {
@@ -1088,6 +1087,41 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                         file => Assert.Equal(data + 2, ReadFormFile(file)),
                         file => Assert.Equal(data + 3, ReadFormFile(file)));
                 });
+        }
+
+        [Fact]
+        public async Task BindModelAsync_MultiDimensionalFormFile_WithArrayNotation()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor
+            {
+                Name = "p",
+                BindingInfo = new BindingInfo(),
+                ParameterType = typeof(MultiDimensionalFormFileContainer)
+            };
+
+            var data = "Some Data Is Better Than No Data.";
+            var testContext = ModelBindingTestHelper.GetTestContext(
+                request =>
+                {
+                    UpdateRequest(request, data + 1, "FormFiles[0][0]");
+                    AddFormFile(request, data + 2, "FormFiles[1][0]");
+                    AddFormFile(request, data + 3, "FormFiles[1][0]");
+                });
+
+            var modelState = testContext.ModelState;
+
+            // Act
+            var modelBindingResult = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.True(modelBindingResult.IsModelSet);
+            var container = Assert.IsType<MultiDimensionalFormFileContainer>(modelBindingResult.Model);
+            Assert.NotNull(container.FormFiles);
+            Assert.Empty(container.FormFiles);
         }
 
         public class MultiDimensionalFormFileContainerLevel2


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/9510

----------------------------------------------

## Description

Binding for IFormFile does not work correctly when the form file is nested but no sibling properties are specified. 

## Customer Impact

This allows a fairly narrow set of model binding scenarios where form files are posted to be bound correctly.

## Regression

We had a regression in 2.2 that was fixed in 3.0. However, this was identified as one of the scenarios that wasn't correctly addressed.

## Risk

Medium. Model binding changes have a fairly large test area, however we have a fair bit of test in this area.
