### PR TITLE
Skip site extensions builds in PRs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -95,6 +95,7 @@ jobs:
             -pack
             -noBuildDeps
             $(_BuildArgs)
+      condition: ne(variables['Build.Reason'], 'PullRequest')
       displayName: Build SiteExtension
 
     # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,


### PR DESCRIPTION
Addresses https://github.com/aspnet/AspNetCore/issues/11534. Since no one currently works on these components which have stabilized after the work in dotnet store. I think it's safe to turn off the build in PRs and only run them on official builds.