### PR TITLE
Three more methods have been added to PrincipalExtensions class

### DIFF
--- a/src/Identity/Extensions.Core/src/PrincipalExtensions.cs
+++ b/src/Identity/Extensions.Core/src/PrincipalExtensions.cs
@@ -27,5 +27,58 @@ namespace System.Security.Claims
             return claim != null ? claim.Value : null;
         }
 
+        /// <summary>
+        /// Returns the value of logged in user's UserId.
+        /// </summary>
+        /// <typeparam name="T">Type of the Identity Store primary key.</typeparam>
+        /// <param name="principal">The <see cref="ClaimsPrincipal"/> instance this method extends.</param>
+        /// <returns>Returns the value of the logged in user's UserId.</returns>
+        public static T GetLoggedInUserId<T>(this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+                throw new ArgumentNullException(nameof(principal));
+
+            var loggedInUserId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (typeof(T) == typeof(string))
+            {
+                return (T)Convert.ChangeType(loggedInUserId, typeof(T));
+            }
+            else if (typeof(T) == typeof(int) || typeof(T) == typeof(long))
+            {
+                return loggedInUserId != null ? (T)Convert.ChangeType(loggedInUserId, typeof(T)) : (T)Convert.ChangeType(0, typeof(T));
+            }
+            else
+            {
+                throw new Exception("Invalid type provided.");
+            }
+        }
+
+        /// <summary>
+        /// Returns the value of logged in user's UserName.
+        /// </summary>
+        /// <param name="principal">The <see cref="ClaimsPrincipal"/> instance this method extends.</param>
+        /// <returns>Returns the value of logged in user's UserName.</returns>
+        public static string GetLoggedInUserName(this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+                throw new ArgumentNullException(nameof(principal));
+
+            return principal.FindFirstValue(ClaimTypes.Name);
+        }
+
+        /// <summary>
+        /// Returns the value of logged in user's Email.
+        /// </summary>
+        /// <param name="principal">The <see cref="ClaimsPrincipal"/> instance this method extends.</param>
+        /// <returns>Returns the value of logged in user's Email.</returns>
+        public static string GetLoggedInUserEmail(this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+                throw new ArgumentNullException(nameof(principal));
+
+            return principal.FindFirstValue(ClaimTypes.Email);
+        }
+
     }
 }

--- a/src/Identity/test/Identity.Test/PrincipalExtensionsTest.cs
+++ b/src/Identity/test/Identity.Test/PrincipalExtensionsTest.cs
@@ -18,6 +18,58 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.Null(id.FindFirstValue("bogus"));
         }
 
+        [Fact]
+        public void IdentityExtensionsGetLoggedInUserIdInStringTypeTest()
+        {
+            // Arrange
+            var id = CreateTestUserIdentityWithStringTypeUserId();
+
+            // Act
+            string loggedInUserId = id.GetLoggedInUserId<string>();
+
+            // Assert
+            Assert.IsType<string>(loggedInUserId);
+        }
+
+        [Fact]
+        public void IdentityExtensionsGetLoggedInUserIdInLongTypeTest()
+        {
+            // Arrange
+            var id = CreateTestUserIdentityWithLongTypeUserId();
+
+            // Act
+            long loggedInUserId = id.GetLoggedInUserId<long>();
+
+            // Assert
+            Assert.IsType<long>(loggedInUserId);
+        }
+
+        [Fact]
+        public void IdentityExtensionsGetLoggedInUserNameTest()
+        {
+            // Arrange
+            var id = CreateTestUserIdentityWithUserNameAndEmail();
+
+            // Act
+            string loggedInUserName = id.GetLoggedInUserName();
+
+            // Assert
+            Assert.Equal("BillGates", loggedInUserName);
+        }
+
+        [Fact]
+        public void IdentityExtensionsGetLoggedInUserEmailTest()
+        {
+            // Arrange
+            var id = CreateTestUserIdentityWithUserNameAndEmail();
+
+            // Act
+            string loggedInUserEmail = id.GetLoggedInUserEmail();
+
+            // Assert
+            Assert.Equal("bill@microsoft.com", loggedInUserEmail);
+        }
+
         private static ClaimsPrincipal CreateTestExternalIdentity()
         {
             return new ClaimsPrincipal(new ClaimsIdentity(
@@ -25,6 +77,37 @@ namespace Microsoft.AspNetCore.Identity.Test
                 {
                     new Claim(ClaimTypes.NameIdentifier, "NameIdentifier", null, ExternalAuthenticationScheme),
                     new Claim(ClaimTypes.Name, "Name")
+                },
+                ExternalAuthenticationScheme));
+        }
+
+        private static ClaimsPrincipal CreateTestUserIdentityWithStringTypeUserId()
+        {
+            return new ClaimsPrincipal(new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString())
+                },
+                ExternalAuthenticationScheme));
+        }
+
+        private static ClaimsPrincipal CreateTestUserIdentityWithLongTypeUserId()
+        {
+            return new ClaimsPrincipal(new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "123456789")
+                },
+                ExternalAuthenticationScheme));
+        }
+
+        private static ClaimsPrincipal CreateTestUserIdentityWithUserNameAndEmail()
+        {
+            return new ClaimsPrincipal(new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.Name, "BillGates"),
+                    new Claim(ClaimTypes.Email,"bill@microsoft.com"), 
                 },
                 ExternalAuthenticationScheme));
         }


### PR DESCRIPTION
Following methods have been added to to the `PrincipalExtensions` class:

1) GetLoggedInUserId<T>();
2) GetLoggedInUserName();
3) GetLoggedInUserEmail();

These method can be useful to get the frequently used logged in user's info such as `UserId`, `UserName`, `Email` with more ease as follows:

        var userId = User.GetLoggedInUserId<string>(); // Specify the type of your UserId;
        var userName = User.GetLoggedInUserName();
        var userEmail = User.GetLoggedInUserEmail();

Unit tests for these newly added methods have also been added in the `PrincipalExtensionsTest` class
