### PR TITLE
Http2MessageBody.TryRead TryStart/TryStop

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -69,11 +69,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override bool TryRead(out ReadResult readResult)
         {
-            var result = _context.RequestBodyPipe.Reader.TryRead(out readResult);
-            _readResult = readResult;
-            CountBytesRead(readResult.Buffer.Length);
+            TryStart();
 
-            return result;
+            var hasResult = _context.RequestBodyPipe.Reader.TryRead(out readResult);
+
+            if (hasResult)
+            {
+                _readResult = readResult;
+
+                CountBytesRead(readResult.Buffer.Length);
+
+                if (readResult.IsCompleted)
+                {
+                    TryStop();
+                }
+            }
+
+            return hasResult;
         }
 
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
#13305 targeting release/3.0

/cc @halter73 

## Ask mode template

#### Description

If an app uses the new PipeReader.TryRead API on an HTTP/2 request body, request rate calculations will be done incorrectly.

#### Customer Impact

This can potentially lead to issues where a client that has met the configured minimum request body rate would still see its request aborted.

#### Regression?

Technically no, since this is a new API, but this would be a regression for apps that switched from using Stream.ReadAsync to using PipeReader.TryRead to read a request body.

#### Risk

Low, since this change only impacts apps that read a request body using PipeReader.TryRead.
