### PR TITLE
Disconnect client/Dispose Circuit on error

### DIFF
--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -2047,6 +2047,127 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
+        public void RenderBatch_HandlesExceptionsFromAllDisposedComponents()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var exception1 = new Exception();
+            var exception2 = new Exception();
+
+            var firstRender = true;
+            var component = new TestComponent(builder =>
+            {
+                if (firstRender)
+                {
+                    builder.AddContent(0, "Hello");
+                    builder.OpenComponent<DisposableComponent>(1);
+                    builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<DisposableComponent>(2);
+                    builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception2));
+                    builder.CloseComponent();
+                }
+            });
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+
+            // Act: Second render
+            firstRender = false;
+            component.TriggerRender();
+
+            // Assert: Applicable children are included in disposal list
+            Assert.Equal(2, renderer.Batches.Count);
+            Assert.Equal(new[] { 1, 2 }, renderer.Batches[1].DisposedComponentIDs);
+
+            // Outer component is still alive and not disposed.
+            Assert.False(component.Disposed);
+            var aex = Assert.IsType<AggregateException>(Assert.Single(renderer.HandledExceptions));
+            Assert.Contains(exception1, aex.InnerExceptions);
+            Assert.Contains(exception2, aex.InnerExceptions);
+        }
+
+        [Fact]
+        public void RenderBatch_DoesNotDisposeComponentMultipleTimes()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var exception1 = new Exception();
+            var exception2 = new Exception();
+
+            var count1 = 0;
+            var count2 = 0;
+            var count3 = 0;
+            var count4 = 0;
+            var count5 = 0;
+
+            var firstRender = true;
+            var component = new TestComponent(builder =>
+            {
+                if (firstRender)
+                {
+                    builder.AddContent(0, "Hello");
+                    builder.OpenComponent<DisposableComponent>(1);
+                    builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count1++; }));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<DisposableComponent>(2);
+                    builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count2++; throw exception1; }));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<DisposableComponent>(3);
+                    builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count3++; }));
+                    builder.CloseComponent();
+                }
+
+                builder.OpenComponent<DisposableComponent>(4);
+                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count4++; throw exception2; }));
+                builder.CloseComponent();
+
+                builder.OpenComponent<DisposableComponent>(5);
+                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count5++; }));
+                builder.CloseComponent();
+            });
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+
+            // Act: Second render
+            firstRender = false;
+            component.TriggerRender();
+
+            // Assert: Applicable children are included in disposal list
+            Assert.Equal(2, renderer.Batches.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, renderer.Batches[1].DisposedComponentIDs);
+
+            // Components "disposed" in the batch were all disposed, components that are still live were not disposed
+            Assert.Equal(1, count1);
+            Assert.Equal(1, count2);
+            Assert.Equal(1, count3);
+            Assert.Equal(0, count4);
+            Assert.Equal(0, count5);
+
+            // Outer component is still alive and not disposed.
+            Assert.False(component.Disposed);
+            var ex = Assert.IsType<Exception>(Assert.Single(renderer.HandledExceptions));
+            Assert.Same(exception1, ex);
+
+            // Act: Dispose renderer
+            renderer.Dispose();
+
+            Assert.Equal(2, renderer.HandledExceptions.Count);
+            ex = renderer.HandledExceptions[1];
+            Assert.Same(exception2, ex);
+
+            // Assert: Everything was disposed once.
+            Assert.Equal(1, count1);
+            Assert.Equal(1, count2);
+            Assert.Equal(1, count3);
+            Assert.Equal(1, count4);
+            Assert.Equal(1, count5);
+            Assert.True(component.Disposed);
+        }
+
+        [Fact]
         public async Task DisposesEventHandlersWhenAttributeValueChanged()
         {
             // Arrange
@@ -3059,7 +3180,7 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
-        public async Task ExceptionsThrownFromHandleAfterRender_AreHandled()
+        public async Task ExceptionsThrownFromHandleAfterRender_Sync_AreHandled()
         {
             // Arrange
             var renderer = new TestRenderer { ShouldHandleExceptions = true };
@@ -3078,7 +3199,7 @@ namespace Microsoft.AspNetCore.Components.Test
                     {
                         new NestedAsyncComponent.ExecutionAction
                         {
-                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncSync,
                             EventAction = () =>
                             {
                                 throw exception;
@@ -3089,12 +3210,11 @@ namespace Microsoft.AspNetCore.Components.Test
                     {
                         new NestedAsyncComponent.ExecutionAction
                         {
-                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
-                            EventAction = async () =>
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncSync,
+                            EventAction = () =>
                             {
-                                await Task.Yield();
                                 taskCompletionSource.TrySetResult(0);
-                                return (1, NestedAsyncComponent.EventType.OnAfterRenderAsync);
+                                return Task.FromResult((1, NestedAsyncComponent.EventType.OnAfterRenderAsyncSync));
                             },
                         }
                     }
@@ -3111,6 +3231,137 @@ namespace Microsoft.AspNetCore.Components.Test
             // OnAfterRenderAsync happens in the background. Make it more predictable, by gating it until we're ready to capture exceptions.
             await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
             Assert.Same(exception, Assert.Single(renderer.HandledExceptions).GetBaseException());
+        }
+
+        [Fact]
+        public async Task ExceptionsThrownFromHandleAfterRender_Async_AreHandled()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new NestedAsyncComponent();
+            var exception = new InvalidTimeZoneException();
+
+            var taskCompletionSource = new TaskCompletionSource<int>();
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            var renderTask = renderer.RenderRootComponentAsync(componentId, ParameterView.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(NestedAsyncComponent.EventActions)] = new Dictionary<int, IList<NestedAsyncComponent.ExecutionAction>>
+                {
+                    [0] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncAsync,
+                            EventAction = async () =>
+                            {
+                                await Task.Yield();
+                                throw exception;
+                            },
+                        }
+                    },
+                    [1] = new[]
+                    {
+                        new NestedAsyncComponent.ExecutionAction
+                        {
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncAsync,
+                            EventAction = async () =>
+                            {
+                                await Task.Yield();
+                                taskCompletionSource.TrySetResult(0);
+                                return (1, NestedAsyncComponent.EventType.OnAfterRenderAsyncAsync);
+                            },
+                        }
+                    }
+                },
+                [nameof(NestedAsyncComponent.WhatToRender)] = new Dictionary<int, Func<NestedAsyncComponent, RenderFragment>>
+                {
+                    [0] = CreateRenderFactory(new[] { 1 }),
+                    [1] = CreateRenderFactory(Array.Empty<int>()),
+                },
+            }));
+
+            Assert.True(renderTask.IsCompletedSuccessfully);
+
+            // OnAfterRenderAsync happens in the background. Make it more predictable, by gating it until we're ready to capture exceptions.
+            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
+            Assert.Same(exception, Assert.Single(renderer.HandledExceptions).GetBaseException());
+        }
+
+        [Fact]
+        public async Task ExceptionThrownFromConstructor()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<ConstructorThrowingComponent>(0);
+                builder.CloseComponent();
+            });
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            var renderTask = renderer.RenderRootComponentAsync(componentId);
+
+            await renderTask;
+            Assert.True(renderTask.IsCompletedSuccessfully);
+            Assert.Same(ConstructorThrowingComponent.Exception, Assert.Single(renderer.HandledExceptions).GetBaseException());
+        }
+
+        private class ConstructorThrowingComponent : IComponent
+        {
+            public static readonly Exception Exception = new InvalidTimeZoneException();
+
+            public ConstructorThrowingComponent()
+            {
+                throw Exception;
+            }
+
+            public void Attach(RenderHandle renderHandle)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task SetParametersAsync(ParameterView parameters)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public async Task ExceptionThrownFromAttach()
+        {
+            // Arrange
+            var renderer = new TestRenderer { ShouldHandleExceptions = true };
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<AttachThrowingComponent>(0);
+                builder.CloseComponent();
+            });
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            var renderTask = renderer.RenderRootComponentAsync(componentId);
+
+            await renderTask;
+            Assert.True(renderTask.IsCompletedSuccessfully);
+            Assert.Same(AttachThrowingComponent.Exception, Assert.Single(renderer.HandledExceptions).GetBaseException());
+        }
+
+        private class AttachThrowingComponent : IComponent
+        {
+            public static readonly Exception Exception = new InvalidTimeZoneException();
+
+            public void Attach(RenderHandle renderHandle)
+            {
+                throw Exception;
+            }
+
+            public Task SetParametersAsync(ParameterView parameters)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         [Fact]
@@ -3132,7 +3383,7 @@ namespace Microsoft.AspNetCore.Components.Test
                     {
                         new NestedAsyncComponent.ExecutionAction
                         {
-                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncAsync,
                             EventAction = () => tcs.Task,
                         }
                     },
@@ -3166,7 +3417,7 @@ namespace Microsoft.AspNetCore.Components.Test
                     {
                         new NestedAsyncComponent.ExecutionAction
                         {
-                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncAsync,
                             EventAction = () => tcs.Task,
                         }
                     },
@@ -3203,7 +3454,7 @@ namespace Microsoft.AspNetCore.Components.Test
                     {
                         new NestedAsyncComponent.ExecutionAction
                         {
-                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsync,
+                            Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncSync,
                             EventAction = () =>
                             {
                                 taskCompletionSource.TrySetResult(0);
@@ -3291,9 +3542,9 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // All components must be disposed even if some throw as part of being diposed.
             Assert.True(component.Disposed);
-            Assert.Equal(2, renderer.HandledExceptions.Count);
-            Assert.Contains(exception1, renderer.HandledExceptions);
-            Assert.Contains(exception2, renderer.HandledExceptions);
+            var aex = Assert.IsType<AggregateException>(Assert.Single(renderer.HandledExceptions));
+            Assert.Contains(exception1, aex.InnerExceptions);
+            Assert.Contains(exception2, aex.InnerExceptions);
         }
 
         [Theory]
@@ -3941,6 +4192,7 @@ namespace Microsoft.AspNetCore.Components.Test
                 if (TryGetEntry(EventType.OnInit, out var entry))
                 {
                     var result = entry.EventAction();
+                    Assert.True(result.IsCompleted, "Task must complete synchronously.");
                     LogResult(result.Result);
                 }
             }
@@ -3949,8 +4201,9 @@ namespace Microsoft.AspNetCore.Components.Test
             {
                 if (TryGetEntry(EventType.OnInitAsyncSync, out var entrySync))
                 {
-                    var result = await entrySync.EventAction();
-                    LogResult(result);
+                    var result = entrySync.EventAction();
+                    Assert.True(result.IsCompleted, "Task must complete synchronously.");
+                    LogResult(result.Result);
                 }
                 else if (TryGetEntry(EventType.OnInitAsyncAsync, out var entryAsync))
                 {
@@ -3964,6 +4217,7 @@ namespace Microsoft.AspNetCore.Components.Test
                 if (TryGetEntry(EventType.OnParametersSet, out var entry))
                 {
                     var result = entry.EventAction();
+                    Assert.True(result.IsCompleted, "Task must complete synchronously.");
                     LogResult(result.Result);
                 }
                 base.OnParametersSet();
@@ -3973,10 +4227,9 @@ namespace Microsoft.AspNetCore.Components.Test
             {
                 if (TryGetEntry(EventType.OnParametersSetAsyncSync, out var entrySync))
                 {
-                    var result = await entrySync.EventAction();
-                    LogResult(result);
-
-                    await entrySync.EventAction();
+                    var result = entrySync.EventAction();
+                    Assert.True(result.IsCompleted, "Task must complete synchronously.");
+                    LogResult(result.Result);
                 }
                 else if (TryGetEntry(EventType.OnParametersSetAsyncAsync, out var entryAsync))
                 {
@@ -3993,9 +4246,15 @@ namespace Microsoft.AspNetCore.Components.Test
 
             protected override async Task OnAfterRenderAsync()
             {
-                if (TryGetEntry(EventType.OnAfterRenderAsync, out var entry))
+                if (TryGetEntry(EventType.OnAfterRenderAsyncSync, out var entrySync))
                 {
-                    var result = await entry.EventAction();
+                    var result = entrySync.EventAction();
+                    Assert.True(result.IsCompleted, "Task must complete synchronously.");
+                    LogResult(result.Result);
+                }
+                if (TryGetEntry(EventType.OnAfterRenderAsyncAsync, out var entryAsync))
+                {
+                    var result = await entryAsync.EventAction();
                     LogResult(result);
                 }
             }
@@ -4054,7 +4313,8 @@ namespace Microsoft.AspNetCore.Components.Test
                 OnParametersSet,
                 OnParametersSetAsyncSync,
                 OnParametersSetAsyncAsync,
-                OnAfterRenderAsync,
+                OnAfterRenderAsyncSync,
+                OnAfterRenderAsyncAsync,
             }
         }
 

--- a/src/Components/Server/src/CircuitDisconnectMiddleware.cs
+++ b/src/Components/Server/src/CircuitDisconnectMiddleware.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Components.Server
         {
             try
             {
-                await Registry.Terminate(circuitId);
+                await Registry.TerminateAsync(circuitId);
                 Log.CircuitTerminatedGracefully(Logger, circuitId);
             }
             catch (Exception e)

--- a/src/Components/Server/src/Circuits/CircuitHandle.cs
+++ b/src/Components/Server/src/Circuits/CircuitHandle.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits
+{
+    // Used to isolate a circuit from a CircuitHost.
+    //
+    // We can't refer to Hub.Items from a CircuitHost - but we want need to be
+    // able to break the link between Hub.Items and a CircuitHost.
+    internal class CircuitHandle
+    {
+        public CircuitHost CircuitHost { get; set; }
+    }
+}

--- a/src/Components/Server/src/Circuits/CircuitRegistry.cs
+++ b/src/Components/Server/src/Circuits/CircuitRegistry.cs
@@ -79,6 +79,10 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 // This will likely never happen, except perhaps in unit tests, since CircuitIds are unique.
                 throw new ArgumentException($"Circuit with identity {circuitHost.CircuitId} is already registered.");
             }
+
+            // Register for unhandled exceptions from the circuit. The registry is responsible for tearing
+            // down the circuit on errors.
+            circuitHost.UnhandledException += CircuitHost_UnhandledException;
         }
 
         public virtual Task DisconnectAsync(CircuitHost circuitHost, string connectionId)
@@ -154,6 +158,16 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             DisconnectedCircuits.Set(circuitHost.CircuitId, entry, entryOptions);
         }
 
+        // ConnectAsync is called from the CircuitHub - but the error handling story is a little bit complicated.
+        // We return the circuit from this method, but need to clean up the circuit on failure. So we don't want to
+        // throw from this method because we don't want to return a *failed* circuit.
+        //
+        // The solution is to handle exceptions here, and then return null to represent failure.
+        //
+        // 1. If the circuit id is invalue return null
+        // 2. If the circuit is not found return null
+        // 3. If the circuit is found, but fails to connect, we need to dispose it here and return null
+        // 4. If everything goes well, return the circuit.
         public virtual async Task<CircuitHost> ConnectAsync(string circuitId, IClientProxy clientProxy, string connectionId, CancellationToken cancellationToken)
         {
             Log.CircuitConnectStarted(_logger, circuitId);
@@ -169,6 +183,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             Task circuitHandlerTask;
 
+            // We don't expect any of the logic inside the lock to throw, or run user code.
             lock (CircuitRegistryLock)
             {
                 // Transition the host from disconnected to connected if it's available. In this critical section, we return
@@ -188,7 +203,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 // b) out of order connection-up \ connection-down events e.g. a client that disconnects as soon it finishes reconnecting.
 
                 // Dispatch the circuit handlers inside the sync context to ensure the order of execution. CircuitHost executes circuit handlers inside of
-                // 
+                // the sync context.
                 circuitHandlerTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
                 {
                     if (previouslyConnected)
@@ -200,13 +215,22 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
                     await circuitHost.OnConnectionUpAsync(cancellationToken);
                 });
-
-                Log.ReconnectionSucceeded(_logger, circuitId);
             }
 
-            await circuitHandlerTask;
+            try
+            {
+                await circuitHandlerTask;
+                Log.ReconnectionSucceeded(_logger, circuitId);
+                return circuitHost;
+            }
+            catch (Exception ex)
+            {
+                Log.FailedToReconnectToCircuit(_logger, circuitId, ex);
+                await TerminateAsync(circuitId);
 
-            return circuitHost;
+                // Return null on failure, because we need to clean up the circuit.
+                return null;
+            }
         }
 
         protected virtual (CircuitHost circuitHost, bool previouslyConnected) ConnectCore(string circuitId, IClientProxy clientProxy, string connectionId)
@@ -268,6 +292,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             try
             {
+                entry.CircuitHost.UnhandledException -= CircuitHost_UnhandledException;
                 await entry.CircuitHost.DisposeAsync();
             }
             catch (Exception ex)
@@ -288,7 +313,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             }
         }
 
