### PR TITLE
Allow retries of SSL exceptions

### DIFF
--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -173,6 +174,9 @@ namespace Templates.Test.SpaTemplateTest
                     }
                 }
                 catch (OperationCanceledException)
+                {
+                }
+                catch (HttpRequestException ex) when (ex.Message.StartsWith("The SSL connection could not be established"))
                 {
                 }
                 await Task.Delay(TimeSpan.FromSeconds(5 * attempt));


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2735.

A possible fix for that issue by allowing us to retry on startup SSL connection issues.

**Description**
We sometimes run into SSL connection issues in the ProjectTemplate tests shortly after startup. We've already got retries in this area, so I've just expanded it to include this exception type.

**Customer Impact**
None. This is a test-only change which could not by itself change a customer experience.

**Regression?**
No.

**Risk**
Very low. The only possible risk of this change would be that the loosening of test strictness would allow a bug through, however we've seen the SSL connection error for quite some time, and the solution has already been to retry. Further, it's not really the point of these types of tests to catch this type of behavior, and they aren't equipped to drive a useful response.