### PR TITLE
[Templating] Infrastructure improvements

### DIFF
--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Remove the value altogether
             setNullButton.Click();
-            Browser.Equal("fail", () => target.GetAttribute("value"));
+            Browser.Equal(string.Empty, () => target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
         }

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Remove the value altogether
             setNullButton.Click();
-            Browser.Equal(string.Empty, () => target.GetAttribute("value"));
+            Browser.Equal("fail", () => target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
         }

--- a/src/Components/test/E2ETest/e2eTestSettings.ci.json
+++ b/src/Components/test/E2ETest/e2eTestSettings.ci.json
@@ -1,3 +1,10 @@
 {
-  "DefaultWaitTimeoutInSeconds": 120
+  // We give each Selenium test assertion up to two minutes to fail before any other test in the
+  // build has failed, after that, we fail after 5 seconds.
+  "DefaultWaitTimeoutInSeconds": 120,
+  // Worst case scenario for 1000 failing tests will cause the build to fail after 84 minutes.
+  // We currently have < 500 E2E tests so even if all tests fail it will take around 40 minutes to do so.
+  // This value is balanced between completing the build fast enough upon failure and giving
+  // each E2E test a fair chance to pass even in the event that a separate test has failed already.
+  "DefaultAfterFailureWaitTimeoutInSeconds": 5
 }

--- a/src/Components/test/E2ETest/e2eTestSettings.ci.json
+++ b/src/Components/test/E2ETest/e2eTestSettings.ci.json
@@ -1,0 +1,3 @@
+{
+  "DefaultWaitTimeoutInSeconds": 120
+}

--- a/src/Components/test/E2ETest/e2eTestSettings.ci.json
+++ b/src/Components/test/E2ETest/e2eTestSettings.ci.json
@@ -2,8 +2,6 @@
   // We give each Selenium test assertion up to two minutes to fail before any other test in the
   // build has failed, after that, we fail after 5 seconds.
   "DefaultWaitTimeoutInSeconds": 120,
-  // Worst case scenario for 1000 failing tests will cause the build to fail after 84 minutes.
-  // We currently have < 500 E2E tests so even if all tests fail it will take around 40 minutes to do so.
   // This value is balanced between completing the build fast enough upon failure and giving
   // each E2E test a fair chance to pass even in the event that a separate test has failed already.
   "DefaultAfterFailureWaitTimeoutInSeconds": 5

--- a/src/Components/test/E2ETest/e2eTestSettings.json
+++ b/src/Components/test/E2ETest/e2eTestSettings.json
@@ -1,4 +1,4 @@
 {
-  "DefaultWaitTimeoutInSeconds": 3,
+  "DefaultWaitTimeoutInSeconds": 20,
   "ScreenShotsPath": "../../screenshots"
 }

--- a/src/Components/test/E2ETest/e2eTestSettings.json
+++ b/src/Components/test/E2ETest/e2eTestSettings.json
@@ -1,0 +1,4 @@
+{
+  "DefaultWaitTimeoutInSeconds": 3,
+  "ScreenShotsPath": "../../screenshots"
+}

--- a/src/ProjectTemplates/test/e2eTestSettings.ci.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.ci.json
@@ -1,3 +1,12 @@
 {
-  "DefaultWaitTimeoutInSeconds": 120
+  // We give each Selenium test assertion up to two minutes to fail before any other test in the
+  // build has failed
+  "DefaultWaitTimeoutInSeconds": 120,
+  // This value is balanced between completing the build fast enough upon failure and giving
+  // each E2E test a fair chance to pass even in the event that a separate test has failed already.
+  // We have around 10-15 tests that use Selenium and is unlikely they'll all fail at the same time,
+  // and even if that's the case, it'll take them 30 minutes tops to do so, which is why it is acceptable
+  // to give each tests 120 seconds to pass, independent of whether or not a separate test has already
+  // failed.
+  "DefaultAfterFailureWaitTimeoutInSeconds": 120
 }

--- a/src/ProjectTemplates/test/e2eTestSettings.ci.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.ci.json
@@ -1,0 +1,3 @@
+{
+  "DefaultWaitTimeoutInSeconds": 120
+}

--- a/src/ProjectTemplates/test/e2eTestSettings.ci.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.ci.json
@@ -4,9 +4,5 @@
   "DefaultWaitTimeoutInSeconds": 120,
   // This value is balanced between completing the build fast enough upon failure and giving
   // each E2E test a fair chance to pass even in the event that a separate test has failed already.
-  // We have around 10-15 tests that use Selenium and is unlikely they'll all fail at the same time,
-  // and even if that's the case, it'll take them 30 minutes tops to do so, which is why it is acceptable
-  // to give each tests 120 seconds to pass, independent of whether or not a separate test has already
-  // failed.
   "DefaultAfterFailureWaitTimeoutInSeconds": 120
 }