-        public ValueTask Terminate(string circuitId)
+        public ValueTask TerminateAsync(string circuitId)
         {
             CircuitHost circuitHost;
             DisconnectedCircuitEntry entry = default;
@@ -302,13 +327,33 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     Log.CircuitDisconnectedPermanently(_logger, circuitHost.CircuitId);
                     circuitHost.Client.SetDisconnected();
                 }
-                else
-                {
-                    return default;
-                }
             }
 
-            return circuitHost?.DisposeAsync() ?? default;
+            if (circuitHost != null)
+            {
+                circuitHost.UnhandledException -= CircuitHost_UnhandledException;
+                return circuitHost.DisposeAsync();
+            }
+
+            return default;
+        }
+
+        // We don't need to do anything with the exception here, logging and sending exceptions to the client
+        // is done inside the circuit host.
+        private async void CircuitHost_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            var circuitHost = (CircuitHost)sender;
+
+            try
+            {
+                // This will dispose the circuit and remove it from the registry.
+                await TerminateAsync(circuitHost.CircuitId);
+            }
+            catch (Exception ex)
+            {
+                // We don't expect TerminateAsync to throw, but we want exceptions here for completeness.
+                Log.CircuitExceptionHandlerFailed(_logger, circuitHost.CircuitId, ex);
+            }
         }
 
         private readonly struct DisconnectedCircuitEntry
