### PR TITLE
Wait until after UseHttps() to read HttpProtocols

### DIFF
--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -216,15 +216,15 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var loggerFactory = listenOptions.KestrelServerOptions?.ApplicationServices.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
 
-            // Set the list of protocols from listen options
-            httpsOptions.HttpProtocols = listenOptions.Protocols;
             listenOptions.IsTls = true;
-
             listenOptions.Use(next =>
             {
+                // Set the list of protocols from listen options
+                httpsOptions.HttpProtocols = listenOptions.Protocols;
                 var middleware = new HttpsConnectionMiddleware(next, httpsOptions, loggerFactory);
                 return middleware.OnConnectionAsync;
             });
+
             return listenOptions;
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -590,10 +590,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(CoreStrings.FormatInvalidServerCertificateEku(cert.Thumbprint), ex.Message);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(HttpProtocols.Http1)]
         [InlineData(HttpProtocols.Http2)]
         [InlineData(HttpProtocols.Http1AndHttp2)]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/corefx/issues/30492")]
         public async Task ListenOptionsProtolsCanBeSetAfterUseHttps(HttpProtocols httpProtocols)
         {
             void ConfigureListenOptions(ListenOptions listenOptions)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -603,30 +603,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.Protocols = httpProtocols;
             }
 
-            await using (var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory), ConfigureListenOptions))
+            await using var server = new TestServer(context => Task.CompletedTask, new TestServiceContext(LoggerFactory), ConfigureListenOptions);
+            using var connection = server.CreateConnection();
+
+            var sslOptions = new SslClientAuthenticationOptions
             {
-                using (var connection = server.CreateConnection())
-                {
-                    // SslStream is used to ensure the certificate is actually passed to the server
-                    // HttpClient might not send the certificate because it is invalid or it doesn't match any
-                    // of the certificate authorities sent by the server in the SSL handshake.
-                    var sslOptions = new SslClientAuthenticationOptions
-                    {
-                        TargetHost = "localhost",
-                        EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11,
-                        ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 },
-                    };
+                TargetHost = "localhost",
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11,
+                ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11, SslApplicationProtocol.Http2 },
+            };
 
-                    using var stream = OpenSslStream(connection.Stream);
-                    await stream.AuthenticateAsClientAsync(sslOptions);
+            using var stream = OpenSslStream(connection.Stream);
+            await stream.AuthenticateAsClientAsync(sslOptions);
 
-                    Assert.Equal(
-                        httpProtocols.HasFlag(HttpProtocols.Http2) ?
-                            SslApplicationProtocol.Http2 :
-                            SslApplicationProtocol.Http11,
-                        stream.NegotiatedApplicationProtocol);
-                }
-            }
+            Assert.Equal(
+                httpProtocols.HasFlag(HttpProtocols.Http2) ?
+                    SslApplicationProtocol.Http2 :
+                    SslApplicationProtocol.Http11,
+                stream.NegotiatedApplicationProtocol);
         }
 
         private static async Task App(HttpContext httpContext)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -595,6 +595,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [InlineData(HttpProtocols.Http2)]
         [InlineData(HttpProtocols.Http1AndHttp2)]
         [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/corefx/issues/30492")]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/10428", Queues = "Debian.8.Amd64.Open")] // Debian 8 uses OpenSSL 1.0.1 which does not support HTTP/2
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win81)]
         public async Task ListenOptionsProtolsCanBeSetAfterUseHttps(HttpProtocols httpProtocols)
         {
             void ConfigureListenOptions(ListenOptions listenOptions)


### PR DESCRIPTION
- This makes it so ListenOptions.HttpProtocols can be set after
  ListenOptions.UseHttps() is called and still function.