### PR TITLE
Improve reliability of reliability tests

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -649,12 +649,12 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             {
                 _intializationStarted = LoggerMessage.Define(
                     LogLevel.Debug,
-                    EventIds.InitializationFailed,
+                    EventIds.InitializationStarted,
                     "Circuit initialization started.");
 
                 _intializationSucceded = LoggerMessage.Define(
                     LogLevel.Debug,
-                    EventIds.InitializationFailed,
+                    EventIds.InitializationSucceeded,
                     "Circuit initialization succeeded.");
 
                 _intializationFailed = LoggerMessage.Define(

--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubInvalidEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubInvalidEventTest.cs
@@ -1,0 +1,138 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.E2ETest;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETests.ServerExecutionTests
+{
+    public class ComponentHubInvalidEventTest : IgnitorTest<AspNetSiteServerFixture>
+    {
+        public ComponentHubInvalidEventTest(AspNetSiteServerFixture serverFixture, ITestOutputHelper output)
+            : base(serverFixture, output)
+        {
+        }
+
+        protected override void InitializeFixture(AspNetSiteServerFixture serverFixture)
+        {
+            serverFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
+        }
+
+        protected async override Task InitializeAsync()
+        {
+            var rootUri = ServerFixture.RootUri;
+            Assert.True(await Client.ConnectAsync(new Uri(rootUri, "/subdir")), "Couldn't connect to the app");
+            Assert.Single(Batches);
+
+            await Client.SelectAsync("test-selector-select", "BasicTestApp.CounterComponent");
+            Assert.Equal(2, Batches.Count);
+        }
+
+        [Fact]
+        public async Task DispatchingAnInvalidEventArgument_DoesNotProduceWarnings()
+        {
+            // Arrange
+            var expectedError = $"There was an unhandled exception on the current circuit, so this circuit will be terminated. For more details turn on " +
+                $"detailed exceptions in 'CircuitOptions.DetailedErrors'. Bad input data.";
+
+            var eventDescriptor = Serialize(new WebEventDescriptor()
+            {
+                BrowserRendererId = 0,
+                EventHandlerId = 3,
+                EventArgsType = "mouse",
+            });
+
+            // Act
+            await Client.ExpectCircuitError(() => Client.HubConnection.SendAsync(
+                "DispatchBrowserEvent",
+                eventDescriptor,
+                "{sadfadsf]"));
+
+            // Assert
+            var actualError = Assert.Single(Errors);
+            Assert.Equal(expectedError, actualError);
+            Assert.DoesNotContain(Logs, l => l.LogLevel > LogLevel.Information);
+            Assert.Contains(Logs, l => (l.LogLevel, l.Exception?.Message) == (LogLevel.Debug, "There was an error parsing the event arguments. EventId: '3'."));
+        }
+
+        [Fact]
+        public async Task DispatchingAnInvalidEvent_DoesNotTriggerWarnings()
+        {
+            // Arrange
+            var expectedError = $"There was an unhandled exception on the current circuit, so this circuit will be terminated. For more details turn on " +
+                $"detailed exceptions in 'CircuitOptions.DetailedErrors'. Failed to dispatch event.";
+
+            var eventDescriptor = Serialize(new WebEventDescriptor()
+            {
+                BrowserRendererId = 0,
+                EventHandlerId = 1990,
+                EventArgsType = "mouse",
+            });
+
+            var eventArgs = new MouseEventArgs
+            {
+                Type = "click",
+                Detail = 1,
+                ScreenX = 47,
+                ScreenY = 258,
+                ClientX = 47,
+                ClientY = 155,
+            };
+
+            // Act
+            await Client.ExpectCircuitError(() => Client.HubConnection.SendAsync(
+                "DispatchBrowserEvent",
+                eventDescriptor,
+                Serialize(eventArgs)));
+
+            // Assert
+            var actualError = Assert.Single(Errors);
+            Assert.Equal(expectedError, actualError);
+            Assert.DoesNotContain(Logs, l => l.LogLevel > LogLevel.Information);
+            Assert.Contains(Logs, l => (l.LogLevel, l.Message, l.Exception?.Message) ==
+                (LogLevel.Debug,
+                "There was an error dispatching the event '1990' to the application.",
+                "There is no event handler associated with this event. EventId: '1990'. (Parameter 'eventHandlerId')"));
+        }
+
+        [Fact]
+        public async Task DispatchingAnInvalidRenderAcknowledgement_DoesNotTriggerWarnings()
+        {
+            // Arrange
+            var expectedError = $"There was an unhandled exception on the current circuit, so this circuit will be terminated. For more details turn on " +
+                $"detailed exceptions in 'CircuitOptions.DetailedErrors'. Failed to complete render batch '1846'.";
+
+
+            Client.ConfirmRenderBatch = false;
+            await Client.ClickAsync("counter");
+
+            // Act
+            await Client.ExpectCircuitError(() => Client.HubConnection.SendAsync(
+                "OnRenderCompleted",
+                1846,
+                null));
+
+            // Assert
+            var actualError = Assert.Single(Errors);
+            Assert.Equal(expectedError, actualError);
+            Assert.DoesNotContain(Logs, l => l.LogLevel > LogLevel.Information);
+
+            var entry = Assert.Single(Logs, l => l.EventId.Name == "OnRenderCompletedFailed");
+            Assert.Equal(LogLevel.Debug, entry.LogLevel);
+            Assert.Matches("Failed to complete render batch '1846' in circuit host '.*'\\.", entry.Message);
+            Assert.Equal("Received an acknowledgement for batch with id '1846' when the last batch produced was '4'.", entry.Exception.Message);
+        }
+
+        private string Serialize<T>(T browserEventDescriptor) =>
+            JsonSerializer.Serialize(browserEventDescriptor, TestJsonSerializerOptionsProvider.Options);
+    }
+}

--- a/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Ignitor;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components
+{
+    // Base class for Ignitor-based tests.
+    public abstract class IgnitorTest<TFixture> : IClassFixture<TFixture>, IAsyncLifetime
+        where TFixture : ServerFixture
+    {
+        private static readonly TimeSpan DefaultTimeout = Debugger.IsAttached ? TimeSpan.MaxValue : TimeSpan.FromSeconds(30);
+
+        protected IgnitorTest(TFixture serverFixture, ITestOutputHelper output)
+        {
+            ServerFixture = serverFixture;
+            Output = output;
+        }
+
+        protected BlazorClient Client { get; private set; }
+
+        protected ConcurrentQueue<LogMessage> Logs { get; } = new ConcurrentQueue<LogMessage>();
+
+        protected ITestOutputHelper Output { get; }
+
+        protected TFixture ServerFixture { get; }
+
+        protected TimeSpan Timeout { get; set; } = DefaultTimeout;
+
+        private TestSink TestSink { get; set; }
+
+        protected IReadOnlyCollection<CapturedRenderBatch> Batches => Client?.Operations?.Batches;
+
+        protected IReadOnlyCollection<string> DotNetCompletions => Client?.Operations?.DotNetCompletions;
+
+        protected IReadOnlyCollection<string> Errors => Client?.Operations?.Errors;
+
+        protected IReadOnlyCollection<CapturedJSInteropCall> JSInteropCalls => Client?.Operations?.JSInteropCalls;
+
+        // Called to initialize the fixture as part of InitializeAsync.
+        protected virtual void InitializeFixture(TFixture serverFixture)
+        {
+        }
+
+        async Task IAsyncLifetime.InitializeAsync()
+        {
+            Client = new BlazorClient()
+            {
+                CaptureOperations = true,
+                DefaultOperationTimeout = Timeout,
+            };
+            Client.LoggerProvider = new XunitLoggerProvider(Output);
+            Client.FormatError = (error) =>
+            {
+                var logs = string.Join(Environment.NewLine, Logs);
+                return new Exception(error + Environment.NewLine + logs);
+            };
+
+            InitializeFixture(ServerFixture);
+            _ = ServerFixture.RootUri; // This is needed for the side-effects of starting the server.
+
+            if (ServerFixture is WebHostServerFixture hostFixture)
+            {
+                TestSink = hostFixture.Host.Services.GetRequiredService<TestSink>();
+                TestSink.MessageLogged += TestSink_MessageLogged;
+            }
+
+            await InitializeAsync();
+        }
+
+        async Task IAsyncLifetime.DisposeAsync()
+        {
+            if (TestSink != null)
+            {
+                TestSink.MessageLogged -= TestSink_MessageLogged;
+            }
+
+            await DisposeAsync();
+        }
+
+        protected virtual Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected virtual Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        private void TestSink_MessageLogged(WriteContext context)
+        {
+            var log = new LogMessage(context.LogLevel, context.EventId, context.Message, context.Exception);
+            Logs.Enqueue(log);
+            Output.WriteLine(log.ToString());
+        }
+
+        [DebuggerDisplay("{LogLevel.ToString(),nq} - {Message ?? \"null\",nq} - {Exception?.Message,nq}")]
+        protected sealed class LogMessage
+        {
+            public LogMessage(LogLevel logLevel, EventId eventId, string message, Exception exception)
+            {
+                LogLevel = logLevel;
+                EventId = eventId;
+                Message = message;
+                Exception = exception;
+            }
+
+            public LogLevel LogLevel { get; set; }
+            public EventId EventId { get; set; }
+            public string Message { get; set; }
+            public Exception Exception { get; set; }
+
+            public override string ToString()
+            {
+                return $"{LogLevel}: {EventId} {Message}{(Exception != null ? Environment.NewLine : "")}{Exception}";
+            }
+        }
+    }
+}

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -21,55 +20,26 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
-    [Flaky("https://github.com/aspnet/AspNetCore/issues/13086", FlakyOn.All)]
-    public class InteropReliabilityTests : IClassFixture<AspNetSiteServerFixture>, IDisposable
+    public class InteropReliabilityTests : IgnitorTest<AspNetSiteServerFixture>
     {
-        private static readonly TimeSpan DefaultLatencyTimeout = TimeSpan.FromSeconds(30);
-        private readonly AspNetSiteServerFixture _serverFixture;
-
         public InteropReliabilityTests(AspNetSiteServerFixture serverFixture, ITestOutputHelper output)
+            : base(serverFixture, output)
         {
-            _serverFixture = serverFixture;
-            Output = output;
+        }
 
+        protected override void InitializeFixture(AspNetSiteServerFixture serverFixture)
+        {
             serverFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
-            CreateDefaultConfiguration();
         }
 
-        public BlazorClient Client { get; set; }
-        public ITestOutputHelper Output { get; set; }
-        private IList<Batch> Batches { get; set; } = new List<Batch>();
-        private List<DotNetCompletion> DotNetCompletions = new List<DotNetCompletion>();
-        private List<JSInteropCall> JSInteropCalls = new List<JSInteropCall>();
-        private IList<string> Errors { get; set; } = new List<string>();
-        private ConcurrentQueue<LogMessage> Logs { get; set; } = new ConcurrentQueue<LogMessage>();
-
-        public TestSink TestSink { get; set; }
-
-        private void CreateDefaultConfiguration()
+        protected async override Task InitializeAsync()
         {
-            Client = new BlazorClient() { DefaultLatencyTimeout = DefaultLatencyTimeout };
-            Client.RenderBatchReceived += (id, data) => Batches.Add(new Batch(id, data));
-            Client.DotNetInteropCompletion += (method) => DotNetCompletions.Add(new DotNetCompletion(method));
-            Client.JSInterop += (asyncHandle, identifier, argsJson) => JSInteropCalls.Add(new JSInteropCall(asyncHandle, identifier, argsJson));
-            Client.OnCircuitError += (error) => Errors.Add(error);
-            Client.LoggerProvider = new XunitLoggerProvider(Output);
-            Client.FormatError = (error) =>
-            {
-                var logs = string.Join(Environment.NewLine, Logs);
-                return new Exception(error + Environment.NewLine + logs);
-            };
+            var rootUri = ServerFixture.RootUri;
+            Assert.True(await Client.ConnectAsync(new Uri(rootUri, "/subdir")), "Couldn't connect to the app");
+            Assert.Single(Batches);
 
-            _ = _serverFixture.RootUri; // this is needed for the side-effects of getting the URI.
-            TestSink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            TestSink.MessageLogged += LogMessages;
-        }
-
-        private void LogMessages(WriteContext context)
-        {
-            var log = new LogMessage(context.LogLevel, context.Message, context.Exception);
-            Logs.Enqueue(log);
-            Output.WriteLine(log.ToString());
+            await Client.SelectAsync("test-selector-select", "BasicTestApp.ReliabilityComponent");
+            Assert.Equal(2, Batches.Count);
         }
 
         [Fact]
@@ -79,7 +49,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "[\"1\"," +
                 "false," +
                 "\"There was an exception invoking \\u0027WriteAllText\\u0027 on assembly \\u0027System.IO.FileSystem\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
-            await GoToTestComponent(Batches);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -90,7 +59,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new[] { ".\\log.txt", "log" }));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -102,8 +71,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027MadeUpMethod\\u0027 on assembly \\u0027BasicTestApp\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
@@ -113,7 +80,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new[] { ".\\log.txt", "log" }));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -125,18 +92,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027NotifyLocationChanged\\u0027 on assembly \\u0027Microsoft.AspNetCore.Components.Server\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
                 "Microsoft.AspNetCore.Components.Server",
                 "NotifyLocationChanged",
                 null,