@@ -339,6 +384,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             private static readonly Action<ILogger, string, Exception> _circuitMarkedDisconnected;
             private static readonly Action<ILogger, string, Exception> _circuitDisconnectedPermanently;
             private static readonly Action<ILogger, string, EvictionReason, Exception> _circuitEvicted;
+            private static readonly Action<ILogger, string, Exception> _circuitExceptionHandlerFailed;
 
             private static class EventIds
             {
@@ -355,6 +401,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 public static readonly EventId CircuitMarkedDisconnected = new EventId(110, "CircuitMarkedDisconnected");
                 public static readonly EventId CircuitEvicted = new EventId(111, "CircuitEvicted");
                 public static readonly EventId CircuitDisconnectedPermanently = new EventId(112, "CircuitDisconnectedPermanently");
+                public static readonly EventId CircuitExceptionHandlerFailed = new EventId(113, "CircuitExceptionHandlerFailed");
             }
 
             static Log()
@@ -428,6 +475,11 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     LogLevel.Debug,
                     EventIds.CircuitEvicted,
                     "Circuit with id {CircuitId} evicted due to {EvictionReason}.");
+
+                _circuitExceptionHandlerFailed = LoggerMessage.Define<string>(
+                    LogLevel.Error,
+                    EventIds.CircuitExceptionHandlerFailed,
+                    "Exception handler for {CircuitId} failed.");
             }
 
             public static void UnhandledExceptionDisposingCircuitHost(ILogger logger, Exception exception) =>
@@ -448,8 +500,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             public static void ConnectingToDisconnectedCircuit(ILogger logger, string circuitId, string connectionId) =>
                 _connectingToDisconnectedCircuit(logger, circuitId, connectionId, null);
 
-            public static void FailedToReconnectToCircuit(ILogger logger, string circuitId) =>
-                _failedToReconnectToCircuit(logger, circuitId, null);
+            public static void FailedToReconnectToCircuit(ILogger logger, string circuitId, Exception exception = null) =>
+                _failedToReconnectToCircuit(logger, circuitId, exception);
 
             public static void ReconnectionSucceeded(ILogger logger, string circuitId) =>
                 _reconnectionSucceeded(logger, circuitId, null);
@@ -471,6 +523,9 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             public static void CircuitEvicted(ILogger logger, string circuitId, EvictionReason evictionReason) =>
                _circuitEvicted(logger, circuitId, evictionReason, null);
+
+            public static void CircuitExceptionHandlerFailed(ILogger logger, string circuitId, Exception exception) =>
+                _circuitExceptionHandlerFailed(logger, circuitId, exception);
         }
     }
 }

