### PR TITLE
Mark bytes as consumed 

### DIFF
--- a/src/Http/WebUtilities/src/FormPipeReader.cs
+++ b/src/Http/WebUtilities/src/FormPipeReader.cs
@@ -252,6 +252,8 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     ParseFormValuesFast(keyValuePair.FirstSpan, ref accumulator, isFinalBlock: true, out var segmentConsumed);
                     Debug.Assert(segmentConsumed == keyValuePair.FirstSpan.Length);
+                    consumedBytes = sequenceReader.Consumed;
+                    consumed = sequenceReader.Position;
                     continue;
                 }
 

--- a/src/Http/WebUtilities/test/FormPipeReaderTests.cs
+++ b/src/Http/WebUtilities/test/FormPipeReaderTests.cs
@@ -184,6 +184,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             var formReader = new FormPipeReader(null, encoding);
 
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(2, accumulator.KeyCount);
             var dict = accumulator.GetResults();
@@ -201,6 +202,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             var formReader = new FormPipeReader(null, encoding);
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(3, accumulator.KeyCount);
             var dict = accumulator.GetResults();
@@ -219,6 +221,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             var formReader = new FormPipeReader(null, encoding);
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(3, accumulator.KeyCount);
             var dict = accumulator.GetResults();
@@ -237,6 +240,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             var formReader = new FormPipeReader(null, encoding);
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(2, accumulator.KeyCount);
             var dict = accumulator.GetResults();
@@ -254,6 +258,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             var formReader = new FormPipeReader(null, encoding);
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(3, accumulator.KeyCount);
             var dict = accumulator.GetResults();
@@ -272,6 +277,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             var formReader = new FormPipeReader(null, encoding);
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(3, accumulator.KeyCount);
             var dict = accumulator.GetResults();
@@ -290,11 +296,29 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             var formReader = new FormPipeReader(null, encoding);
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             Assert.Equal(2, accumulator.KeyCount);
             var dict = accumulator.GetResults();
             Assert.Equal("\"%-.<>\\^_`{|}~", dict["\"%-.<>\\^_`{|}~"]);
             Assert.Equal("wow", dict["\"%-.<>\\^_`{|}"]);
+        }
+
+        [Fact]
+        public void TryParseFormValues_MultiSegmentFastPathWorks()
+        {
+            var readOnlySequence = ReadOnlySequenceFactory.CreateSegments(Encoding.UTF8.GetBytes("foo=bar&"), Encoding.UTF8.GetBytes("baz=boo"));
+
+            KeyValueAccumulator accumulator = default;
+
+            var formReader = new FormPipeReader(null);
+            formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
+
+            Assert.Equal(2, accumulator.KeyCount);
+            var dict = accumulator.GetResults();
+            Assert.Equal("bar", dict["foo"]);
+            Assert.Equal("boo", dict["baz"]);
         }
 
         [Fact]
@@ -411,6 +435,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             };
 
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             IDictionary<string, StringValues> values = accumulator.GetResults();
             Assert.Contains("fo", values);
@@ -431,6 +456,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             };
 
             formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: true);
+            Assert.True(readOnlySequence.IsEmpty);
 
             IDictionary<string, StringValues> values = accumulator.GetResults();
             Assert.Contains("fo", values);


### PR DESCRIPTION
#13372 @Pilchie 
This looks like a preview9 regression from #12749 where we refactored the form parser. It's externally reported as impacting OpenIdConnect auth, but I was only able to reproduce it using WsFed auth. The request fails and the client is unable to log in. I don't see any immediate workarounds.

The issue happens if the form is long enough to take the slow path (multiple buffer segments), but the last key=value pair is short and takes the single segment fast path. In that case it fails to mark the last bytes as consumed and the parser mistakenly aborts.

Compare the fix to what happens in the slow path on lines 294 and 295 bellow.