--- a/src/ProjectTemplates/test/e2eTestSettings.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.json
@@ -1,4 +1,4 @@
 {
-  "DefaultWaitTimeoutInSeconds": 3,
+  "DefaultWaitTimeoutInSeconds": 20,
   "ScreenShotsPath": "../../screenshots"
 }

--- a/src/ProjectTemplates/test/e2eTestSettings.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.json
@@ -1,0 +1,4 @@
+{
+  "DefaultWaitTimeoutInSeconds": 3,
+  "ScreenShotsPath": "../../screenshots"
+}

--- a/src/Shared/E2ETesting/BrowserAssertFailedException.cs
+++ b/src/Shared/E2ETesting/BrowserAssertFailedException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Xunit.Sdk;
 
 namespace OpenQA.Selenium
@@ -12,16 +13,14 @@ namespace OpenQA.Selenium
     // case.
     public class BrowserAssertFailedException : XunitException
     {
-        public BrowserAssertFailedException(IReadOnlyList<LogEntry> logs, Exception innerException)
-            : base(BuildMessage(logs), innerException)
+        public BrowserAssertFailedException(IReadOnlyList<LogEntry> logs, Exception innerException, string screenShotPath)
+            : base(BuildMessage(logs, screenShotPath), innerException)
         {
         }
 
-        private static string BuildMessage(IReadOnlyList<LogEntry> logs)
-        {
-            return
-                "Encountered browser errors while running assertion." + Environment.NewLine +
-                string.Join(Environment.NewLine, logs);
-        }
+        private static string BuildMessage(IReadOnlyList<LogEntry> logs, string screenShotPath) =>
+            (File.Exists(screenShotPath) ? $"Screen shot captured at '{screenShotPath}'" + Environment.NewLine : "") +
+            (logs.Count > 0 ? "Encountered browser errors" : "No browser errors found") + " while running the assertion." + Environment.NewLine +
+            string.Join(Environment.NewLine, logs);
     }
 }

--- a/src/Shared/E2ETesting/E2ETestOptions.cs
+++ b/src/Shared/E2ETesting/E2ETestOptions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.AspNetCore.E2ETesting
+{
+    public class E2ETestOptions
+    {
+        private const string TestingOptionsPrefix = "Microsoft.AspNetCore.E2ETesting";
+        public static readonly IConfiguration Configuration;
+
+        public static E2ETestOptions Instance;
+
+        static E2ETestOptions()
+        {
+            // Capture all the attributes that start with Microsoft.AspNetCore.E2ETesting and add them as a memory collection
+            // to the list of settings. We use GetExecutingAssembly, this works because E2ETestOptions is shared source.
+            var metadataAttributes = Assembly.GetExecutingAssembly()
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Where(ama => ama.Key.StartsWith(TestingOptionsPrefix))
+                .ToDictionary(kvp => kvp.Key.Substring(TestingOptionsPrefix.Length + 1), kvp => kvp.Value);
+
+            try
+            {
+                // We save the configuration just to make resolved values easier to debug.
+                var builder = new ConfigurationBuilder()
+                    .AddInMemoryCollection(metadataAttributes);
+
+                if (!metadataAttributes.TryGetValue("CI", out var value) || string.IsNullOrEmpty(value))
+                {
+                    builder.AddJsonFile("e2eTestSettings.json", optional: true);
+                }
+                else
+                {
+                    builder.AddJsonFile("e2eTestSettings.ci.json", optional: true);
+                }
+
+                Configuration = builder 
+                    .AddEnvironmentVariables("E2ETESTS")
+                    .Build();
+
+                var instance = new E2ETestOptions();
+                Configuration.Bind(instance);
+                Instance = instance;
+            }
+            catch
+            {
+            }
+        }
+
+        public int DefaultWaitTimeoutInSeconds { get; set; } = 3;
+
+        public string ScreenShotsPath { get; set; }
+    }
+}

--- a/src/Shared/E2ETesting/E2ETestOptions.cs
+++ b/src/Shared/E2ETesting/E2ETestOptions.cs
@@ -54,5 +54,7 @@ namespace Microsoft.AspNetCore.E2ETesting
         public int DefaultWaitTimeoutInSeconds { get; set; } = 3;
 
         public string ScreenShotsPath { get; set; }
+
+        public double DefaultAfterFailureWaitTimeoutInSeconds { get; set; } = 3;
     }
 }

--- a/src/Shared/E2ETesting/E2ETesting.props
+++ b/src/Shared/E2ETesting/E2ETesting.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <_DefaultProjectFilter>$(MSBuildProjectDirectory)\..\..</_DefaultProjectFilter>
     <DefaultItemExcludes>$(DefaultItemExcludes);node_modules\**</DefaultItemExcludes>
+    <SeleniumScreenShotsFolderPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)','$(MSBuildProjectName)'))</SeleniumScreenShotsFolderPath>
     <SeleniumProcessTrackingFolder Condition="'$(SeleniumProcessTrackingFolder)' == ''">$([MSBuild]::EnsureTrailingSlash('$(RepoRoot)'))artifacts\tmp\selenium\</SeleniumProcessTrackingFolder>
     <SeleniumE2ETestsSupported Condition="'$(SeleniumE2ETestsSupported)' == '' and '$(TargetArchitecture)' != 'arm' and '$(OS)' == 'Windows_NT'">true</SeleniumE2ETestsSupported>
 
