### PR TITLE
Remove value span usage

### DIFF
--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -222,13 +222,11 @@ namespace Microsoft.AspNetCore.Http.Connections
                 switch (reader.TokenType)
                 {
                     case JsonTokenType.PropertyName:
-                        var memberName = reader.ValueSpan;
-
-                        if (memberName.SequenceEqual(TransportPropertyNameBytes.EncodedUtf8Bytes))
+                        if (reader.ValueTextEquals(TransportPropertyNameBytes.EncodedUtf8Bytes))
                         {
                             availableTransport.Transport = reader.ReadAsString(TransportPropertyName);
                         }
-                        else if (memberName.SequenceEqual(TransferFormatsPropertyNameBytes.EncodedUtf8Bytes))
+                        else if (reader.ValueTextEquals(TransferFormatsPropertyNameBytes.EncodedUtf8Bytes))
                         {
                             reader.CheckRead();
                             reader.EnsureArrayStart();

--- a/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
+++ b/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null)]
         [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token")]
         [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null)]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null)]
         public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken)
         {
             var responseData = Encoding.UTF8.GetBytes(json);


### PR DESCRIPTION
`ValueTextEquals` will handle escaping correctly, whereas checking the UTF8 bytes explicitly will not.

This would only affect custom clients that for some reason escape the property names in the negotiate, or some weird proxy that escaped stuff on the wire?!

@anurse I'm proposing this for 3.1 since it's low pri, but I could see us moving it to 5.0.

cc @ahsonkhan 