### PR TITLE
Fix retries with port selection

### DIFF
--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -94,10 +94,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
                 RunWebConfigActions(contentRoot);
 
-                var testUri = TestUriHelper.BuildTestUri(ServerType.IISExpress, DeploymentParameters.ApplicationBaseUriHint);
 
                 // Launch the host process.
-                var (actualUri, hostExitToken) = await StartIISExpressAsync(testUri, contentRoot);
+                var (actualUri, hostExitToken) = await StartIISExpressAsync(contentRoot);
 
                 Logger.LogInformation("Application ready at URL: {appUrl}", actualUri);
 
@@ -152,27 +151,28 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             return dllRoot;
         }
 
-        private async Task<(Uri url, CancellationToken hostExitToken)> StartIISExpressAsync(Uri uri, string contentRoot)
+        private async Task<(Uri url, CancellationToken hostExitToken)> StartIISExpressAsync(string contentRoot)
         {
             using (Logger.BeginScope("StartIISExpress"))
             {
-                var port = uri.Port;
-                if (port == 0)
-                {
-                    port = (uri.Scheme == "https") ? TestPortHelper.GetNextSSLPort() : TestPortHelper.GetNextPort();
-                }
-
-                Logger.LogInformation("Attempting to start IIS Express on port: {port}", port);
-                PrepareConfig(contentRoot, port);
-
-                var parameters = string.IsNullOrEmpty(DeploymentParameters.ServerConfigLocation) ?
-                                string.Format("/port:{0} /path:\"{1}\" /trace:error /systray:false", uri.Port, contentRoot) :
-                                string.Format("/site:{0} /config:{1} /trace:error /systray:false", DeploymentParameters.SiteName, DeploymentParameters.ServerConfigLocation);
-
                 var iisExpressPath = GetIISExpressPath();
 
                 for (var attempt = 0; attempt < MaximumAttempts; attempt++)
                 {
+                    var uri = TestUriHelper.BuildTestUri(ServerType.IISExpress, DeploymentParameters.ApplicationBaseUriHint);
+                    var port = uri.Port;
+                    if (port == 0)
+                    {
+                        port = (uri.Scheme == "https") ? TestPortHelper.GetNextSSLPort() : TestPortHelper.GetNextPort();
+                    }
+
+                    Logger.LogInformation("Attempting to start IIS Express on port: {port}", port);
+                    PrepareConfig(contentRoot, port);
+
+                    var parameters = string.IsNullOrEmpty(DeploymentParameters.ServerConfigLocation) ?
+                                    string.Format("/port:{0} /path:\"{1}\" /trace:error /systray:false", uri.Port, contentRoot) :
+                                    string.Format("/site:{0} /config:{1} /trace:error /systray:false", DeploymentParameters.SiteName, DeploymentParameters.ServerConfigLocation);
+
                     Logger.LogInformation("Executing command : {iisExpress} {parameters}", iisExpressPath, parameters);
 
                     var startInfo = new ProcessStartInfo
@@ -264,8 +264,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
                         Logger.LogInformation("Started iisexpress successfully. Process Id : {processId}, Port: {port}", _hostProcess.Id, port);
                         return (url: url, hostExitToken: hostExitTokenSource.Token);
                     }
-
-                    ChangePort(contentRoot, (uri.Scheme == "https") ? TestPortHelper.GetNextSSLPort() : TestPortHelper.GetNextPort());
                 }
 
                 var message = $"Failed to initialize IIS Express after {MaximumAttempts} attempts to select a port";

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -313,14 +313,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             File.WriteAllText(DeploymentParameters.ServerConfigLocation, serverConfig);
         }
 
-        private void ChangePort(string contentRoot, int port)
-        {
-            var serverConfig = File.ReadAllText(DeploymentParameters.ServerConfigLocation);
-            XDocument config = XDocument.Parse(serverConfig);
-            ConfigureModuleAndBinding(config.Root, contentRoot, port);
-            File.WriteAllText(DeploymentParameters.ServerConfigLocation, serverConfig);
-        }
-
         private void AddAspNetCoreElement(XElement config)
         {
             var aspNetCore = config


### PR DESCRIPTION
I thought I made a fix to retries with port selection by changing the port in the application host config, but we actually pass in the port via command line to IISExpress (whoops). This adds retries to IISExpress select different ports.

Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2943.