### PR TITLE
Fix privacy link in Identity UI

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/_Layout.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/_Layout.cshtml
@@ -56,7 +56,14 @@
     </div>
     <footer class="footer border-top pl-3 text-muted">
         <div class="container">
-        &copy; @DateTime.Now.Year - @Environment.ApplicationName - <a asp-area="" asp-page="Privacy">Privacy</a>
+        &copy; @DateTime.Now.Year - @Environment.ApplicationName -
+            @{
+                var foundPrivacy = Url.Page("/Privacy", new { area = "" });
+            }
+            @if (foundPrivacy != null)
+            {
+                <a asp-area="" asp-page="/Privacy">Privacy</a>
+            }
         </div>
     </footer>
 


### PR DESCRIPTION
#### Description 

Fix for #9403

The identity UI footers have a broken link to the privacy page, this fix makes it so the UI conditionally renders the Privacy link based on whether the file exists, and also fixes the area link to actually work
 

#### Customer Impact 

Privacy link in the footer of any pages within the identity UI would just point back to the current page without this fix.
 

#### Regression? 

 The privacy link did work in 2.2

#### Risk 

Low