### PR TITLE
Extend timeout and enforce usings

### DIFF
--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -45,7 +45,7 @@ namespace Templates.Test.SpaTemplateTest
         {
             Project = await ProjectFactory.GetOrCreateProject(key, Output);
 
-            var createResult = await Project.RunDotNetNewAsync(template, auth: usesAuth ? "Individual" : null, language: null, useLocalDb);
+            using var createResult = await Project.RunDotNetNewAsync(template, auth: usesAuth ? "Individual" : null, language: null, useLocalDb);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", Project, createResult));
 
             // We shouldn't have to do the NPM restore in tests because it should happen
@@ -61,26 +61,26 @@ namespace Templates.Test.SpaTemplateTest
                 Assert.Contains(".db", projectFileContents);
             }
 
-            var npmRestoreResult = await Project.RestoreWithRetryAsync(Output, clientAppSubdirPath);
+            using var npmRestoreResult = await Project.RestoreWithRetryAsync(Output, clientAppSubdirPath);
             Assert.True(0 == npmRestoreResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm restore", Project, npmRestoreResult));
 
-            var lintResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run lint");
+            using var lintResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run lint");
             Assert.True(0 == lintResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm run lint", Project, lintResult));
 
             if (template == "react" || template == "reactredux")
             {
-                var testResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run test");
+                using var testResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run test");
                 Assert.True(0 == testResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm run test", Project, testResult));
             }
 
-            var publishResult = await Project.RunDotNetPublishAsync();
+            using var publishResult = await Project.RunDotNetPublishAsync();
             Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", Project, publishResult));
 
             // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
             // The output from publish will go into bin/Release/netcoreapp3.0/publish and won't be affected by calling build
             // later, while the opposite is not true.
 
-            var buildResult = await Project.RunDotNetBuildAsync();
+            using var buildResult = await Project.RunDotNetBuildAsync();
             Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", Project, buildResult));
 
             // localdb is not installed on the CI machines, so skip it.
@@ -88,13 +88,13 @@ namespace Templates.Test.SpaTemplateTest
 
             if (usesAuth)
             {
-                var migrationsResult = await Project.RunDotNetEfCreateMigrationAsync(template);
+                using var migrationsResult = await Project.RunDotNetEfCreateMigrationAsync(template);
                 Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", Project, migrationsResult));
                 Project.AssertEmptyMigration(template);
 
                 if (shouldVisitFetchData)
                 {
-                    var dbUpdateResult = await Project.RunDotNetEfUpdateDatabaseAsync();
+                    using var dbUpdateResult = await Project.RunDotNetEfUpdateDatabaseAsync();
                     Assert.True(0 == dbUpdateResult.ExitCode, ErrorMessages.GetFailedProcessMessage("update database", Project, dbUpdateResult));
                 }
             }
@@ -247,7 +247,7 @@ namespace Templates.Test.SpaTemplateTest
                 browser.Equal("Weather forecast", () => browser.FindElement(By.TagName("h1")).Text);
 
                 // Asynchronously loads and displays the table of weather forecasts
-                browser.Exists(By.CssSelector("table>tbody>tr"));
+                browser.Exists(By.CssSelector("table>tbody>tr"), TimeSpan.FromSeconds(10));
                 browser.Equal(5, () => browser.FindElements(By.CssSelector("p+table>tbody>tr")).Count);
             }
 

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -45,10 +45,8 @@ namespace Templates.Test.SpaTemplateTest
         {
             Project = await ProjectFactory.GetOrCreateProject(key, Output);
 
-            using (var createResult = await Project.RunDotNetNewAsync(template, auth: usesAuth ? "Individual" : null, language: null, useLocalDb))
-            {
-                Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", Project, createResult));
-            }
+            using var createResult = await Project.RunDotNetNewAsync(template, auth: usesAuth ? "Individual" : null, language: null, useLocalDb);
+            Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", Project, createResult));
 
             // We shouldn't have to do the NPM restore in tests because it should happen
             // automatically at build time, but by doing it up front we can avoid having
@@ -63,15 +61,12 @@ namespace Templates.Test.SpaTemplateTest
                 Assert.Contains(".db", projectFileContents);
             }
 
-            using (var npmRestoreResult = await Project.RestoreWithRetryAsync(Output, clientAppSubdirPath))
-            {
-                Assert.True(0 == npmRestoreResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm restore", Project, npmRestoreResult));
-            }
+            using var npmRestoreResult = await Project.RestoreWithRetryAsync(Output, clientAppSubdirPath);
+            Assert.True(0 == npmRestoreResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm restore", Project, npmRestoreResult));
 
-            using (var lintResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run lint"))
-            {
-                Assert.True(0 == lintResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm run lint", Project, lintResult));
-            }
+
+            using var lintResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run lint");
+            Assert.True(0 == lintResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm run lint", Project, lintResult));
 
             if (template == "react" || template == "reactredux")
             {
@@ -79,29 +74,24 @@ namespace Templates.Test.SpaTemplateTest
                 Assert.True(0 == testResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm run test", Project, testResult));
             }
 
-            using (var publishResult = await Project.RunDotNetPublishAsync())
-            {
-                Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", Project, publishResult));
-            }
+            using var publishResult = await Project.RunDotNetPublishAsync();
+            Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", Project, publishResult));
 
             // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
             // The output from publish will go into bin/Release/netcoreapp3.0/publish and won't be affected by calling build
             // later, while the opposite is not true.
 
-            using (var buildResult = await Project.RunDotNetBuildAsync())
-            {
-                Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", Project, buildResult));
-            }
+            using var buildResult = await Project.RunDotNetBuildAsync();
+            Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", Project, buildResult));
 
             // localdb is not installed on the CI machines, so skip it.
             var shouldVisitFetchData = !useLocalDb;
 
             if (usesAuth)
             {
-                using (var migrationsResult = await Project.RunDotNetEfCreateMigrationAsync(template))
-                {
-                    Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", Project, migrationsResult));
-                }
+                using var migrationsResult = await Project.RunDotNetEfCreateMigrationAsync(template);
+                Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", Project, migrationsResult));
+
                 Project.AssertEmptyMigration(template);
 
                 if (shouldVisitFetchData)

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -64,7 +64,6 @@ namespace Templates.Test.SpaTemplateTest
             using var npmRestoreResult = await Project.RestoreWithRetryAsync(Output, clientAppSubdirPath);
             Assert.True(0 == npmRestoreResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm restore", Project, npmRestoreResult));
 
-
             using var lintResult = await ProcessEx.RunViaShellAsync(Output, clientAppSubdirPath, "npm run lint");
             Assert.True(0 == lintResult.ExitCode, ErrorMessages.GetFailedProcessMessage("npm run lint", Project, lintResult));
 

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -91,7 +91,6 @@ namespace Templates.Test.SpaTemplateTest
             {
                 using var migrationsResult = await Project.RunDotNetEfCreateMigrationAsync(template);
                 Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", Project, migrationsResult));
-
                 Project.AssertEmptyMigration(template);
 
                 if (shouldVisitFetchData)

--- a/src/Shared/E2ETesting/WaitAssert.cs
+++ b/src/Shared/E2ETesting/WaitAssert.cs
@@ -42,7 +42,10 @@ namespace Microsoft.AspNetCore.E2ETesting
             => WaitAssertCore(driver, () => Assert.Single(actualValues()));
 
         public static void Exists(this IWebDriver driver, By finder)
-            => WaitAssertCore(driver, () => Assert.NotEmpty(driver.FindElements(finder)));
+            => Exists(driver, finder, default);
+
+        public static void Exists(this IWebDriver driver, By finder, TimeSpan timeout)
+            => WaitAssertCore(driver, () => Assert.NotEmpty(driver.FindElements(finder)), timeout);
 
         private static void WaitAssertCore(IWebDriver driver, Action assertion, TimeSpan timeout = default)
         {


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2585.

Examining the logs for this it seems that the WeatherForcast api call is starting but not having a chance to finish. Considering that some of the beefier requests in these logs are taking 10+ seconds I don't think it's crazy to give the wait for this API call a longer timeout.

I also noticed that a bunch of these objects are actually IDisposable and not getting disposed, which could conceivably lead to orphaned process', file locking and other sadness, so I've put those all into usings.