### PR TITLE
Make InputDateInteractsWithEditContext_NullableDateTimeOffset more reliable

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             display = Browser.FindElement(By.Id("input_type_text_datetime_value"));
             Browser.Equal(new DateTime(1985, 3, 4).ToString(cultureInfo), () => display.Text);
 
-            ReplaceText(input, new DateTime(2000, 1, 2).ToString(cultureInfo));
+            input.ReplaceText(new DateTime(2000, 1, 2).ToString(cultureInfo));
             input.SendKeys("\t");
             Browser.Equal(new DateTime(2000, 1, 2).ToString(cultureInfo), () => display.Text);
 
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             display = Browser.FindElement(By.Id("input_type_text_datetimeoffset_value"));
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString(cultureInfo), () => display.Text);
 
-            ReplaceText(input, new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
+            input.ReplaceText(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
             input.SendKeys("\t");
             Browser.Equal(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo), () => display.Text);
         }
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal(new DateTime(1985, 3, 4).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTime(1985, 3, 4).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
-            ReplaceText(extraInput, new DateTime(2000, 1, 2).ToString(cultureInfo));
+            extraInput.ReplaceText(new DateTime(2000, 1, 2).ToString(cultureInfo));
             extraInput.SendKeys("\t");
             Browser.Equal(new DateTime(2000, 1, 2).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTime(2000, 1, 2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
-            ReplaceText(extraInput, new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
+            extraInput.ReplaceText(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
             extraInput.SendKeys("\t");
             Browser.Equal(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal(new DateTime(1985, 3, 4).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTime(1985, 3, 4).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
-            ReplaceText(extraInput, new DateTime(2000, 1, 2).ToString(cultureInfo));
+            extraInput.ReplaceText(new DateTime(2000, 1, 2).ToString(cultureInfo));
             extraInput.SendKeys("\t");
             Browser.Equal(new DateTime(2000, 1, 2).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTime(2000, 1, 2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
@@ -206,19 +206,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
-            ReplaceText(extraInput, new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
+            extraInput.ReplaceText(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
             extraInput.SendKeys("\t");
             Browser.Equal(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
-        }
-
-        // see: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/214
-        //
-        // Calling Clear() can trigger onchange, which will revert the value to its default.
-        private static void ReplaceText(IWebElement element, string text)
-        {
-            element.SendKeys(Keys.Control + "a");
-            element.SendKeys(text);
         }
 
         private void SetCulture(string culture)

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -228,9 +228,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified valid", () => expiryDateInput.GetAttribute("class"));
 
             // Can become invalid
-            // Note that we have to update it via JS not via SendKeys, because date inputs are special. Selenium's mechanism for
-            // simulating keystrokes causes date inputs to behave inconsistently in this specific scenario.
-            ChangeDateInputField(".expiry-date input", "11111-11-11");
+            expiryDateInput.ReplaceText("111111111");
             Browser.Equal("modified invalid", () => expiryDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The OptionalExpiryDate field must be a date." }, messagesAccessor);
 
@@ -384,15 +382,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 .Select(x => x.Text)
                 .OrderBy(x => x)
                 .ToArray();
-        }
-
-        private void ChangeDateInputField(string cssSelector, string newValue)
-        {
-            var javascript = (IJavaScriptExecutor)Browser;
-            javascript.ExecuteScript(
-                $"var elem = document.querySelector('{cssSelector}');"
-                + $"elem.value = {JsonSerializer.Serialize(newValue, TestJsonSerializerOptionsProvider.Options)};"
-                + "elem.dispatchEvent(new KeyboardEvent('change'));");
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -196,21 +196,21 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Validates on edit
             Browser.Equal("valid", () => renewalDateInput.GetAttribute("class"));
-            renewalDateInput.SendKeys("01/01/2000\t");
+            renewalDateInput.ReplaceText("01/01/2000\t");
             Browser.Equal("modified valid", () => renewalDateInput.GetAttribute("class"));
 
             // Can become invalid
-            renewalDateInput.SendKeys("0/0/0");
+            renewalDateInput.ReplaceText("0/0/0");
             Browser.Equal("modified invalid", () => renewalDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
             // Empty is invalid, because it's not nullable
-            renewalDateInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
+            renewalDateInput.ReplaceText($"{Keys.Backspace}");
             Browser.Equal("modified invalid", () => renewalDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
             // Can become valid
-            renewalDateInput.SendKeys("01/01/01\t");
+            renewalDateInput.ReplaceText("01/01/01");
             Browser.Equal("modified valid", () => renewalDateInput.GetAttribute("class"));
             Browser.Empty(messagesAccessor);
         }

--- a/src/Shared/E2ETesting/WebElementExtensions.cs
+++ b/src/Shared/E2ETesting/WebElementExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace OpenQA.Selenium
+{
+    public static class WebElementExtensions
+    {
+        // see: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/214
+        //
+        // Calling Clear() can trigger onchange, which will revert the value to its default.
+        public static void ReplaceText(IWebElement element, string text)
+        {
+            element.SendKeys(Keys.Control + "a");
+            element.SendKeys(text);
+        }
+    }
+}

--- a/src/Shared/E2ETesting/WebElementExtensions.cs
+++ b/src/Shared/E2ETesting/WebElementExtensions.cs
@@ -8,7 +8,7 @@ namespace OpenQA.Selenium
         // see: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/214
         //
         // Calling Clear() can trigger onchange, which will revert the value to its default.
-        public static void ReplaceText(IWebElement element, string text)
+        public static void ReplaceText(this IWebElement element, string text)
         {
             element.SendKeys(Keys.Control + "a");
             element.SendKeys(text);


### PR DESCRIPTION
This E2E test has been flaky since it was first created (and was marked as such).

I think the reason is that `<input type=date>` has some quite special behaviors that trip up Selenium's `SetKeys` logic. This type of input has multiple sub-inputs so you can't just append keystrokes to it - depending on where the cursor was before, and whether you unfocused then refocused it, the keystrokes get directed to different parts of the date.

I had the test failing fairly often locally, but not at all since the change in this PR. Hopefully we will see the same effect in CI.