### PR TITLE
Don't serve angular static files in dev mode

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
@@ -88,7 +88,10 @@ namespace Company.WebApplication1
 
 #endif
             app.UseStaticFiles();
-            app.UseSpaStaticFiles();
+            if (env.IsProduction())
+            {
+                app.UseSpaStaticFiles();
+            }
 
             app.UseRouting();
 

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
@@ -88,7 +88,7 @@ namespace Company.WebApplication1
 
 #endif
             app.UseStaticFiles();
-            if (env.IsProduction())
+            if (!env.IsDevelopment())
             {
                 app.UseSpaStaticFiles();
             }


### PR DESCRIPTION
Fixes #11797.

**Description**
Currently if a developer generates a "dist" folder (by doing `dotnet publish` for example), then runs their site in Development mode they will still be served the static files from the dist folder.

**Customer impact**
Since the static files are being served the developer will not receive Hot Module Replacement (HMR) when they update their modules (an example would be that text of a page which was edited in the source is not then displayed in the browser).,

**Regression?**
No. To our knowledge this was always the behavior.

**Risk**
Low to Very Low. As this is only a change to the template we cannot break any existing projects, and if a developer DID have a problem with the way a new template behaves these changes are all within the Startup.cs file which they can edit as they would any of "their code".