-                JsonSerializer.Serialize(new[] { _serverFixture.RootUri }));
+                JsonSerializer.Serialize(new[] { ServerFixture.RootUri }));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -148,18 +113,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027NotifyLocationChanged\\u0027 on assembly \\u0027\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
                 "",
                 "NotifyLocationChanged",
                 null,
-                JsonSerializer.Serialize(new object[] { _serverFixture.RootUri + "counter", false }));
+                JsonSerializer.Serialize(new object[] { ServerFixture.RootUri + "counter", false }));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -171,18 +134,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027\\u0027 on assembly \\u0027Microsoft.AspNetCore.Components.Server\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
                 "Microsoft.AspNetCore.Components.Server",
                 "",
                 null,
-                JsonSerializer.Serialize(new object[] { _serverFixture.RootUri + "counter", false }));
+                JsonSerializer.Serialize(new object[] { ServerFixture.RootUri + "counter", false }));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
 
             await ValidateClientKeepsWorking(Client, Batches);
         }
@@ -196,8 +157,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027Reverse\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
@@ -206,7 +165,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 null,
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
-            Assert.Single(DotNetCompletions, c => c.Message == expectedDotNetObjectRef);
+            Assert.Single(DotNetCompletions, c => c == expectedDotNetObjectRef);
 
             await Client.InvokeDotNetMethod(
                 "1",
@@ -216,7 +175,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == "[\"1\",true,\"tnatropmI\"]");
+            Assert.Single(DotNetCompletions, c => c == "[\"1\",true,\"tnatropmI\"]");
 
             await Client.InvokeDotNetMethod(
                 "1",
@@ -225,7 +184,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 3, // non existing ref
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -238,8 +197,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027ReceiveTrivial\\u0027 on assembly \\u0027BasicTestApp\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             await Client.InvokeDotNetMethod(
                 "1",
                 "BasicTestApp",
@@ -247,7 +204,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 null,
                 JsonSerializer.Serialize(Array.Empty<object>()));
 
-            Assert.Single(DotNetCompletions, c => c.Message == expectedImportantDotNetObjectRef);
+            Assert.Single(DotNetCompletions, c => c == expectedImportantDotNetObjectRef);
 
             // Act
             await Client.InvokeDotNetMethod(
@@ -258,18 +215,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 JsonSerializer.Serialize(new object[] { new { __dotNetObject = 1 } }));
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore/issues/13086", FlakyOn.AzP.Windows)]
         public async Task ContinuesWorkingAfterInvalidAsyncReturnCallback()
         {
             // Arrange
             var expectedError = "An exception occurred executing JS interop: The JSON value could not be converted to System.Int32. Path: $ | LineNumber: 0 | BytePositionInLine: 3.. See InnerException for more details.";
-
-            await GoToTestComponent(Batches);
 
             // Act
             await Client.ClickAsync("triggerjsinterop-malformed");
@@ -278,11 +232,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.NotEqual(default, call);
 
             var id = call.AsyncHandle;
-            await Client.HubConnection.InvokeAsync(
-                "EndInvokeJSFromDotNet",
-                id,
-                true,
-                $"[{id}, true, \"{{\"]");
+            await Client.ExpectRenderBatch(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
+                    "EndInvokeJSFromDotNet",
+                    id,
+                    true,
+                    $"[{id}, true, \"{{\"]");
+            });
 
             var text = Assert.Single(
                 Client.FindElementById("errormessage-malformed").Children.OfType<TextNode>(),
@@ -295,10 +252,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task JSInteropCompletionSuccess()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
             await Client.ClickAsync("triggerjsinterop-success");
@@ -307,27 +260,27 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.NotEqual(default, call);
 
             var id = call.AsyncHandle;
-            await Client.HubConnection.InvokeAsync(
-                "EndInvokeJSFromDotNet",
-                id++,
-                true,
-                $"[{id}, true, null]");
+            await Client.ExpectRenderBatch(async () =>
+            {
+                await Client.HubConnection.InvokeAsync(
+                    "EndInvokeJSFromDotNet",
+                    id,
+                    true,
+                    $"[{id}, true, null]");
+            });
 
             Assert.Single(
                 Client.FindElementById("errormessage-success").Children.OfType<TextNode>(),
                 e => "" == e.TextContent);
 
-            Assert.Contains((LogLevel.Debug, "EndInvokeJSSucceeded"), logEvents);
+            var entry = Assert.Single(Logs, l => l.EventId.Name == "EndInvokeJSSucceeded");
+            Assert.Equal(LogLevel.Debug, entry.LogLevel);
         }
 
         [Fact]
         public async Task JSInteropThrowsInUserCode()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
             await Client.ClickAsync("triggerjsinterop-failure");
