### PR TITLE
Do not throw if RouteComparison compares two identical references

### DIFF
--- a/src/Components/Components/src/Routing/RouteEntry.cs
+++ b/src/Components/Components/src/Routing/RouteEntry.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Components.Routing
 {
+    [DebuggerDisplay("Handler = {Handler}, Template = {Template}")]
     internal class RouteEntry
     {
         public RouteEntry(RouteTemplate template, Type handler, string[] unusedRouteParameterNames)

--- a/src/Components/Components/src/Routing/RouteTableFactory.cs
+++ b/src/Components/Components/src/Routing/RouteTableFactory.cs
@@ -114,6 +114,11 @@ namespace Microsoft.AspNetCore.Components
         /// </summary>
         internal static int RouteComparison(RouteEntry x, RouteEntry y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
             var xTemplate = x.Template;
             var yTemplate = y.Template;
             if (xTemplate.Segments.Length != y.Template.Segments.Length)

--- a/src/Components/Components/src/Routing/RouteTemplate.cs
+++ b/src/Components/Components/src/Routing/RouteTemplate.cs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
+using System.Diagnostics;
+
 namespace Microsoft.AspNetCore.Components.Routing
 {
+    [DebuggerDisplay("{TemplateText}")]
     internal class RouteTemplate
     {
         public RouteTemplate(string templateText, TemplateSegment[] segments)

--- a/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
@@ -366,6 +366,41 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
             Assert.Equal("a/brilliant", routeTable.Routes[0].Template.TemplateText);
         }
 
+        [Fact]
+        public void DoesNotThrowIfStableSortComparesRouteWithItself()
+        {
+            // Test for https://github.com/aspnet/AspNetCore/issues/13313
+            // Arrange & Act
+            var builder = new TestRouteTableBuilder();
+            builder.AddRoute("r16");
+            builder.AddRoute("r05");
+            builder.AddRoute("r09");
+            builder.AddRoute("r00");
+            builder.AddRoute("r13");
+            builder.AddRoute("r02");
+            builder.AddRoute("r03");
+            builder.AddRoute("r10");
+            builder.AddRoute("r15");
+            builder.AddRoute("r14");
+            builder.AddRoute("r12");
+            builder.AddRoute("r07");
+            builder.AddRoute("r11");
+            builder.AddRoute("r08");
+            builder.AddRoute("r06");
+            builder.AddRoute("r04");
+            builder.AddRoute("r01");
+
+            var routeTable = builder.Build();
+
+            // Act
+            Assert.Equal(17, routeTable.Routes.Length);
+            for (var i = 0; i < 17; i++)
+            {
+                var templateText = "r" + i.ToString().PadLeft(2, '0');
+                Assert.Equal(templateText, routeTable.Routes[i].Template.TemplateText);
+            }
+        }
+
         [Theory]
         [InlineData("/literal", "/Literal/")]
         [InlineData("/{parameter}", "/{parameter}/")]


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/13313

--------------------------------------------------

#### Description

Blazor uses a comparison to produce a stable sort for Routes. The comparison throws if two templates are identical, however does not account for the case when it's comparing left and right where both are the same instance.

#### Customer Impact

The Blazor application fails to start and it's unclear as to how to fix it.

#### Regression?

No. We've always had this issue, but reproducing relies in the order in which sorting happens on the route table.

#### Risk

Low. The code change is to perform a reference comparison on `RouteTable` instances before doing any further work on it.
