### PR TITLE
Remove unnecessary tag for Razor Class Library template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -4,8 +4,7 @@
   "classifications": [
     "Web",
     "Razor",
-    "Library",
-    "Razor Class Library"
+    "Library"
   ],
   "name": "Razor Class Library",
   "generatorVersions": "[1.0.0.0-*)",


### PR DESCRIPTION
Contributes to https://github.com/dotnet/templating/issues/2062.

I don't see any reason why the full name of the template name should be repeated in a classification/tag. Doing this should improve the default output of `dotnet new` from:

![](https://user-images.githubusercontent.com/287848/62788671-acb03c80-bac7-11e9-8114-b7791975390c.png)

To:

![](https://user-images.githubusercontent.com/287848/62793018-dc177700-bad0-11e9-8c14-c0edd4c78e5d.png)

This means more information is visible in the terminal without resizing or scrolling and that accessing the rest of the information will require less scrolling.