--- a/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
@@ -6,12 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.AspNetCore.Components.Web.Rendering;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web.Rendering;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,9 +20,9 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
     {
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly ILogger _logger;
         private readonly CircuitIdFactory _circuitIdFactory;
         private readonly CircuitOptions _options;
+        private readonly ILogger _logger;
 
         public DefaultCircuitFactory(
             IServiceScopeFactory scopeFactory,
@@ -34,10 +31,11 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             IOptions<CircuitOptions> options)
         {
             _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
-            _loggerFactory = loggerFactory;
-            _logger = _loggerFactory.CreateLogger<CircuitFactory>();
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _circuitIdFactory = circuitIdFactory ?? throw new ArgumentNullException(nameof(circuitIdFactory));
-            _options = options.Value;
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+
+            _logger = _loggerFactory.CreateLogger<DefaultCircuitFactory>();
         }
 
         public override CircuitHost CreateCircuitHost(
@@ -49,7 +47,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             // We do as much intialization as possible eagerly in this method, which makes the error handling
             // story much simpler. If we throw from here, it's handled inside the initial hub method.
-            var components = ResolveComponentMetadata(httpContext, client);
+            var components = ResolveComponentMetadata(httpContext);
 
             var scope = _scopeFactory.CreateScope();
             var encoder = scope.ServiceProvider.GetRequiredService<HtmlEncoder>();
@@ -88,6 +86,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var circuitHost = new CircuitHost(
                 _circuitIdFactory.CreateCircuitId(),
                 scope,
+                _options,
                 client,
                 renderer,
                 components,
@@ -103,28 +102,17 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             return circuitHost;
         }
 
-        internal static List<ComponentDescriptor> ResolveComponentMetadata(HttpContext httpContext, CircuitClientProxy client)
+        public static IReadOnlyList<ComponentDescriptor> ResolveComponentMetadata(HttpContext httpContext)
         {
-            if (!client.Connected)
+            var endpoint = httpContext.GetEndpoint();
+            if (endpoint == null)
             {
-                // This is the prerendering case. Descriptors will be registered by the prerenderer.
-                return new List<ComponentDescriptor>();
+                throw new InvalidOperationException(
+                    $"{nameof(ComponentHub)} doesn't have an associated endpoint. " +
+                    "Use 'app.UseEndpoints(endpoints => endpoints.MapBlazorHub<App>(\"app\"))' to register your hub.");
             }
-            else
-            {
-                var endpointFeature = httpContext.Features.Get<IEndpointFeature>();
-                var endpoint = endpointFeature?.Endpoint;
-                if (endpoint == null)
-                {
-                    throw new InvalidOperationException(
-                        $"{nameof(ComponentHub)} doesn't have an associated endpoint. " +
-                        "Use 'app.UseEndpoints(endpoints => endpoints.MapBlazorHub<App>(\"app\"))' to register your hub.");
-                }
 
-                var componentsMetadata = endpoint.Metadata.OfType<ComponentDescriptor>().ToList();
-
-                return componentsMetadata;
-            }
+            return endpoint.Metadata.GetOrderedMetadata<ComponentDescriptor>();
         }
 
         private static class Log

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -7,15 +7,35 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Components.Server
 {
-    /// <summary>
-    /// A SignalR hub that accepts connections to an ASP.NET Core Components application.
-    /// </summary>
+    // Some notes about our expectations for error handling:
+    //
+    // In general, we need to prevent any client from interacting with a circuit that's in an unpredictable
+    // state. This means that when a circuit throws an unhandled exception our top priority is to
+    // unregister and dispose the circuit. This will prevent any new dispatches from the client
+    // from making it into application code.
+    //
+    // As part of this process, we also notify the client (if there is one) of the error, and we
+    // *expect* a well-behaved client to disconnect. A malicious client can't be expected to disconnect,
+    // but since we've unregistered the circuit they won't be able to access it anyway. When a call
+    // comes into any hub method and the circuit has been disassociated, we will abort the connection.
+    // It's safe to assume that's the result of a race condition or misbehaving client.
+    //
+    // Now it's important to remember that we can only abort a connection as part of a hub method call.
+    // We can dispose a circuit in the background, but we have to deal with a possible race condition
+    // any time we try to acquire access to the circuit - because it could have gone away in the
+    // background - outside of the scope of a hub method.
+    //
+    // In general we author our Hub methods as async methods, but we fire-and-forget anything that
+    // needs access to the circuit/application state to unblock the message loop. Using async in our
+    // Hub methods allows us to ensure message delivery to the client before we abort the connection
+    // in error cases.
     internal sealed class ComponentHub : Hub
     {
         private static readonly object CircuitKey = new object();
@@ -24,10 +44,6 @@ namespace Microsoft.AspNetCore.Components.Server
         private readonly CircuitOptions _options;
         private readonly ILogger _logger;
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not instantiate
-        /// this class directly.
-        /// </summary>
         public ComponentHub(
             CircuitFactory circuitFactory,
             CircuitRegistry circuitRegistry,
@@ -45,24 +61,11 @@ namespace Microsoft.AspNetCore.Components.Server
         /// </summary>
         public static PathString DefaultPath { get; } = "/_blazor";
 
-        /// <summary>
-        /// For unit testing only.
-        /// </summary>
-        // We store the circuit host in Context.Items which is tied to the lifetime of the underlying
-        // SignalR connection. There's no need to clean this up, it's a non-owning reference and it
-        // will go away when the connection does.
-        internal CircuitHost CircuitHost
-        {
-            get => (CircuitHost)Context.Items[CircuitKey];
-            private set => Context.Items[CircuitKey] = value;
-        }
-
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
         public override Task OnDisconnectedAsync(Exception exception)
         {
-            var circuitHost = CircuitHost;
+            // If the CircuitHost is gone now this isn't an error. This could happen if the disconnect
+            // if the result of well behaving client hanging up after an unhandled exception.
+            var circuitHost = GetCircuit();
             if (circuitHost == null)
             {
                 return Task.CompletedTask;
@@ -71,15 +74,16 @@ namespace Microsoft.AspNetCore.Components.Server
             return _circuitRegistry.DisconnectAsync(circuitHost, Context.ConnectionId);
         }
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
-        public string StartCircuit(string baseUri, string uri)
+        public async ValueTask<string> StartCircuit(string baseUri, string uri)
         {
-            if (CircuitHost != null)
+            var circuitHost = GetCircuit();
+            if (circuitHost != null)
             {
-                Log.CircuitAlreadyInitialized(_logger, CircuitHost.CircuitId);
-                NotifyClientError(Clients.Caller, $"The circuit host '{CircuitHost.CircuitId}' has already been initialized.");
+                // This is an error condition and an attempt to bind multiple circuits to a single connection.
+                // We can reject this and terminate the connection.
+                Log.CircuitAlreadyInitialized(_logger, circuitHost.CircuitId);
+                await NotifyClientError(Clients.Caller, $"The circuit host '{circuitHost.CircuitId}' has already been initialized.");
+                Context.Abort();
                 return null;
             }
 
@@ -90,33 +94,32 @@ namespace Microsoft.AspNetCore.Components.Server
             {
                 // We do some really minimal validation here to prevent obviously wrong data from getting in
                 // without duplicating too much logic.
+                //
+                // This is an error condition attempting to initialize the circuit in a way that would fail.
+                // We can reject this and terminate the connection.
                 Log.InvalidInputData(_logger);
-                _ = NotifyClientError(Clients.Caller, $"The uris provided are invalid.");
+                await NotifyClientError(Clients.Caller, $"The uris provided are invalid.");
+                Context.Abort();
                 return null;
             }
 
-            var circuitClient = new CircuitClientProxy(Clients.Caller, Context.ConnectionId);
-            if (DefaultCircuitFactory.ResolveComponentMetadata(Context.GetHttpContext(), circuitClient).Count == 0)
+            // From this point, we can try to actually initialize the circuit.
+            if (DefaultCircuitFactory.ResolveComponentMetadata(Context.GetHttpContext()).Count == 0)
             {
-                var endpointFeature = Context.GetHttpContext().Features.Get<IEndpointFeature>();
-                var endpoint = endpointFeature?.Endpoint;
-
-                Log.NoComponentsRegisteredInEndpoint(_logger, endpoint.DisplayName);
-
                 // No components preregistered so return. This is totally normal if the components were prerendered.
+                Log.NoComponentsRegisteredInEndpoint(_logger, Context.GetHttpContext().GetEndpoint()?.DisplayName);
                 return null;
             }
 
             try
             {
-                var circuitHost = _circuitFactory.CreateCircuitHost(
+                var circuitClient = new CircuitClientProxy(Clients.Caller, Context.ConnectionId);
+                circuitHost = _circuitFactory.CreateCircuitHost(
                     Context.GetHttpContext(),
                     circuitClient,
                     baseUri,
                     uri,
                     Context.User);
-
-                circuitHost.UnhandledException += CircuitHost_UnhandledException;
 
                 // Fire-and-forget the initialization process, because we can't block the
                 // SignalR message loop (we'd get a deadlock if any of the initialization
@@ -127,141 +130,136 @@ namespace Microsoft.AspNetCore.Components.Server
                 // It's safe to *publish* the circuit now because nothing will be able
                 // to run inside it until after InitializeAsync completes.
                 _circuitRegistry.Register(circuitHost);
-                CircuitHost = circuitHost;
+                SetCircuit(circuitHost);
                 return circuitHost.CircuitId;
             }
             catch (Exception ex)
             {
+                // If the circuit fails to initialize synchronously we can notify the client immediately
+                // and shut down the connection.
                 Log.CircuitInitializationFailed(_logger, ex);
-                NotifyClientError(Clients.Caller, "The circuit failed to initialize.");
+                await NotifyClientError(Clients.Caller, "The circuit failed to initialize.");
+                Context.Abort();
                 return null;
             }
         }
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
-        public async Task<bool> ConnectCircuit(string circuitId)
+        public async ValueTask<bool> ConnectCircuit(string circuitId)
         {
+            // ConnectionAsync will not throw.
             var circuitHost = await _circuitRegistry.ConnectAsync(circuitId, Clients.Caller, Context.ConnectionId, Context.ConnectionAborted);
             if (circuitHost != null)
             {
-                CircuitHost = circuitHost;
-                CircuitHost.UnhandledException += CircuitHost_UnhandledException;
-
+                SetCircuit(circuitHost);
                 circuitHost.SetCircuitUser(Context.User);
                 circuitHost.SendPendingBatches();
                 return true;
             }
 
+            // If we get here the circuit does not exist anymore. This is something that's valid for a client to
+            // recover from, and the client is not holding any resources right now other than the connection.
             return false;
         }
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
-        public void BeginInvokeDotNetFromJS(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson)
+        public async ValueTask BeginInvokeDotNetFromJS(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson)
         {
-            if (CircuitHost == null)
+            var circuitHost = await GetActiveCircuitAsync();
+            if (circuitHost == null)
             {
-                Log.CircuitHostNotInitialized(_logger);
-                _ = NotifyClientError(Clients.Caller, "Circuit not initialized.");
                 return;
             }
 
-            _ = CircuitHost.BeginInvokeDotNetFromJS(callId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
+             _ = circuitHost.BeginInvokeDotNetFromJS(callId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
         }
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
-        public void EndInvokeJSFromDotNet(long asyncHandle, bool succeeded, string arguments)
+        public async ValueTask EndInvokeJSFromDotNet(long asyncHandle, bool succeeded, string arguments)
         {
-            if (CircuitHost == null)
+            var circuitHost = await GetActiveCircuitAsync();
+            if (circuitHost == null)
             {
-                Log.CircuitHostNotInitialized(_logger);
-                _ = NotifyClientError(Clients.Caller, "Circuit not initialized.");
                 return;
             }
 
-            _ = CircuitHost.EndInvokeJSFromDotNet(asyncHandle, succeeded, arguments);
+             _ = circuitHost.EndInvokeJSFromDotNet(asyncHandle, succeeded, arguments);
         }
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
-        public void DispatchBrowserEvent(string eventDescriptor, string eventArgs)
+        public async ValueTask DispatchBrowserEvent(string eventDescriptor, string eventArgs)
         {
-            if (CircuitHost == null)
+            var circuitHost = await GetActiveCircuitAsync();
+            if (circuitHost == null)
             {
-                Log.CircuitHostNotInitialized(_logger);
-                _ = NotifyClientError(Clients.Caller, "Circuit not initialized.");
                 return;
             }
 
-            _ = CircuitHost.DispatchEvent(eventDescriptor, eventArgs);
+             _ = circuitHost.DispatchEvent(eventDescriptor, eventArgs);
         }
 
-        /// <summary>
-        /// Intended for framework use only. Applications should not call this method directly.
-        /// </summary>
-        public void OnRenderCompleted(long renderId, string errorMessageOrNull)
+        public async ValueTask OnRenderCompleted(long renderId, string errorMessageOrNull)
         {
-            if (CircuitHost == null)
+            var circuitHost = await GetActiveCircuitAsync();
+            if (circuitHost == null)
             {
-                Log.CircuitHostNotInitialized(_logger);
-                NotifyClientError(Clients.Caller, "Circuit not initialized.");
                 return;
             }
 
             Log.ReceivedConfirmationForBatch(_logger, renderId);
-            _ = CircuitHost.Renderer.OnRenderCompleted(renderId, errorMessageOrNull);
+            _ = circuitHost.Renderer.OnRenderCompleted(renderId, errorMessageOrNull);
         }
 
-        public void OnLocationChanged(string uri, bool intercepted)
+        public async ValueTask OnLocationChanged(string uri, bool intercepted)
         {
-            if (CircuitHost == null)
+            var circuitHost = await GetActiveCircuitAsync();
+            if (circuitHost == null)
             {
-                Log.CircuitHostNotInitialized(_logger);
-                NotifyClientError(Clients.Caller, "Circuit not initialized.");
                 return;
             }
 
-            _ = CircuitHost.OnLocationChangedAsync(uri, intercepted);
+             _ = circuitHost.OnLocationChangedAsync(uri, intercepted);
         }
 
-        private async void CircuitHost_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        // We store the CircuitHost through a *handle* here because Context.Items is tied to the lifetime
+        // of the connection. It's possible that a misbehaving client could cause disposal of a CircuitHost
+        // but keep a connection open indefinitely, preventing GC of the Circuit and related application state.
+        // Using a handle allows the CircuitHost to clear this reference in the background.
+        //
+        // See comment on error handling on the class definition.
+        private async ValueTask<CircuitHost> GetActiveCircuitAsync([CallerMemberName] string callSite = "")
         {
-            var circuitHost = (CircuitHost)sender;
-            var circuitId = circuitHost?.CircuitId;
-
-            try
+            var handle = (CircuitHandle)Context.Items[CircuitKey];
+            var circuitHost = handle?.CircuitHost;
+            if (handle != null && circuitHost == null)
             {
-                Log.UnhandledExceptionInCircuit(_logger, circuitId, (Exception)e.ExceptionObject);
-                if (_options.DetailedErrors)
-                {
-                    await NotifyClientError(circuitHost.Client, e.ExceptionObject.ToString());
-                }
-                else
-                {
-                    var message = $"There was an unhandled exception on the current circuit, so this circuit will be terminated. For more details turn on " +
-                        $"detailed exceptions in '{typeof(CircuitOptions).Name}.{nameof(CircuitOptions.DetailedErrors)}'";
-
-                    await NotifyClientError(circuitHost.Client, message);
-                }
-
-                // We generally can't abort the connection here since this is an async
-                // callback. The Hub has already been torn down. We'll rely on the
-                // client to abort the connection if we successfully transmit an error.
+                // This can occur when a circuit host does not exist anymore due to an unhandled exception.
+                // We can reject this and terminate the connection.
+                Log.CircuitHostShutdown(_logger, callSite);
+                await NotifyClientError(Clients.Caller, "Circuit has been shut down due to error.");
+                Context.Abort();
+                return null;
             }
-            catch (Exception ex)
+            else if (circuitHost == null)
             {
-                Log.FailedToTransmitException(_logger, circuitId, ex);
+                // This can occur when a circuit host does not exist anymore due to an unhandled exception.
+                // We can reject this and terminate the connection.
+                Log.CircuitHostNotInitialized(_logger, callSite);
+                await NotifyClientError(Clients.Caller, "Circuit not initialized.");
+                Context.Abort();
+                return null;
             }
+
+            return circuitHost;
         }
 
-        private static Task NotifyClientError(IClientProxy client, string error) =>
-            client.SendAsync("JS.Error", error);
+        private CircuitHost GetCircuit()
+        {
+            return ((CircuitHandle)Context.Items[CircuitKey])?.CircuitHost;
+        }
+
+        private void SetCircuit(CircuitHost circuitHost)
+        {
+            Context.Items[CircuitKey] = circuitHost?.Handle;
+        }
+
+        private static Task NotifyClientError(IClientProxy client, string error) => client.SendAsync("JS.Error", error);
 
         private static class Log
         {
@@ -274,14 +272,14 @@ namespace Microsoft.AspNetCore.Components.Server
             private static readonly Action<ILogger, string, Exception> _unhandledExceptionInCircuit =
                 LoggerMessage.Define<string>(LogLevel.Warning, new EventId(3, "UnhandledExceptionInCircuit"), "Unhandled exception in circuit {CircuitId}");
 
-            private static readonly Action<ILogger, string, Exception> _failedToTransmitException =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, "FailedToTransmitException"), "Failed to transmit exception to client in circuit {CircuitId}");
-
             private static readonly Action<ILogger, string, Exception> _circuitAlreadyInitialized =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, "CircuitAlreadyInitialized"), "The circuit host '{CircuitId}' has already been initialized");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, "CircuitAlreadyInitialized"), "The circuit host '{CircuitId}' has already been initialized");
 
             private static readonly Action<ILogger, string, Exception> _circuitHostNotInitialized =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, "CircuitHostNotInitialized"), "Call to '{CallSite}' received before the circuit host initialization");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, "CircuitHostNotInitialized"), "Call to '{CallSite}' received before the circuit host initialization");
