### PR TITLE
Complete upload streams on connection close

### DIFF
--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -585,7 +585,10 @@ namespace Microsoft.AspNetCore.SignalR
                 _ = InnerAbortConnection(connection);
 
                 // Use _streamTracker to avoid lazy init from StreamTracker getter if it doesn't exist
-                connection._streamTracker?.CompleteAll();
+                if (connection._streamTracker != null)
+                {
+                    connection._streamTracker.CompleteAll(new OperationCanceledException("The underlying connection was closed."));
+                }
             }
 
             static async Task InnerAbortConnection(HubConnectionContext connection)

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -583,6 +583,9 @@ namespace Microsoft.AspNetCore.SignalR
             finally
             {
                 _ = InnerAbortConnection(connection);
+
+                // Use _streamTracker to avoid lazy init from StreamTracker getter if it doesn't exist
+                connection._streamTracker?.CompleteAll();
             }
 
             static async Task InnerAbortConnection(HubConnectionContext connection)

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -77,6 +77,14 @@ namespace Microsoft.AspNetCore.SignalR
             return true;
         }
 
+        public void CompleteAll(Exception ex = null)
+        {
+            foreach (var converter in _lookup)
+            {
+                converter.Value.TryComplete(ex);
+            }
+        }
+
         private static IStreamConverter BuildStream<T>(int streamBufferCapacity)
         {
             return new ChannelConverter<T>(streamBufferCapacity);

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.SignalR
             return true;
         }
 
-        public void CompleteAll(Exception ex = null)
+        public void CompleteAll(Exception ex)
         {
             foreach (var converter in _lookup)
             {

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -298,6 +298,26 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 output.Complete();
             }
         }
+
+        public async Task UploadDoesWorkOnComplete(ChannelReader<string> source)
+        {
+            var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Context.Items[nameof(UploadDoesWorkOnComplete)] = tcs.Task;
+
+            try
+            {
+                while (await source.WaitToReadAsync())
+                {
+                    while (source.TryRead(out var item))
+                    {
+                    }
+                }
+            }
+            finally
+            {
+                tcs.SetResult(59);
+            }
+        }
     }
 
     public abstract class TestHub : Hub

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -313,9 +313,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
             finally
             {
-                tcs.SetResult(59);
+                tcs.TrySetResult(42);
             }
         }
     }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -3729,8 +3729,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await connectionHandlerTask.OrTimeout();
 
                 // This task completes if the upload stream is completed, via closing the connection
-                var result = await ((Task<int>)client.Connection.Items[nameof(MethodHub.UploadDoesWorkOnComplete)]).OrTimeout();
-                Assert.Equal(59, result);
+                var task = (Task<int>)client.Connection.Items[nameof(MethodHub.UploadDoesWorkOnComplete)];
+
+                var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => task).OrTimeout();
+                Assert.Equal("The underlying connection was closed.", exception.Message);
             }
         }
 


### PR DESCRIPTION
#### Description
In 3.0 we introduced a new feature, client upload streaming. We found an issue where a developers code should be running but doesn't because the GC cleans up a continuation. The fix is to complete the task correctly and allow the continuation to run (which is the users code).
		
#### Customer Impact
Code that users expect to run will not run sometimes. Example:
```csharp
try
{
    await channel.ReadAllAsync();
}
finally
{
    // do some cleanup
    service.CleanupState();
    // this never runs in some cases because the continuation is GC'd
}
```
		
#### Regression?
No, the feature is new in 3.0
		
#### Risk
Very low. Change doesn't affect existing tests or scenarios and new test verifies correct behavior.