### PR TITLE
Dispose DI scope with async support in circuit host

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -170,7 +170,18 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 try
                 {
                     Renderer.Dispose();
-                    _scope.Dispose();
+
+                    // This cast is needed because it's possible the scope may not support async dispose.
+                    // Our DI container does, but other DI systems may not.
+                    if (_scope is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync();
+                    }
+                    else
+                    {
+                        _scope.Dispose();
+                    }
+
                     Log.DisposeSucceeded(_logger, CircuitId);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Fixes part of #12918

This fixes the part of this issue that we're going to be able to do in
3.0 safely.

