### PR TITLE
Trim request finished ms

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 _cachedToString = string.Format(
                     CultureInfo.InvariantCulture,
-                    "Request finished in {0}ms {1} {2}",
+                    "Request finished in {0:F2}ms {1} {2}",
                     _elapsed.TotalMilliseconds,
                     _httpContext.Response.StatusCode,
                     _httpContext.Response.ContentType);


### PR DESCRIPTION
The request finished log has been having display issues for a while now. I added some formatting parameters.

Before:
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 1.2913000000000001ms 200
```
After:
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished in 0.37ms 200
```

@glennc 