### PR TITLE
Increase cancelTimeoutInMinutes

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -69,6 +69,11 @@ parameters:
   installJdk: true
   timeoutInMinutes: 180
 
+  # We need longer than the default amount of 5 minutes to upload our logs/artifacts. (We currently take around 5 mins in the best case).
+  # This makes sure we have time to upload everything in the case of a build timeout - really important for investigating a build
+  # timeout due to test hangs.
+  cancelTimeoutInMinutes: 15
+
 jobs:
 - job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
   displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore/issues/12848

This is a setting AZDO supports to control how long you have after a
build is canceled before all of the work is terminated.

When a build reaches a timeout, usually the `build.{cmd|sh}` step will
be terminated, and then you have cancelTimeoutInMinutes number of
minutes to do everything else before everything shuts down.

We need to a value larger than the default of 5 minutes because it takes
us *about* 5 minutes to upload all of our logs and artifacts in a
success case.

This should give us a sufficient grace period to upload all of our logs
in the case that a build fails due to a test hang.
