### PR TITLE
Fix a typo and address remaining service reference TODO items

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Client/src/GetCurrentOpenApiReference.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/src/GetCurrentOpenApiReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Build.Framework;
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.ApiDescription.Client
     /// <summary>
     /// Restore <see cref="ITaskItem"/>s from given property value.
     /// </summary>
-    public class GetCurrentItems : Task
+    public class GetCurrentOpenApiReference : Task
     {
         /// <summary>
         /// The property value to deserialize.

--- a/src/Tools/Extensions.ApiDescription.Client/src/GetOpenApiReferenceMetadata.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/src/GetOpenApiReferenceMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.ApiDescription.Client
     /// Adds or corrects ClassName, FirstForGenerator, Namespace, and OutputPath metadata in OpenApiReference items.
     /// Also stores final metadata as SerializedMetadata.
     /// </summary>
-    public class GetFileReferenceMetadata : Task
+    public class GetOpenApiReferenceMetadata : Task
     {
         private const string TypeScriptLanguageName = "TypeScript";
 

--- a/src/Tools/Extensions.ApiDescription.Client/src/Microsoft.Extensions.ApiDescription.Client.csproj
+++ b/src/Tools/Extensions.ApiDescription.Client/src/Microsoft.Extensions.ApiDescription.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Do not complain about lack of lib folder. -->
     <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -9,7 +9,7 @@
     <PackageId>$(MSBuildProjectName)</PackageId>
     <PackageTags>Build Tasks;MSBuild;Swagger;OpenAPI;code generation;Web API client;service reference</PackageTags>
     <IsShippingPackage>true</IsShippingPackage>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DevelopmentDependency>true</DevelopmentDependency>
     <HasReferenceAssembly>false</HasReferenceAssembly>
   </PropertyGroup>

--- a/src/Tools/Extensions.ApiDescription.Client/src/Microsoft.Extensions.ApiDescription.Client.nuspec
+++ b/src/Tools/Extensions.ApiDescription.Client/src/Microsoft.Extensions.ApiDescription.Client.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8">
     $CommonMetadataElements$
@@ -7,7 +7,6 @@
   <files>
     <file src="build\*" target="build" />
     <file src="buildMultiTargeting\*" target="buildMultiTargeting" />
-    <file src="$baseOutputPath$\$configuration$\net461\Microsoft.Extensions.ApiDescription.Client.*" target="tasks\net461" />
     <file src="$baseOutputPath$\$configuration$\netstandard2.0\Microsoft.Extensions.ApiDescription.Client.*" target="tasks\netstandard2.0" />
   </files>
 </package>

--- a/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -1,15 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
   <PropertyGroup>
-    <_ApiDescriptionClientAssemblyTarget
-        Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_ApiDescriptionClientAssemblyTarget>
-    <_ApiDescriptionClientAssemblyTarget
-        Condition="'$(MSBuildRuntimeType)' != 'Core'">net461</_ApiDescriptionClientAssemblyTarget>
-    <_ApiDescriptionClientAssemblyPath>$(MSBuildThisFileDirectory)/../tasks/$(_ApiDescriptionClientAssemblyTarget)/Microsoft.Extensions.ApiDescription.Client.dll</_ApiDescriptionClientAssemblyPath>
-    <_ApiDescriptionClientAssemblyTarget />
+    <_ApiDescriptionClientAssemblyPath>$(MSBuildThisFileDirectory)/../tasks/netstandard2.0/Microsoft.Extensions.ApiDescription.Client.dll</_ApiDescriptionClientAssemblyPath>
   </PropertyGroup>
-  <UsingTask TaskName="GetCurrentItems" AssemblyFile="$(_ApiDescriptionClientAssemblyPath)" />
-  <UsingTask TaskName="GetFileReferenceMetadata" AssemblyFile="$(_ApiDescriptionClientAssemblyPath)" />
+  <UsingTask TaskName="GetCurrentOpenApiReference" AssemblyFile="$(_ApiDescriptionClientAssemblyPath)" />
+  <UsingTask TaskName="GetOpenApiReferenceMetadata" AssemblyFile="$(_ApiDescriptionClientAssemblyPath)" />
 
   <!--
     Settings users may update as they see fit.
@@ -98,6 +93,13 @@
 
     <!-- OpenApiProjectReference items may include all OpenApiReference metadata. -->
     <OpenApiProjectReference>
+      <!--
+        Semicolon-separated list of global properties to remove in a @(ProjectReference) item created for this
+        @(OpenApiProjectReference). These properties, along with Configuration, Platform, RuntimeIdentifier and
+        TargetFrameworks, are also removed when invoking the 'OpenApiGetDocuments' target in the referenced project.
+      -->
+      <GlobalPropertiesToRemove>TargetFramework</GlobalPropertiesToRemove>
+
       <!--
         Name of the class to generate. Defaults to match filename in %(OutputPath). To avoid compilation errors,
         override only if the referenced project has a single registered document.

--- a/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
   <!-- Internal settings. Not intended for customization. -->
   <PropertyGroup>
@@ -25,7 +25,6 @@
       @(OpenApiProjectReference) items.
     -->
     <ProjectReference Include="@(OpenApiProjectReference)" Exclude="@(ProjectReference)">
-      <GlobalPropertiesToRemove>TargetFramework</GlobalPropertiesToRemove>
       <Private>false</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
@@ -44,7 +43,7 @@
         BuildInParallel="$(BuildInParallel)"
         Projects="@(OpenApiProjectReference)"
         RebaseOutputs="true"
-        RemoveProperties="Configuration;Platform;RuntimeIdentifier;TargetFramework;TargetFrameworks">
+        RemoveProperties="Configuration;Platform;RuntimeIdentifier;TargetFrameworks;%(OpenApiProjectReference.GlobalPropertiesToRemove)">
       <Output TaskParameter="TargetOutputs" ItemName="_Temporary" />
     </MSBuild>
 
@@ -61,12 +60,12 @@
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
 
-    <GetFileReferenceMetadata Inputs="@(OpenApiReference)"
+    <GetOpenApiReferenceMetadata Inputs="@(OpenApiReference)"
         Extension="$(DefaultLanguageSourceExtension)"
         Namespace="$(RootNamespace)"
         OutputDirectory="$(OpenApiCodeDirectory)">
       <Output TaskParameter="Outputs" ItemName="_Temporary" />
-    </GetFileReferenceMetadata>
+    </GetOpenApiReferenceMetadata>
 
     <ItemGroup>
       <OpenApiReference Remove="@(OpenApiReference)" />
@@ -76,9 +75,9 @@
   </Target>
 
   <Target Name="_GetCurrentOpenApiReference">
-    <GetCurrentItems Input="$(GeneratorMetadata)">
+    <GetCurrentOpenApiReference Input="$(GeneratorMetadata)">
       <Output TaskParameter="Outputs" ItemName="CurrentOpenApiReference" />
-    </GetCurrentItems>
+    </GetCurrentOpenApiReference>
   </Target>
 
   <Target Name="_InnerGenerateOpenApiCode" DependsOnTargets="_GetCurrentOpenApiReference;$(GeneratorTarget)" />
@@ -132,7 +131,7 @@
       </Compile>
 
       <FileWrites Exclude="@(FileWrites)"
-          Include="@(_Files);@(_Directories -> '%(Identity)/**/*.ts;%(Identity)/**/*.tsx;%(Identity)/**/*.$(DefaultLanguageSourceExtension)'" />
+          Include="@(_Files);@(_Directories -> '%(Identity)/**/*.ts;%(Identity)/**/*.tsx;%(Identity)/**/*.$(DefaultLanguageSourceExtension)')" />
 
       <_Files Remove="@(_Files)" />
       <_Directories Remove="@(_Directories)" />

--- a/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -43,7 +43,7 @@
         BuildInParallel="$(BuildInParallel)"
         Projects="@(OpenApiProjectReference)"
         RebaseOutputs="true"
-        RemoveProperties="Configuration;Platform;RuntimeIdentifier;TargetFrameworks;%(OpenApiProjectReference.GlobalPropertiesToRemove)">
+        RemoveProperties="RuntimeIdentifier;TargetFrameworks;%(OpenApiProjectReference.GlobalPropertiesToRemove)">
       <Output TaskParameter="TargetOutputs" ItemName="_Temporary" />
     </MSBuild>
 

--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -65,7 +65,7 @@
   <!-- Unless this is an inner build or default timing is disabled, tie document retrieval into the build. -->
 
   <Target Name="_GenerateOpenApiDocuments"
-      AfterTargets="Build"
+      AfterTargets="CoreBuild"
       Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == 'true' AND ('$(TargetFramework)' == '' OR '$(TargetFrameworks)' == '') "
       DependsOnTargets="GenerateOpenApiDocuments" />
 </Project>

--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -65,7 +65,7 @@
   <!-- Unless this is an inner build or default timing is disabled, tie document retrieval into the build. -->
 
   <Target Name="_GenerateOpenApiDocuments"
-      AfterTargets="CoreBuild"
+      BeforeTargets="Build"
       Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == 'true' AND ('$(TargetFramework)' == '' OR '$(TargetFrameworks)' == '') "
       DependsOnTargets="GenerateOpenApiDocuments" />
 </Project>

--- a/src/Tools/Extensions.ApiDescription.Server/src/buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets
@@ -1,16 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <ItemGroup>
-    <_OpenApiGenerateDocumentsTFMs Remove="@(_OpenApiGenerateDocumentsTFMs)" />
-    <_OpenApiGenerateDocumentsTFMs Include="$(TargetFrameworks)" Exclude="netcoreapp1.0;netcoreapp1.1;netcoreapp2.0" />
-  </ItemGroup>
-
   <PropertyGroup>
     <!-- Default value may lead to an inner build error if $(OpenApiGenerateDocuments) is explicitly set to 'true'. -->
     <_OpenApiGenerateDocumentsTFM>$(TargetFrameworks.Trim(';').Split(';')[0])</_OpenApiGenerateDocumentsTFM>
 
     <!-- Prefer first TFM of those the tool supports. -->
-    <_Temporary>$(@(_OpenApiGenerateDocumentsTFMs).Trim(';'))</_Temporary>
+    <_Temporary>$(TargetFrameworks
+        .Replace('netcoreapp1.0', '')
+        .Replace('netcoreapp1.1', '')
+        .Replace('netcoreapp2.0', '')
+        .Trim(';'))</_Temporary>
     <_OpenApiGenerateDocumentsTFM
         Condition=" '$(_Temporary)' != '' ">$(_Temporary.Split(';')[0])</_OpenApiGenerateDocumentsTFM>
 
@@ -33,8 +32,9 @@
         RemoveProperties="RuntimeIdentifier" />
   </Target>
 
+  <!-- DispatchToInnerBuilds is last target outer Build depends on. -->
   <Target Name="_GenerateOpenApiDocuments"
-      AfterTargets="Build"
+      AfterTargets="DispatchToInnerBuilds"
       Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == 'true' "
       DependsOnTargets="GenerateOpenApiDocuments" />
 

--- a/src/Tools/Extensions.ApiDescription.Server/src/buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets
@@ -32,9 +32,8 @@
         RemoveProperties="RuntimeIdentifier" />
   </Target>
 
-  <!-- DispatchToInnerBuilds is last target outer Build depends on. -->
   <Target Name="_GenerateOpenApiDocuments"
-      AfterTargets="DispatchToInnerBuilds"
+      BeforeTargets="Build"
       Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == 'true' "
       DependsOnTargets="GenerateOpenApiDocuments" />
 

--- a/src/Tools/GetDocumentInsider/src/GetDocumentInsider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocumentInsider.csproj
@@ -18,7 +18,7 @@
     <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" />
   </ItemGroup>
 
-  <Target Name="BuildX86" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' != 'x86' ">
+  <Target Name="BuildX86" AfterTargets="CoreBuild" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' != 'x86' ">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=x86" Targets="Build" />
   </Target>
 </Project>

--- a/src/Tools/GetDocumentInsider/src/GetDocumentInsider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocumentInsider.csproj
@@ -18,7 +18,7 @@
     <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" />
   </ItemGroup>
 
-  <Target Name="BuildX86" AfterTargets="CoreBuild" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' != 'x86' ">
+  <Target Name="BuildX86" BeforeTargets="Build" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' != 'x86' ">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=x86" Targets="Build" />
   </Target>
 </Project>


### PR DESCRIPTION
- #4923
- typo caused problems when cleaning files
- add `%(OpenApiProjectReference.GlobalPropertiesToRemove)` metadata
- address timing issues cropping up occasionally in builds using service ref features
  - avoid `AfterTargets="Build"`; referencing projects sometimes continue while post-build work is done
    - run after `CoreBuild` in inner builds and after `DispatchToInnerBuilds` in outer builds
    - do same in GetDocumentInsider.csproj
- set only properties in buildMultiTargeting\Microsoft.Extensions.ApiDescription.Server.targets
  - items not evaluated early enough to reference in all cases
- rename Microsoft.Extensions.ApiDescription.Client tasks
- remove net461 task assembly