### PR TITLE
Create CircuitSecret

### DIFF
--- a/src/Components/Server/src/Circuits/Circuit.cs
+++ b/src/Components/Server/src/Circuits/Circuit.cs
@@ -18,6 +18,6 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         /// <summary>
         /// Gets the identifier for the <see cref="Circuit"/>.
         /// </summary>
-        public string Id => _circuitHost.CircuitId;
+        public string Id => _circuitHost.CircuitId.Id;
     }
 }

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         public event UnhandledExceptionEventHandler UnhandledException;
 
         public CircuitHost(
-            string circuitId,
+            CircuitId circuitId,
             IServiceScope scope,
             CircuitOptions options,
             CircuitClientProxy client,
@@ -49,7 +49,12 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             CircuitHandler[] circuitHandlers,
             ILogger logger)
         {
-            CircuitId = circuitId ?? throw new ArgumentNullException(nameof(circuitId));
+            CircuitId = circuitId;
+            if (CircuitId.Secret is null)
+            {
+                // Prevent the use of a 'default' secret.
+                throw new ArgumentException(nameof(circuitId));
+            }
 
             _scope = scope ?? throw new ArgumentNullException(nameof(scope));
             _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -71,7 +76,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
         public CircuitHandle Handle { get; }
 
-        public string CircuitId { get; }
+        public CircuitId CircuitId { get; }
 
         public Circuit Circuit { get; }
 
@@ -195,7 +200,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         // exceptions.
         private async Task OnCircuitOpenedAsync(CancellationToken cancellationToken)
         {
-            Log.CircuitOpened(_logger, Circuit.Id);
+            Log.CircuitOpened(_logger, CircuitId);
 
             Renderer.Dispatcher.AssertAccess();
 
@@ -224,7 +229,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
         public async Task OnConnectionUpAsync(CancellationToken cancellationToken)
         {
-            Log.ConnectionUp(_logger, Circuit.Id, Client.ConnectionId);
+            Log.ConnectionUp(_logger, CircuitId, Client.ConnectionId);
 
             Renderer.Dispatcher.AssertAccess();
             
@@ -253,7 +258,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
         public async Task OnConnectionDownAsync(CancellationToken cancellationToken)
         {
-            Log.ConnectionDown(_logger, Circuit.Id, Client.ConnectionId);
+            Log.ConnectionDown(_logger, CircuitId, Client.ConnectionId);
 
             Renderer.Dispatcher.AssertAccess();
             
@@ -282,7 +287,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
         private async Task OnCircuitDownAsync(CancellationToken cancellationToken)
         {
-            Log.CircuitClosed(_logger, Circuit.Id);
+            Log.CircuitClosed(_logger, CircuitId);
 
             List<Exception> exceptions = null;
 
@@ -586,19 +591,19 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             private static readonly Action<ILogger, Exception> _intializationStarted;
             private static readonly Action<ILogger, Exception> _intializationSucceded;
             private static readonly Action<ILogger, Exception> _intializationFailed;
-            private static readonly Action<ILogger, string, Exception> _disposeStarted;
-            private static readonly Action<ILogger, string, Exception> _disposeSucceded;
-            private static readonly Action<ILogger, string, Exception> _disposeFailed;
-            private static readonly Action<ILogger, string, Exception> _onCircuitOpened;
-            private static readonly Action<ILogger, string, string, Exception> _onConnectionUp;
-            private static readonly Action<ILogger, string, string, Exception> _onConnectionDown;
-            private static readonly Action<ILogger, string, Exception> _onCircuitClosed;
+            private static readonly Action<ILogger, CircuitId, Exception> _disposeStarted;
+            private static readonly Action<ILogger, CircuitId, Exception> _disposeSucceded;
+            private static readonly Action<ILogger, CircuitId, Exception> _disposeFailed;
+            private static readonly Action<ILogger, CircuitId, Exception> _onCircuitOpened;
+            private static readonly Action<ILogger, CircuitId, string, Exception> _onConnectionUp;
+            private static readonly Action<ILogger, CircuitId, string, Exception> _onConnectionDown;
+            private static readonly Action<ILogger, CircuitId, Exception> _onCircuitClosed;
             private static readonly Action<ILogger, Type, string, string, Exception> _circuitHandlerFailed;
-            private static readonly Action<ILogger, string, Exception> _circuitUnhandledException;
-            private static readonly Action<ILogger, string, Exception> _circuitTransmittingClientError;
-            private static readonly Action<ILogger, string, Exception> _circuitTransmittedClientErrorSuccess;
-            private static readonly Action<ILogger, string, Exception> _circuitTransmitErrorFailed;
-            private static readonly Action<ILogger, string, Exception> _unhandledExceptionClientDisconnected;
+            private static readonly Action<ILogger, CircuitId, Exception> _circuitUnhandledException;
+            private static readonly Action<ILogger, CircuitId, Exception> _circuitTransmittingClientError;
+            private static readonly Action<ILogger, CircuitId, Exception> _circuitTransmittedClientErrorSuccess;
+            private static readonly Action<ILogger, CircuitId, Exception> _circuitTransmitErrorFailed;
+            private static readonly Action<ILogger, CircuitId, Exception> _unhandledExceptionClientDisconnected;
 
             private static readonly Action<ILogger, string, string, string, Exception> _beginInvokeDotNetStatic;
             private static readonly Action<ILogger, string, long, string, Exception> _beginInvokeDotNetInstance;
@@ -609,11 +614,11 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             private static readonly Action<ILogger, long, Exception> _endInvokeJSSucceeded;
             private static readonly Action<ILogger, Exception> _dispatchEventFailedToParseEventData;
             private static readonly Action<ILogger, string, Exception> _dispatchEventFailedToDispatchEvent;
-            private static readonly Action<ILogger, string, string, Exception> _locationChange;
-            private static readonly Action<ILogger, string, string, Exception> _locationChangeSucceeded;
-            private static readonly Action<ILogger, string, string, Exception> _locationChangeFailed;
-            private static readonly Action<ILogger, string, string, Exception> _locationChangeFailedInCircuit;
-            private static readonly Action<ILogger, long, string, Exception> _onRenderCompletedFailed;
+            private static readonly Action<ILogger, string, CircuitId, Exception> _locationChange;
+            private static readonly Action<ILogger, string, CircuitId, Exception> _locationChangeSucceeded;
+            private static readonly Action<ILogger, string, CircuitId, Exception> _locationChangeFailed;
+            private static readonly Action<ILogger, string, CircuitId, Exception> _locationChangeFailedInCircuit;
+            private static readonly Action<ILogger, long, CircuitId, Exception> _onRenderCompletedFailed;
 
             private static class EventIds
             {
@@ -648,7 +653,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 public static readonly EventId LocationChangeSucceded = new EventId(209, "LocationChangeSucceeded");
                 public static readonly EventId LocationChangeFailed = new EventId(210, "LocationChangeFailed");
                 public static readonly EventId LocationChangeFailedInCircuit = new EventId(211, "LocationChangeFailedInCircuit");
-                public static readonly EventId OnRenderCompletedFailed = new EventId(212, " OnRenderCompletedFailed");
+                public static readonly EventId OnRenderCompletedFailed = new EventId(212, "OnRenderCompletedFailed");
             }
 
             static Log()
@@ -668,37 +673,37 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     EventIds.InitializationFailed,
                     "Circuit initialization failed.");
 
-                _disposeStarted = LoggerMessage.Define<string>(
+                _disposeStarted = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.DisposeStarted,
                     "Disposing circuit '{CircuitId}' started.");
 
-                _disposeSucceded = LoggerMessage.Define<string>(
+                _disposeSucceded = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.DisposeSucceeded,
                     "Disposing circuit '{CircuitId}' succeded.");
 
-                _disposeFailed = LoggerMessage.Define<string>(
+                _disposeFailed = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.DisposeFailed,
                     "Disposing circuit '{CircuitId}' failed.");
 
-                _onCircuitOpened = LoggerMessage.Define<string>(
+                _onCircuitOpened = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.OnCircuitOpened,
                     "Opening circuit with id '{CircuitId}'.");
 
-                _onConnectionUp = LoggerMessage.Define<string, string>(
+                _onConnectionUp = LoggerMessage.Define<CircuitId, string>(
                     LogLevel.Debug,
                     EventIds.OnConnectionUp,
                     "Circuit id '{CircuitId}' connected using connection '{ConnectionId}'.");
 
-                _onConnectionDown = LoggerMessage.Define<string, string>(
+                _onConnectionDown = LoggerMessage.Define<CircuitId, string>(
                     LogLevel.Debug,
                     EventIds.OnConnectionDown,
                     "Circuit id '{CircuitId}' disconnected from connection '{ConnectionId}'.");
 
-                _onCircuitClosed = LoggerMessage.Define<string>(
+                _onCircuitClosed = LoggerMessage.Define<CircuitId>(
                    LogLevel.Debug,
                    EventIds.OnCircuitClosed,
                    "Closing circuit with id '{CircuitId}'.");
@@ -708,27 +713,27 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     EventIds.CircuitHandlerFailed,
                     "Unhandled error invoking circuit handler type {handlerType}.{handlerMethod}: {Message}");
 
-                _circuitUnhandledException = LoggerMessage.Define<string>(
+                _circuitUnhandledException = LoggerMessage.Define<CircuitId>(
                    LogLevel.Error,
                    EventIds.CircuitUnhandledException,
                    "Unhandled exception in circuit '{CircuitId}'.");
 
-                _circuitTransmittingClientError = LoggerMessage.Define<string>(
+                _circuitTransmittingClientError = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.CircuitTransmittingClientError,
                     "About to notify client of an error in circuit '{CircuitId}'.");
 
-                _circuitTransmittedClientErrorSuccess = LoggerMessage.Define<string>(
+                _circuitTransmittedClientErrorSuccess = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.CircuitTransmittedClientErrorSuccess,
                     "Successfully transmitted error to client in circuit '{CircuitId}'.");
 
-                _circuitTransmitErrorFailed = LoggerMessage.Define<string>(
+                _circuitTransmitErrorFailed = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.CircuitTransmitErrorFailed,
                     "Failed to transmit exception to client in circuit '{CircuitId}'.");
 
-                _unhandledExceptionClientDisconnected = LoggerMessage.Define<string>(
+                _unhandledExceptionClientDisconnected = LoggerMessage.Define<CircuitId>(
                     LogLevel.Debug,
                     EventIds.UnhandledExceptionClientDisconnected,
                     "An exception ocurred on the circuit host '{CircuitId}' while the client is disconnected.");
@@ -778,27 +783,27 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     EventIds.DispatchEventFailedToDispatchEvent,
                     "There was an error dispatching the event '{EventHandlerId}' to the application.");
 
-                _locationChange = LoggerMessage.Define<string, string>(
+                _locationChange = LoggerMessage.Define<string, CircuitId>(
                     LogLevel.Debug,
                     EventIds.LocationChange,
                     "Location changing to {URI} in circuit '{CircuitId}'.");
 
-                _locationChangeSucceeded = LoggerMessage.Define<string, string>(
+                _locationChangeSucceeded = LoggerMessage.Define<string, CircuitId>(
                     LogLevel.Debug,
                     EventIds.LocationChangeSucceded,
                     "Location change to '{URI}' in circuit '{CircuitId}' succeded.");
 
-                _locationChangeFailed = LoggerMessage.Define<string, string>(
+                _locationChangeFailed = LoggerMessage.Define<string, CircuitId>(
                     LogLevel.Debug,
                     EventIds.LocationChangeFailed,
                     "Location change to '{URI}' in circuit '{CircuitId}' failed.");
 
-                _locationChangeFailedInCircuit = LoggerMessage.Define<string, string>(
+                _locationChangeFailedInCircuit = LoggerMessage.Define<string, CircuitId>(
                     LogLevel.Error,
                     EventIds.LocationChangeFailed,
                     "Location change to '{URI}' in circuit '{CircuitId}' failed.");
 
-                _onRenderCompletedFailed = LoggerMessage.Define<long, string>(
+                _onRenderCompletedFailed = LoggerMessage.Define<long, CircuitId>(
                     LogLevel.Debug,
                     EventIds.OnRenderCompletedFailed,
                     "Failed to complete render batch '{RenderId}' in circuit host '{CircuitId}'.");
@@ -807,13 +812,13 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             public static void InitializationStarted(ILogger logger) => _intializationStarted(logger, null);
             public static void InitializationSucceeded(ILogger logger) => _intializationSucceded(logger, null);
             public static void InitializationFailed(ILogger logger, Exception exception) => _intializationFailed(logger, exception);
-            public static void DisposeStarted(ILogger logger, string circuitId) => _disposeStarted(logger, circuitId, null);
-            public static void DisposeSucceeded(ILogger logger, string circuitId) => _disposeSucceded(logger, circuitId, null);
-            public static void DisposeFailed(ILogger logger, string circuitId, Exception exception) => _disposeFailed(logger, circuitId, exception);
-            public static void CircuitOpened(ILogger logger, string circuitId) => _onCircuitOpened(logger, circuitId, null);
-            public static void ConnectionUp(ILogger logger, string circuitId, string connectionId) => _onConnectionUp(logger, circuitId, connectionId, null);
-            public static void ConnectionDown(ILogger logger, string circuitId, string connectionId) => _onConnectionDown(logger, circuitId, connectionId, null);
-            public static void CircuitClosed(ILogger logger, string circuitId) => _onCircuitClosed(logger, circuitId, null);
+            public static void DisposeStarted(ILogger logger, CircuitId circuitId) => _disposeStarted(logger, circuitId, null);
+            public static void DisposeSucceeded(ILogger logger, CircuitId circuitId) => _disposeSucceded(logger, circuitId, null);
+            public static void DisposeFailed(ILogger logger, CircuitId circuitId, Exception exception) => _disposeFailed(logger, circuitId, exception);
+            public static void CircuitOpened(ILogger logger, CircuitId circuitId) => _onCircuitOpened(logger, circuitId, null);
+            public static void ConnectionUp(ILogger logger, CircuitId circuitId, string connectionId) => _onConnectionUp(logger, circuitId, connectionId, null);
+            public static void ConnectionDown(ILogger logger, CircuitId circuitId, string connectionId) => _onConnectionDown(logger, circuitId, connectionId, null);
+            public static void CircuitClosed(ILogger logger, CircuitId circuitId) => _onCircuitClosed(logger, circuitId, null);
 
             public static void CircuitHandlerFailed(ILogger logger, CircuitHandler handler, string handlerMethod, Exception exception)
             {
@@ -825,8 +830,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     exception);
             }
 
-            public static void CircuitUnhandledException(ILogger logger, string circuitId, Exception exception) => _circuitUnhandledException(logger, circuitId, exception);
-            public static void CircuitTransmitErrorFailed(ILogger logger, string circuitId, Exception exception) => _circuitTransmitErrorFailed(logger, circuitId, exception);
+            public static void CircuitUnhandledException(ILogger logger, CircuitId circuitId, Exception exception) => _circuitUnhandledException(logger, circuitId, exception);
+            public static void CircuitTransmitErrorFailed(ILogger logger, CircuitId circuitId, Exception exception) => _circuitTransmitErrorFailed(logger, circuitId, exception);
             public static void EndInvokeDispatchException(ILogger logger, Exception ex) => _endInvokeDispatchException(logger, ex);
             public static void EndInvokeJSFailed(ILogger logger, long asyncHandle, string arguments) => _endInvokeJSFailed(logger, asyncHandle, arguments, null);
             public static void EndInvokeJSSucceeded(ILogger logger, long asyncCall) => _endInvokeJSSucceeded(logger, asyncCall, null);
@@ -857,14 +862,14 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 }
             }
 
-            public static void LocationChange(ILogger logger, string uri, string circuitId) => _locationChange(logger, uri, circuitId, null);
-            public static void LocationChangeSucceeded(ILogger logger, string uri, string circuitId) => _locationChangeSucceeded(logger, uri, circuitId, null);
-            public static void LocationChangeFailed(ILogger logger, string uri, string circuitId, Exception exception) => _locationChangeFailed(logger, uri, circuitId, exception);
-            public static void LocationChangeFailedInCircuit(ILogger logger, string uri, string circuitId, Exception exception) => _locationChangeFailedInCircuit(logger, uri, circuitId, exception);
-            public static void UnhandledExceptionClientDisconnected(ILogger logger, string circuitId, Exception exception) => _unhandledExceptionClientDisconnected(logger, circuitId, exception);
-            public static void CircuitTransmittingClientError(ILogger logger, string circuitId) => _circuitTransmittingClientError(logger, circuitId, null);
-            public static void CircuitTransmittedClientErrorSuccess(ILogger logger, string circuitId) => _circuitTransmittedClientErrorSuccess(logger, circuitId, null);
-            public static void OnRenderCompletedFailed(ILogger logger, long renderId, string circuitId, Exception e) => _onRenderCompletedFailed(logger, renderId, circuitId, e);
+            public static void LocationChange(ILogger logger, string uri, CircuitId circuitId) => _locationChange(logger, uri, circuitId, null);
+            public static void LocationChangeSucceeded(ILogger logger, string uri, CircuitId circuitId) => _locationChangeSucceeded(logger, uri, circuitId, null);
+            public static void LocationChangeFailed(ILogger logger, string uri, CircuitId circuitId, Exception exception) => _locationChangeFailed(logger, uri, circuitId, exception);
+            public static void LocationChangeFailedInCircuit(ILogger logger, string uri, CircuitId circuitId, Exception exception) => _locationChangeFailedInCircuit(logger, uri, circuitId, exception);
+            public static void UnhandledExceptionClientDisconnected(ILogger logger, CircuitId circuitId, Exception exception) => _unhandledExceptionClientDisconnected(logger, circuitId, exception);
+            public static void CircuitTransmittingClientError(ILogger logger, CircuitId circuitId) => _circuitTransmittingClientError(logger, circuitId, null);
+            public static void CircuitTransmittedClientErrorSuccess(ILogger logger, CircuitId circuitId) => _circuitTransmittedClientErrorSuccess(logger, circuitId, null);
+            public static void OnRenderCompletedFailed(ILogger logger, long renderId, CircuitId circuitId, Exception e) => _onRenderCompletedFailed(logger, renderId, circuitId, e);
         }
     }
 }

--- a/src/Components/Server/src/Circuits/CircuitId.cs
+++ b/src/Components/Server/src/Circuits/CircuitId.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits
+{
+    // Consists of a secret (data protected payload) and a non-secret identifier
+    // for use in logs and user code.
+    //
+    // The contract of this is that the id is derived from the Secret. We use the secret
+    // for comparisons, but we use the id for display (and exposing to user code). As a result,
+    // we don't include the id in any comparisons done by this class.
+    //
+    // Intentionally not overriding ToString here so that this won't accidentally
+    // get logged. It's ok to log the secret at TRACE.
+    internal readonly struct CircuitId : IEquatable<CircuitId>
+    {
+        public CircuitId(string secret, string id)
+        {
+            Secret = secret ?? throw new ArgumentNullException(nameof(secret));
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+        }
+
+        public string Id { get; }
+
+        public string Secret { get; }
+
+        public bool Equals([AllowNull] CircuitId other)
+        {
+            // We want to use a fixed time equality comparison for a *real* comparisons.
+            // The only use case for Secret being null is with a default struct value,
+            // which wouldn't be the result of untrusted input.
+            if (other.Secret == null)
+            {
+                return Secret == null;
+            }
+
+            return
+                CryptographicOperations.FixedTimeEquals(
+                    MemoryMarshal.AsBytes(Secret.AsSpan()),
+                    MemoryMarshal.AsBytes(other.Secret.AsSpan()));
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CircuitId other ? Equals(other) : false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Secret);
+        }
+
+        public override string ToString()
+        {
+            return Id;
+        }
+    }
+}

--- a/src/Components/Server/src/Circuits/CircuitIdFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitIdFactory.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits
 {
@@ -13,7 +13,12 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
     // Generates strong cryptographic ids for circuits that are protected with authenticated encryption.
     internal class CircuitIdFactory
     {
-        private const string CircuitIdProtectorPurpose = "Microsoft.AspNetCore.Components.Server";
+        private const string CircuitIdProtectorPurpose = "Microsoft.AspNetCore.Components.Server.CircuitIdFactory";
+
+        // We use 64 bytes, where the last 32 are the public version of the id.
+        // This way we can always recover the public id from the secret form.
+        private const int SecretLength = 64;
+        private const int IdLength = 32;
 
         private readonly RandomNumberGenerator _generator = RandomNumberGenerator.Create();
         private readonly IDataProtector _protector;
@@ -27,29 +32,58 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         // we don't care about the underlying payload, other than its uniqueness and the fact that we
         // authenticate encrypt it using data protection.
         // For validation, the fact that we can unprotect the payload is guarantee enough.
-        public string CreateCircuitId()
+        public CircuitId CreateCircuitId()
         {
-            var buffer = new byte[32];
+            var buffer = new byte[SecretLength];
             _generator.GetBytes(buffer);
-            var payload = _protector.Protect(buffer);
 
-            return Base64UrlTextEncoder.Encode(payload);
+            var id = new byte[IdLength];
+            Array.Copy(
+                sourceArray: buffer,
+                sourceIndex: SecretLength - IdLength,
+                destinationArray: id,
+                destinationIndex: 0,
+                length: IdLength);
+
+            var secret = _protector.Protect(buffer);
+            return new CircuitId(Base64UrlTextEncoder.Encode(secret), Base64UrlTextEncoder.Encode(id));
         }
 
-        public bool ValidateCircuitId(string circuitId)
+        public bool TryParseCircuitId(string text, out CircuitId circuitId)
         {
+            if (text is null)
+            {
+                circuitId = default;
+                return false;
+            }
+
             try
             {
-                var protectedBytes = Base64UrlTextEncoder.Decode(circuitId);
-                _protector.Unprotect(protectedBytes);
+                var protectedBytes = Base64UrlTextEncoder.Decode(text);
+                var unprotectedBytes = _protector.Unprotect(protectedBytes);
 
-                // Its enough that we prove that we can unprotect the payload to validate the circuit id,
-                // as this demonstrates that it the id wasn't tampered with.
+                if (unprotectedBytes.Length != SecretLength)
+                {
+                    // Wrong length
+                    circuitId = default;
+                    return false;
+                }
+
+                var id = new byte[IdLength];
+                Array.Copy(
+                    sourceArray: unprotectedBytes,
+                    sourceIndex: SecretLength - IdLength,
+                    destinationArray: id,
+                    destinationIndex: 0,
+                    length: IdLength);
+
+                circuitId = new CircuitId(text, Base64UrlTextEncoder.Encode(id));
                 return true;
             }
             catch (Exception)
             {
                 // The payload format is not correct (either not base64urlencoded or not data protected)
+                circuitId = default;
                 return false;
             }
         }

--- a/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/DefaultCircuitFactory.cs
@@ -113,11 +113,11 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
         private static class Log
         {
-            private static readonly Action<ILogger, string, string, Exception> _createdConnectedCircuit =
-                LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(1, "CreatedConnectedCircuit"), "Created circuit {CircuitId} for connection {ConnectionId}");
+            private static readonly Action<ILogger, CircuitId, string, Exception> _createdConnectedCircuit =
+                LoggerMessage.Define<CircuitId, string>(LogLevel.Debug, new EventId(1, "CreatedConnectedCircuit"), "Created circuit {CircuitId} for connection {ConnectionId}");
 
-            private static readonly Action<ILogger, string, Exception> _createdDisconnectedCircuit =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(2, "CreatedDisconnectedCircuit"), "Created circuit {CircuitId} for disconnected client");
+            private static readonly Action<ILogger, CircuitId, Exception> _createdDisconnectedCircuit =
+                LoggerMessage.Define<CircuitId>(LogLevel.Debug, new EventId(2, "CreatedDisconnectedCircuit"), "Created circuit {CircuitId} for disconnected client");
 
             internal static void CreatedCircuit(ILogger logger, CircuitHost circuitHost)
             {

--- a/src/Components/Server/test/CircuitDisconnectMiddlewareTest.cs
+++ b/src/Components/Server/test/CircuitDisconnectMiddlewareTest.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Components.Server
         {
             // Arrange
             var circuitIdFactory = TestCircuitIdFactory.CreateTestFactory();
-            var id = circuitIdFactory.CreateCircuitId();
+            var circuitId = circuitIdFactory.CreateCircuitId();
             var registry = new CircuitRegistry(
                 Options.Create(new CircuitOptions()),
                 NullLogger<CircuitRegistry>.Instance,
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Components.Server
                 (ctx) => Task.CompletedTask);
 
             using var memory = new MemoryStream();
-            await new FormUrlEncodedContent(new Dictionary<string, string> { ["circuitId"] = id }).CopyToAsync(memory);
+            await new FormUrlEncodedContent(new Dictionary<string, string> { ["circuitId"] = circuitId.Secret, }).CopyToAsync(memory);
             memory.Seek(0, SeekOrigin.Begin);
 
             var context = new DefaultHttpContext();
@@ -171,8 +171,8 @@ namespace Microsoft.AspNetCore.Components.Server
         {
             // Arrange
             var circuitIdFactory = TestCircuitIdFactory.CreateTestFactory();
-            var id = circuitIdFactory.CreateCircuitId();
-            var testCircuitHost = TestCircuitHost.Create(id);
+            var circuitId = circuitIdFactory.CreateCircuitId();
+            var testCircuitHost = TestCircuitHost.Create(circuitId);
 
             var registry = new CircuitRegistry(
                 Options.Create(new CircuitOptions()),
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Components.Server
                 (ctx) => Task.CompletedTask);
 
             using var memory = new MemoryStream();
-            await new FormUrlEncodedContent(new Dictionary<string, string> { ["circuitId"] = id }).CopyToAsync(memory);
+            await new FormUrlEncodedContent(new Dictionary<string, string> { ["circuitId"] = circuitId.Secret, }).CopyToAsync(memory);
             memory.Seek(0, SeekOrigin.Begin);
 
             var context = new DefaultHttpContext();
@@ -208,8 +208,8 @@ namespace Microsoft.AspNetCore.Components.Server
         {
             // Arrange
             var circuitIdFactory = TestCircuitIdFactory.CreateTestFactory();
-            var id = circuitIdFactory.CreateCircuitId();
-            var circuitHost = TestCircuitHost.Create(id);
+            var circuitId = circuitIdFactory.CreateCircuitId();
+            var circuitHost = TestCircuitHost.Create(circuitId);
 
             var registry = new CircuitRegistry(
                 Options.Create(new CircuitOptions()),
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Components.Server
                 (ctx) => Task.CompletedTask);
 
             using var memory = new MemoryStream();
-            await new FormUrlEncodedContent(new Dictionary<string, string> { ["circuitId"] = id }).CopyToAsync(memory);
+            await new FormUrlEncodedContent(new Dictionary<string, string> { ["circuitId"] = circuitId.Secret }).CopyToAsync(memory);
             memory.Seek(0, SeekOrigin.Begin);
 
             var context = new DefaultHttpContext();

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -26,9 +26,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var serviceScope = new Mock<IServiceScope>();
             var remoteRenderer = GetRemoteRenderer();
             var circuitHost = TestCircuitHost.Create(
-                Guid.NewGuid().ToString(),
-                serviceScope.Object,
-                remoteRenderer);
+                serviceScope: serviceScope.Object,
+                remoteRenderer: remoteRenderer);
 
             // Act
             await circuitHost.DisposeAsync();
@@ -52,9 +51,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             var remoteRenderer = GetRemoteRenderer();
             var circuitHost = TestCircuitHost.Create(
-                Guid.NewGuid().ToString(),
-                serviceScope.Object,
-                remoteRenderer);
+                serviceScope: serviceScope.Object,
+                remoteRenderer: remoteRenderer);
 
             // Act
             await circuitHost.DisposeAsync();
@@ -77,9 +75,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 .Throws<InvalidTimeZoneException>();
             var remoteRenderer = GetRemoteRenderer();
             var circuitHost = TestCircuitHost.Create(
-                Guid.NewGuid().ToString(),
-                serviceScope.Object,
-                remoteRenderer,
+                serviceScope: serviceScope.Object,
+                remoteRenderer: remoteRenderer,
                 handlers: new[] { handler.Object });
 
             var throwOnDisposeComponent = new ThrowOnDisposeComponent();
@@ -101,9 +98,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var serviceScope = new Mock<IServiceScope>();
             var remoteRenderer = GetRemoteRenderer();
             var circuitHost = TestCircuitHost.Create(
-                Guid.NewGuid().ToString(),
-                serviceScope.Object,
-                remoteRenderer);
+                serviceScope: serviceScope.Object,
+                remoteRenderer: remoteRenderer);
 
             var component = new DispatcherComponent(circuitHost.Renderer.Dispatcher);
             circuitHost.Renderer.AssignRootComponentId(component);

--- a/src/Components/Server/test/Circuits/CircuitIdFactoryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitIdFactoryTest.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Linq;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits
 {
-    public class CircuitIdFactoryTest
+    public class circuitIdFactoryTest
     {
         [Fact]
         public void CreateCircuitId_Generates_NewRandomId()
@@ -17,12 +16,12 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var factory = TestCircuitIdFactory.CreateTestFactory();
 
             // Act
-            var id = factory.CreateCircuitId();
+            var secret = factory.CreateCircuitId();
 
             // Assert
-            Assert.NotNull(id);
+            Assert.NotNull(secret.Secret);
             // This is the magic data protection header that validates its protected
-            Assert.StartsWith("CfDJ", id);
+            Assert.StartsWith("CfDJ", secret.Secret);
         }
 
         [Fact]
@@ -32,13 +31,14 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var factory = TestCircuitIdFactory.CreateTestFactory();
 
             // Act
-            var ids = Enumerable.Range(0, 100).Select(i => factory.CreateCircuitId()).ToArray();
+            var secrets = Enumerable.Range(0, 100).Select(i => factory.CreateCircuitId()).Select(s => s.Secret).ToArray();
 
             // Assert
-            Assert.All(ids, id => Assert.NotNull(id));
-            Assert.Equal(100, ids.Distinct(StringComparer.Ordinal).Count());
+            Assert.All(secrets, secret => Assert.NotNull(secret));
+            Assert.Equal(100, secrets.Distinct(StringComparer.Ordinal).Count());
         }
 
+        // Note that this test also verifies that the ID can be reproduced from the secret.
         [Fact]
         public void CircuitIds_Roundtrip()
         {
@@ -47,10 +47,13 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var id = factory.CreateCircuitId();
 
             // Act
-            var isValid = factory.ValidateCircuitId(id);
+            var isValid = factory.TryParseCircuitId(id.Secret, out var parsed);
 
             // Assert
             Assert.True(isValid, "Failed to validate id");
+            Assert.Equal(id, parsed);
+            Assert.Equal(id.Secret, parsed.Secret);
+            Assert.Equal(id.Id, parsed.Id);
         }
 
         [Fact]
@@ -60,7 +63,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             var factory = TestCircuitIdFactory.CreateTestFactory();
 
             // Act
-            var isValid = factory.ValidateCircuitId("$%@&==");
+            var isValid = factory.TryParseCircuitId("$%@&==", out _);
 
             // Assert
             Assert.False(isValid, "Accepted an invalid payload");
@@ -71,16 +74,16 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         {
             // Arrange
             var factory = TestCircuitIdFactory.CreateTestFactory();
-            var id = factory.CreateCircuitId();
-            var protectedBytes = Base64UrlTextEncoder.Decode(id);
+            var secret = factory.CreateCircuitId();
+            var protectedBytes = Base64UrlTextEncoder.Decode(secret.Secret);
             for (int i = protectedBytes.Length - 10; i < protectedBytes.Length; i++)
             {
                 protectedBytes[i] = 0;
             }
-            var tamperedId = Base64UrlTextEncoder.Encode(protectedBytes);
+            var tampered = Base64UrlTextEncoder.Encode(protectedBytes);
 
             // Act
-            var isValid = factory.ValidateCircuitId(tamperedId);
+            var isValid = factory.TryParseCircuitId(tampered, out _);
 
             // Assert
             Assert.False(isValid, "Accepted a tampered payload");

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -163,14 +163,14 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             // Arrange
             var registry = CreateRegistry();
             var circuitHost = TestCircuitHost.Create();
-            registry.DisconnectedCircuits.Set(circuitHost.CircuitId, circuitHost, new MemoryCacheEntryOptions { Size = 1 });
+            registry.DisconnectedCircuits.Set(circuitHost.CircuitId.Secret, circuitHost, new MemoryCacheEntryOptions { Size = 1 });
 
             // Act
             await registry.DisconnectAsync(circuitHost, circuitHost.Client.ConnectionId);
 
             // Assert
             Assert.Empty(registry.ConnectedCircuits.Values);
-            Assert.True(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId, out _));
+            Assert.True(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId.Secret, out _));
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             Assert.Same(client, circuitHost.Client.Client);
             Assert.Equal(newId, circuitHost.Client.ConnectionId);
 
-            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId, out _));
+            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId.Secret, out _));
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             Assert.Same(client, circuitHost.Client.Client);
             Assert.Equal(newId, circuitHost.Client.ConnectionId);
 
-            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId, out _));
+            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId.Secret, out _));
         }
 
         [Fact]