+
+            private static readonly Action<ILogger, string, Exception> _circuitHostShutdown =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, "CircuitHostShutdown"), "Call to '{CallSite}' received after the circuit was shut down");
 
             private static readonly Action<ILogger, string, Exception> _circuitTerminatedGracefully =
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, "CircuitTerminatedGracefully"), "Circuit '{CircuitId}' terminated gracefully");
@@ -307,14 +305,11 @@ namespace Microsoft.AspNetCore.Components.Server
                 _unhandledExceptionInCircuit(logger, circuitId, exception);
             }
 
-            public static void FailedToTransmitException(ILogger logger, string circuitId, Exception transmissionException)
-            {
-                _failedToTransmitException(logger, circuitId, transmissionException);
-            }
-
             public static void CircuitAlreadyInitialized(ILogger logger, string circuitId) => _circuitAlreadyInitialized(logger, circuitId, null);
 
             public static void CircuitHostNotInitialized(ILogger logger, [CallerMemberName] string callSite = "") => _circuitHostNotInitialized(logger, callSite, null);
+
+            public static void CircuitHostShutdown(ILogger logger, [CallerMemberName] string callSite = "") => _circuitHostShutdown(logger, callSite, null);
 
             public static void CircuitTerminatedGracefully(ILogger logger, string circuitId) => _circuitTerminatedGracefully(logger, circuitId, null);
 

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.ExceptionServices;
 using System.Text.Encodings.Web;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Rendering;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,14 +16,9 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 {
     internal class TestCircuitHost : CircuitHost
     {
-        private TestCircuitHost(string circuitId, IServiceScope scope, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, CircuitHandler[] circuitHandlers, ILogger logger)
-            : base(circuitId, scope, client, renderer, descriptors, jsRuntime, circuitHandlers, logger)
+        private TestCircuitHost(string circuitId, IServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, CircuitHandler[] circuitHandlers, ILogger logger)
+            : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, circuitHandlers, logger)
         {
-        }
-
-        protected override void OnHandlerError(CircuitHandler circuitHandler, string handlerMethod, Exception ex)
-        {
-            ExceptionDispatchInfo.Capture(ex).Throw();
         }
 
         public static CircuitHost Create(
@@ -55,6 +48,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             return new TestCircuitHost(
                 circuitId ?? Guid.NewGuid().ToString(),
                 serviceScope,
+                new CircuitOptions(),
                 clientProxy,
                 remoteRenderer,
                 new List<ComponentDescriptor>(),

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -16,8 +16,9 @@
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
     <BaseOutputPath />
     
-    
     <OutputPath />
+
+    <GenerateLoggingTestingAssemblyAttributes>false</GenerateLoggingTestingAssemblyAttributes>
 
   </PropertyGroup>
 
@@ -29,6 +30,7 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
+    <Reference Include="Microsoft.Extensions.Logging.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -10,28 +11,63 @@ using Ignitor;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
-    [Flaky("https://github.com/aspnet/AspNetCore/issues/12940", FlakyOn.All)]
-    public class InteropReliabilityTests : IClassFixture<AspNetSiteServerFixture>
+    public class InteropReliabilityTests : IClassFixture<AspNetSiteServerFixture>, IDisposable
     {
-        private static readonly TimeSpan DefaultLatencyTimeout = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan DefaultLatencyTimeout = TimeSpan.FromSeconds(30);
         private readonly AspNetSiteServerFixture _serverFixture;
 
-        public InteropReliabilityTests(AspNetSiteServerFixture serverFixture)
+        public InteropReliabilityTests(AspNetSiteServerFixture serverFixture, ITestOutputHelper output)
         {
-            serverFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
             _serverFixture = serverFixture;
+            Output = output;
+
+            serverFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
+            CreateDefaultConfiguration();
         }
 
-        public BlazorClient Client { get; set; } = new BlazorClient() { DefaultLatencyTimeout = DefaultLatencyTimeout };
+        public BlazorClient Client { get; set; }
+        public ITestOutputHelper Output { get; set; }
+        private IList<Batch> Batches { get; set; } = new List<Batch>();
+        private List<DotNetCompletion> DotNetCompletions = new List<DotNetCompletion>();
+        private List<JSInteropCall> JSInteropCalls = new List<JSInteropCall>();
+        private IList<string> Errors { get; set; } = new List<string>();
+        private ConcurrentQueue<LogMessage> Logs { get; set; } = new ConcurrentQueue<LogMessage>();
+
+        public TestSink TestSink { get; set; }
+
+        private void CreateDefaultConfiguration()
+        {
+            Client = new BlazorClient() { DefaultLatencyTimeout = DefaultLatencyTimeout };
+            Client.RenderBatchReceived += (id, data) => Batches.Add(new Batch(id, data));
+            Client.DotNetInteropCompletion += (method) => DotNetCompletions.Add(new DotNetCompletion(method));
+            Client.JSInterop += (asyncHandle, identifier, argsJson) => JSInteropCalls.Add(new JSInteropCall(asyncHandle, identifier, argsJson));
+            Client.OnCircuitError += (error) => Errors.Add(error);
+            Client.LoggerProvider = new XunitLoggerProvider(Output);
+            Client.FormatError = (error) =>
+            {
+                var logs = string.Join(Environment.NewLine, Logs);
+                return new Exception(error + Environment.NewLine + logs);
+            };
+
+            _ = _serverFixture.RootUri; // this is needed for the side-effects of getting the URI.
+            TestSink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
+            TestSink.MessageLogged += LogMessages;
+        }
+
+        private void LogMessages(WriteContext context)
+        {
+            var log = new LogMessage(context.LogLevel, context.Message, context.Exception);
+            Logs.Enqueue(log);
+            Output.WriteLine(log.ToString());
+        }
 
         [Fact]
         public async Task CannotInvokeNonJSInvokableMethods()
@@ -40,8 +76,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027WriteAllText\\u0027 on assembly \\u0027System.IO.FileSystem\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -52,9 +87,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new[] { ".\\log.txt", "log" }));
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -64,8 +98,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027MadeUpMethod\\u0027 on assembly \\u0027BasicTestApp\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -76,19 +110,19 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new[] { ".\\log.txt", "log" }));
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/12940")]
+        [Fact]
         public async Task CannotInvokeJSInvokableMethodsWithWrongNumberOfArguments()
         {
             // Arrange
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027NotifyLocationChanged\\u0027 on assembly \\u0027Microsoft.AspNetCore.Components.Server\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -99,9 +133,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new[] { _serverFixture.RootUri }));
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -111,8 +144,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027NotifyLocationChanged\\u0027 on assembly \\u0027\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -123,9 +156,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new object[] { _serverFixture.RootUri + "counter", false }));
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -135,8 +167,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027\\u0027 on assembly \\u0027Microsoft.AspNetCore.Components.Server\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -147,9 +179,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new object[] { _serverFixture.RootUri + "counter", false }));
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
 
