### PR TITLE
#12511 - Moved identity EF core identity configuration

### DIFF
--- a/src/Identity/EntityFrameworkCore/ref/Microsoft.AspNetCore.Identity.EntityFrameworkCore.netcoreapp3.0.cs
+++ b/src/Identity/EntityFrameworkCore/ref/Microsoft.AspNetCore.Identity.EntityFrameworkCore.netcoreapp3.0.cs
@@ -213,6 +213,102 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         public override System.Threading.Tasks.Task<Microsoft.AspNetCore.Identity.IdentityResult> UpdateAsync(TUser user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public partial class RoleClaimConfiguration<TKey> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.RoleClaimConfiguration<Microsoft.AspNetCore.Identity.IdentityRoleClaim<TKey>, TKey> where TKey : System.IEquatable<TKey>
+    {
+        public RoleClaimConfiguration() { }
+    }
+    public partial class RoleClaimConfiguration<TRoleClaim, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TRoleClaim> where TRoleClaim : Microsoft.AspNetCore.Identity.IdentityRoleClaim<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public RoleClaimConfiguration() { }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TRoleClaim> builder) { }
+    }
+    public partial class RoleConfiguration<TRole, TKey> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.RoleConfiguration<TRole, Microsoft.AspNetCore.Identity.IdentityUserRole<TKey>, Microsoft.AspNetCore.Identity.IdentityRoleClaim<TKey>, TKey> where TRole : Microsoft.AspNetCore.Identity.IdentityRole<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public RoleConfiguration() { }
+    }
+    public partial class RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TRole> where TRole : Microsoft.AspNetCore.Identity.IdentityRole<TKey> where TUserRole : Microsoft.AspNetCore.Identity.IdentityUserRole<TKey> where TRoleClaim : Microsoft.AspNetCore.Identity.IdentityRoleClaim<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public RoleConfiguration() { }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TRole> builder) { }
+    }
+    public partial class UserClaimConfiguration : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserClaimConfiguration<Microsoft.AspNetCore.Identity.IdentityUserClaim<string>>
+    {
+        public UserClaimConfiguration() { }
+    }
+    public partial class UserClaimConfiguration<TUserClaim> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserClaimConfiguration<TUserClaim, string> where TUserClaim : Microsoft.AspNetCore.Identity.IdentityUserClaim<string>
+    {
+        public UserClaimConfiguration() { }
+    }
+    public partial class UserClaimConfiguration<TUserClaim, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TUserClaim> where TUserClaim : Microsoft.AspNetCore.Identity.IdentityUserClaim<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserClaimConfiguration() { }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TUserClaim> builder) { }
+    }
+    public partial class UserConfiguration : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserConfiguration<Microsoft.AspNetCore.Identity.IdentityUser, Microsoft.AspNetCore.Identity.IdentityUserClaim<string>, Microsoft.AspNetCore.Identity.IdentityUserLogin<string>, Microsoft.AspNetCore.Identity.IdentityUserToken<string>, string>
+    {
+        public UserConfiguration() { }
+    }
+    public partial class UserConfiguration<TUser> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserConfiguration<TUser, Microsoft.AspNetCore.Identity.IdentityUserClaim<string>, Microsoft.AspNetCore.Identity.IdentityUserLogin<string>, Microsoft.AspNetCore.Identity.IdentityUserToken<string>, string> where TUser : Microsoft.AspNetCore.Identity.IdentityUser<string>
+    {
+        public UserConfiguration() { }
+    }
+    public partial class UserConfiguration<TUser, TUserClaim, TUserLogin, TUserToken, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TUser> where TUser : Microsoft.AspNetCore.Identity.IdentityUser<TKey> where TUserClaim : Microsoft.AspNetCore.Identity.IdentityUserClaim<TKey> where TUserLogin : Microsoft.AspNetCore.Identity.IdentityUserLogin<TKey> where TUserToken : Microsoft.AspNetCore.Identity.IdentityUserToken<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserConfiguration() { }
+        public int MaxKeyLength { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<string, string> PersonalDataConverter { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TUser> builder) { }
+    }
+    public partial class UserHasRolesConfiguration<TUser, TKey> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserHasRolesConfiguration<TUser, Microsoft.AspNetCore.Identity.IdentityUserRole<TKey>, TKey> where TUser : Microsoft.AspNetCore.Identity.IdentityUser<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserHasRolesConfiguration() { }
+    }
+    public partial class UserHasRolesConfiguration<TUser, TUserRole, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TUser> where TUser : Microsoft.AspNetCore.Identity.IdentityUser<TKey> where TUserRole : Microsoft.AspNetCore.Identity.IdentityUserRole<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserHasRolesConfiguration() { }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TUser> builder) { }
+    }
+    public partial class UserLoginConfiguration : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserLoginConfiguration<Microsoft.AspNetCore.Identity.IdentityUserLogin<string>, string>
+    {
+        public UserLoginConfiguration() { }
+    }
+    public partial class UserLoginConfiguration<TUserLogin> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserLoginConfiguration<TUserLogin, string> where TUserLogin : Microsoft.AspNetCore.Identity.IdentityUserLogin<string>
+    {
+        public UserLoginConfiguration() { }
+    }
+    public partial class UserLoginConfiguration<TUserLogin, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TUserLogin> where TUserLogin : Microsoft.AspNetCore.Identity.IdentityUserLogin<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserLoginConfiguration() { }
+        public int MaxKeyLength { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TUserLogin> builder) { }
+    }
+    public partial class UserRoleConfiguration<TKey> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserRoleConfiguration<Microsoft.AspNetCore.Identity.IdentityUserRole<TKey>, TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserRoleConfiguration() { }
+    }
+    public partial class UserRoleConfiguration<TUserRole, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TUserRole> where TUserRole : Microsoft.AspNetCore.Identity.IdentityUserRole<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserRoleConfiguration() { }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TUserRole> builder) { }
+    }
+    public partial class UserTokenConfiguration : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserTokenConfiguration<Microsoft.AspNetCore.Identity.IdentityUserToken<string>, string>
+    {
+        public UserTokenConfiguration() { }
+    }
+    public partial class UserTokenConfiguration<TUserToken> : Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration.UserTokenConfiguration<TUserToken, string> where TUserToken : Microsoft.AspNetCore.Identity.IdentityUserToken<string>
+    {
+        public UserTokenConfiguration() { }
+    }
+    public partial class UserTokenConfiguration<TUserToken, TKey> : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<TUserToken> where TUserToken : Microsoft.AspNetCore.Identity.IdentityUserToken<TKey> where TKey : System.IEquatable<TKey>
+    {
+        public UserTokenConfiguration() { }
+        public int MaxKeyLength { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<string, string> PersonalDataConverter { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public virtual void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TUserToken> builder) { }
+    }
+}
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class IdentityEntityFrameworkBuilderExtensions

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleClaimConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleClaimConfiguration.cs
@@ -12,11 +12,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
          where TKey : IEquatable<TKey>
     {
         public virtual void Configure(EntityTypeBuilder<TRoleClaim> builder)
-        {
-         
+        {         
                 builder.HasKey(rc => rc.Id);
-                builder.ToTable("AspNetRoleClaims");
-            
+                builder.ToTable("AspNetRoleClaims");            
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleClaimConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleClaimConfiguration.cs
@@ -7,6 +7,11 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class RoleClaimConfiguration<TKey> : RoleClaimConfiguration<IdentityRoleClaim<TKey>, TKey>
+         where TKey : IEquatable<TKey>
+    {     
+    }
+
     public class RoleClaimConfiguration<TRoleClaim, TKey> : IEntityTypeConfiguration<TRoleClaim>      
          where TRoleClaim : IdentityRoleClaim<TKey>
          where TKey : IEquatable<TKey>

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleClaimConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleClaimConfiguration.cs
@@ -1,0 +1,22 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class RoleClaimConfiguration<TRoleClaim, TKey> : IEntityTypeConfiguration<TRoleClaim>      
+         where TRoleClaim : IdentityRoleClaim<TKey>
+         where TKey : IEquatable<TKey>
+    {
+        public virtual void Configure(EntityTypeBuilder<TRoleClaim> builder)
+        {
+         
+                builder.HasKey(rc => rc.Id);
+                builder.ToTable("AspNetRoleClaims");
+            
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleConfiguration.cs
@@ -1,0 +1,31 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey> : IEntityTypeConfiguration<TRole>
+         where TRole : IdentityRole<TKey>
+         where TUserRole : IdentityUserRole<TKey>
+         where TRoleClaim : IdentityRoleClaim<TKey>
+         where TKey : IEquatable<TKey>
+
+    {
+        public virtual void Configure(EntityTypeBuilder<TRole> builder)
+        {
+            builder.HasKey(r => r.Id);
+            builder.HasIndex(r => r.NormalizedName).HasName("RoleNameIndex").IsUnique();
+            builder.ToTable("AspNetRoles");
+            builder.Property(r => r.ConcurrencyStamp).IsConcurrencyToken();
+
+            builder.Property(u => u.Name).HasMaxLength(256);
+            builder.Property(u => u.NormalizedName).HasMaxLength(256);
+
+            builder.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.RoleId).IsRequired();
+            builder.HasMany<TRoleClaim>().WithOne().HasForeignKey(rc => rc.RoleId).IsRequired();
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleConfiguration.cs
@@ -7,11 +7,17 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class RoleConfiguration<TRole, TKey> : RoleConfiguration<TRole, IdentityUserRole<TKey>, IdentityRoleClaim<TKey>, TKey>
+        where TRole : IdentityRole<TKey>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
     public class RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey> : IEntityTypeConfiguration<TRole>
-         where TRole : IdentityRole<TKey>
-         where TUserRole : IdentityUserRole<TKey>
-         where TRoleClaim : IdentityRoleClaim<TKey>
-         where TKey : IEquatable<TKey>
+        where TRole : IdentityRole<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TKey : IEquatable<TKey>
     {
         public virtual void Configure(EntityTypeBuilder<TRole> builder)
         {

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/RoleConfiguration.cs
@@ -12,7 +12,6 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
          where TUserRole : IdentityUserRole<TKey>
          where TRoleClaim : IdentityRoleClaim<TKey>
          where TKey : IEquatable<TKey>
-
     {
         public virtual void Configure(EntityTypeBuilder<TRole> builder)
         {

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserClaimConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserClaimConfiguration.cs
@@ -10,6 +10,15 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class UserClaimConfiguration : UserClaimConfiguration<IdentityUserClaim<string>>
+    {
+    }
+
+    public class UserClaimConfiguration<TUserClaim> : UserClaimConfiguration<TUserClaim, string>
+       where TUserClaim : IdentityUserClaim<string>
+    {
+    }
+
     public class UserClaimConfiguration<TUserClaim, TKey> : IEntityTypeConfiguration<TUserClaim>
          where TUserClaim : IdentityUserClaim<TKey>
          where TKey : IEquatable<TKey>

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserClaimConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserClaimConfiguration.cs
@@ -1,0 +1,23 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class UserClaimConfiguration<TUserClaim, TKey> : IEntityTypeConfiguration<TUserClaim>
+         where TUserClaim : IdentityUserClaim<TKey>
+         where TKey : IEquatable<TKey>
+    {
+        public virtual void Configure(EntityTypeBuilder<TUserClaim> builder)
+        {
+            builder.HasKey(uc => uc.Id);
+            builder.ToTable("AspNetUserClaims");
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
          where TUser : IdentityUser<TKey>
          where TUserRole : IdentityUserRole<TKey>
          where TKey : IEquatable<TKey>
-
     {
         public virtual void Configure(EntityTypeBuilder<TUser> builder)
         {

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
@@ -1,0 +1,21 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class UserConfiguration<TUser, TUserRole, TKey> : IEntityTypeConfiguration<TUser>
+         where TUser : IdentityUser<TKey>
+         where TUserRole : IdentityUserRole<TKey>
+         where TKey : IEquatable<TKey>
+
+    {
+        public virtual void Configure(EntityTypeBuilder<TUser> builder)
+        {
+            builder.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
@@ -9,6 +9,15 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class UserConfiguration : UserConfiguration<IdentityUser, IdentityUserClaim<string>, IdentityUserLogin<string>, IdentityUserToken<string>, string>
+    {
+    }
+
+    public class UserConfiguration<TUser> : UserConfiguration<TUser, IdentityUserClaim<string>, IdentityUserLogin<string>, IdentityUserToken<string>, string>
+        where TUser : IdentityUser<string>
+    {
+    }
+
     public class UserConfiguration<TUser, TUserClaim, TUserLogin, TUserToken, TKey> : IEntityTypeConfiguration<TUser>
          where TUser : IdentityUser<TKey>
          where TUserClaim : IdentityUserClaim<TKey>

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserConfiguration.cs
@@ -2,19 +2,63 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
-    public class UserConfiguration<TUser, TUserRole, TKey> : IEntityTypeConfiguration<TUser>
+    public class UserConfiguration<TUser, TUserClaim, TUserLogin, TUserToken, TKey> : IEntityTypeConfiguration<TUser>
          where TUser : IdentityUser<TKey>
-         where TUserRole : IdentityUserRole<TKey>
+         where TUserClaim : IdentityUserClaim<TKey>
+         where TUserLogin : IdentityUserLogin<TKey>
+         where TUserToken : IdentityUserToken<TKey>
          where TKey : IEquatable<TKey>
     {
+        /// <summary>
+        /// Specifies the maximum key length.
+        /// </summary>
+        /// <remarks>Only applied if greater than 0.</remarks>
+        public int MaxKeyLength { get; set; } = 0;
+
+        /// <summary>
+        /// If set, all properties on type <typeparamref name="TUser"/> marked with a <see cref="ProtectedPersonalDataAttribute"/> will be converted using this <see cref="ValueConverter"/>.
+        /// </summary>
+        public ValueConverter<string, string> PersonalDataConverter { get; set; } = null;
+
         public virtual void Configure(EntityTypeBuilder<TUser> builder)
         {
-            builder.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
+
+            builder.HasKey(u => u.Id);
+            builder.HasIndex(u => u.NormalizedUserName).HasName("UserNameIndex").IsUnique();
+            builder.HasIndex(u => u.NormalizedEmail).HasName("EmailIndex");
+            builder.ToTable("AspNetUsers");
+            builder.Property(u => u.ConcurrencyStamp).IsConcurrencyToken();
+
+            builder.Property(u => u.UserName).HasMaxLength(256);
+            builder.Property(u => u.NormalizedUserName).HasMaxLength(256);
+            builder.Property(u => u.Email).HasMaxLength(256);
+            builder.Property(u => u.NormalizedEmail).HasMaxLength(256);
+
+            if (PersonalDataConverter != null)
+            {
+                var personalDataProps = typeof(TUser).GetProperties().Where(
+                                prop => Attribute.IsDefined(prop, typeof(ProtectedPersonalDataAttribute)));
+                foreach (var p in personalDataProps)
+                {
+                    if (p.PropertyType != typeof(string))
+                    {
+                        throw new InvalidOperationException(Resources.CanOnlyProtectStrings);
+                    }
+                    builder.Property(typeof(string), p.Name).HasConversion(PersonalDataConverter);
+                }
+            }
+
+            builder.HasMany<TUserClaim>().WithOne().HasForeignKey(uc => uc.UserId).IsRequired();
+            builder.HasMany<TUserLogin>().WithOne().HasForeignKey(ul => ul.UserId).IsRequired();
+            builder.HasMany<TUserToken>().WithOne().HasForeignKey(ut => ut.UserId).IsRequired();
+
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserHasRolesConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserHasRolesConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,7 +7,13 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
-    public class UserWithRolesConfiguration<TUser, TUserRole, TKey> : IEntityTypeConfiguration<TUser>
+    public class UserHasRolesConfiguration<TUser, TKey> : UserHasRolesConfiguration<TUser, IdentityUserRole<TKey>, TKey>
+         where TUser : IdentityUser<TKey>
+         where TKey : IEquatable<TKey>
+    {       
+    }
+
+    public class UserHasRolesConfiguration<TUser, TUserRole, TKey> : IEntityTypeConfiguration<TUser>
          where TUser : IdentityUser<TKey>
          where TUserRole : IdentityUserRole<TKey>
          where TKey : IEquatable<TKey>

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserLoginConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserLoginConfiguration.cs
@@ -7,9 +7,18 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class UserLoginConfiguration : UserLoginConfiguration<IdentityUserLogin<string>, string>
+    {
+    }
+
+    public class UserLoginConfiguration<TUserLogin> : UserLoginConfiguration<TUserLogin, string>
+        where TUserLogin : IdentityUserLogin<string>
+    {
+    }
+
     public class UserLoginConfiguration<TUserLogin, TKey> : IEntityTypeConfiguration<TUserLogin>
-        where TUserLogin : IdentityUserLogin<TKey>
-        where TKey : IEquatable<TKey>
+    where TUserLogin : IdentityUserLogin<TKey>
+    where TKey : IEquatable<TKey>
     {
         /// <summary>
         /// Specifies the maximum key length.

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserLoginConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserLoginConfiguration.cs
@@ -1,0 +1,33 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class UserLoginConfiguration<TUserLogin, TKey> : IEntityTypeConfiguration<TUserLogin>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        /// Specifies the maximum key length.
+        /// </summary>
+        /// <remarks>Only applied if greater than 0.</remarks>
+        public int MaxKeyLength { get; set; } = 0;
+
+        public virtual void Configure(EntityTypeBuilder<TUserLogin> builder)
+        {
+            builder.HasKey(l => new { l.LoginProvider, l.ProviderKey });
+
+            if (MaxKeyLength > 0)
+            {
+                builder.Property(l => l.LoginProvider).HasMaxLength(MaxKeyLength);
+                builder.Property(l => l.ProviderKey).HasMaxLength(MaxKeyLength);
+            }
+
+            builder.ToTable("AspNetUserLogins");
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserRoleConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserRoleConfiguration.cs
@@ -7,6 +7,11 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class UserRoleConfiguration<TKey> : UserRoleConfiguration<IdentityUserRole<TKey>, TKey>
+        where TKey : IEquatable<TKey>
+    {      
+    }
+
     public class UserRoleConfiguration<TUserRole, TKey> : IEntityTypeConfiguration<TUserRole>      
          where TUserRole : IdentityUserRole<TKey>
          where TKey : IEquatable<TKey>

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserRoleConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserRoleConfiguration.cs
@@ -1,0 +1,20 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class UserRoleConfiguration<TUserRole, TKey> : IEntityTypeConfiguration<TUserRole>      
+         where TUserRole : IdentityUserRole<TKey>
+         where TKey : IEquatable<TKey>
+    {
+        public virtual void Configure(EntityTypeBuilder<TUserRole> builder)
+        {
+            builder.HasKey(r => new { r.UserId, r.RoleId });
+            builder.ToTable("AspNetUserRoles");
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserTokenConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserTokenConfiguration.cs
@@ -1,0 +1,54 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class UserTokenConfiguration<TUserToken, TKey> : IEntityTypeConfiguration<TUserToken>
+       where TUserToken : IdentityUserToken<TKey>
+       where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        /// Specifies the maximum key length.
+        /// </summary>
+        /// <remarks>Only applied if greater than 0.</remarks>
+        public int MaxKeyLength { get; set; } = 0;
+
+        /// <summary>
+        /// If set, all properties on type <typeparamref name="TUserToken"/> marked with a <see cref="ProtectedPersonalDataAttribute"/> will be converted using this <see cref="ValueConverter"/>.
+        /// </summary>
+        public ValueConverter<string, string> PersonalDataConverter { get; set; } = null;
+
+        public virtual void Configure(EntityTypeBuilder<TUserToken> builder)
+        {
+            builder.HasKey(t => new { t.UserId, t.LoginProvider, t.Name });
+
+            if (MaxKeyLength > 0)
+            {
+                builder.Property(t => t.LoginProvider).HasMaxLength(MaxKeyLength);
+                builder.Property(t => t.Name).HasMaxLength(MaxKeyLength);
+            }
+
+            if (PersonalDataConverter != null)
+            {
+                var tokenProps = typeof(TUserToken).GetProperties().Where(
+                                prop => Attribute.IsDefined(prop, typeof(ProtectedPersonalDataAttribute)));
+                foreach (var p in tokenProps)
+                {
+                    if (p.PropertyType != typeof(string))
+                    {
+                        throw new InvalidOperationException(Resources.CanOnlyProtectStrings);
+                    }
+                    builder.Property(typeof(string), p.Name).HasConversion(PersonalDataConverter);
+                }
+            }
+
+            builder.ToTable("AspNetUserTokens");          
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserTokenConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserTokenConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,15 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
 {
+    public class UserTokenConfiguration : UserTokenConfiguration<IdentityUserToken<string>, string>
+    {
+    }
+
+    public class UserTokenConfiguration<TUserToken> : UserTokenConfiguration<TUserToken, string>
+       where TUserToken : IdentityUserToken<string>
+    {
+    }
+
     public class UserTokenConfiguration<TUserToken, TKey> : IEntityTypeConfiguration<TUserToken>
        where TUserToken : IdentityUserToken<TKey>
        where TKey : IEquatable<TKey>
@@ -48,7 +57,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
                 }
             }
 
-            builder.ToTable("AspNetUserTokens");          
+            builder.ToTable("AspNetUserTokens");
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserWithRolesConfiguration.cs
+++ b/src/Identity/EntityFrameworkCore/src/EntityConfiguration/UserWithRolesConfiguration.cs
@@ -1,0 +1,20 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration
+{
+    public class UserWithRolesConfiguration<TUser, TUserRole, TKey> : IEntityTypeConfiguration<TUser>
+         where TUser : IdentityUser<TKey>
+         where TUserRole : IdentityUserRole<TKey>
+         where TKey : IEquatable<TKey>
+    {
+        public virtual void Configure(EntityTypeBuilder<TUser> builder)
+        {
+            builder.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         {
             base.OnModelCreating(builder);
 
-            builder.ApplyConfiguration(new UserConfiguration<TUser, TUserRole, TKey>());
+            builder.ApplyConfiguration(new UserWithRolesConfiguration<TUser, TUserRole, TKey>());
             builder.ApplyConfiguration(new RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey>());
             builder.ApplyConfiguration(new RoleClaimConfiguration<TRoleClaim, TKey>());
             builder.ApplyConfiguration(new UserRoleConfiguration<TUserRole, TKey>());                

--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration;
 using Microsoft.EntityFrameworkCore;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
@@ -120,36 +121,12 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
-            builder.Entity<TUser>(b =>
-            {
-                b.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
-            });
 
-            builder.Entity<TRole>(b =>
-            {
-                b.HasKey(r => r.Id);
-                b.HasIndex(r => r.NormalizedName).HasName("RoleNameIndex").IsUnique();
-                b.ToTable("AspNetRoles");
-                b.Property(r => r.ConcurrencyStamp).IsConcurrencyToken();
-
-                b.Property(u => u.Name).HasMaxLength(256);
-                b.Property(u => u.NormalizedName).HasMaxLength(256);
-
-                b.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.RoleId).IsRequired();
-                b.HasMany<TRoleClaim>().WithOne().HasForeignKey(rc => rc.RoleId).IsRequired();
-            });
-
-            builder.Entity<TRoleClaim>(b =>
-            {
-                b.HasKey(rc => rc.Id);
-                b.ToTable("AspNetRoleClaims");
-            });
-
-            builder.Entity<TUserRole>(b =>
-            {
-                b.HasKey(r => new { r.UserId, r.RoleId });
-                b.ToTable("AspNetUserRoles");
-            });
+            builder.ApplyConfiguration(new UserConfiguration<TUser, TUserRole, TKey>());
+            builder.ApplyConfiguration(new RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey>());
+            builder.ApplyConfiguration(new RoleClaimConfiguration<TRoleClaim, TKey>());
+            builder.ApplyConfiguration(new UserRoleConfiguration<TUserRole, TKey>());      
+          
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -125,8 +125,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
             builder.ApplyConfiguration(new UserConfiguration<TUser, TUserRole, TKey>());
             builder.ApplyConfiguration(new RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey>());
             builder.ApplyConfiguration(new RoleClaimConfiguration<TRoleClaim, TKey>());
-            builder.ApplyConfiguration(new UserRoleConfiguration<TUserRole, TKey>());      
-          
+            builder.ApplyConfiguration(new UserRoleConfiguration<TUserRole, TKey>());                
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         {
             base.OnModelCreating(builder);
 
-            builder.ApplyConfiguration(new UserWithRolesConfiguration<TUser, TUserRole, TKey>());
+            builder.ApplyConfiguration(new UserHasRolesConfiguration<TUser, TUserRole, TKey>());
             builder.ApplyConfiguration(new RoleConfiguration<TRole, TUserRole, TRoleClaim, TKey>());
             builder.ApplyConfiguration(new RoleClaimConfiguration<TRoleClaim, TKey>());
             builder.ApplyConfiguration(new UserRoleConfiguration<TUserRole, TKey>());                

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryCustomContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryCustomContext.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore.EntityConfiguration;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
+{
+    public class InMemoryCustomContext :
+        InMemoryCustomContext<IdentityUser, IdentityRole, string>
+    {
+        private InMemoryCustomContext(DbConnection connection) : base(connection)
+        { }
+
+        public new static InMemoryCustomContext Create(DbConnection connection)
+            => Initialize(new InMemoryCustomContext(connection));
+
+        public static TContext Initialize<TContext>(TContext context) where TContext : DbContext
+        {
+            context.Database.EnsureCreated();
+
+            return context;
+        }
+    }
+
+    public class InMemoryCustomContext<TUser> :
+        DbContext
+        where TUser : IdentityUser
+    {
+        private readonly DbConnection _connection;
+        private InMemoryCustomContext(DbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public static InMemoryCustomContext<TUser> Create(DbConnection connection)
+            => InMemoryCustomContext.Initialize(new InMemoryCustomContext<TUser>(connection));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            var maxKeyLength = 50;
+
+            modelBuilder.ApplyConfiguration(new UserConfiguration<TUser>() { MaxKeyLength = maxKeyLength });
+            modelBuilder.ApplyConfiguration(new UserClaimConfiguration());
+            modelBuilder.ApplyConfiguration(new UserLoginConfiguration() { MaxKeyLength = maxKeyLength });
+            modelBuilder.ApplyConfiguration(new UserTokenConfiguration() { MaxKeyLength = maxKeyLength });
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseSqlite(_connection);
+    }
+
+    public class InMemoryCustomContext<TUser, TRole, TKey> : InMemoryCustomContext<TUser, TRole, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>, IdentityUserToken<TKey>>
+        where TUser : IdentityUser<TKey>
+        where TRole : IdentityRole<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        private readonly DbConnection _connection;
+
+        protected InMemoryCustomContext(DbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public static InMemoryCustomContext<TUser, TRole, TKey> Create(DbConnection connection)
+            => InMemoryCustomContext.Initialize(new InMemoryCustomContext<TUser, TRole, TKey>(connection));
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseSqlite(_connection);
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.ApplyConfiguration(new UserHasRolesConfiguration<TUser, TKey>());
+            modelBuilder.ApplyConfiguration(new RoleConfiguration<TRole, TKey>());
+            modelBuilder.ApplyConfiguration(new RoleClaimConfiguration<TKey>());
+            modelBuilder.ApplyConfiguration(new UserRoleConfiguration<TKey>());
+
+        }
+    }
+
+    public abstract class InMemoryCustomContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> :
+            DbContext
+        where TUser : IdentityUser<TKey>
+        where TRole : IdentityRole<TKey>
+        where TKey : IEquatable<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+    {
+        protected InMemoryCustomContext() { }
+
+        protected InMemoryCustomContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            var maxKeyLength = 50;
+
+            modelBuilder.ApplyConfiguration(new UserConfiguration<TUser, TUserClaim, TUserLogin, TUserToken, TKey>() { MaxKeyLength = maxKeyLength });
+            modelBuilder.ApplyConfiguration(new UserClaimConfiguration<TUserClaim, TKey>());
+            modelBuilder.ApplyConfiguration(new UserLoginConfiguration<TUserLogin, TKey>() { MaxKeyLength = maxKeyLength });
+            modelBuilder.ApplyConfiguration(new UserTokenConfiguration<TUserToken, TKey>() { MaxKeyLength = maxKeyLength });
+        }
+
+    }
+}

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedContext.cs
@@ -8,14 +8,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 {
-    public class InMemoryCustomContext :
-        InMemoryCustomContext<IdentityUser, IdentityRole, string>
+    public class InMemoryNonIdentityDerivedContext :
+        InMemoryNonIdentityDerivedContext<IdentityUser, IdentityRole, string>
     {
-        private InMemoryCustomContext(DbConnection connection) : base(connection)
+        private InMemoryNonIdentityDerivedContext(DbConnection connection) : base(connection)
         { }
 
-        public new static InMemoryCustomContext Create(DbConnection connection)
-            => Initialize(new InMemoryCustomContext(connection));
+        public new static InMemoryNonIdentityDerivedContext Create(DbConnection connection)
+            => Initialize(new InMemoryNonIdentityDerivedContext(connection));
 
         public static TContext Initialize<TContext>(TContext context) where TContext : DbContext
         {
@@ -25,18 +25,18 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         }
     }
 
-    public class InMemoryCustomContext<TUser> :
+    public class InMemoryNonIdentityDerivedContext<TUser> :
         DbContext
         where TUser : IdentityUser
     {
         private readonly DbConnection _connection;
-        private InMemoryCustomContext(DbConnection connection)
+        private InMemoryNonIdentityDerivedContext(DbConnection connection)
         {
             _connection = connection;
         }
 
-        public static InMemoryCustomContext<TUser> Create(DbConnection connection)
-            => InMemoryCustomContext.Initialize(new InMemoryCustomContext<TUser>(connection));
+        public static InMemoryNonIdentityDerivedContext<TUser> Create(DbConnection connection)
+            => InMemoryNonIdentityDerivedContext.Initialize(new InMemoryNonIdentityDerivedContext<TUser>(connection));
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -54,20 +54,20 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
             => optionsBuilder.UseSqlite(_connection);
     }
 
-    public class InMemoryCustomContext<TUser, TRole, TKey> : InMemoryCustomContext<TUser, TRole, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>, IdentityUserToken<TKey>>
+    public class InMemoryNonIdentityDerivedContext<TUser, TRole, TKey> : InMemoryNonIdentityDerivedContext<TUser, TRole, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>, IdentityUserToken<TKey>>
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
     {
         private readonly DbConnection _connection;
 
-        protected InMemoryCustomContext(DbConnection connection)
+        protected InMemoryNonIdentityDerivedContext(DbConnection connection)
         {
             _connection = connection;
         }
 
-        public static InMemoryCustomContext<TUser, TRole, TKey> Create(DbConnection connection)
-            => InMemoryCustomContext.Initialize(new InMemoryCustomContext<TUser, TRole, TKey>(connection));
+        public static InMemoryNonIdentityDerivedContext<TUser, TRole, TKey> Create(DbConnection connection)
+            => InMemoryNonIdentityDerivedContext.Initialize(new InMemoryNonIdentityDerivedContext<TUser, TRole, TKey>(connection));
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseSqlite(_connection);
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         }
     }
 
-    public abstract class InMemoryCustomContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> :
+    public abstract class InMemoryNonIdentityDerivedContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> :
             DbContext
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
@@ -95,9 +95,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
     {
-        protected InMemoryCustomContext() { }
+        protected InMemoryNonIdentityDerivedContext() { }
 
-        protected InMemoryCustomContext(DbContextOptions options)
+        protected InMemoryNonIdentityDerivedContext(DbContextOptions options)
             : base(options)
         {
         }

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedEFOnlyUsersTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedEFOnlyUsersTest.cs
@@ -10,23 +10,22 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 {
-
-    public class InMemoryEFOnlyUsersTest
-        : UserManagerSpecificationTestBase<IdentityUser, string>,
-            IClassFixture<InMemoryDatabaseFixture>
+    public class InMemoryNonIdentityDerivedEFOnlyUsersTest
+    : UserManagerSpecificationTestBase<IdentityUser, string>,
+        IClassFixture<InMemoryDatabaseFixture>
     {
         private readonly InMemoryDatabaseFixture _fixture;
 
-        public InMemoryEFOnlyUsersTest(InMemoryDatabaseFixture fixture)
+        public InMemoryNonIdentityDerivedEFOnlyUsersTest(InMemoryDatabaseFixture fixture)
         {
             _fixture = fixture;
         }
 
         protected override object CreateTestContext()
-            => InMemoryContext<IdentityUser>.Create(_fixture.Connection);
+            => InMemoryNonIdentityDerivedContext<IdentityUser>.Create(_fixture.Connection);
 
         protected override void AddUserStore(IServiceCollection services, object context = null)
-            => services.AddSingleton<IUserStore<IdentityUser>>(new UserStore<IdentityUser, IdentityRole, DbContext, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityUserToken<string>, IdentityRoleClaim<string>>((InMemoryContext<IdentityUser>)context, new IdentityErrorDescriber()));
+            => services.AddSingleton<IUserStore<IdentityUser>>(new UserStore<IdentityUser, IdentityRole, DbContext, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityUserToken<string>, IdentityRoleClaim<string>>((InMemoryNonIdentityDerivedContext<IdentityUser>)context, new IdentityErrorDescriber()));
 
         protected override IdentityUser CreateTestUser(string namePrefix = "", string email = "", string phoneNumber = "",
             bool lockoutEnabled = false, DateTimeOffset? lockoutEnd = default(DateTimeOffset?), bool useNamePrefixAsUserName = false)

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedEFUserStoreWithGenericsTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedEFUserStoreWithGenericsTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 
             var services = new ServiceCollection();
             services.AddHttpContextAccessor();
-            services.AddDbContext<InMemoryContextWithGenerics>(
+            services.AddDbContext<InMemoryNonIdentityDerivedContextWithGenerics>(
                 options => options
                     .UseSqlite(_fixture.Connection)
                     .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)));

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedEFUserStoreWithGenericsTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryNonIdentityDerivedEFUserStoreWithGenericsTest.cs
@@ -2,13 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -17,15 +14,14 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 {
-
-    public class InMemoryEFUserStoreTestWithGenerics
-        : IdentitySpecificationTestBase<IdentityUserWithGenerics, MyIdentityRole, string>, IClassFixture<InMemoryDatabaseFixture>
+    public class InMemoryNonIdentityDerivedEFUserStoreWithGenericsTest
+    : IdentitySpecificationTestBase<IdentityUserWithGenerics, MyIdentityRole, string>, IClassFixture<InMemoryDatabaseFixture>
     {
         private readonly InMemoryDatabaseFixture _fixture;
-        private readonly InMemoryContextWithGenerics _context;
-        private UserStoreWithGenerics _store;
+        private readonly InMemoryNonIdentityDerivedContextWithGenerics _context;
+        private UserStoreWithNonIdentityDerivedDbContextAndGenerics _store;
 
-        public InMemoryEFUserStoreTestWithGenerics(InMemoryDatabaseFixture fixture)
+        public InMemoryNonIdentityDerivedEFUserStoreWithGenericsTest(InMemoryDatabaseFixture fixture)
         {
             _fixture = fixture;
 
@@ -35,7 +31,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
                 options => options
                     .UseSqlite(_fixture.Connection)
                     .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)));
-            _context = services.BuildServiceProvider().GetRequiredService<InMemoryContextWithGenerics>();
+            _context = services.BuildServiceProvider().GetRequiredService<InMemoryNonIdentityDerivedContextWithGenerics>();
 
             _context.Database.EnsureCreated();
         }
@@ -47,13 +43,13 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 
         protected override void AddUserStore(IServiceCollection services, object context = null)
         {
-            _store = new UserStoreWithGenerics((InMemoryContextWithGenerics)context, "TestContext");
+            _store = new UserStoreWithNonIdentityDerivedDbContextAndGenerics((InMemoryNonIdentityDerivedContextWithGenerics)context, "TestContext");
             services.AddSingleton<IUserStore<IdentityUserWithGenerics>>(_store);
         }
 
         protected override void AddRoleStore(IServiceCollection services, object context = null)
         {
-            services.AddSingleton<IRoleStore<MyIdentityRole>>(new RoleStoreWithGenerics((InMemoryContextWithGenerics)context, "TestContext"));
+            services.AddSingleton<IRoleStore<MyIdentityRole>>(new RoleStoreWithNonIdentityDerivedDbContextAndGenerics((InMemoryNonIdentityDerivedContextWithGenerics)context, "TestContext"));
         }
 
         protected override IdentityUserWithGenerics CreateTestUser(string namePrefix = "", string email = "", string phoneNumber = "",
@@ -164,161 +160,70 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
             Assert.Equal(claim.Value, newClaim.Value);
             Assert.Equal(claim.Issuer, newClaim.Issuer);
         }
-    }
 
-    public class ClaimEqualityComparer : IEqualityComparer<Claim>
-    {
-        public static IEqualityComparer<Claim> Default = new ClaimEqualityComparer();
-
-        public bool Equals(Claim x, Claim y)
+        protected class InMemoryNonIdentityDerivedContextWithGenerics : InMemoryNonIdentityDerivedContext<IdentityUserWithGenerics, MyIdentityRole, string, IdentityUserClaimWithIssuer, IdentityUserRoleWithDate, IdentityUserLoginWithContext, IdentityRoleClaimWithIssuer, IdentityUserTokenWithStuff>
         {
-            return x.Value == y.Value && x.Type == y.Type && x.Issuer == y.Issuer;
+            public InMemoryNonIdentityDerivedContextWithGenerics(DbContextOptions<InMemoryNonIdentityDerivedContextWithGenerics> options) : base(options)
+            { }
         }
 
-        public int GetHashCode(Claim obj)
+        protected class UserStoreWithNonIdentityDerivedDbContextAndGenerics : UserStore<IdentityUserWithGenerics, MyIdentityRole, InMemoryNonIdentityDerivedContextWithGenerics, string, IdentityUserClaimWithIssuer, IdentityUserRoleWithDate, IdentityUserLoginWithContext, IdentityUserTokenWithStuff, IdentityRoleClaimWithIssuer>
         {
-            return 1;
-        }
-    }
+            public string LoginContext { get; set; }
 
-
-    #region Generic Type defintions
-
-    public class IdentityUserWithGenerics : IdentityUser<string>
-    {
-        public IdentityUserWithGenerics()
-        {
-            Id = Guid.NewGuid().ToString();
-        }
-    }
-
-    public class UserStoreWithGenerics : UserStore<IdentityUserWithGenerics, MyIdentityRole, InMemoryContextWithGenerics, string, IdentityUserClaimWithIssuer, IdentityUserRoleWithDate, IdentityUserLoginWithContext, IdentityUserTokenWithStuff, IdentityRoleClaimWithIssuer>
-    {
-        public string LoginContext { get; set; }
-
-        public UserStoreWithGenerics(InMemoryContextWithGenerics context, string loginContext) : base(context)
-        {
-            LoginContext = loginContext;
-        }
-
-        protected override IdentityUserRoleWithDate CreateUserRole(IdentityUserWithGenerics user, MyIdentityRole role)
-        {
-            return new IdentityUserRoleWithDate()
+            public UserStoreWithNonIdentityDerivedDbContextAndGenerics(InMemoryNonIdentityDerivedContextWithGenerics context, string loginContext) : base(context)
             {
-                RoleId = role.Id,
-                UserId = user.Id,
-                Created = DateTime.UtcNow
-            };
-        }
+                LoginContext = loginContext;
+            }
 
-        protected override IdentityUserClaimWithIssuer CreateUserClaim(IdentityUserWithGenerics user, Claim claim)
-        {
-            return new IdentityUserClaimWithIssuer { UserId = user.Id, ClaimType = claim.Type, ClaimValue = claim.Value, Issuer = claim.Issuer };
-        }
-
-        protected override IdentityUserLoginWithContext CreateUserLogin(IdentityUserWithGenerics user, UserLoginInfo login)
-        {
-            return new IdentityUserLoginWithContext
+            protected override IdentityUserRoleWithDate CreateUserRole(IdentityUserWithGenerics user, MyIdentityRole role)
             {
-                UserId = user.Id,
-                ProviderKey = login.ProviderKey,
-                LoginProvider = login.LoginProvider,
-                ProviderDisplayName = login.ProviderDisplayName,
-                Context = LoginContext
-            };
-        }
+                return new IdentityUserRoleWithDate()
+                {
+                    RoleId = role.Id,
+                    UserId = user.Id,
+                    Created = DateTime.UtcNow
+                };
+            }
 
-        protected override IdentityUserTokenWithStuff CreateUserToken(IdentityUserWithGenerics user, string loginProvider, string name, string value)
-        {
-            return new IdentityUserTokenWithStuff
+            protected override IdentityUserClaimWithIssuer CreateUserClaim(IdentityUserWithGenerics user, Claim claim)
             {
-                UserId = user.Id,
-                LoginProvider = loginProvider,
-                Name = name,
-                Value = value,
-                Stuff = "stuff"
-            };
-        }
-    }
+                return new IdentityUserClaimWithIssuer { UserId = user.Id, ClaimType = claim.Type, ClaimValue = claim.Value, Issuer = claim.Issuer };
+            }
 
-    public class RoleStoreWithGenerics : RoleStore<MyIdentityRole, InMemoryContextWithGenerics, string, IdentityUserRoleWithDate, IdentityRoleClaimWithIssuer>
-    {
-        private string _loginContext;
-        public RoleStoreWithGenerics(InMemoryContextWithGenerics context, string loginContext) : base(context)
+            protected override IdentityUserLoginWithContext CreateUserLogin(IdentityUserWithGenerics user, UserLoginInfo login)
+            {
+                return new IdentityUserLoginWithContext
+                {
+                    UserId = user.Id,
+                    ProviderKey = login.ProviderKey,
+                    LoginProvider = login.LoginProvider,
+                    ProviderDisplayName = login.ProviderDisplayName,
+                    Context = LoginContext
+                };
+            }
+
+            protected override IdentityUserTokenWithStuff CreateUserToken(IdentityUserWithGenerics user, string loginProvider, string name, string value)
+            {
+                return new IdentityUserTokenWithStuff
+                {
+                    UserId = user.Id,
+                    LoginProvider = loginProvider,
+                    Name = name,
+                    Value = value,
+                    Stuff = "stuff"
+                };
+            }
+        }
+
+        protected class RoleStoreWithNonIdentityDerivedDbContextAndGenerics : RoleStore<MyIdentityRole, InMemoryNonIdentityDerivedContextWithGenerics, string, IdentityUserRoleWithDate, IdentityRoleClaimWithIssuer>
         {
-            _loginContext = loginContext;
-        }
+            private string _loginContext;
+            public RoleStoreWithNonIdentityDerivedDbContextAndGenerics(InMemoryNonIdentityDerivedContextWithGenerics context, string loginContext) : base(context)
+            {
+                _loginContext = loginContext;
+            }
 
-    }
-
-    public class IdentityUserClaimWithIssuer : IdentityUserClaim<string>
-    {
-        public string Issuer { get; set; }
-
-        public override Claim ToClaim()
-        {
-            return new Claim(ClaimType, ClaimValue, null, Issuer);
-        }
-
-        public override void InitializeFromClaim(Claim other)
-        {
-            ClaimValue = other.Value;
-            ClaimType = other.Type;
-            Issuer = other.Issuer;
         }
     }
-
-    public class IdentityRoleClaimWithIssuer : IdentityRoleClaim<string>
-    {
-        public string Issuer { get; set; }
-
-        public override Claim ToClaim()
-        {
-            return new Claim(ClaimType, ClaimValue, null, Issuer);
-        }
-
-        public override void InitializeFromClaim(Claim other)
-        {
-            ClaimValue = other.Value;
-            ClaimType = other.Type;
-            Issuer = other.Issuer;
-        }
-    }
-
-    public class IdentityUserRoleWithDate : IdentityUserRole<string>
-    {
-        public DateTime Created { get; set; }
-    }
-
-    public class MyIdentityRole : IdentityRole<string>
-    {
-        public MyIdentityRole() : base()
-        {
-            Id = Guid.NewGuid().ToString();
-        }
-
-        public MyIdentityRole(string roleName) : this()
-        {
-            Name = roleName;
-        }
-
-    }
-
-    public class IdentityUserTokenWithStuff : IdentityUserToken<string>
-    {
-        public string Stuff { get; set; }
-    }
-
-    public class IdentityUserLoginWithContext : IdentityUserLogin<string>
-    {
-        public string Context { get; set; }
-    }
-
-    public class InMemoryContextWithGenerics : InMemoryContext<IdentityUserWithGenerics, MyIdentityRole, string, IdentityUserClaimWithIssuer, IdentityUserRoleWithDate, IdentityUserLoginWithContext, IdentityRoleClaimWithIssuer, IdentityUserTokenWithStuff>
-    {
-        public InMemoryContextWithGenerics(DbContextOptions<InMemoryContextWithGenerics> options) : base(options)
-        { }
-    }
-
-    #endregion
 }


### PR DESCRIPTION
Moved entity configuration for the EF Core identity entities into `IEntityTypeConfiguration<TEntity>` implementations. 

Addresses #12511 (in this specific format) - **partly addresses**