@@ -349,9 +302,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 Client.FindElementById("errormessage-failure").Children.OfType<TextNode>(),
                 e => "There was an error invoking sendFailureCallbackReturn" == e.TextContent);
 
-            Assert.Contains((LogLevel.Debug, "EndInvokeJSFailed"), logEvents);
+            var entry = Assert.Single(Logs, l => l.EventId.Name == "EndInvokeJSFailed");
+            Assert.Equal(LogLevel.Debug, entry.LogLevel);
 
-            Assert.DoesNotContain(logEvents, m => m.logLevel > LogLevel.Information);
+            Assert.DoesNotContain(Logs, m => m.LogLevel > LogLevel.Information);
 
             await ValidateClientKeepsWorking(Client, Batches);
         }
@@ -360,10 +314,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task MalformedJSInteropCallbackDisposesCircuit()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
             await Client.ClickAsync("triggerjsinterop-malformed");
@@ -386,7 +336,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 Client.FindElementById("errormessage-malformed").Children.OfType<TextNode>(),
                 e => "" == e.TextContent);
 
-            Assert.Contains((LogLevel.Debug, "EndInvokeDispatchException"), logEvents);
+            var entry = Assert.Single(Logs, l => l.EventId.Name == "EndInvokeDispatchException");
+            Assert.Equal(LogLevel.Debug, entry.LogLevel);
 
             await Client.ExpectCircuitErrorAndDisconnect(async () =>
             {
@@ -402,8 +353,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027NotifyLocationChanged\\u0027 on assembly \\u0027Microsoft.AspNetCore.Components.Server\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
@@ -413,7 +362,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "[ \"invalidPayload\"}");
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -425,8 +374,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "false," +
                 "\"There was an exception invoking \\u0027ReceiveTrivial\\u0027 on assembly \\u0027BasicTestApp\\u0027. For more details turn on detailed exceptions in \\u0027CircuitOptions.DetailedErrors\\u0027\"]";
 
-            await GoToTestComponent(Batches);
-
             // Act
             await Client.InvokeDotNetMethod(
                 "1",
@@ -436,7 +383,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "[ { \"data\": {\"}} ]");
 
             // Assert
-            Assert.Single(DotNetCompletions, c => c.Message == expectedError);
+            Assert.Single(DotNetCompletions, c => c == expectedError);
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
@@ -444,10 +391,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task DispatchingEventsWithInvalidPayloadsShutsDownCircuitGracefully()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
             await Client.ExpectCircuitError(async () =>
@@ -458,9 +401,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 null);
             });
 
