### PR TITLE
Remove ProjectTemplates ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /src/Hosting/                   @tratcher @anurse
 /src/Http/                      @tratcher @jkotalik @anurse
 /src/Middleware/                @tratcher @anurse
-/src/ProjectTemplates/          @ryanbrandenburg
+# /src/ProjectTemplates/          @ryanbrandenburg
 /src/Security/                  @tratcher @anurse
 /src/Servers/                   @tratcher @jkotalik @anurse @halter73
 /src/Middleware/Rewrite         @jkotalik @anurse


### PR DESCRIPTION
This ended up being super noisy as a huge variety of changes require a reaction in ProjectTemplates, but few of those actually need my input. For those which do require my attention it's likely I'll be a review suggestion anyway, and otherwise it's well known within the team that I'm the one to talk to about Templates.

To be clear, this is not me disclaiming ownership, just trying to manage the amount of non-actionable email I get.