### PR TITLE
Skip/disable tests in 2.2 for IIS

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/RequestTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/RequestTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalTheory]
+        [RequiresNewHandler]
         [InlineData("/RequestPath/a/b/../c", "/a/c")]
         [InlineData("/RequestPath/a/b/./c", "/a/b/c")]
         public async Task Request_WithNavigation_Removed(string input, string expectedPath)
@@ -59,6 +60,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
         }
 
         [ConditionalTheory]
+        [RequiresNewHandler]
         [InlineData("/RequestPath/a/b/%2E%2E/c", "/a/c")]
         [InlineData("/RequestPath/a/b/%2E/c", "/a/b/c")]
         public async Task Request_WithEscapedNavigation_Removed(string input, string expectedPath)

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
@@ -49,7 +49,6 @@ namespace IIS.FunctionalTests
         }
 
         [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7 | WindowsVersions.Win8, "Test has invalid configuration on CI.")]
         [RequiresIIS(IISCapability.ApplicationInitialization)]
         [InlineData(HostingModel.InProcess)]
         [InlineData(HostingModel.OutOfProcess)]
@@ -71,7 +70,7 @@ namespace IIS.FunctionalTests
 
                 var result = await DeployAsync(baseDeploymentParameters);
 
-                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), 10, 200);
+                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), 10, 3000);
                 StopServer();
                 EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result));
             }

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ServicesTests.cs
@@ -49,6 +49,7 @@ namespace IIS.FunctionalTests
         }
 
         [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7 | WindowsVersions.Win8, "Test has invalid configuration on CI.")]
         [RequiresIIS(IISCapability.ApplicationInitialization)]
         [InlineData(HostingModel.InProcess)]
         [InlineData(HostingModel.OutOfProcess)]


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2631 and some always failing tests in 2.2: http://aspnetci/viewLog.html?buildId=669576&tab=buildResultsDiv&buildTypeId=Releases_22xPublic_Win2012.
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2571

I can't access our 2.2 agent to figure out what is wrong on the agent. I ran it locally and it passed.