### PR TITLE
Ensure blazor client side logger checks for enabled log levels

### DIFF
--- a/src/Components/Blazor/Blazor/src/Services/WebAssemblyConsoleLogger.cs
+++ b/src/Components/Blazor/Blazor/src/Services/WebAssemblyConsoleLogger.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Blazor.Services
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
+            if (!IsEnabled(logLevel)) return;
             var formattedMessage = formatter(state, exception);
             Console.WriteLine($"[{logLevel}] {formattedMessage}");
         }

--- a/src/Components/Blazor/Blazor/src/Services/WebAssemblyConsoleLogger.cs
+++ b/src/Components/Blazor/Blazor/src/Services/WebAssemblyConsoleLogger.cs
@@ -20,7 +20,11 @@ namespace Microsoft.AspNetCore.Blazor.Services
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            if (!IsEnabled(logLevel)) return;
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+            
             var formattedMessage = formatter(state, exception);
             Console.WriteLine($"[{logLevel}] {formattedMessage}");
         }


### PR DESCRIPTION
Added a check for IsEnabled in the log method of WebAssemblyConsoleLogger

Addresses #12859
