### PR TITLE
Fix AzureAd options validation

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
@@ -21,6 +21,11 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         public void Configure(string name, CookieAuthenticationOptions options)
         {
             var AzureADScheme = GetAzureADScheme(name);
+            if (AzureADScheme is null)
+            {
+                return;
+            }
+            
             var AzureADOptions = _AzureADOptions.Get(AzureADScheme);
             if (name != AzureADOptions.CookieSchemeName)
             {

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADJwtBearerOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADJwtBearerOptionsConfiguration.cs
@@ -24,6 +24,11 @@ namespace Microsoft.AspNetCore.Authentication
         public void Configure(string name, JwtBearerOptions options)
         {
             var azureADScheme = GetAzureADScheme(name);
+            if (azureADScheme is null)
+            {
+                return;
+            }
+
             var azureADOptions = _azureADOptions.Get(azureADScheme);
             if (name != azureADOptions.JwtBearerSchemeName)
             {

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
@@ -269,6 +269,22 @@ namespace Microsoft.AspNetCore.Authentication
         }
 
         [Fact]
+        public void AddAzureAD_SkipsOptionsValidationForNonAzureCookies()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILoggerFactory>(new NullLoggerFactory());
+
+            services.AddAuthentication()
+                .AddAzureAD(o => { })
+                .AddCookie("other");
+
+            var provider = services.BuildServiceProvider();
+            var cookieAuthOptions = provider.GetService<IOptionsMonitor<CookieAuthenticationOptions>>();
+
+            Assert.NotNull(cookieAuthOptions.Get("other"));
+        }
+
+        [Fact]
         public void AddAzureADBearer_AddsAllAuthenticationHandlers()
         {
             // Arrange
@@ -452,6 +468,22 @@ namespace Microsoft.AspNetCore.Authentication
                 () => azureADOptionsMonitor.Get(AzureADDefaults.AuthenticationScheme));
 
             Assert.Contains(expectedMessage, exception.Failures);
+        }
+
+        [Fact]
+        public void AddAzureADBearer_SkipsOptionsValidationForNonAzureCookies()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILoggerFactory>(new NullLoggerFactory());
+
+            services.AddAuthentication()
+                .AddAzureADBearer(o => { })
+                .AddJwtBearer("other", o => { });
+
+            var provider = services.BuildServiceProvider();
+            var jwtOptions = provider.GetService<IOptionsMonitor<JwtBearerOptions>>();
+
+            Assert.NotNull(jwtOptions.Get("other"));
         }
     }
 }


### PR DESCRIPTION
## Ask mode template

#### Description

#9967 added options validation for AzureAd auth options, but it introduced a regression where it would throw for other cookie or jwt auth providers.

#13327 was a community members fix for cookies in master. I've cherry picked that commit, also fixed jwt, and added tests.

#### Customer Impact

Customers may not be able to use AzureAd auth combine with other kinds of auth in one app.

#### Regression?

Yes, identified externally in preview8.

#### Risk

Low.

@Pilchie 