### PR TITLE
Ignore MaxRequestBodySize for upgraded requests

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -313,6 +313,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             }
 
             _wasUpgraded = true;
+            //MaxRequestBodySize = null;
 
             StatusCode = StatusCodes.Status101SwitchingProtocols;
             ReasonPhrase = ReasonPhrases.GetReasonPhrase(StatusCodes.Status101SwitchingProtocols);

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -312,8 +312,8 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 throw new InvalidOperationException(CoreStrings.UpgradeCannotBeCalledMultipleTimes);
             }
 
+            MaxRequestBodySize = null;
             _wasUpgraded = true;
-            //MaxRequestBodySize = null;
 
             StatusCode = StatusCodes.Status101SwitchingProtocols;
             ReasonPhrase = ReasonPhrases.GetReasonPhrase(StatusCodes.Status101SwitchingProtocols);

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
@@ -98,6 +98,7 @@ namespace TestSite
 
             // Upgrade the connection
             Stream opaqueTransport = await upgradeFeature.UpgradeAsync();
+            Assert.Null(context.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize);
 
             // Get the WebSocket object
             var ws = WebSocket.CreateFromStream(opaqueTransport, isServer: true, subProtocol: null, keepAliveInterval: TimeSpan.FromMinutes(2));


### PR DESCRIPTION
## Ask mode template
### Description
Customer reported issue in https://github.com/aspnet/AspNetCore/issues/13470.
When using WebSockets and IIS the client will be terminated after sending 30MB of data (by default) over the lifetime of the connection.
### Customer Impact

Customers using Blazor or SignalR will have clients abruptly terminated if they stay connected for a long time, or are active and send ~30MB of data.
### Regression?

Yes. Caused by https://github.com/aspnet/AspNetCore/pull/9475 when we added the MaxRequestBodySize feature to IIS in-proc.
### Risk

Low.