### PR TITLE
Add AdditionalAssemblies to Router

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.csproj
@@ -7,11 +7,13 @@
     <Compile Include="Microsoft.AspNetCore.Components.netstandard2.0.cs" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions"  />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  />
+    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources"  />
     <Reference Include="System.Buffers"  />
   </ItemGroup>
 <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Microsoft.AspNetCore.Components.netcoreapp3.0.cs" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions"  />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  />
+    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources"  />
   </ItemGroup>
 </Project>

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp3.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp3.0.cs
@@ -532,6 +532,8 @@ namespace Microsoft.AspNetCore.Components.Routing
     {
         public Router() { }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Collections.Generic.IEnumerable<System.Reflection.Assembly> AdditionalAssemblies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
         public System.Reflection.Assembly AppAssembly { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Found { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -532,6 +532,8 @@ namespace Microsoft.AspNetCore.Components.Routing
     {
         public Router() { }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public System.Collections.Generic.IEnumerable<System.Reflection.Assembly> AdditionalAssemblies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
         public System.Reflection.Assembly AppAssembly { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Found { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -38,6 +39,12 @@ namespace Microsoft.AspNetCore.Components.Routing
         [Parameter] public Assembly AppAssembly { get; set; }
 
         /// <summary>
+        /// Gets or sets a collection of additional assemblies that should be searched for components
+        /// that can match URIs.
+        /// </summary>
+        [Parameter] public IEnumerable<Assembly> AdditionalAssemblies { get; set; }
+
+        /// <summary>
         /// Gets or sets the content to display when no match is found for the requested route.
         /// </summary>
         [Parameter] public RenderFragment NotFound { get; set; }
@@ -64,6 +71,11 @@ namespace Microsoft.AspNetCore.Components.Routing
         {
             parameters.SetParameterProperties(this);
 
+            if (AppAssembly == null)
+            {
+                throw new InvalidOperationException($"The {nameof(Router)} component requires a value for the parameter {nameof(AppAssembly)}.");
+            }
+
             // Found content is mandatory, because even though we could use something like <RouteView ...> as a
             // reasonable default, if it's not declared explicitly in the template then people will have no way
             // to discover how to customize this (e.g., to add authorization).
@@ -79,7 +91,9 @@ namespace Microsoft.AspNetCore.Components.Routing
                 throw new InvalidOperationException($"The {nameof(Router)} component requires a value for the parameter {nameof(NotFound)}.");
             }
 
-            Routes = RouteTableFactory.Create(AppAssembly);
+
+            var assemblies = AdditionalAssemblies == null ? new[] { AppAssembly } : new[] { AppAssembly }.Concat(AdditionalAssemblies);
+            Routes = RouteTableFactory.Create(assemblies);
             Refresh(isNavigationIntercepted: false);
             return Task.CompletedTask;
         }

--- a/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
@@ -12,6 +12,45 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
     public class RouteTableFactoryTests
     {
         [Fact]
+        public void CanCacheRouteTable()
+        {
+            // Arrange
+            var routes1 = RouteTableFactory.Create(new[] { GetType().Assembly, });
+
+            // Act
+            var routes2 = RouteTableFactory.Create(new[] { GetType().Assembly, });
+
+            // Assert
+            Assert.Same(routes1, routes2);
+        }
+
+        [Fact]
+        public void CanCacheRouteTableWithDifferentAssembliesAndOrder()
+        {
+            // Arrange
+            var routes1 = RouteTableFactory.Create(new[] { typeof(object).Assembly, GetType().Assembly, });
+
+            // Act
+            var routes2 = RouteTableFactory.Create(new[] { GetType().Assembly, typeof(object).Assembly, });
+
+            // Assert
+            Assert.Same(routes1, routes2);
+        }
+
+        [Fact]
+        public void DoesNotCacheRouteTableForDifferentAssemblies()
+        {
+            // Arrange
+            var routes1 = RouteTableFactory.Create(new[] { GetType().Assembly, });
+
+            // Act
+            var routes2 = RouteTableFactory.Create(new[] { GetType().Assembly, typeof(object).Assembly, });
+
+            // Assert
+            Assert.NotSame(routes1, routes2);
+        }
+
+        [Fact]
         public void CanDiscoverRoute()
         {
             // Arrange & Act

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -419,6 +419,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void RoutingToComponentOutsideMainAppWorksWithAdditionalAssemblySpecified()
+        {
+            SetUrlViaPushState("/routeablecomponentfrompackage.html");
+
+            var app = MountTestComponent<TestRouterWithAdditionalAssembly>();
+            Assert.Contains("This component, including the CSS and image required to produce its", app.FindElement(By.CssSelector("div.special-style")).Text);
+        }
+
+        [Fact]
         public void ResetsScrollPositionWhenPerformingInternalNavigation_LinkClick()
         {
             SetUrlViaPushState("/LongPage1");

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -61,6 +61,7 @@
         <option value="BasicTestApp.ReorderingFocusComponent">Reordering focus retention</option>
         <option value="BasicTestApp.RouterTest.NavigationManagerComponent">NavigationManager Test</option>
         <option value="BasicTestApp.RouterTest.TestRouter">Router</option>
+        <option value="BasicTestApp.RouterTest.TestRouterWithAdditionalAssembly">Router with additional assembly</option>
         <option value="BasicTestApp.SvgComponent">SVG</option>
         <option value="BasicTestApp.SvgWithChildComponent">SVG with child component</option>
         <option value="BasicTestApp.TextOnlyComponent">Plain text</option>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithAdditionalAssembly.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithAdditionalAssembly.razor
@@ -1,0 +1,11 @@
+@using Microsoft.AspNetCore.Components.Routing
+<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" AdditionalAssemblies="@(new[] { typeof(TestContentPackage.RouteableComponentFromPackage).Assembly, })">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(RouterTestLayout)">
+            <div id="test-info">Oops, that component wasn't found!</div>
+        </LayoutView>
+    </NotFound>
+</Router>


### PR DESCRIPTION
Adds the ability to specify multiple assemblies to the Router
component.

Prior to preview 8, the router would search all dependencies of
`AppAssembly` for routable components. We made an intentional change to
stop that. However, we haven't yet give users a way to specify multiple
assemblies if their components are split across assemblies.