-            Assert.Contains(
-                (LogLevel.Debug, "DispatchEventFailedToParseEventData"),
-                logEvents);
+            var entry = Assert.Single(Logs, l => l.EventId.Name == "DispatchEventFailedToParseEventData");
+            Assert.Equal(LogLevel.Debug, entry.LogLevel);
 
             // Taking any other action will fail because the circuit is disposed.
             await Client.ExpectCircuitErrorAndDisconnect(async () =>
@@ -473,10 +415,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task DispatchingEventsWithInvalidEventDescriptor()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name));
 
             // Act
             await Client.ExpectCircuitError(async () =>
@@ -487,9 +425,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "{}");
             });
 
-            Assert.Contains(
-                (LogLevel.Debug, "DispatchEventFailedToParseEventData"),
-                logEvents);
+            var entry = Assert.Single(Logs, l => l.EventId.Name == "DispatchEventFailedToParseEventData");
+            Assert.Equal(LogLevel.Debug, entry.LogLevel);
 
             // Taking any other action will fail because the circuit is disposed.
             await Client.ExpectCircuitErrorAndDisconnect(async () =>
@@ -502,10 +439,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task DispatchingEventsWithInvalidEventArgs()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string eventIdName, Exception exception)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name, wc.Exception));
 
             // Act
             var browserDescriptor = new WebEventDescriptor()
