### PR TITLE
Reset endpoint and route values during exception handling.

### DIFF
--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -51,8 +51,6 @@ namespace Microsoft.AspNetCore.Routing
             if (endpoint != null)
             {
                 Log.MatchSkipped(_logger, endpoint);
-
-                // Someone else set the endpoint, we'll let them handle the unsetting.
                 return _next(httpContext);
             }
 
@@ -89,7 +87,7 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private async Task SetRoutingAndContinue(HttpContext httpContext)
+        private Task SetRoutingAndContinue(HttpContext httpContext)
         {
             // If there was no mutation of the endpoint then log failure
             var endpoint = httpContext.GetEndpoint();
@@ -109,16 +107,7 @@ namespace Microsoft.AspNetCore.Routing
                 Log.MatchSuccess(_logger, endpoint);
             }
 
-            try
-            {
-                await _next(httpContext);
-            }
-            finally
-            {
-                // We unset the endpoint after calling through to the next middleware. This enables any future calls into
-                // endpoint routing don't no-op from there already being an endpoint set.
-                httpContext.SetEndpoint(endpoint: null);
-            }
+            return _next(httpContext);
         }
 
         // Initialization is async to avoid blocking threads while reflection and things

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Routing
             {
                 Log.MatchSkipped(_logger, endpoint);
 
-                // Someone else set the endpoint, we'll let them handle the clearing of the endpoint.
+                // Someone else set the endpoint, we'll let them handle the unsetting.
                 return _next(httpContext);
             }
 
@@ -88,6 +88,7 @@ namespace Microsoft.AspNetCore.Routing
 
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private async Task SetRoutingAndContinue(HttpContext httpContext)
         {
             // If there was no mutation of the endpoint then log failure
@@ -114,7 +115,8 @@ namespace Microsoft.AspNetCore.Routing
             }
             finally
             {
-                // This allows a second call in a single request (such as from the ErrorHandlerMiddleware) to perform routing again.
+                // We unset the endpoint after calling through to the next middleware. This enables any future calls into
+                // endpoint routing don't no-op from there already being an endpoint set.
                 httpContext.SetEndpoint(endpoint: null);
             }
         }

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.Extensions.Logging;
 
@@ -116,9 +116,6 @@ namespace Microsoft.AspNetCore.Routing
             {
                 // This allows a second call in a single request (such as from the ErrorHandlerMiddleware) to perform routing again.
                 httpContext.SetEndpoint(endpoint: null);
-
-                var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
-                routeValuesFeature?.RouteValues?.Clear();
             }
         }
 

