### PR TITLE
Johluo/blazor preview

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,9 @@
     <PreReleasePreviewNumber>1</PreReleasePreviewNumber>
     <PreReleaseVersionLabel>rc$(PreReleasePreviewNumber)</PreReleaseVersionLabel>
     <PreReleaseBrandingLabel>Release Candidate $(PreReleasePreviewNumber)</PreReleaseBrandingLabel>
+    <!-- Blazor Client packages will not RTM with 3.0 -->
+    <BlazorClientPreReleasePreviewNumber>9</BlazorClientPreReleasePreviewNumber>
+    <BlazorClientPreReleaseVersionLabel>preview$(BlazorClientPreReleasePreviewNumber)</BlazorClientPreReleaseVersionLabel>
     <AspNetCoreMajorMinorVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</AspNetCoreMajorMinorVersion>
     <!-- Additional assembly attributes are already configured to include the source revision ID. -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <!-- Override prerelease label and use preview 9, even in the final build -->
+    <PreReleaseVersionLabel>$(BlazorClientPreReleaseVersionLabel)</PreReleaseVersionLabel>
+    <DotNetFinalVersionKind></DotNetFinalVersionKind>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Addresses https://github.com/aspnet/AspNetCore/issues/13054. We will continue branding these packages with preview9-buildnumber for 3.0, even during the RTM builds.

I've tested locally, but will check a daily build to ensure the changes are as expected when this goes through. FYI, you can't verify this on a PR build since the versions are 3.0.0-ci.