### PR TITLE
Microsoft.dotnet-openapi is a shipping package

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -54,6 +54,7 @@
     <FileSignInfo Include="dotnet-sql-cache.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="dotnet-user-secrets.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="dotnet-watch.exe" CertificateName="Microsoft400" />
+    <FileSignInfo Include="Microsoft.dotnet-openapi.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="Microsoft.AspNetCore.Blazor.Build.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="sni.dll" CertificateName="Microsoft400" />
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -54,7 +54,7 @@
     <FileSignInfo Include="dotnet-sql-cache.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="dotnet-user-secrets.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="dotnet-watch.exe" CertificateName="Microsoft400" />
-    <FileSignInfo Include="Microsoft.dotnet-openapi.exe" CertificateName="Microsoft400" />
+    <FileSignInfo Include="dotnet-openapi.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="Microsoft.AspNetCore.Blazor.Build.exe" CertificateName="Microsoft400" />
     <FileSignInfo Include="sni.dll" CertificateName="Microsoft400" />
 

--- a/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
@@ -7,8 +7,7 @@
     <AssemblyName>dotnet-openapi</AssemblyName>
     <PackageId>Microsoft.dotnet-openapi</PackageId>
     <PackAsTool>true</PackAsTool>
-    <!-- This package is for internal use only. It contains a CLI tool. -->
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Make sure that the Microsoft.dotnet-openapi package ships by default.