### PR TITLE
Renderer use-after-disposal tweaks. Fixes #13056

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteRenderer.cs
+++ b/src/Components/Server/src/Circuits/RemoteRenderer.cs
@@ -284,7 +284,15 @@ namespace Microsoft.AspNetCore.Components.Web.Rendering
                 // missing.
 
                 // We return the task in here, but the caller doesn't await it.
-                return Dispatcher.InvokeAsync(() => ProcessPendingRender());
+                return Dispatcher.InvokeAsync(() =>
+                {
+                    // Now we're on the sync context, check again whether we got disposed since this
+                    // work item was queued. If so there's nothing to do.
+                    if (!_disposing)
+                    {
+                        ProcessPendingRender();
+                    }
+                });
             }
         }
 

--- a/src/Components/Shared/test/TestRenderer.cs
+++ b/src/Components/Shared/test/TestRenderer.cs
@@ -125,5 +125,8 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
             OnUpdateDisplayComplete?.Invoke();
             return NextRenderResultTask;
         }
+
+        public new void ProcessPendingRender()
+            => base.ProcessPendingRender();
     }
 }


### PR DESCRIPTION
Adds two new behaviors:

 * The `Renderer` base class no longer allows subclasses to call `ProcessPendingRender` to start processing the render queue after disposal
 * The `Renderer` base class now ensures that when *components* try to render themselves after the renderer itself was disposed, this is a no-op and not an error

The first of those doesn't change the existing situation much - it would already have caused an `ObjectDisposedException` from the `ArrayBuilder`. The only change here is that the exception message is now clearer, since it states that the renderer was disposed.

The second one is important because this happens in normal user code (e.g., a component doing async work may request a render after the renderer was disposed), and we don't want this to throw.