@@ -524,9 +457,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
 
             Assert.Contains(
-                logEvents,
-                e => e.eventIdName == "DispatchEventFailedToParseEventData" && e.logLevel == LogLevel.Debug &&
-                     e.exception.Message == "There was an error parsing the event arguments. EventId: '6'.");
+                Logs,
+                e => e.EventId.Name == "DispatchEventFailedToParseEventData" && e.LogLevel == LogLevel.Debug &&
+                     e.Exception.Message == "There was an error parsing the event arguments. EventId: '6'.");
 
             // Taking any other action will fail because the circuit is disposed.
             await Client.ExpectCircuitErrorAndDisconnect(async () =>
@@ -539,10 +472,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task DispatchingEventsWithInvalidEventHandlerId()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string eventIdName, Exception exception)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name, wc.Exception));
 
             // Act
             var mouseEventArgs = new MouseEventArgs()
@@ -566,9 +495,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
 
             Assert.Contains(
-                logEvents,
-                e => e.eventIdName == "DispatchEventFailedToDispatchEvent" && e.logLevel == LogLevel.Debug &&
-                     e.exception is ArgumentException ae && ae.Message.Contains("There is no event handler associated with this event. EventId: '1'."));
+                Logs,
+                e => e.EventId.Name == "DispatchEventFailedToDispatchEvent" && e.LogLevel == LogLevel.Debug &&
+                     e.Exception is ArgumentException ae && ae.Message.Contains("There is no event handler associated with this event. EventId: '1'."));
 
             // Taking any other action will fail because the circuit is disposed.
             await Client.ExpectCircuitErrorAndDisconnect(async () =>
@@ -581,21 +510,18 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task EventHandlerThrowsSyncExceptionTerminatesTheCircuit()
         {
             // Arrange
-            await GoToTestComponent(Batches);
-            var sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
-            var logEvents = new List<(LogLevel logLevel, string eventIdName, Exception exception)>();
-            sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name, wc.Exception));
 
             // Act
