### PR TITLE
[Identity] Add warnings when using Bootstrap3 and errors when using an unknown framework version

### DIFF
--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -30,6 +30,8 @@
     <Content Remove="@(Content)" />
     <Content Include="wwwroot\**\*" Pack="true" />
     <None Include="build\*" Pack="true" PackagePath="build\" />
+    <None Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting\" />
+    <None Include="buildTransitive\*" Pack="true" PackagePath="buildTransitive\" />
     <None Include="THIRD-PARTY-NOTICES.txt" Pack="true" PackagePath="/THIRD-PARTY-NOTICES.txt" />
   </ItemGroup>
 

--- a/src/Identity/UI/src/build/Microsoft.AspnetCore.Identity.UI.targets
+++ b/src/Identity/UI/src/build/Microsoft.AspnetCore.Identity.UI.targets
@@ -1,0 +1,34 @@
+<Project>
+
+  <Target Name="ValidateIdentityUIFrameworkVersion" BeforeTargets="Build">
+
+    <PropertyGroup>
+      <_IdentityUIBootstrap3WarningMessage>'Bootstrap3' is obsolete. It is recommended that the application is updated to use a supported Bootstrap version by removing the 'IdentityUIFrameworkVersion' property from '$(MSBuildProjectFile)' or setting 'IdentityUIFrameworkVersion' explicitly to 'Bootstrap4'.
+        </_IdentityUIBootstrap3WarningMessage>
+      <_IdentityUIUnknownVersionErrorMessage>The 'IdentityUIFrameworkVersion' '$(IdentityUIFrameworkVersion)' in '$(MSBuildProjectFile)' is not valid. Valid versions are 'Bootstrap3' and 'Bootstrap4'.
+      </_IdentityUIUnknownVersionErrorMessage>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_IdentityUIActiveWarnings Include="IdentityUI001;IdentityUI002" Exclude="$(NoWarn)" />
+    </ItemGroup>
+
+    <Warning Code="IdentityUI001"
+             Text="$(_IdentityUIBootstrap3WarningMessage)"
+             File="@(MSBuildThisProjectFile)"
+             Condition="'$(IdentityUIFrameworkVersion)' == 'Bootstrap3' and '%(_IdentityUIActiveWarnings.Identity)' == 'IdentityUI001' and '$(WarningsAsErrors)' != 'true'" />
+
+    <Error Code="IdentityUI001"
+           Text="$(_IdentityUIBootstrap3WarningMessage)"
+           File="@(MSBuildThisProjectFile)"
+           Condition="'$(IdentityUIFrameworkVersion)' == 'Bootstrap3' and '%(_IdentityUIActiveWarnings.Identity)' == 'IdentityUI001' and '$(WarningsAsErrors)' == 'true'" />
+
+    <Error
+           Code="IdentityUI002"
+           Text="$(_IdentityUIUnknownVersionErrorMessage)"
+           File="@(MSBuildThisProjectFile)"
+           Condition="'$(IdentityUIFrameworkVersion)' != 'Bootstrap3' and $(IdentityUIFrameworkVersion) != 'Bootstrap4' and '%(_IdentityUIActiveWarnings.Identity)' == 'IdentityUI002'" />
+
+  </Target>
+
+</Project>

--- a/src/Identity/UI/src/buildMultiTargeting/Microsoft.AspnetCore.Identity.UI.targets
+++ b/src/Identity/UI/src/buildMultiTargeting/Microsoft.AspnetCore.Identity.UI.targets
@@ -1,5 +1,5 @@
 <Project>
 
-  <Import project="..\build\Microsoft.AspnetCore.Identity.UI.targets" />
+  <Import Project="..\build\Microsoft.AspnetCore.Identity.UI.targets" />
 
 </Project>

--- a/src/Identity/UI/src/buildMultiTargeting/Microsoft.AspnetCore.Identity.UI.targets
+++ b/src/Identity/UI/src/buildMultiTargeting/Microsoft.AspnetCore.Identity.UI.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import project="..\build\Microsoft.AspnetCore.Identity.UI.targets" />
+
+</Project>

--- a/src/Identity/UI/src/buildTransitive/Microsoft.AspnetCore.Identity.UI.targets
+++ b/src/Identity/UI/src/buildTransitive/Microsoft.AspnetCore.Identity.UI.targets
@@ -1,5 +1,5 @@
 <Project>
 
-  <Import project="..\buildMultiTargeting\Microsoft.AspnetCore.Identity.UI.targets" />
+  <Import Project="..\buildMultiTargeting\Microsoft.AspnetCore.Identity.UI.targets" />
 
 </Project>

--- a/src/Identity/UI/src/buildTransitive/Microsoft.AspnetCore.Identity.UI.targets
+++ b/src/Identity/UI/src/buildTransitive/Microsoft.AspnetCore.Identity.UI.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import project="..\buildMultiTargeting\Microsoft.AspnetCore.Identity.UI.targets" />
+
+</Project>


### PR DESCRIPTION
* Adds a target that validates the Identity UI framework version chosen at build time.
* Adds a warning when using Bootrstrap3 and provides guidance to switch to Bootstrap4.
* Adds an error when selecting an unsupported Identity UI framework version.