### PR TITLE
Move AfterBuild Target to more accurate project

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
@@ -37,11 +37,6 @@
     <Reference Include="System.Reactive.Linq" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BuildNodeJS)' == 'true'">
-    <ProjectReference Include="..\signalr\signalr.npmproj" />
-    <ProjectReference Include="..\signalr-protocol-msgpack\signalr-protocol-msgpack.npmproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <Folder Include="wwwroot\js\" />
   </ItemGroup>
@@ -58,25 +53,5 @@
     <TypeScriptCompile Include="ts\WebSocketTests.ts" />
     <TypeScriptCompile Include="ts\WebWorkerTests.ts" />
   </ItemGroup>
-
-  <Target Name="ClientBuild" BeforeTargets="AfterBuild">
-      <ItemGroup>
-        <MsgPack5Files Include="$(MSBuildThisFileDirectory)../signalr-protocol-msgpack/node_modules/msgpack5/dist/*.js" />
-      </ItemGroup>
-      <Copy SourceFiles="@(MsgPack5Files)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/msgpack5" />
-      <ItemGroup>
-        <JasmineFiles Include="$(MSBuildThisFileDirectory)node_modules/jasmine-core/lib/jasmine-core/*.js" />
-        <JasmineFiles Include="$(MSBuildThisFileDirectory)node_modules/jasmine-core/lib/jasmine-core/*.css" />
-      </ItemGroup>
-      <Copy SourceFiles="@(JasmineFiles)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/jasmine" />
-
-      <ItemGroup>
-        <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/browser/*" />
-        <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr-protocol-msgpack/dist/browser/*" />
-        <SignalRJSWebWorkerClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/webworker/*" />
-      </ItemGroup>
-      <Copy SourceFiles="@(SignalRJSBrowserClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr" />
-      <Copy SourceFiles="@(SignalRJSWebWorkerClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr-webworker" />
- </Target>
 
 </Project>

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="SignalR.Npm.FunctionalTests.npmproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="wwwroot\js\" />
   </ItemGroup>
 

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
@@ -38,10 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="SignalR.Npm.FunctionalTests.npmproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="wwwroot\js\" />
   </ItemGroup>
 

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -42,4 +42,24 @@
           WorkingDirectory="$(RepoRoot)src/SignalR/clients/ts/FunctionalTests" />
   </Target>
 
+  <Target Name="ClientBuild" BeforeTargets="AfterBuild">
+    <ItemGroup>
+      <MsgPack5Files Include="$(MSBuildThisFileDirectory)../signalr-protocol-msgpack/node_modules/msgpack5/dist/*.js" />
+    </ItemGroup>
+    <Copy SourceFiles="@(MsgPack5Files)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/msgpack5" />
+    <ItemGroup>
+      <JasmineFiles Include="$(MSBuildThisFileDirectory)node_modules/jasmine-core/lib/jasmine-core/*.js" />
+      <JasmineFiles Include="$(MSBuildThisFileDirectory)node_modules/jasmine-core/lib/jasmine-core/*.css" />
+    </ItemGroup>
+    <Copy SourceFiles="@(JasmineFiles)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/jasmine" />
+
+    <ItemGroup>
+      <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/browser/*" />
+      <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr-protocol-msgpack/dist/browser/*" />
+      <SignalRJSWebWorkerClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/webworker/*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(SignalRJSBrowserClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr" />
+    <Copy SourceFiles="@(SignalRJSWebWorkerClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr-webworker" />
+  </Target>
+
 </Project>

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -42,7 +42,7 @@
           WorkingDirectory="$(RepoRoot)src/SignalR/clients/ts/FunctionalTests" />
   </Target>
 
-  <Target Name="ClientBuild" BeforeTargets="AfterBuild">
+  <Target Name="ClientBuild" AfterTargets="Build">
     <ItemGroup>
       <MsgPack5Files Include="$(MSBuildThisFileDirectory)../signalr-protocol-msgpack/node_modules/msgpack5/dist/*.js" />
     </ItemGroup>

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="SignalR.Client.FunctionalTestApp.csproj" />
     <ProjectReference Include="..\client-ts.npmproj" />
+    <ProjectReference Include="SignalR.Client.FunctionalTestApp.csproj" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\client-ts.npmproj" />
     <ProjectReference Include="SignalR.Client.FunctionalTestApp.csproj" />
+    <ProjectReference Include="..\client-ts.npmproj" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />

--- a/src/SignalR/clients/ts/FunctionalTests/package.json
+++ b/src/SignalR/clients/ts/FunctionalTests/package.json
@@ -43,7 +43,7 @@
     "build:inner": "yarn run build:lint && yarn run build:webpack",
     "build:lint": "node ../common/node_modules/tslint/bin/tslint -c ../tslint.json -p ./tsconfig.json",
     "build:webpack": "node ../common/node_modules/webpack-cli/bin/cli.js",
-    "pretest": "yarn run build && dotnet build SignalR.Client.FunctionalTestApp.csproj",
+    "pretest": "yarn run build && dotnet build SignalR.Npm.FunctionalTests.npmproj",
     "test": "tsc --noEmit && yarn run test:local",
     "test:inner": "yarn run build:inner && ts-node --project ./scripts/tsconfig.json ./scripts/run-tests.ts",
     "test:local": "yarn run pretest && ts-node --project ./scripts/tsconfig.json ./scripts/run-tests.ts",


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/3002

FYI SignalR team, this change does add a small quirk to running the JS Functional tests manually.

You will need to build the "SignalR.Npm.FunctionalTests.npmproj" first. From the command line you can do that via `dotnet msbuild SignalR.Npm.FunctionalTests.npmproj`. And whenever changes are made to the client you'll need to rebuild it.

This is **only** for manual test runs. npm test or yarn test should still be fine.