### PR TITLE
Add CreateXmlReader overload - adds Type parameter

### DIFF
--- a/src/Mvc/Mvc.Formatters.Xml/ref/Microsoft.AspNetCore.Mvc.Formatters.Xml.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/ref/Microsoft.AspNetCore.Mvc.Formatters.Xml.netcoreapp3.0.cs
@@ -46,6 +46,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public System.Xml.XmlDictionaryReaderQuotas XmlDictionaryReaderQuotas { get { throw null; } }
         protected override bool CanReadType(System.Type type) { throw null; }
         protected virtual System.Xml.Serialization.XmlSerializer CreateSerializer(System.Type type) { throw null; }
+        protected virtual System.Xml.XmlReader CreateXmlReader(System.IO.Stream readStream, System.Text.Encoding encoding, System.Type type) { throw null; }
         protected virtual System.Xml.XmlReader CreateXmlReader(System.IO.Stream readStream, System.Text.Encoding encoding) { throw null; }
         protected virtual System.Xml.Serialization.XmlSerializer GetCachedSerializer(System.Type type) { throw null; }
         protected virtual System.Type GetSerializableType(System.Type declaredType) { throw null; }

--- a/src/Mvc/Mvc.Formatters.Xml/ref/Microsoft.AspNetCore.Mvc.Formatters.Xml.netcoreapp3.0.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/ref/Microsoft.AspNetCore.Mvc.Formatters.Xml.netcoreapp3.0.cs
@@ -46,8 +46,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public System.Xml.XmlDictionaryReaderQuotas XmlDictionaryReaderQuotas { get { throw null; } }
         protected override bool CanReadType(System.Type type) { throw null; }
         protected virtual System.Xml.Serialization.XmlSerializer CreateSerializer(System.Type type) { throw null; }
-        protected virtual System.Xml.XmlReader CreateXmlReader(System.IO.Stream readStream, System.Text.Encoding encoding, System.Type type) { throw null; }
         protected virtual System.Xml.XmlReader CreateXmlReader(System.IO.Stream readStream, System.Text.Encoding encoding) { throw null; }
+        protected virtual System.Xml.XmlReader CreateXmlReader(System.IO.Stream readStream, System.Text.Encoding encoding, System.Type type) { throw null; }
         protected virtual System.Xml.Serialization.XmlSerializer GetCachedSerializer(System.Type type) { throw null; }
         protected virtual System.Type GetSerializableType(System.Type declaredType) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]

--- a/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerInputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerInputFormatter.cs
@@ -119,8 +119,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             try
             {
-                using var xmlReader = CreateXmlReader(readStream, encoding);
-                var type = GetSerializableType(context.ModelType);
+                var type = GetSerializableType(context.ModelType);                
+                using var xmlReader = CreateXmlReader(readStream, encoding, type);
 
                 var serializer = GetCachedSerializer(type);
 
@@ -189,6 +189,18 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                                                     new WrapperProviderContext(declaredType, isSerialization: false));
 
             return wrapperProvider?.WrappingType ?? declaredType;
+        }
+
+        /// <summary>
+        /// Called during deserialization to get the <see cref="XmlReader"/>.
+        /// </summary>
+        /// <param name="readStream">The <see cref="Stream"/> from which to read.</param>
+        /// <param name="encoding">The <see cref="Encoding"/> used to read the stream.</param>
+        /// <param name="type">The <see cref="Type"/> that is to be deserialized.</param>
+        /// <returns>The <see cref="XmlReader"/> used during deserialization.</returns>
+        protected virtual XmlReader CreateXmlReader(Stream readStream, Encoding encoding, Type type)
+        {
+            return CreateXmlReader(readStream, encoding);
         }
 
         /// <summary>


### PR DESCRIPTION
This change allows inheritors of `XmlSerializerInputFormatter` to return a different `XmlReader` depending on the type being serialized. For example, an inheritor could return XSD-validating readers that validate against one schema or another (or perhaps not validate at all), depending on the value of the type parameter.

For backwards compatibility, the original `CreateXmlReader` method is left intact - the base implementation of the new overload simply calls the original `CreateXmlReader` method.

This pull request does not include any additional tests because no functionality has been changed. Also, there were no tests around the original `CreateXmlReader` method.