### PR TITLE
Improve performance when huge connections arrive within a short period

### DIFF
--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConstants.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConstants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 {
     internal static class LibuvConstants
     {
-        public const int ListenBacklog = 128;
+        public const int ListenBacklog = int.MaxValue;
 
         public const int EOF = -4095;
         public static readonly int? ECONNRESET = GetECONNRESET();

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
             EndPoint = listenSocket.LocalEndPoint;
 
-            listenSocket.Listen(512);
+            listenSocket.Listen(int.MaxValue);
 
             _listenSocket = listenSocket;
         }


### PR DESCRIPTION
The backlog parameter pass to listen() is too low, when huge connections arrive within a short period, many of them will result a very high latency or just timeout.

To improve, we could set the backlog parameter to the maximum value operation system allowed.

Also see: https://github.com/dotnet/corefx/issues/9680

------------

The reason about why increase backlog parameter could improve latency:

When using reactor style api (such as epoll),  accept requires READ event, when READ event arrive, the acceptor can accept up to $backlog connections, so the flow would like (notice epoll has an internal event queue):

```
accept 128 connections => handle 128 connections => accept 128 connections => handle 256 connections => ... accept 128 connections => handle 9600 connections => ...
```

The time until accept a new connection will be longer and longer when more connections accepted. I don't know if this apply to iocp, but on linux it improves much.

------------

Following is benchmark results on ubuntu 18.04 (somaxconn = 65535):

Execute Asp.NET Core application:

```
taskset -c 0 dotnet run -c Release # single core
taskset -c 0,1 dotnet run -c Release # dual core
```

Benchmark:

```
taskset -c 2,3 ./wrk -c 10000 -t 2 -d 60s --latency --timeout 100s http://127.0.0.1:5000
```

Before this patch, socket transport, single core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.55s     5.50s    0.92m    93.43%
    Req/Sec     2.48k     1.43k    7.74k    68.94%
  Latency Distribution
     50%    1.98s
     75%    2.82s
     90%    4.86s
     99%   28.36s
  226931 requests in 1.00m, 26.62MB read
Requests/sec:   3776.27
Transfer/sec:    453.59KB
```

After this patch, socket transport, single core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.24s   582.47ms   6.56s    85.50%
    Req/Sec     2.33k     1.48k    7.82k    66.17%
  Latency Distribution
     50%    2.15s
     75%    2.45s
     90%    2.79s
     99%    4.56s
  258841 requests in 1.00m, 30.36MB read
Requests/sec:   4309.40
Transfer/sec:    517.63KB
```

Before this patch, socket transport, dual core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.54s     3.51s   38.58s    96.36%
    Req/Sec     4.96k     3.26k   15.69k    66.81%
  Latency Distribution
     50%  936.32ms
     75%    1.06s
     90%    1.30s
     99%   22.09s
  561802 requests in 1.00m, 65.90MB read
Requests/sec:   9348.74
Transfer/sec:      1.10MB
```

After this patch, socket transport, dual core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   996.85ms  187.23ms   1.81s    71.65%
    Req/Sec     5.11k     3.06k   17.23k    66.89%
  Latency Distribution
     50%  980.17ms
     75%    1.11s
     90%    1.24s
     99%    1.55s
  568251 requests in 1.00m, 66.66MB read
Requests/sec:   9455.22
Transfer/sec:      1.11MB
```

Before this patch, libuv transport, single core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.40s     2.57s   35.01s    93.99%
    Req/Sec     3.03k     2.35k   10.81k    65.49%
  Latency Distribution
     50%    1.89s
     75%    2.16s
     90%    3.05s
     99%   15.31s
  247864 requests in 1.00m, 29.07MB read
Requests/sec:   4129.03
Transfer/sec:    495.97KB
```

After this patch, libuv transport, single core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.91s   613.18ms   4.38s    84.32%
    Req/Sec     3.44k     2.70k   12.94k    66.43%
  Latency Distribution
     50%    1.85s
     75%    2.02s
     90%    2.57s
     99%    4.03s
  303320 requests in 1.00m, 35.58MB read
Requests/sec:   5046.88
Transfer/sec:    606.22KB
```

Before this patch, libuv transport, dual core:

```
taskset -c 2,3 ./wrk -c 10000 -t 2 -d 60s --latency --timeout 100s http://127.0.0.1:5000
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.78s     3.84s   44.59s    95.99%
    Req/Sec     4.20k     2.73k   14.36k    64.37%
  Latency Distribution
     50%    1.10s
     75%    1.31s
     90%    1.74s
     99%   23.15s
  415795 requests in 1.00m, 48.77MB read
Requests/sec:   6919.36
Transfer/sec:    831.13KB
```

After this patch, libuv transport, dual core:

```
Running 1m test @ http://127.0.0.1:5000
  2 threads and 10000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.30s   347.21ms   2.67s    85.34%
    Req/Sec     4.47k     2.68k   11.74k    63.52%
  Latency Distribution
     50%    1.32s
     75%    1.47s
     90%    1.61s
     99%    2.39s
  445916 requests in 1.00m, 52.31MB read
Requests/sec:   7424.09
Transfer/sec:      0.87MB
```