### PR TITLE
Fix AllProtocols with duplicates

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubProtocolResolver.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubProtocolResolver.cs
@@ -23,13 +23,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             _logger = logger ?? NullLogger<DefaultHubProtocolResolver>.Instance;
             _availableProtocols = new Dictionary<string, IHubProtocol>(StringComparer.OrdinalIgnoreCase);
 
-            // We might get duplicates in _hubProtocols, but we're going to check it and overwrite in just a sec.
-            _hubProtocols = availableProtocols.ToList();
-            foreach (var protocol in _hubProtocols)
+            foreach (var protocol in availableProtocols)
             {
                 Log.RegisteredSignalRProtocol(_logger, protocol.Name, protocol.GetType());
                 _availableProtocols[protocol.Name] = protocol;
             }
+            _hubProtocols = _availableProtocols.Values.ToList();
         }
 
         public virtual IHubProtocol GetProtocol(string protocolName, IReadOnlyList<string> supportedProtocols)

--- a/src/SignalR/server/SignalR/test/Internal/DefaultHubProtocolResolverTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/DefaultHubProtocolResolverTests.cs
@@ -84,6 +84,22 @@ namespace Microsoft.AspNetCore.SignalR.Common.Protocol.Tests
             Assert.Same(jsonProtocol2, resolvedProtocol);
         }
 
+        [Fact]
+        public void AllProtocolsOnlyReturnsLatestOfSameType()
+        {
+            var jsonProtocol1 = new NewtonsoftJsonHubProtocol();
+            var jsonProtocol2 = new NewtonsoftJsonHubProtocol();
+            var resolver = new DefaultHubProtocolResolver(new[] {
+                jsonProtocol1,
+                jsonProtocol2
+            }, NullLogger<DefaultHubProtocolResolver>.Instance);
+
+            var hubProtocols = resolver.AllProtocols;
+            Assert.Equal(1, hubProtocols.Count);
+
+            Assert.Same(jsonProtocol2, hubProtocols[0]);
+        }
+
         public static IEnumerable<object[]> HubProtocolNames => HubProtocolHelpers.AllProtocols.Select(p => new object[] {p.Name});
     }
 }


### PR DESCRIPTION
#### Description

In 3.0 we added support for System.Text.Json and changed the default from Newtonsoft.Json to System.Text.Json. Users can still use Newtonsoft.Json if they prefer it and have existing configuration with it.

When using a backplane such as Azure SignalR Service we accidentally send both JSON types over the wire which causes issues for customers expecting Newtonsoft.Json.

#### Customer Impact
Reported via: https://github.com/aspnet/AspNetCore/issues/10041#issuecomment-522279598
Code that users have to configure Newtonsoft.Json serialization wont work properly.

Example:

```csharp
services.AddAzureSignalR()
    .AddNewtonsoftJsonProtocol(options =>
    {
        options.PayloadSerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver() { NamingStrategy = new SnakeCaseNamingStrategy() };
    });
```

Another example, if a user expects to be using Newtonsoft.Json and sends an object that isn't supported by System.Text.Json it may send an empty object to the client.

```csharp
public class Test
{
    public string SomeThing; // no getter/setter is not supported by System.Text.Json
}
```

#### Regression?

Yes, existing apps can have unexpected behavior if the server is updated and they're using a backplane.

#### Risk

Low. Added new test to verify expected behavior.