### PR TITLE
[Blazor] Adds a version to the Circuit ID purpose

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitIdFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitIdFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
     // Generates strong cryptographic ids for circuits that are protected with authenticated encryption.
     internal class CircuitIdFactory
     {
-        private const string CircuitIdProtectorPurpose = "Microsoft.AspNetCore.Components.Server.CircuitIdFactory";
+        private const string CircuitIdProtectorPurpose = "Microsoft.AspNetCore.Components.Server.CircuitIdFactory,V1";
 
         // We use 64 bytes, where the last 32 are the public version of the id.
         // This way we can always recover the public id from the secret form.


### PR DESCRIPTION
* This is so that we can invalidate old circuit id payloads automatically if we ever switch the format.
* We do this in other places as recommended by @GrabYourPitchforks.