### PR TITLE
Correct capitalization of JavaScript in template site.js files

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/js/site.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/js/site.js
@@ -1,4 +1,4 @@
 ﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
-// Write your Javascript code.
+// Write your JavaScript code.

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/js/site.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/js/site.js
@@ -1,4 +1,4 @@
 ﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
-// Write your Javascript code.
+// Write your JavaScript code.


### PR DESCRIPTION
Ran `Get-ChildItem -Recurse -Filter "site.js" | Select-String  -Pattern "Javascript" -CaseSensitive` in powershell in src\ProjectTemplates and got these two files.

Fixes #10414