### PR TITLE
Do not infer Required attributes based on context for non-nullable ge…

### DIFF
--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
             var contextAttributes = context.Attributes;
             var contextAttributesCount = contextAttributes.Count;
             var attributes = new List<object>(contextAttributesCount);
-            
+
             for (var i = 0; i < contextAttributesCount; i++)
             {
                 var attribute = contextAttributes[i];
@@ -367,15 +367,15 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
                 else if (context.Key.MetadataKind == ModelMetadataKind.Property)
                 {
                     addInferredRequiredAttribute = IsNullableReferenceType(
-                        context.Key.ContainerType, 
-                        member: null, 
+                        context.Key.ContainerType,
+                        member: null,
                         context.PropertyAttributes);
                 }
                 else if (context.Key.MetadataKind == ModelMetadataKind.Parameter)
                 {
                     addInferredRequiredAttribute = IsNullableReferenceType(
-                        context.Key.ParameterInfo?.Member.ReflectedType, 
-                        context.Key.ParameterInfo.Member, 
+                        context.Key.ParameterInfo?.Member.ReflectedType,
+                        context.Key.ParameterInfo.Member,
                         context.ParameterAttributes);
                 }
                 else
@@ -494,6 +494,15 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
 
         internal static bool IsNullableBasedOnContext(Type containingType, MemberInfo member)
         {
+            // For generic types, inspecting the nullability requirement additionally requires
+            // inspecting the nullability constraint on generic type parameters. This is fairly non-triviial
+            // so we'll just avoid calculating it. Users should still be able to apply an explicit [Required]
+            // attribute on these members.
+            if (containingType.IsGenericType)
+            {
+                return false;
+            }
+
             // The [Nullable] and [NullableContext] attributes are not inherited.
             //
             // The [NullableContext] attribute can appear on a method or on the module.
@@ -516,7 +525,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
                 }
 
                 type = type.DeclaringType;
-            } 
+            }
             while (type != null);
 
             // If we don't find the attribute on the declaring type then repeat at the module level

--- a/src/Mvc/Mvc.DataAnnotations/test/DataAnnotationsMetadataProviderTest.cs
+++ b/src/Mvc/Mvc.DataAnnotations/test/DataAnnotationsMetadataProviderTest.cs
@@ -1340,6 +1340,38 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
         }
 
         [Fact]
+        public void IsNullableReferenceType_ReturnsFalse_ForKeyValuePairWithoutNullableConstraints()
+        {
+            // Arrange
+            var type = typeof(KeyValuePair<string, object>);
+            var property = type.GetProperty(nameof(KeyValuePair<string, object>.Key));
+
+            // Act
+            var result = DataAnnotationsMetadataProvider.IsNullableReferenceType(type, member: null, property.GetCustomAttributes(inherit: true));
+
+            // Assert
+            Assert.False(result);
+        }
+
+#nullable enable
+        [Fact]
+        public void IsNullableReferenceType_ReturnsTrue_ForKeyValuePairWithNullableConstraints()
+        {
+            // Arrange
+            var type = typeof(KeyValuePair<string, object>);
+            var property = type.GetProperty(nameof(KeyValuePair<string, object>.Key))!;
+
+            // Act
+            var result = DataAnnotationsMetadataProvider.IsNullableReferenceType(type, member: null, property.GetCustomAttributes(inherit: true));
+
+            // Assert
+            // While we'd like for result to be 'true', we don't have a very good way of actually calculating it correctly.
+            // This test is primarily here to document the behavior.
+            Assert.False(result);
+        }
+#nullable restore
+
+        [Fact]
         public void IsNonNullable_FindsNullableProperty()
         {
             // Arrange


### PR DESCRIPTION
…neric types

Fixes https://github.com/aspnet/AspNetCore/issues/13512

------------------------------------------------

### Description

MVC attempts to apply `Required` validation based on the presence of C# 8.0’s nullable attribute. The code has a bug when it comes to generic types. In the user’s case, MVC is incorrectly treating the `Key` and `Value` properties of a `KeyValuePair<TKey, TValue>` as being required, when the user has made no gesture in their projects to use the nullability feature. This results in MVC doing extra validation and disallowing null keys and values. 

### Customer impact

By default, users upgrading to 3.0 would get this incorrect behavior. 

### Regression

Yes. The feature is new to 3.0

### Impact

Low. The change prevents MVC from inferring nullability for generic types. Users can continue to use `RequiredAttribute` to require properties to be non-null.