### PR TITLE
Correct the spelling of 'EnableEndpointRouting'

### DIFF
--- a/src/Analyzers/Analyzers/src/StartupAnalyzer.Diagnostics.cs
+++ b/src/Analyzers/Analyzers/src/StartupAnalyzer.Diagnostics.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Analyzers
             internal readonly static DiagnosticDescriptor UnsupportedUseMvcWithEndpointRouting = new DiagnosticDescriptor(
                 "MVC1005",
                 "Cannot use UseMvc with Endpoint Routing.",
-                "Using '{0}' to configure MVC is not supported while using Endpoint Routing. To continue using '{0}', please set 'MvcOptions.EnableEndpointRounting = false' inside '{1}'.",
+                "Using '{0}' to configure MVC is not supported while using Endpoint Routing. To continue using '{0}', please set 'MvcOptions.EnableEndpointRouting = false' inside '{1}'.",
                 "Usage",
                 DiagnosticSeverity.Warning,
                 isEnabledByDefault: true,


### PR DESCRIPTION
Message had "EnableEndpointRounting" instead of "EnableEndpointRouting"

Addresses #11467