### PR TITLE
[SPA] Enable support for publish single file

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
@@ -61,6 +61,7 @@
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/React-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/React-CSharp.csproj.in
@@ -56,6 +56,7 @@
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
@@ -45,6 +45,7 @@
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
**Description**
SPA templates won't work with single file publish

**Customer Impact**
Customers won't be able to use single file publish with the SPA templates out of the box.

**Regression?**
No, PublishSingleFile is a new feature

**Risk**
Very low.

Customers can workaround the issue in the same way this PR does, but it offers a bad out of the box experience and the fix is trivial.