### PR TITLE
Update gRPC template dependency for preview 9

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -221,7 +221,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>0.2.23-dev201908160701</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>0.2.23-pre1</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0-preview7.33</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0-preview7.33</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0-preview7.33</IdentityServer4PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -221,7 +221,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>0.1.22-pre3</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>0.2.23-dev201908160701</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0-preview7.33</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0-preview7.33</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0-preview7.33</IdentityServer4PackageVersion>


### PR DESCRIPTION
**Description**

Update gRPC template to use new Grpc.AspNetCore dependency.

**Customer impact**

This change is required to include preview 9 fixes and improvements from Grpc.AspNetCore in the template.

**Regression?**

No

**Risk**

Low. Only includes new dependency in template. Nothing depends on this.