--- a/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         [Fact]
-        public async Task UseRouting_ServicesRegistered_Match_DoesNotSetFeature()
+        public async Task UseRouting_ServicesRegistered_Match_DoesNotSetsFeature()
         {
             // Arrange
             var endpoint = new RouteEndpoint(
@@ -104,6 +104,7 @@ namespace Microsoft.AspNetCore.Builder
             // Assert
             var feature = httpContext.Features.Get<IEndpointFeature>();
             Assert.NotNull(feature);
+            Assert.Same(endpoint, httpContext.GetEndpoint());
         }
 
         [Fact]

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -21,48 +21,6 @@ namespace Microsoft.AspNetCore.Routing
     public class EndpointRoutingMiddlewareTest
     {
         [Fact]
-        public async Task Invoke_ChangedPath_ResultsInDifferentResult()
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-            var matcher = new Mock<Matcher>();
-            var pathToEndpoints = new Dictionary<string, Endpoint>()
-            {
-                ["/initial"] = new Endpoint(c => Task.CompletedTask, new EndpointMetadataCollection(), "initialEndpoint"),
-                ["/changed"] = new Endpoint(c => Task.CompletedTask, new EndpointMetadataCollection(), "changedEndpoint")
-            };
-            matcher.Setup(m => m.MatchAsync(httpContext))
-                .Callback<HttpContext>(context =>
-                {
-                    var endpointToSet = pathToEndpoints[context.Request.Path];
-                    context.SetEndpoint(endpointToSet);
-                })
-                .Returns(Task.CompletedTask)
-                .Verifiable();
-            var matcherFactory = Mock.Of<MatcherFactory>(factory => factory.CreateMatcher(It.IsAny<EndpointDataSource>()) == matcher.Object);
-            var middleware = CreateMiddleware(
-                matcherFactory: matcherFactory,
-                next: context =>
-                {
-                    Assert.True(pathToEndpoints.TryGetValue(context.Request.Path, out var expectedEndpoint));
-
-                    var currentEndpoint = context.GetEndpoint();
-                    Assert.Equal(expectedEndpoint, currentEndpoint);
-
-                    return Task.CompletedTask;
-                });
-
-            // Act
-            httpContext.Request.Path = "/initial";
-            await middleware.Invoke(httpContext);
-            httpContext.Request.Path = "/changed";
-            await middleware.Invoke(httpContext);
-
-            // Assert
-            matcher.Verify();
-        }
-
-        [Fact]
         public async Task Invoke_OnException_ResetsEndpoint()
         {
             // Arrange

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -103,26 +103,6 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Fact]
-        public async Task Invoke_OnCall_SetsEndpointFeatureAndResetsRouteValues()
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-            var initialRouteData = new RouteData();
-            initialRouteData.Values["test"] = true;
-            httpContext.Features.Set<IRoutingFeature>(new RoutingFeature()
-            {
-                RouteData = initialRouteData,
-            });
-            var middleware = CreateMiddleware();
-
-            // Act
-            await middleware.Invoke(httpContext);
-
-            // Assert
-            Assert.Null(httpContext.GetRouteValue("test"));
-        }
-
-        [Fact]
         public async Task Invoke_SkipsRoutingAndMaintainsEndpoint_IfEndpointSet()
         {
             // Arrange
@@ -182,29 +162,22 @@ namespace Microsoft.AspNetCore.Routing
         {
             // Arrange
             var httpContext = CreateHttpContext();
-            var nextCalled = false;
 
-            var middleware = CreateMiddleware(next: context =>
-            {
-                var routeData = httpContext.GetRouteData();
-                var routeValue = httpContext.GetRouteValue("controller");
-                var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
-                nextCalled = true;
+            var middleware = CreateMiddleware();
 
-                // Assert
-                Assert.NotNull(routeData);
-                Assert.Equal("Home", (string)routeValue);
-
-                // changing route data value is reflected in endpoint feature values
-                routeData.Values["testKey"] = "testValue";
-                Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
-
-                return Task.CompletedTask;
-            });
-
-            // Act & Assert
+            // Act
             await middleware.Invoke(httpContext);
-            Assert.True(nextCalled);
+            var routeData = httpContext.GetRouteData();
+            var routeValue = httpContext.GetRouteValue("controller");
+            var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
+
+            // Assert
+            Assert.NotNull(routeData);
+            Assert.Equal("Home", (string)routeValue);
+
+            // changing route data value is reflected in endpoint feature values
+            routeData.Values["testKey"] = "testValue";
+            Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
         }
 
         [Fact]
@@ -212,29 +185,22 @@ namespace Microsoft.AspNetCore.Routing
         {
             // Arrange
             var httpContext = CreateHttpContext();
-            var called = false;
 
-            var middleware = CreateMiddleware(next: context =>
-            {
-                var routeData = httpContext.GetRouteData();
-                var routeValue = httpContext.GetRouteValue("controller");
-                var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
-                called = true;
+            var middleware = CreateMiddleware();
 
-                // Assert
-                Assert.NotNull(routeData);
-                Assert.Equal("Home", (string)routeValue);
-
-                // changing route data value is reflected in endpoint feature values
-                routeData.Values["testKey"] = "testValue";
-                Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
-
-                return Task.CompletedTask;
-            });
-
-            // Act & Assert
+            // Act
             await middleware.Invoke(httpContext);
-            Assert.True(called);
+            var routeData = httpContext.GetRouteData();
+            var routeValue = httpContext.GetRouteValue("controller");
+            var routeValuesFeature = httpContext.Features.Get<IRouteValuesFeature>();
+
+            // Assert
+            Assert.NotNull(routeData);
+            Assert.Equal("Home", (string)routeValue);
+
+            // changing route data value is reflected in endpoint feature values
+            routeData.Values["testKey"] = "testValue";
+            Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
         }
 
         [Fact]

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -21,30 +21,7 @@ namespace Microsoft.AspNetCore.Routing
     public class EndpointRoutingMiddlewareTest
     {
         [Fact]
-        public async Task Invoke_OnException_ResetsEndpoint()
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-
-            var middleware = CreateMiddleware(next: context => throw new Exception());
-
-            // Act
-            try
-            {
-                await middleware.Invoke(httpContext);
-            }
-            catch
-            {
-                // Do nothing, we expect the test to throw.
-            }
-
-            // Assert
-            var endpoint = httpContext.GetEndpoint();
-            Assert.Null(endpoint);
-        }
-
-        [Fact]
-        public async Task Invoke_OnCall_SetsEndpointFeatureAndResetsEndpoint()
+        public async Task Invoke_OnCall_SetsEndpointFeature()
         {
             // Arrange
             var httpContext = CreateHttpContext();
@@ -57,16 +34,14 @@ namespace Microsoft.AspNetCore.Routing
             // Assert
             var endpointFeature = httpContext.Features.Get<IEndpointFeature>();
             Assert.NotNull(endpointFeature);
-            Assert.Null(endpointFeature.Endpoint);
         }
 
         [Fact]
-        public async Task Invoke_SkipsRoutingAndMaintainsEndpoint_IfEndpointSet()
+        public async Task Invoke_SkipsRouting_IfEndpointSet()
         {
             // Arrange
             var httpContext = CreateHttpContext();
-            var expectedEndpoint = new Endpoint(c => Task.CompletedTask, new EndpointMetadataCollection(), "myapp");
-            httpContext.SetEndpoint(expectedEndpoint);
+            httpContext.SetEndpoint(new Endpoint(c => Task.CompletedTask, new EndpointMetadataCollection(), "myapp"));
 
             var middleware = CreateMiddleware();
 
@@ -75,7 +50,7 @@ namespace Microsoft.AspNetCore.Routing
 
             // Assert
             var endpoint = httpContext.GetEndpoint();
-            Assert.Same(expectedEndpoint, endpoint);
+            Assert.NotNull(endpoint);
             Assert.Equal("myapp", endpoint.DisplayName);
         }
 

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Diagnostics
+{
+    public class ExceptionHandlerMiddlewareTest
+    {
+        [Fact]
+        public async Task Invoke_ExceptionThrownResultsInClearedRouteValuesAndEndpoint()
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            httpContext.SetEndpoint(new Endpoint((_) => Task.CompletedTask, new EndpointMetadataCollection(), "Test"));
+            httpContext.Request.RouteValues["John"] = "Doe";
+
+            var optionsAccessor = CreateOptionsAccessor(
+                exceptionHandler: context =>
+                {
+                    Assert.Empty(context.Request.RouteValues);
+                    Assert.Null(context.GetEndpoint());
+                    return Task.CompletedTask;
+                });
+            var middleware = CreateMiddleware(_ => throw new InvalidOperationException(), optionsAccessor);
+
+            // Act & Assert
+            await middleware.Invoke(httpContext);
+        }
+
+        private HttpContext CreateHttpContext()
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                RequestServices = new TestServiceProvider()
+            };
+
+            return httpContext;
+        }
+
+        private IOptions<ExceptionHandlerOptions> CreateOptionsAccessor(
+            RequestDelegate exceptionHandler = null,
+            string exceptionHandlingPath = null)
+        {
+            exceptionHandler ??= c => Task.CompletedTask;
+            var options = new ExceptionHandlerOptions()
+            {
+                ExceptionHandler = exceptionHandler,
+                ExceptionHandlingPath = exceptionHandlingPath,
+            };
+            var optionsAccessor = Mock.Of<IOptions<ExceptionHandlerOptions>>(o => o.Value == options);
+            return optionsAccessor;
+        }
+
+        private ExceptionHandlerMiddleware CreateMiddleware(
+            RequestDelegate next,
+            IOptions<ExceptionHandlerOptions> options)
+        {
+            next ??= c => Task.CompletedTask;
+            var listener = new DiagnosticListener("Microsoft.AspNetCore");
+
+            var middleware = new ExceptionHandlerMiddleware(
+                next,
+                NullLoggerFactory.Instance,
+                options,
+                listener);
+
+            return middleware;
+        }
+
+        private class TestServiceProvider : IServiceProvider
+        {
+            public object GetService(Type serviceType)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- We initially did this change as part of endpoint routing but the impact of that change resulted in a variety of performance regressions. To mitigate the impact of resetting state for a request we now only reset the state when an exception has occurred in a way that does not require any additional async state machines to be allocated.
- Added a test to validate that http context state gets reset on exception handling.
- As part of this PR I've also reverted all of the endpoint routing statefulness changes that we might prior that introduced the async state machine.

## Ask mode template

#### Description
The original bug was users who happened to throw exceptions in their views would never hit the exception handler and therefore wouldn't see an appropriate error page. It also invoked the original action that threw to be invoked multiple times. This PR contains reverts our old way of doing this and changes the ExceptionHandlerMiddleware bits to have an equivalent fix but isolates the work only to cases when an exception is thrown. After the [original fix](https://github.com/aspnet/AspNetCore/pull/12330) we verified that the RPS had regressed slightly; however, what was unintended was the way in which the perf regressed. Turns out the original change resulted in lots of allocations to the large object heap and had other unintended consequences /cc @sebastienros feel free to insert more detail here if you feel it's needed.

#### Customer Impact
Performance

#### Regression?
Yes in daily builds, no for publicly available preview builds.

#### Risk
Very low. We've already tested out a higher impact variant of this fix (which this PR reverts).

Addresses #12897