### PR TITLE
AddNativeClient AllowOfflineAccess

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/src/Options/ClientBuilder.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Options/ClientBuilder.cs
@@ -66,7 +66,14 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
                 .WithLogoutRedirectUri(NativeAppClientRedirectUri)
                 .WithPkce()
                 .WithoutClientSecrets()
-                .WithScopes(IdentityServerConstants.StandardScopes.OfflineAccess);
+                .WithOfflineAccess();
+        }
+
+        public ClientBuilder WithOfflineAccess()
+        {
+            WithScopes(IdentityServerConstants.StandardScopes.OfflineAccess);
+            _client.AllowOfflineAccess = true;
+            return this;
         }
 
         /// <summary>

--- a/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/ConfigureClientsTests.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/test/Configuration/ConfigureClientsTests.cs
@@ -92,6 +92,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
             Assert.Equal("MyClient", client.ClientId);
             Assert.Equal("MyClient", client.ClientName);
             Assert.False(client.AllowAccessTokensViaBrowser);
+            Assert.True(client.AllowOfflineAccess);
             Assert.Equal(new[] { "urn:ietf:wg:oauth:2.0:oob" }, client.RedirectUris.ToArray());
             Assert.Equal(new[] { "urn:ietf:wg:oauth:2.0:oob" }, client.PostLogoutRedirectUris.ToArray());
             Assert.Empty(client.AllowedCorsOrigins);


### PR DESCRIPTION
Summary of the changes
 - `AddNativeClient` sets `AllowOfflineAccess` to `true`

Addresses #13434 

I don't know which branch to target to ship it in 3.0.
