### PR TITLE
Ignore overriden properties in component parameters

### DIFF
--- a/src/Components/Components/src/Reflection/ComponentProperties.cs
+++ b/src/Components/Components/src/Reflection/ComponentProperties.cs
@@ -238,9 +238,15 @@ namespace Microsoft.AspNetCore.Components.Reflection
                         continue;
                     }
 
+                    var propertyName = propertyInfo.Name;
+                    if (parameterAttribute != null && (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic))
+                    {
+                        throw new InvalidOperationException(
+                            $"The type '{targetType.FullName}' declares a parameter matching the name '{propertyName}' that is not public. Parameters must be public.");
+                    }
+
                     var propertySetter = MemberAssignment.CreatePropertySetter(targetType, propertyInfo, cascading: cascadingParameterAttribute != null);
 
-                    var propertyName = propertyInfo.Name;
                     if (WritersByName.ContainsKey(propertyName))
                     {
                         throw new InvalidOperationException(

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -2231,7 +2231,7 @@ namespace Microsoft.AspNetCore.Components.Test
             public object ObjectProperty { get; set; }
 
             [Parameter]
-            public string ReadonlyProperty { get; private set; }
+            public string ReadonlyProperty { get; set; }
 
             [Parameter]
             public string PrivateProperty { get; set; }

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -3791,10 +3791,10 @@ namespace Microsoft.AspNetCore.Components.Test
         private class FakeComponent : IComponent
         {
             [Parameter]
-            public int IntProperty { get; private set; }
+            public int IntProperty { get; set; }
 
             [Parameter]
-            public string StringProperty { get; private set; }
+            public string StringProperty { get; set; }
 
             [Parameter]
             public object ObjectProperty { get; set; }
@@ -3927,7 +3927,7 @@ namespace Microsoft.AspNetCore.Components.Test
         private class ReRendersParentComponent : AutoRenderComponent
         {
             [Parameter]
-            public TestComponent Parent { get; private set; }
+            public TestComponent Parent { get; set; }
 
             private bool _isFirstTime = true;
 
@@ -4057,7 +4057,7 @@ namespace Microsoft.AspNetCore.Components.Test
             public bool Disposed { get; private set; }
 
             [Parameter]
-            public Action DisposeAction { get; private set; }
+            public Action DisposeAction { get; set; }
 
             public void Dispose()
             {


### PR DESCRIPTION
* Modify MemberAssignment to return shadowed properties, but not inherited properties
* Modify ComponentProperties to throw if a Parameter property is non-public

Fixes https://github.com/aspnet/AspNetCore/issues/13162

