### PR TITLE
Make `$(HelixTestName)` more routing-friendly

### DIFF
--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -14,7 +14,7 @@
     <HelixTimeout>00:30:00</HelixTimeout>
     <IsWindowsHelixQueue>false</IsWindowsHelixQueue>
     <IsWindowsHelixQueue Condition="$(HelixTargetQueue.Contains('Windows')) or $(HelixTargetQueue.Contains('windows'))">true</IsWindowsHelixQueue>
-    <HelixTestName>$(MSBuildProjectName)/$(TargetFramework)</HelixTestName>
+    <HelixTestName>$(MSBuildProjectName)-$(TargetFramework)</HelixTestName>
     <HelixUseArchive>false</HelixUseArchive>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">true</LoggingTestingDisableFileLogging>
     <NodeVersion>10.15.3</NodeVersion>
@@ -39,7 +39,7 @@
   <ItemGroup Condition="'$(TestDependsOnNode)' == 'true' AND '$(IsWindowsHelixQueue)' == 'false'">
     <HelixPreCommand Include="./installnode.sh $(NodeVersion) $(TargetArchitecture)" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TestDependsOnNode)' == 'true' AND '$(IsWindowsHelixQueue)' == 'true'">
     <HelixPreCommand Include="call RunPowershell.cmd InstallNode.ps1 $(NodeVersion) %25HELIX_CORRELATION_PAYLOAD%25\node\bin || exit /b 1" />
   </ItemGroup>


### PR DESCRIPTION
- work around dotnet/arcade#3602
- this property is part of URLs e.g. https://helix.dot.net/api/{Date}/jobs/{GUID}/workitems/{HelixTestName}/console