### PR TITLE
Add User-Agent header to Java client

### DIFF
--- a/src/SignalR/clients/java/signalr/build.gradle
+++ b/src/SignalR/clients/java/signalr/build.gradle
@@ -108,3 +108,27 @@ task generatePOM {
 }
 
 task createPackage(dependsOn: [jar,sourceJar,javadocJar,generatePOM])
+
+task generateVersionClass {
+    inputs.property "version", project.version
+    outputs.dir "$buildDir/generated"
+    doFirst {
+        def versionFile = file("$buildDir/../src/main/java/com/microsoft/signalr/Version.java")
+        versionFile.parentFile.mkdirs()
+        versionFile.text =
+                """
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+public class Version {
+	public static String getDetailedVersion() {
+		return "$project.version";
+	}
+}
+"""
+    }
+}
+
+compileJava.dependsOn generateVersionClass

--- a/src/SignalR/clients/java/signalr/build.gradle
+++ b/src/SignalR/clients/java/signalr/build.gradle
@@ -123,9 +123,9 @@ task generateVersionClass {
 package com.microsoft.signalr;
 
 public class Version {
-	public static String getDetailedVersion() {
-		return "$project.version";
-	}
+    public static String getDetailedVersion() {
+        return "$project.version";
+    }
 }
 """
     }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -21,6 +21,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.subjects.*;
 
+
 /**
  * A connection used to invoke hub methods on a SignalR Server.
  */
@@ -327,7 +328,7 @@ public class HubConnection {
         handshakeResponseSubject = CompletableSubject.create();
         handshakeReceived = false;
         CompletableSubject tokenCompletable = CompletableSubject.create();
-        localHeaders.put("User-Agent", "Microsoft/SignalR/3.1/OtherUserAgentThings");
+        localHeaders.put(UserAgentHelper.getUserAgentName(), UserAgentHelper.createUserAgentString());
         if (headers != null) {
             this.localHeaders.putAll(headers);
         }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -21,7 +21,6 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.subjects.*;
 
-
 /**
  * A connection used to invoke hub methods on a SignalR Server.
  */

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -327,6 +327,7 @@ public class HubConnection {
         handshakeResponseSubject = CompletableSubject.create();
         handshakeReceived = false;
         CompletableSubject tokenCompletable = CompletableSubject.create();
+        localHeaders.put("User-Agent", "Microsoft/SignalR/3.1/OtherUserAgentThings");
         if (headers != null) {
             this.localHeaders.putAll(headers);
         }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserAgentHelper.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserAgentHelper.java
@@ -11,7 +11,7 @@ public class UserAgentHelper {
         return USER_AGENT;
     }
 
-    public static String createUserAgentString(){
+    public static String createUserAgentString() {
         StringBuilder agentBuilder = new StringBuilder("Microsoft SignalR/");
 
         // Parsing version numbers

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserAgentHelper.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserAgentHelper.java
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+public class UserAgentHelper {
+
+    private final static String USER_AGENT = "User-Agent";
+
+    public static String getUserAgentName() {
+        return USER_AGENT;
+    }
+
+    public static String createUserAgentString(){
+        StringBuilder agentBuilder = new StringBuilder("Microsoft SignalR/");
+
+        // Parsing version numbers
+        String detailedVersion = Version.getDetailedVersion();
+        agentBuilder.append(getVersion(detailedVersion));
+        agentBuilder.append("; ");
+        agentBuilder.append(detailedVersion);
+        agentBuilder.append("; ");
+
+        // Getting the OS name
+        agentBuilder.append(findOSName(System.getProperty("os.name")));
+        agentBuilder.append("; Java; ");
+
+        // Vendor and Version
+        agentBuilder.append(System.getProperty("java.vendor"));
+        agentBuilder.append("; ");
+        agentBuilder.append(System.getProperty("java.version"));
+
+        return agentBuilder.toString();
+    }
+
+    static String getVersion(String detailedVersion) {
+        String version;
+        if (detailedVersion.contains("-")) {
+            version = detailedVersion.substring(0, detailedVersion.indexOf('-'));
+        } else {
+            version = detailedVersion;
+        }
+        return version;
+    }
+
+    static String findOSName(String operatingSystem) {
+        operatingSystem = operatingSystem.toLowerCase();
+        if (operatingSystem.indexOf("win") >= 0) {
+            return "Windows NT";
+        } else if (operatingSystem.contains("mac")) {
+            return "Mac";
+        } else if (operatingSystem.contains("nix") || operatingSystem.contains("nux") || operatingSystem.contains("aix")) {
+            return "Linux";
+        }
+
+        return "";
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
@@ -1,0 +1,11 @@
+
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+public class Version {
+	public static String getDetailedVersion() {
+		return "99.99.99-dev";
+	}
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
@@ -1,11 +1,10 @@
-
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 package com.microsoft.signalr;
 
 public class Version {
-	public static String getDetailedVersion() {
-		return "99.99.99-dev";
-	}
+    public static String getDetailedVersion() {
+        return "99.99.99-dev";
+    }
 }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2196,7 +2196,6 @@ class HubConnectionTest {
                                     + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
                         });
 
-
         MockTransport transport = new MockTransport();
         HubConnection hubConnection = HubConnectionBuilder.create("http://example.com")
                 .withTransportImplementation(transport)
@@ -2219,7 +2218,6 @@ class HubConnectionTest {
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                     + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
                         });
-
 
         MockTransport transport = new MockTransport();
         HubConnection hubConnection = HubConnectionBuilder.create("http://example.com")

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2205,7 +2205,8 @@ class HubConnectionTest {
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
-        assertEquals("Microsoft/SignalR/3.1/OtherUserAgentThings", header.get());
+
+        assertTrue(header.get().startsWith("Microsoft SignalR/"));
     }
 
     @Test

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/UserAgentTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/UserAgentTest.java
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserAgentTest {
+
+    private static Stream<Arguments> OperatingSystems() {
+        return Stream.of(
+                Arguments.of("Windows XP", "Windows NT"),
+                Arguments.of("wInDoWs 95", "Windows NT"),
+                Arguments.of("Macintosh", "Mac"),
+                Arguments.of("Linux", "Linux"),
+                Arguments.of("unix", "Linux"),
+                Arguments.of("", ""),
+                Arguments.of("1234", ""));
+    }
+
+    private static Stream<Arguments> Versions() {
+        return Stream.of(
+                Arguments.of("1.0.0", "1.0.0"),
+                Arguments.of("3.1.4-preview9-12345", "3.1.4"),
+                Arguments.of("3.1.4-preview9-12345-extrastuff", "3.1.4"),
+                Arguments.of("99.99.99-dev", "99.99.99"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("Versions")
+    public void getVersionFromDetailedVersion(String detailedVersion, String version) {
+        assertEquals(version, UserAgentHelper.getVersion(detailedVersion));
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/UserAgentTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/UserAgentTest.java
@@ -3,13 +3,13 @@
 
 package com.microsoft.signalr;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class UserAgentTest {
 


### PR DESCRIPTION
Issue:#12295 
It looks like we already add the User-Agent header in the .NET Client and since the header is set by browsers by default we only need to set it in the Java client now.

https://github.com/aspnet/AspNetCore/blob/8c02467b4a218df3b1b0a69bceb50f5b64f482b1/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs#L554

