### PR TITLE
Throw NotSupportedException given FileHandleEndPoint

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -62,6 +62,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 throw new InvalidOperationException(SocketsStrings.TransportAlreadyBound);
             }
 
+            // Check if EndPoint is a FileHandleEndpoint before attempting to access EndPoint.AddressFamily
+            // since that will throw an NotImplementedException.
+            if (EndPoint is FileHandleEndPoint)
+            {
+                throw new NotSupportedException(SocketsStrings.FileHandleEndPointNotSupported);
+            }
+
             Socket listenSocket;
 
             // Unix domain sockets are unspecified

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketsStrings.resx
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketsStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FileHandleEndPointNotSupported" xml:space="preserve">
+    <value>The Socket transport does not support FileHandleEndPoints. Consider using the libuv transport instead.</value>
+  </data>
   <data name="OnlyIPEndPointsSupported" xml:space="preserve">
     <value>Only ListenType.IPEndPoint is supported by the Socket Transport. https://go.microsoft.com/fwlink/?linkid=874850</value>
   </data>

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketsStrings.resx
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketsStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FileHandleEndPointNotSupported" xml:space="preserve">
-    <value>The Socket transport does not support FileHandleEndPoints. Consider using the libuv transport instead.</value>
+    <value>The Socket transport does not support binding to file handles. Consider using the libuv transport instead.</value>
   </data>
   <data name="OnlyIPEndPointsSupported" xml:space="preserve">
     <value>Only ListenType.IPEndPoint is supported by the Socket Transport. https://go.microsoft.com/fwlink/?linkid=874850</value>

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportFactoryTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Sockets.BindTests
+{
+    public class SocketTransportFactoryTests
+    {
+        [Fact]
+        public async Task ThrowsNotSupportedExceptionWhenBindingToFileHandleEndPoint()
+        {
+            var socketTransportFactory = new SocketTransportFactory(Options.Create(new SocketTransportOptions()), Mock.Of<ILoggerFactory>());
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await socketTransportFactory.BindAsync(new FileHandleEndPoint(0, FileHandleType.Auto)));
+        }
+    }
+}
+


### PR DESCRIPTION
- Kestrel's default socket transport does not support FileHandleEndPoint
- Throw a NotSupportedException instead of a NotImplementedException

Addresses #13020 

This is targeting master (aka .NET 5.0) for now. If anyone thinks this should be moved up to an earlier release, I'm fine with that.