### PR TITLE
[Blazor] Make interop tests timeouts more conservative to reduce flakyness

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -19,10 +19,9 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
-    [Flaky("https://github.com/aspnet/AspNetCore/issues/12940", FlakyOn.All)]
     public class InteropReliabilityTests : IClassFixture<AspNetSiteServerFixture>
     {
-        private static readonly TimeSpan DefaultLatencyTimeout = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan DefaultLatencyTimeout = TimeSpan.FromSeconds(5);
         private readonly AspNetSiteServerFixture _serverFixture;
 
         public InteropReliabilityTests(AspNetSiteServerFixture serverFixture)


### PR DESCRIPTION
* Makes the timeout 5 seconds.
* It won't affect normal runs.
* Each test will take at most 5 seconds to fail.