-            await ValidateClientKeepsWorking(Client, batches);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -160,8 +192,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027Reverse\\u0027 on assembly \\u0027\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -171,7 +203,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 null,
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
-            Assert.Single(dotNetCompletions, expectedDotNetObjectRef);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedDotNetObjectRef);
 
             await Client.InvokeDotNetMethod(
                 "1",
@@ -181,7 +213,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
             // Assert
-            Assert.Single(dotNetCompletions, "[\"1\",true,\"tnatropmI\"]");
+            Assert.Single(DotNetCompletions, c => c.Message == "[\"1\",true,\"tnatropmI\"]");
 
             await Client.InvokeDotNetMethod(
                 "1",
@@ -190,9 +222,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 3, // non existing ref
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
-            Assert.Single(dotNetCompletions, expectedError);
-
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -204,8 +235,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027ReceiveTrivial\\u0027 on assembly \\u0027BasicTestApp\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
 
             await Client.InvokeDotNetMethod(
                 "1",
@@ -214,7 +244,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 null,
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
-            Assert.Single(dotNetCompletions, expectedImportantDotNetObjectRef);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedImportantDotNetObjectRef);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -225,9 +255,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new object[] { new { __dotNetObject = 1 } }));
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -236,16 +265,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             // Arrange
             var expectedError = "An exception occurred executing JS interop: The JSON value could not be converted to System.Int32. Path: $ | LineNumber: 0 | BytePositionInLine: 3.. See InnerException for more details.";
 
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.ClickAsync("triggerjsinterop-malformed");
 
-            var call = interopCalls.FirstOrDefault(call => call.identifier == "sendMalformedCallbackReturn");
+            var call = JSInteropCalls.FirstOrDefault(call => call.Identifier == "sendMalformedCallbackReturn");
             Assert.NotEqual(default, call);
 
-            var id = call.id;
+            var id = call.AsyncHandle;
             await Client.HubConnection.InvokeAsync(
                 "EndInvokeJSFromDotNet",
                 id,
@@ -256,41 +284,25 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 Client.FindElementById("errormessage-malformed").Children.OfType<TextNode>(),
                 e => expectedError == e.TextContent);
 
-            await ValidateClientKeepsWorking(Client, batches);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/12940")]
-        public async Task LogsJSInteropCompletionsCallbacksAndContinuesWorkingInAllSituations()
+        [Fact]
+        public async Task JSInteropCompletionSuccess()
         {
             // Arrange
-
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
             var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
             var logEvents = new List<(LogLevel logLevel, string)>();
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
-            await Client.ClickAsync("triggerjsinterop-malformed");
+            await Client.ClickAsync("triggerjsinterop-success");
 
-            var call = interopCalls.FirstOrDefault(call => call.identifier == "sendMalformedCallbackReturn");
+            var call = JSInteropCalls.FirstOrDefault(call => call.Identifier == "sendSuccessCallbackReturn");
             Assert.NotEqual(default, call);
 
-            var id = call.id;
-            await Client.HubConnection.InvokeAsync(
-                "EndInvokeJSFromDotNet",
-                id,
-                true,
-                $"[{id}, true, }}");
-
-            // A completely malformed payload like the one above never gets to the application.
-            Assert.Single(
-                Client.FindElementById("errormessage-malformed").Children.OfType<TextNode>(),
-                e => "" == e.TextContent);
-
-            Assert.Contains((LogLevel.Debug, "EndInvokeDispatchException"), logEvents);
-
-            await Client.ClickAsync("triggerjsinterop-success");
+            var id = call.AsyncHandle;
             await Client.HubConnection.InvokeAsync(
                 "EndInvokeJSFromDotNet",
                 id++,
@@ -302,13 +314,32 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 e => "" == e.TextContent);
 
             Assert.Contains((LogLevel.Debug, "EndInvokeJSSucceeded"), logEvents);
+        }
 
+        [Fact]
+        public async Task JSInteropThrowsInUserCode()
+        {
+            // Arrange
+            await GoToTestComponent(Batches);
+            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
+            var logEvents = new List<(LogLevel logLevel, string)>();
+            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
+
+            // Act
             await Client.ClickAsync("triggerjsinterop-failure");
-            await Client.HubConnection.InvokeAsync(
-                "EndInvokeJSFromDotNet",
-                id++,
-                false,
-                $"[{id}, false, \"There was an error invoking sendFailureCallbackReturn\"]");
+
+            var call = JSInteropCalls.FirstOrDefault(call => call.Identifier == "sendFailureCallbackReturn");
+            Assert.NotEqual(default, call);
+
+            var id = call.AsyncHandle;
+            await Client.ExpectRenderBatch(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
+                    "EndInvokeJSFromDotNet",
+                    id,
+                    false,
+                    $"[{id}, false, \"There was an error invoking sendFailureCallbackReturn\"]");
+            });
 
             Assert.Single(
                 Client.FindElementById("errormessage-failure").Children.OfType<TextNode>(),
@@ -318,7 +349,45 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             Assert.DoesNotContain(logEvents, m => m.logLevel > LogLevel.Information);
 
-            await ValidateClientKeepsWorking(Client, batches);
+            await ValidateClientKeepsWorking(Client, Batches);
+        }
+
+        [Fact]
+        public async Task MalformedJSInteropCallbackDisposesCircuit()
+        {
+            // Arrange
+            await GoToTestComponent(Batches);
+            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
+            var logEvents = new List<(LogLevel logLevel, string)>();
+            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
+
+            // Act
+            await Client.ClickAsync("triggerjsinterop-malformed");
+
+            var call = JSInteropCalls.FirstOrDefault(call => call.Identifier == "sendMalformedCallbackReturn");
+            Assert.NotEqual(default, call);
+
+            var id = call.AsyncHandle;
+            await Client.ExpectCircuitError(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
+                    "EndInvokeJSFromDotNet",
+                    id,
+                    true,
+                    $"[{id}, true, }}");
+            });
+
+            // A completely malformed payload like the one above never gets to the application.
+            Assert.Single(
+                Client.FindElementById("errormessage-malformed").Children.OfType<TextNode>(),
+                e => "" == e.TextContent);
+
+            Assert.Contains((LogLevel.Debug, "EndInvokeDispatchException"), logEvents);
+
+            await Client.ExpectCircuitErrorAndDisconnect(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: true));
+            });
         }
 
         [Fact]
@@ -329,8 +398,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027NotifyLocationChanged\\u0027 on assembly \\u0027Microsoft.AspNetCore.Components.Server\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -341,8 +409,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "[ \"invalidPayload\"}");
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
@@ -353,8 +421,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027ReceiveTrivial\\u0027 on assembly \\u0027BasicTestApp\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            var (_, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -365,62 +432,73 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "[ { \"data\": {\"}} ]");
 
             // Assert
-            Assert.Single(dotNetCompletions, expectedError);
-            await ValidateClientKeepsWorking(Client, batches);
+            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
-        public async Task DispatchingEventsWithInvalidPayloadsDoesNotCrashTheCircuit()
+        public async Task DispatchingEventsWithInvalidPayloadsShutsDownCircuitGracefully()
         {
             // Arrange
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
             var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
             var logEvents = new List<(LogLevel logLevel, string)>();
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
-            await Client.HubConnection.InvokeAsync(
+            await Client.ExpectCircuitError(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
                 "DispatchBrowserEvent",
                 null,
                 null);
+            });
 
             Assert.Contains(
                 (LogLevel.Debug, "DispatchEventFailedToParseEventData"),
                 logEvents);
 
-            await ValidateClientKeepsWorking(Client, batches);
+            // Taking any other action will fail because the circuit is disposed.
+            await Client.ExpectCircuitErrorAndDisconnect(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: true));
+            });
         }
 
         [Fact]
         public async Task DispatchingEventsWithInvalidEventDescriptor()
         {
             // Arrange
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
             var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
             var logEvents = new List<(LogLevel logLevel, string)>();
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
-            await Client.HubConnection.InvokeAsync(
+            await Client.ExpectCircuitError(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
                 "DispatchBrowserEvent",
                 "{Invalid:{\"payload}",
                 "{}");
+            });
 
             Assert.Contains(
                 (LogLevel.Debug, "DispatchEventFailedToParseEventData"),
                 logEvents);
 
-            await ValidateClientKeepsWorking(Client, batches);
+            // Taking any other action will fail because the circuit is disposed.
+            await Client.ExpectCircuitErrorAndDisconnect(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: true));
+            });
         }
 
         [Fact]
         public async Task DispatchingEventsWithInvalidEventArgs()
         {
             // Arrange
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
             var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
             var logEvents = new List<(LogLevel logLevel, string)>();
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
@@ -433,24 +511,30 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 EventArgsType = "mouse",
             };
 
-            await Client.HubConnection.InvokeAsync(
-                "DispatchBrowserEvent",
-                JsonSerializer.Serialize(browserDescriptor, TestJsonSerializerOptionsProvider.Options),
-                "{Invalid:{\"payload}");
+            await Client.ExpectCircuitError(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
+                    "DispatchBrowserEvent",
+                    JsonSerializer.Serialize(browserDescriptor, TestJsonSerializerOptionsProvider.Options),
+                    "{Invalid:{\"payload}");
+            });
 
             Assert.Contains(
                 (LogLevel.Debug, "DispatchEventFailedToParseEventData"),
                 logEvents);
 
