### PR TITLE
Fixup Razor Class Library template namespace and component content

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/Component1.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/Component1.razor
@@ -1,3 +1,3 @@
 ﻿<div class="my-component">
-    This Blazor component is defined in the <strong>RazorClassLibrary-CSharp</strong> package.
+    This Blazor component is defined in the <strong>Company.RazorClassLibrary1</strong> package.
 </div>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
@@ -1,7 +1,7 @@
 using Microsoft.JSInterop;
 using System.Threading.Tasks;
 
-namespace RazorClassLibrary_CSharp
+namespace Company.RazorClassLibrary1
 {
     public class ExampleJsInterop
     {


### PR DESCRIPTION
Fixes #13418. 

Token replacement is based on the `sourceName` specified for the template here: https://github.com/aspnet/AspNetCore/blob/release/3.0/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json#L21