-            await Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: false);
-
-            await Task.Delay(1000);
+            await Client.ExpectCircuitError(async () =>
+            {
+                await Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: false);
+            });
 
             Assert.Contains(
-                logEvents,
-                e => LogLevel.Error == e.logLevel &&
-                    "CircuitUnhandledException" == e.eventIdName &&
-                    "Handler threw an exception" == e.exception.Message);
+                Logs,
+                e => LogLevel.Error == e.LogLevel &&
+                    "CircuitUnhandledException" == e.EventId.Name &&
+                    "Handler threw an exception" == e.Exception.Message);
 
             // Now if you try to click again, you will get *forcibly* disconnected for trying to talk to
             // a circuit that's gone.
@@ -605,7 +531,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
         }
 
-        private Task ValidateClientKeepsWorking(BlazorClient Client, IList<Batch> batches) =>
+        private Task ValidateClientKeepsWorking(BlazorClient Client, IReadOnlyCollection<CapturedRenderBatch> batches) =>
             ValidateClientKeepsWorking(Client, () => batches.Count);
 
         private async Task ValidateClientKeepsWorking(BlazorClient Client, Func<int> countAccessor)
@@ -614,76 +540,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await Client.ClickAsync("thecounter");
 
             Assert.Equal(currentBatches + 1, countAccessor());
