### PR TITLE
[ApiAuthorization] Disables pop-up logout by default

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/src/api-authorization/authorize.service.ts
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/src/api-authorization/authorize.service.ts
@@ -121,6 +121,10 @@ export class AuthorizeService {
 
   public async signOut(state: any): Promise<IAuthenticationResult> {
     try {
+      if (this.popUpDisabled) {
+        throw new Error('Popup disabled. Change \'authorize.service.ts:AuthorizeService.popupDisabled\' to false to enable it.');
+      }
+
       await this.ensureUserManagerInitialized();
       await this.userManager.signoutPopup(this.createArguments());
       this.userSubject.next(null);

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
@@ -98,6 +98,10 @@ export class AuthorizeService {
     async signOut(state) {
         await this.ensureUserManagerInitialized();
         try {
+            if (this._popUpDisabled) {
+                throw new Error('Popup disabled. Change \'AuthorizeService.js:AuthorizeService._popupDisabled\' to false to enable it.')
+            }
+
             await this.userManager.signoutPopup(this.createArguments());
             this.updateState(undefined);
             return this.success(state);


### PR DESCRIPTION
**Description**
Fix for https://github.com/aspnet/AspNetCore/issues/13380

The default logout experience for the SPA templates with authentication is broken on Edge.

**Customer Impact**
Users will logout from the identity provider, but the SPA application will not reflect they logged out correctly and 
an error will be displayed on the logout pop-up.

The fix is to simply disable pop-up logout functionality by default the same way we do for login.

**Regression?**
No, this is a new feature for 3.0

**Risk**
Very low