-            await ValidateClientKeepsWorking(Client, batches);
+            // Taking any other action will fail because the circuit is disposed.
+            await Client.ExpectCircuitErrorAndDisconnect(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: true));
+            });
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/12940")]
+        [Fact]
         public async Task DispatchingEventsWithInvalidEventHandlerId()
         {
             // Arrange
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
             var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
             var logEvents = new List<(LogLevel logLevel, string eventIdName, Exception exception)>();
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name, wc.Exception));
@@ -468,25 +552,31 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 EventArgsType = "mouse",
             };
 
-            await Client.HubConnection.InvokeAsync(
+            await Client.ExpectCircuitError(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
                 "DispatchBrowserEvent",
                 JsonSerializer.Serialize(browserDescriptor, TestJsonSerializerOptionsProvider.Options),
                 JsonSerializer.Serialize(mouseEventArgs, TestJsonSerializerOptionsProvider.Options));
+            });
 
             Assert.Contains(
                 logEvents,
                 e => e.eventIdName == "DispatchEventFailedToDispatchEvent" && e.logLevel == LogLevel.Debug &&
                      e.exception is ArgumentException ae && ae.Message.Contains("There is no event handler with ID 1"));
 
-            await ValidateClientKeepsWorking(Client, batches);
+            // Taking any other action will fail because the circuit is disposed.
+            await Client.ExpectCircuitErrorAndDisconnect(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: true));
+            });
         }
 
         [Fact]
         public async Task EventHandlerThrowsSyncExceptionTerminatesTheCircuit()
         {
             // Arrange
-            var (interopCalls, dotNetCompletions, batches) = ConfigureClient();
-            await GoToTestComponent(batches);
+            await GoToTestComponent(Batches);
             var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
             var logEvents = new List<(LogLevel logLevel, string eventIdName, Exception exception)>();
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name, wc.Exception));
@@ -496,12 +586,19 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             Assert.Contains(
                 logEvents,
-                e => LogLevel.Warning == e.logLevel &&
-                    "UnhandledExceptionInCircuit" == e.eventIdName &&
+                e => LogLevel.Error == e.logLevel &&
+                    "CircuitUnhandledException" == e.eventIdName &&
                     "Handler threw an exception" == e.exception.Message);
+
+            // Now if you try to click again, you will get *forcibly* disconnected for trying to talk to
+            // a circuit that's gone.
+            await Client.ExpectCircuitErrorAndDisconnect(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: true));
+            });
         }
 
-        private Task ValidateClientKeepsWorking(BlazorClient Client, List<(int, byte[])> batches) =>
+        private Task ValidateClientKeepsWorking(BlazorClient Client, IList<Batch> batches) =>
             ValidateClientKeepsWorking(Client, () => batches.Count);
 
         private async Task ValidateClientKeepsWorking(BlazorClient Client, Func<int> countAccessor)
@@ -512,7 +609,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Equal(currentBatches + 1, countAccessor());
         }
 
-        private async Task GoToTestComponent(List<(int, byte[])> batches)
+        private async Task GoToTestComponent(IList<Batch> batches)
         {
             var rootUri = _serverFixture.RootUri;
             Assert.True(await Client.ConnectAsync(new Uri(rootUri, "/subdir"), prerendered: false), "Couldn't connect to the app");
@@ -522,15 +619,64 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Equal(2, batches.Count);
         }
 
-        private (List<(int id, string identifier, string args)>, List<string>, List<(int, byte[])>) ConfigureClient()
+        public void Dispose()
         {
-            var interopCalls = new List<(int, string, string)>();
-            Client.JSInterop += (int arg1, string arg2, string arg3) => interopCalls.Add((arg1, arg2, arg3));
-            var batches = new List<(int, byte[])>();
-            Client.RenderBatchReceived += (renderer, data) => batches.Add((renderer, data));
-            var endInvokeDotNetCompletions = new List<string>();
-            Client.DotNetInteropCompletion += (completion) => endInvokeDotNetCompletions.Add(completion);
-            return (interopCalls, endInvokeDotNetCompletions, batches);
+            TestSink.MessageLogged -= LogMessages;
+        }
+
+        private class LogMessage
+        {
+            public LogMessage(LogLevel logLevel, string message, Exception exception)
+            {
+                LogLevel = logLevel;
+                Message = message;
+                Exception = exception;
+            }
+
+            public LogLevel LogLevel { get; set; }
+            public string Message { get; set; }
+            public Exception Exception { get; set; }
+
+            public override string ToString()
+            {
+                return $"{LogLevel}: {Message}{(Exception != null ? Environment.NewLine : "")}{Exception}";
+            }
+        }
+
+        private class Batch
+        {
+            public Batch(int id, byte[] data)
+            {
+                Id = id;
+                Data = data;
+            }
+
+            public int Id { get; }
+            public byte[] Data { get; }
+        }
+
+        private class DotNetCompletion
+        {
+            public DotNetCompletion(string message)
+            {
+                Message = message;
+            }
+
+            public string Message { get; }
+        }
+
+        private class JSInteropCall
+        {
+            public JSInteropCall(int asyncHandle, string identifier, string argsJson)
+            {
+                AsyncHandle = asyncHandle;
+                Identifier = identifier;
+                ArgsJson = argsJson;
+            }
+
+            public int AsyncHandle { get; }
+            public string Identifier { get; }
+            public string ArgsJson { get; }
         }
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -51,6 +51,7 @@
         <option value="BasicTestApp.MouseEventComponent">Mouse events</option>
         <option value="BasicTestApp.MovingCheckboxesComponent">Moving checkboxes diff case</option>
         <option value="BasicTestApp.MultipleChildContent">Multiple child content</option>
+        <option value="BasicTestApp.NavigationFailureComponent">Navigation failure</option>
         <option value="BasicTestApp.ParentChildComponent">Parent component with child</option>
         <option value="BasicTestApp.PropertiesChangedHandlerParent">Parent component that changes parameters on child</option>
         <option value="BasicTestApp.RazorTemplates">Razor Templates</option>

