### PR TITLE
ConcurrentPipeWriter read ValueTask result once

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
         {
-            if (!_currentFlush.IsCompletedSuccessfully)
+            if (!_currentFlush.IsCompleted)
             {
                 return new ValueTask<FlushResult>(_currentFlush);
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/ConcurrentPipeWriter.cs
@@ -118,7 +118,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
             {
                 if (_currentFlushTcs != null)
                 {
-                    CompleteFlushUnsynchronized(flushTask.GetAwaiter().GetResult(), null);
+                    var flushResult = flushTask.GetAwaiter().GetResult();
+                    CompleteFlushUnsynchronized(flushResult, null);
+
+                    // Create a new ValueTask from the result rather than passing out the original
+                    // as the act of reading the result above can reset the ValueTask if its backed by an IValueTaskSource
+                    return new ValueTask<FlushResult>(flushResult);
                 }
 
                 return flushTask;


### PR DESCRIPTION
Seen in https://github.com/aspnet/AspNetCore/issues/13384#issuecomment-524496274

Only read ValueTask's result once (rather potentially 1+)

Change to `Task<FlushResult>` rather than `TaskCompletionSource<FlushResult>`

Reading the result of the same task multiple times may additionally cause issue if/when this happens https://github.com/dotnet/coreclr/pull/26310 and ValueTask statemachine boxes are pooled.