### PR TITLE
Enable Docker Support checkbox for Blazor Server apps and gRPC apps.

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -61,5 +61,6 @@
   "excludeLaunchSettings": false,
   "azureReplyUrlPortName": "HttpsPort",
   "minFullFrameworkVersion": "4.6.1",
-  "disableHttpsSymbol": "NoHttps"
+  "disableHttpsSymbol": "NoHttps",
+  "supportsDocker": true
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/vs-2017.3.host.json
@@ -14,6 +14,6 @@
   "icon": "vs-2017.3/gRPC.png",
   "learnMoreLink": "https://go.microsoft.com/fwlink/?LinkID=784883",
   "uiFilters": [ "oneaspnet" ],
-  "supportsDocker": false,
+  "supportsDocker": true,
   "excludeLaunchSettings": false
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Enable "Enable Docker Support" checkbox for Blazor Server apps.
 - Enable "Enable Docker Support" checkbox for gRPC apps.

Addresses [#938514](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/938514) And [#938373](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/938373).
