### PR TITLE
Update manually generated reference for RenderTreeFrame

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.Manual.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.Manual.cs
@@ -1,47 +1,58 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Components.Rendering;
+
 namespace Microsoft.AspNetCore.Components.RenderTree
 {
     // https://github.com/dotnet/arcade/pull/2033
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Explicit, Pack = 4)]
     public readonly partial struct RenderTreeFrame
     {
-        [System.Runtime.InteropServices.FieldOffsetAttribute(8)]
-        public readonly int AttributeEventHandlerId;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly string AttributeName;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(24)]
-        public readonly object AttributeValue;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(12)]
-        public readonly int ComponentId;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly System.Action<object> ComponentReferenceCaptureAction;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(8)]
-        public readonly int ComponentReferenceCaptureParentFrameIndex;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(8)]
-        public readonly int ComponentSubtreeLength;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly System.Type ComponentType;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly string ElementName;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(24)]
-        public readonly System.Action<Microsoft.AspNetCore.Components.ElementReference> ElementReferenceCaptureAction;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly string ElementReferenceCaptureId;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(8)]
-        public readonly int ElementSubtreeLength;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(4)]
-        public readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType FrameType;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly string MarkupContent;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(8)]
-        public readonly int RegionSubtreeLength;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-        public readonly int Sequence;
-        [System.Runtime.InteropServices.FieldOffsetAttribute(16)]
-        public readonly string TextContent;
-        public Microsoft.AspNetCore.Components.IComponent Component { get { throw null; } }
-        public override string ToString() { throw null; }
+        [FieldOffset(0)] public readonly int Sequence;
+
+        [FieldOffset(4)] public readonly RenderTreeFrameType FrameType;
+
+        [FieldOffset(8)] public readonly int ElementSubtreeLength;
+
+        [FieldOffset(16)] public readonly string ElementName;
+
+        [FieldOffset(24)] public readonly object ElementKey;
+
+        [FieldOffset(16)] public readonly string TextContent;
+
+        [FieldOffset(8)] public readonly ulong AttributeEventHandlerId;
+
+        [FieldOffset(16)] public readonly string AttributeName;
+
+        [FieldOffset(24)] public readonly object AttributeValue;
+
+        [FieldOffset(32)] public readonly string AttributeEventUpdatesAttributeName;
+
+        [FieldOffset(8)] public readonly int ComponentSubtreeLength;
+
+        [FieldOffset(12)] public readonly int ComponentId;
+
+        [FieldOffset(16)] public readonly Type ComponentType;
+
+        [FieldOffset(32)] public readonly object ComponentKey;
+
+        public IComponent Component => null;
+
+        [FieldOffset(8)] public readonly int RegionSubtreeLength;
+
+        [FieldOffset(16)] public readonly string ElementReferenceCaptureId;
+
+        [FieldOffset(24)] public readonly Action<ElementReference> ElementReferenceCaptureAction;
+
+        [FieldOffset(8)] public readonly int ComponentReferenceCaptureParentFrameIndex;
+
+        [FieldOffset(16)] public readonly Action<object> ComponentReferenceCaptureAction;
+
+        [FieldOffset(16)] public readonly string MarkupContent;
+
+        public override string ToString() => null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/13504

---------------------------------

### Description

The reference assembly for one of the of the types in Blazor is manually generated. We missed updating this as part of preview8 when there were API changes to the type A user discovered and reported this.

### Customer impact

Customers may get MissingMethodException at runtime if they compile against type in the ref assembly.

### Regression

It's a regression since preview8

### Risk

Low. This is changes to a ref assembly. We do not have automated tests to verify that the ref assembly is correct, but I verified it manually.