-        }
-
-        private async Task GoToTestComponent(IList<Batch> batches)
-        {
-            var rootUri = _serverFixture.RootUri;
-            Assert.True(await Client.ConnectAsync(new Uri(rootUri, "/subdir")), "Couldn't connect to the app");
-            Assert.Single(batches);
-
-            await Client.SelectAsync("test-selector-select", "BasicTestApp.ReliabilityComponent");
-            Assert.Equal(2, batches.Count);
-        }
-
-        public void Dispose()
-        {
-            TestSink.MessageLogged -= LogMessages;
-        }
-
-        private class LogMessage
-        {
-            public LogMessage(LogLevel logLevel, string message, Exception exception)
-            {
-                LogLevel = logLevel;
-                Message = message;
-                Exception = exception;
-            }
-
-            public LogLevel LogLevel { get; set; }
-            public string Message { get; set; }
-            public Exception Exception { get; set; }
-
-            public override string ToString()
-            {
-                return $"{LogLevel}: {Message}{(Exception != null ? Environment.NewLine : "")}{Exception}";
-            }
-        }
-
-        private class Batch
-        {
-            public Batch(int id, byte[] data)
-            {
-                Id = id;
-                Data = data;
-            }
-
-            public int Id { get; }
-            public byte[] Data { get; }
-        }
-
-        private class DotNetCompletion
-        {
-            public DotNetCompletion(string message)
-            {
-                Message = message;
-            }
-
-            public string Message { get; }
-        }
-
-        private class JSInteropCall
-        {
-            public JSInteropCall(int asyncHandle, string identifier, string argsJson)
-            {
-                AsyncHandle = asyncHandle;
-                Identifier = identifier;
-                ArgsJson = argsJson;
-            }
-
-            public int AsyncHandle { get; }
-            public string Identifier { get; }
-            public string ArgsJson { get; }
         }
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
@@ -77,7 +77,7 @@
 {
     int currentCount = 0;
     string errorMalformed = "";
-    string errorSuccess = "";
+    string errorSuccess = "(this will be cleared)";
     string errorFailure = "";
     bool showConstructorThrow;
     bool showAttachThrow;
@@ -116,6 +116,10 @@
             var result = await JSRuntime.InvokeAsync<object>(
                 "sendSuccessCallbackReturn",
                 Array.Empty<object>());
+
+            // Make sure we trigger a render when the interop call completes.
+            // The test uses a render to synchronize.
+            errorSuccess = "";
         }
         catch (Exception e)
         {

--- a/src/Components/test/testassets/Ignitor/CapturedJSInteropCall.cs
+++ b/src/Components/test/testassets/Ignitor/CapturedJSInteropCall.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Ignitor
+{
+    public class CapturedJSInteropCall
+    {
+        public CapturedJSInteropCall(int asyncHandle, string identifier, string argsJson)
+        {
+            AsyncHandle = asyncHandle;
+            Identifier = identifier;
+            ArgsJson = argsJson;
+        }
+
+        public int AsyncHandle { get; }
+        public string Identifier { get; }
+        public string ArgsJson { get; }
+    }
+}

--- a/src/Components/test/testassets/Ignitor/CapturedRenderBatch.cs
+++ b/src/Components/test/testassets/Ignitor/CapturedRenderBatch.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Ignitor
+{
+    public class CapturedRenderBatch
+    {
+        public CapturedRenderBatch(int id, byte[] data)
+        {
+            Id = id;
+            Data = data;
+        }
+
+        public int Id { get; }
+        public byte[] Data { get; }
+    }
+}

--- a/src/Components/test/testassets/Ignitor/Operations.cs
+++ b/src/Components/test/testassets/Ignitor/Operations.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+
+namespace Ignitor
+{
+    public sealed class Operations
+    {
+        public ConcurrentQueue<CapturedRenderBatch> Batches { get; } = new ConcurrentQueue<CapturedRenderBatch>();
+
+        public ConcurrentQueue<string> DotNetCompletions { get; } = new ConcurrentQueue<string>();
+
+        public ConcurrentQueue<string> Errors { get; } = new ConcurrentQueue<string>();
+
+        public ConcurrentQueue<CapturedJSInteropCall> JSInteropCalls { get; } = new ConcurrentQueue<CapturedJSInteropCall>();
+    }
+}

--- a/src/Components/test/testassets/Ignitor/Program.cs
+++ b/src/Components/test/testassets/Ignitor/Program.cs
@@ -2,10 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -38,9 +34,9 @@ namespace Ignitor
             var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // Click the counter button 1000 times
-            client.RenderBatchReceived += (int batchId, byte[] data) =>
+            client.RenderBatchReceived += (batch) =>
             {
-                if (batchId < 1000)
+                if (batch.Id < 1000)
                 {
                     var _ = client.ClickAsync("thecounter");
                 }
@@ -56,8 +52,8 @@ namespace Ignitor
             return 0;
         }
 
-        private static void OnJSInterop(int callId, string identifier, string argsJson) =>
-            Console.WriteLine("JS Invoke: " + identifier + " (" + argsJson + ")");
+        private static void OnJSInterop(CapturedJSInteropCall call) =>
+            Console.WriteLine("JS Invoke: " + call.Identifier + " (" + call.ArgsJson + ")");
 
         public Program()
         {


### PR DESCRIPTION
Fixes: #13086

- Fixed some wrong logging (wrong EventIds)
- Added a base class for ignitor tests
- Centralized code for capturing data in ignitor
- Make `WaitForXyz` methods return the thing they found
- Make `WaitForXyz` methods report logs on timeout
- Fix synchronization problems with some tests
- Split invalid event tests into their own class for code reuse

The main thing here is that some of the JS interop reliability tests had
causality/synchronization problems. They were either not waiting for a
render batch, or they were not *triggering* a render batch.

In addition to that, I did a general consolidation of the infrastructure
for these tests to make sure that they are all using the same set of
practices. I found and fixed cases where tests were using timeouts that
were too small (inconsistency) or where they were using non-threadsafe
data structures (these tests always involve concurrency).