### PR TITLE
Skip getting AzureAdOptions for not AzureADUi Cookies scheme #13311

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
@@ -21,6 +21,11 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         public void Configure(string name, CookieAuthenticationOptions options)
         {
             var AzureADScheme = GetAzureADScheme(name);
+            if (AzureADScheme is null)
+            {
+                return;
+            }
+            
             var AzureADOptions = _AzureADOptions.Get(AzureADScheme);
             if (name != AzureADOptions.CookieSchemeName)
             {


### PR DESCRIPTION
Summary of the changes
 - Don't get AzureADOptions if the class is called for another cookie scheme not related to AzureADUI.

Addresses #13311