--- a/src/Components/test/testassets/BasicTestApp/InteropTest/JavaScriptInterop.cs
+++ b/src/Components/test/testassets/BasicTestApp/InteropTest/JavaScriptInterop.cs
@@ -1,17 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.JSInterop;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
 namespace BasicTestApp.InteropTest
 {
     public class JavaScriptInterop
     {
-        public static IDictionary<string, object[]> Invocations = new Dictionary<string, object[]>();
+        public static ConcurrentDictionary<string, object[]> Invocations = new ConcurrentDictionary<string, object[]>();
 
         [JSInvokable]
         public static void ThrowException() => throw new InvalidOperationException("Threw an exception!");

--- a/src/Components/test/testassets/BasicTestApp/NavigationFailureComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/NavigationFailureComponent.razor
@@ -1,0 +1,28 @@
+@implements IDisposable
+@inject NavigationManager Navigation
+@using Microsoft.AspNetCore.Components.Routing
+<p>
+    This component is used to test the behaviour when you attach to NavigationManager.LocationChanged
+    and throw an exception. We have a special code path to recognize this case and treat it as a failure
+    in user code rather than invalid input.
+
+    This component is used headless tests for error handling. Markup that's provided here is for manually
+    testing this case in the browser.
+</p>
+
+<a href="test">Click here for some fireworks.</a>
+
+@code {
+
+    protected override void OnInitialized()
+    {
+        Navigation.LocationChanged += NavigationManager_LocationChanged;
+    }
+
+    private void NavigationManager_LocationChanged(object sender, LocationChangedEventArgs e)
+    {
+        throw new InvalidTimeZoneException();
+    }
+
+    void IDisposable.Dispose() => Navigation.LocationChanged -= NavigationManager_LocationChanged;
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
@@ -1,6 +1,8 @@
 @using Microsoft.JSInterop
 @inject IJSRuntime JSRuntime
 @namespace BasicTestApp
+@using BasicTestApp.ServerReliability
+
 <h1>Server reliability</h1>
 <p>
     This component is used on the server-side execution model to validate that the circuit is resilient to failures, intentional or not.
@@ -23,12 +25,68 @@
 
 <button id="thecounter" @onclick="@IncrementCount">Click me</button>
 
+<button id="constructor-throw" @onclick="@(() => showConstructorThrow = true)">Trigger exception on constructor</button>
+@if (showConstructorThrow)
+{
+    <ThrowingConstructorComponent />
+}
+
+<button id="attach-throw" @onclick="@(() => showAttachThrow = true)">Trigger exception on Attach</button>
+@if (showAttachThrow)
+{
+    <ThrowingAttachComponent />
+}
+
+<button id="setparameters-sync-throw" @onclick="@(() => showSetParametersSyncThrow = true)">Trigger exception synchronously on SetParametersAsync</button>
+@if (showSetParametersSyncThrow)
+{
+    <ThrowingSetParametersSyncComponent />
+}
+
+<button id="setparameters-async-throw" @onclick="@(() => showSetParametersAsyncThrow = true)">Trigger exception synchronously on SetParametersAsync</button>
+@if (showSetParametersAsyncThrow)
+{
+    <ThrowingSetParametersAsyncComponent />
+}
+
+<button id="render-throw" @onclick="@(() => showRenderThrow = true)">Trigger exception during rendering</button>
+@if (showRenderThrow)
+{
+    <ThrowingRenderComponent />
+}
+
+<button id="afterrender-sync-throw" @onclick="@(() => showOnAfterRenderSyncThrow = true)">Trigger exception synchronously on OnAfterRenderAsync</button>
+@if (showOnAfterRenderSyncThrow)
+{
+    <ThrowingOnAfterRenderSyncComponent />
+}
+
+<button id="afterrender-async-throw" @onclick="@(() => showOnAfterRenderAsyncThrow = true)">Trigger exception asynchronously on OnAfterRenderAsync</button>
+@if (showOnAfterRenderAsyncThrow)
+{
+    <ThrowingOnAfterRenderAsyncComponent />
+}
+
+<button id="dispose-throw" @onclick="@(() => showDisposeThrow = !showDisposeThrow)">Trigger exception during Dispose</button>
+@if (showDisposeThrow)
+{
+    <ThrowingDisposeComponent />
+}
+
 @code
 {
     int currentCount = 0;
     string errorMalformed = "";
     string errorSuccess = "";
     string errorFailure = "";
+    bool showConstructorThrow;
+    bool showAttachThrow;
+    bool showSetParametersSyncThrow;
+    bool showSetParametersAsyncThrow;
+    bool showRenderThrow;
+    bool showOnAfterRenderSyncThrow;
+    bool showOnAfterRenderAsyncThrow;
+    bool showDisposeThrow;
 
     void IncrementCount()
     {

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingAttachComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingAttachComponent.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingAttachComponent : IComponent
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+            throw new InvalidTimeZoneException();
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingConstructorComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingConstructorComponent.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingConstructorComponent : IComponent
+    {
+        public ThrowingConstructorComponent()
+        {
+            throw new InvalidTimeZoneException();
+        }
+
+        public void Attach(RenderHandle renderHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingDisposeComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingDisposeComponent.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingDisposeComponent : IComponent, IDisposable
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+            renderHandle.Render(builder =>
+            {
+                // Do nothing.
+            });
+        }
+
+        public void Dispose()
+        {
+            throw new InvalidTimeZoneException();
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderAsyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderAsyncComponent.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingOnAfterRenderAsyncComponent : IComponent, IHandleAfterRender
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+            renderHandle.Render(builder =>
+            {
+                // Do nothing.
+            });
+        }
+
+        public async Task OnAfterRenderAsync()
+        {
+            await Task.Yield();
+            throw new InvalidTimeZoneException();
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderSyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderSyncComponent.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingOnAfterRenderSyncComponent : IComponent, IHandleAfterRender
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+            renderHandle.Render(builder =>
+            {
+                // Do nothing.
+            });
+        }
+
+        public Task OnAfterRenderAsync()
+        {
+            throw new InvalidTimeZoneException();
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingRenderComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingRenderComponent.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingRenderComponent : IComponent
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+            renderHandle.Render(builder =>
+            {
+                throw new InvalidTimeZoneException();
+            });
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersAsyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersAsyncComponent.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingSetParametersAsyncComponent : IComponent
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+        }
+
+        public async Task SetParametersAsync(ParameterView parameters)
+        {
+            await Task.Yield();
+            throw new InvalidTimeZoneException();
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersSyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersSyncComponent.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace BasicTestApp.ServerReliability
+{
+    public class ThrowingSetParametersSyncComponent : IComponent
+    {
+        public void Attach(RenderHandle renderHandle)
+        {
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            throw new InvalidTimeZoneException();
+        }
+    }
+}

--- a/src/Shared/E2ETesting/BrowserAssertFailedException.cs
+++ b/src/Shared/E2ETesting/BrowserAssertFailedException.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+namespace OpenQA.Selenium
+{
+    // Used to report errors when we find errors in the browser. This is useful
+    // because the underlying assert probably doesn't provide good information in that
+    // case.
+    public class BrowserAssertFailedException : XunitException
+    {
+        public BrowserAssertFailedException(IReadOnlyList<LogEntry> logs, Exception innerException)
+            : base(BuildMessage(logs), innerException)
+        {
+        }
+
+        private static string BuildMessage(IReadOnlyList<LogEntry> logs)
+        {
+            return
+                "Encountered browser errors while running assertion." + Environment.NewLine +
+                string.Join(Environment.NewLine, logs);
+        }
+    }
+}

--- a/src/Shared/E2ETesting/BrowserTestBase.cs
+++ b/src/Shared/E2ETesting/BrowserTestBase.cs
@@ -80,15 +80,14 @@ namespace Microsoft.AspNetCore.E2ETesting
 
         protected IWebElement WaitUntilExists(By findBy, int timeoutSeconds = 10, bool throwOnError = false)
         {
-            List<LogEntry> errors = null;
+            IReadOnlyList<LogEntry> errors = null;
             IWebElement result = null;
             new WebDriverWait(Browser, TimeSpan.FromSeconds(timeoutSeconds)).Until(driver =>
             {
                 if (throwOnError && Browser.Manage().Logs.AvailableLogTypes.Contains(LogType.Browser))
                 {
                     // Fail-fast if any errors were logged to the console.
-                    var log = Browser.Manage().Logs.GetLog(LogType.Browser);
-                    errors = log.Where(IsError).ToList();
+                    errors = Browser.GetBrowserLogs(LogLevel.Severe);
                     if (errors.Count > 0)
                     {
                         return true;

--- a/src/Shared/E2ETesting/WaitAssert.cs
+++ b/src/Shared/E2ETesting/WaitAssert.cs
@@ -73,7 +73,12 @@ namespace Microsoft.AspNetCore.E2ETesting
             }
             catch (WebDriverTimeoutException)
             {
-                if (lastException != null)
+                var errors = driver.GetBrowserLogs(LogLevel.Severe);
+                if (errors.Count > 0)
+                {
+                    throw new BrowserAssertFailedException(errors, lastException);
+                }
+                else if (lastException != null)
                 {
                     ExceptionDispatchInfo.Capture(lastException).Throw();
                 }

--- a/src/Shared/E2ETesting/WebDriverExtensions.cs
+++ b/src/Shared/E2ETesting/WebDriverExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenQA.Selenium
+{
+    public static class WebDriverExtensions
+    {
+        public static IReadOnlyList<LogEntry> GetBrowserLogs(this IWebDriver driver, LogLevel level)
+        {
+            if (driver is null)
+            {
+                throw new ArgumentNullException(nameof(driver));
+            }
+
+            // Fail-fast if any errors were logged to the console.
+            var log = driver.Manage().Logs.GetLog(LogType.Browser);
+            if (log == null)
+            {
+                return Array.Empty<LogEntry>();
+            }
+
+            var logs = log.Where(entry => entry.Level >= level && !ShouldIgnore(entry)).ToList();
+            if (logs.Count > 0)
+            {
+                return logs;
+            }
+
+            return Array.Empty<LogEntry>();
+        }
+
+        // Be careful adding anything new to this list. We only want to put things here that are ignorable
+        // in all cases.
+        private static bool ShouldIgnore(LogEntry entry)
+        {
+            // Don't fail if we're missing the favicon, that's not super important.
+            if (entry.Message.Contains("favicon.ico"))
+            {
+                return true;
+            }
+
+            // These two messages appear sometimes, but it doesn't actually block the tests.
+            if (entry.Message.Contains("WASM: wasm streaming compile failed: TypeError: Could not download wasm module"))
+            {
+                return true;
+            }
+            if (entry.Message.Contains("WASM: falling back to ArrayBuffer instantiation"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #11845

Heads up on a few things if you are reviewing this bad-boi:
- This assumes Javier's changes about disconnect handling will go in first (I did a mad katz cherry pick)
- You have no hope to review this without looking commit-by-commit - it will just look like I massacred `CircuitHost`. 

This does however express some of the main ideas, along with fixing some of the things that were needed as follow ups from previous work I did in this area. 

My goal is that at the end of this we all feel really happy with the overall strategy for error handling, and agree that it's complete. 

Main points:
- Hub methods handle obvious error cases as part of the call to the hub where possible
  - Respond to the call with something that indicates success or failure
  - Terminate the connection where it makes sense 
- CircuitHost/Registry methods are *fire-and-forget* from the Hub and do async error handling
  - Async error handler means sending an "error" to the client
  - Clients should hang up when they see an error
  - Misbehaving clients might not hang up
  - Therefore we should dispose the circuit
  - The next message a misbehaving client sends will disconnect them
- We don't want to let clients interact with a circuit in an unknown state
  - We err on the side of tearing them down when something goes wrong
- Errors that occur when the client is disconnected should tear down the circuit
  - Reporting back to the client that something bad happened is *best-effort*
- We want to make a distinction between invalid input and user-code throwing
  - Log invalid input and other shenanigans with debug verbosity, and respons with generic errors
  - Log user-code throwing with error verbosity and respond with exception details in development mode

I think what's here covers all of these points pretty comprehensively, and I think these are already details we agree about in principle.

-----

So the major change here is that we now subscribe to unhandled exceptions in the registry rather than the Hub. This is something I tried to address in an earlier PR because it was super wrong. We can't attach event handlers from the Hub, because Hubs need to go away.  The registry is guaranteed to outlive a circuit and already knows how to clean one up.