### PR TITLE
Add test for supported scenario

### DIFF
--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1050,4 +1050,32 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public bool TokenStateInDisconnected { get; set; }
     }
+
+    public class CallerServiceHub : Hub
+    {
+        private readonly CallerService _service;
+
+        public CallerServiceHub(CallerService service)
+        {
+            _service = service;
+        }
+
+        public override Task OnConnectedAsync()
+        {
+            _service.SetCaller(Clients.Caller);
+            var tcs = (TaskCompletionSource<bool>)Context.Items["ConnectedTask"];
+            tcs?.TrySetResult(true);
+            return base.OnConnectedAsync();
+        }
+    }
+
+    public class CallerService
+    {
+        public IClientProxy Caller { get; private set; }
+
+        public void SetCaller(IClientProxy caller)
+        {
+            Caller = caller;
+        }
+    }
 }


### PR DESCRIPTION
This is something Components uses a lot and when I found out about it Andrew and I discussed whether it should be supported or not and decided it would be. So now we have a test making sure `Clients.Caller` is usable outside the hub.

cc @rynowak 