### PR TITLE
Add retries to selfhost deployer

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/NginxDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/NginxDeployer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     DotnetPublish();
                 }
 
-                var (appUri, exitToken) = await StartSelfHostAsync(redirectUri);
+                var (appUri, exitToken, _) = await StartSelfHostAsync(redirectUri);
 
                 SetupNginx(appUri.ToString(), uri);
 

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/NginxDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/NginxDeployer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     DotnetPublish();
                 }
 
-                var (appUri, exitToken, _) = await StartSelfHostAsync(redirectUri);
+                var (appUri, exitToken) = await StartSelfHostAsync(redirectUri);
 
                 SetupNginx(appUri.ToString(), uri);
 

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/SelfHostDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/SelfHostDeployer.cs
@@ -66,10 +66,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                         DeploymentParameters.StatusMessagesEnabled);
                     var (actualUrl, hostExitToken) = await StartSelfHostAsync(hintUrl);
 
-                    if (DeploymentParameters.ServerType == ServerType.HttpSys)
+                    if (DeploymentParameters.ServerType == ServerType.HttpSys && hostExitToken.IsCancellationRequested)
                     {
                         // Retry HttpSys deployments due to port conflicts.
-                        // TODO consider implementing port 0 for HttpSys
                         continue;
                     }
 

--- a/src/Hosting/build.cmd
+++ b/src/Hosting/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET RepoRoot=%~dp0..\..
+%RepoRoot%\build.cmd -projects %~dp0**\*.*proj %*


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2450. Port conflict issues need retries. This is used for both Kestrel and HttpSys. I've only seen this issue on HttpSys.