@@ -30,6 +31,22 @@
   <ItemGroup>
     <Reference Include="Selenium.Support" />
     <Reference Include="Selenium.WebDriver" />
+    <Reference Include="Microsoft.Extensions.Configuration" />
+    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>Microsoft.AspNetCore.E2ETesting.CI</_Parameter1>
+      <_Parameter2>$(ContinuousIntegrationBuild)</_Parameter2>      
+    </AssemblyAttribute>
+    
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>Microsoft.AspNetCore.E2ETesting.ScreenshotsPath</_Parameter1>
+      <_Parameter2>$(SeleniumScreenShotsFolderPath)</_Parameter2>      
+    </AssemblyAttribute>
+
   </ItemGroup>
 
 </Project>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -2,6 +2,23 @@
   <!-- Version of this SDK is set in global.json -->
   <Sdk Name="Yarn.MSBuild" />
 
+  <!-- Make sure the settings files get copied to the test output folder. -->
+  <ItemGroup>
+    <None Update="e2eTestSettings.ci.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="e2eTestSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    
+    <Content Update="e2eTestSettings.ci.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Update="e2eTestSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <!-- Ensuring that everything is ready before build -->
 
   <Target Name="EnsureNodeJSRestored" Condition="'$(SeleniumE2ETestsSupported)' == 'true'" BeforeTargets="Build">
@@ -53,20 +70,20 @@
   <!-- Resolve content roots at build time -->
 
   <Target Name="_ResolveTestProjectReferences" DependsOnTargets="ResolveReferences">
-      <PropertyGroup>
-        <_DefaultProjectRoot>$([System.IO.Path]::GetFullPath($(_DefaultProjectFilter)))</_DefaultProjectRoot>
-      </PropertyGroup>
-      <ItemGroup>
-        <_ContentRootProjectReferencesUnfiltered
-          Include="@(ReferencePath)"
-          Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
-        <_ContentRootProjectReferencesFilter
-          Include="@(_ContentRootProjectReferencesUnfiltered->StartsWith('$(_DefaultProjectRoot)'))" />
-        <_ContentRootProjectReferences
-          Include="@(_ContentRootProjectReferencesFilter)"
-          Condition="'%(Identity)' == 'True'" />
-      </ItemGroup>
-    </Target>
+    <PropertyGroup>
+      <_DefaultProjectRoot>$([System.IO.Path]::GetFullPath($(_DefaultProjectFilter)))</_DefaultProjectRoot>
+    </PropertyGroup>
+    <ItemGroup>
+      <_ContentRootProjectReferencesUnfiltered
+        Include="@(ReferencePath)"
+        Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
+      <_ContentRootProjectReferencesFilter
+        Include="@(_ContentRootProjectReferencesUnfiltered->StartsWith('$(_DefaultProjectRoot)'))" />
+      <_ContentRootProjectReferences
+        Include="@(_ContentRootProjectReferencesFilter)"
+        Condition="'%(Identity)' == 'True'" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="_AddTestProjectMetadataAttributes" BeforeTargets="BeforeCompile" DependsOnTargets="_ResolveTestProjectReferences">
     <ItemGroup>
@@ -112,6 +129,10 @@
         <_Parameter2>$(SeleniumProcessTrackingFolder)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
+  </Target>
+
+  <Target Name="_EnsureSeleniumScreenShotsFolder" BeforeTargets="Build">
+    <MakeDir Directories="$(SeleniumScreenShotsFolderPath)" />
   </Target>
 
 </Project>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -4,17 +4,10 @@
 
   <!-- Make sure the settings files get copied to the test output folder. -->
   <ItemGroup>
-    <None Update="e2eTestSettings.ci.json">
+    <None Update="e2eTestSettings.*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="e2eTestSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    
-    <Content Update="e2eTestSettings.ci.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Update="e2eTestSettings.json">
+    <Content Update="e2eTestSettings.*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
* Automatically capture a screenshot when an assertion fails.
* Enable configurable options for different environments (CI|dev).
  * First test on CI fails after 120 seconds.
  * Subsequent tests fail after 5 seconds for components, 120 seconds for templates.
* Introduce a DefaultTimeout and a FailureTimeout for faster timeouts after the first test failure.
* Include log errors in all exceptions.

Here is fast failure mode in action within components
![image](https://user-images.githubusercontent.com/6995051/64260466-c3d42580-cedf-11e9-9b6d-6ea96cf380cd.png)

When looking at the test failure the results will contain the path to a screenshot from the browser taken at the time of the assertion failure and the error logs from the console if any at the time of the assertion.

Screenshots for the tests can be accessed on the CI by looking at Windows_Test_Results in the artifacts (top right corner).

There will be a folder there with the test project name and inside that folder there will be a PNG file associated with each test failure.