@@ -322,9 +322,9 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             // Act
             // Verify it's present in the dictionary.
-            Assert.True(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId, out var _));
+            Assert.True(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId.Secret, out var _));
             await Task.Run(() => tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(10)));
-            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId, out var _));
+            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId.Secret, out var _));
         }
 
         [Fact]
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             Assert.True(registry.ConnectedCircuits.TryGetValue(circuitHost.CircuitId, out var cacheValue));
             Assert.Same(circuitHost, cacheValue);
             // Nothing should be disconnected.
-            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId, out var _));
+            Assert.False(registry.DisconnectedCircuits.TryGetValue(circuitHost.CircuitId.Secret, out var _));
         }
 
         private class TestCircuitRegistry : CircuitRegistry
@@ -370,7 +370,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             public Action OnAfterEntryEvicted { get; set; }
 
-            protected override (CircuitHost, bool) ConnectCore(string circuitId, IClientProxy clientProxy, string connectionId)
+            protected override (CircuitHost, bool) ConnectCore(CircuitId circuitId, IClientProxy clientProxy, string connectionId)
             {
                 if (BeforeConnect != null)
                 {

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -15,13 +15,13 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 {
     internal class TestCircuitHost : CircuitHost
     {
-        private TestCircuitHost(string circuitId, IServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, CircuitHandler[] circuitHandlers, ILogger logger)
+        private TestCircuitHost(CircuitId circuitId, IServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, CircuitHandler[] circuitHandlers, ILogger logger)
             : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, circuitHandlers, logger)
         {
         }
 
         public static CircuitHost Create(
-            string circuitId = null,
+            CircuitId? circuitId = null,
             IServiceScope serviceScope = null,
             RemoteRenderer remoteRenderer = null,
             CircuitHandler[] handlers = null,
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
             handlers = handlers ?? Array.Empty<CircuitHandler>();
             return new TestCircuitHost(
-                circuitId ?? Guid.NewGuid().ToString(),
+                circuitId is null ? new CircuitId(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()) : circuitId.Value,
                 serviceScope,
                 new CircuitOptions(),
                 clientProxy,

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -68,9 +68,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             // Arrange & Act
             Browser.Close();
-            // Set to null so that other tests in this class can create a new browser if necessary so
-            // that tests don't fail when running together.
-
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
             // Assert

--- a/src/Components/test/testassets/TestServer/appsettings.json
+++ b/src/Components/test/testassets/TestServer/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Microsoft.AspNetCore.Components": "Debug"
+      "Microsoft.AspNetCore.Components": "Trace"
     },
     "Debug": {
       "LogLevel": {


### PR DESCRIPTION
Fixes: #13012

This change introduces CircuitSecret as the concept that's used when
doing handshaking between the client and the server, and makes CircuitId
(visible to user-code) a separate concept (not a secret, can't be used
to open a connection).

The scope of this grew once I realized that we probably shouldn't be
logging Circuit Secret in so many places, we should be logging CircuitId
as the piece of data we use for correlation, and try to keep the secret
out of logs except where really necessary (and with trace level).

I ended up creating a new type to represent the secret and prevent
accidental misuse, and then chased down all of the build errors.

