### PR TITLE
[Templates] Add retries to network requests

### DIFF
--- a/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
+++ b/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
@@ -61,7 +61,7 @@ namespace Templates.Test.Helpers
             {
                 AllowAutoRedirect = true,
                 UseCookies = true,
-                CookieContainer = new CookieContainer(),
+                CookieContainer = new CookieContainer(),                
                 ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
             };
 

--- a/src/ProjectTemplates/test/Helpers/RetryHandler.cs
+++ b/src/ProjectTemplates/test/Helpers/RetryHandler.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Templates.Test.Helpers
+{
+    internal class RetryHandler : DelegatingHandler
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly int _maxRetries;
+        private TimeSpan _waitIntervalBeforeRetry;
+
+        public RetryHandler(
+            HttpClientHandler httpClientHandler,
+            ITestOutputHelper output,
+            TimeSpan initialWaitTime,
+            int maxAttempts) : base(httpClientHandler)
+        {
+            _waitIntervalBeforeRetry = initialWaitTime;
+            _output = output;
+            _maxRetries = maxAttempts;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage result = null;
+            var url = request.RequestUri;
+            var method = request.Method;
+
+            for (var i = 0; i < _maxRetries; i++)
+            {
+                try
+                {
+                    _output.WriteLine($"Sending request '{method} - {url}' {i + 1} attempt.");
+                    result = await base.SendAsync(request, cancellationToken);
+                    _output.WriteLine($"Request '{method} - {url}' ended with {result.StatusCode}.");
+                    return result;
+                }
+                catch (Exception e)
+                {
+                    _output.WriteLine($"Request '{method} - {url}' failed with {e.ToString()}");
+                }
+                finally
+                {
+                    await Task.Delay(_waitIntervalBeforeRetry);
+                    _waitIntervalBeforeRetry = _waitIntervalBeforeRetry * 2;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ProjectTemplates/test/Helpers/RetryHandler.cs
+++ b/src/ProjectTemplates/test/Helpers/RetryHandler.cs
@@ -28,10 +28,10 @@ namespace Templates.Test.Helpers
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            HttpResponseMessage result = null;
             var url = request.RequestUri;
             var method = request.Method;
 
+            HttpResponseMessage result = null;
             for (var i = 0; i < _maxRetries; i++)
             {
                 try
@@ -44,14 +44,18 @@ namespace Templates.Test.Helpers
                 catch (Exception e)
                 {
                     _output.WriteLine($"Request '{method} - {url}' failed with {e.ToString()}");
+                    result?.Dispose();
                 }
                 finally
                 {
-                    await Task.Delay(_waitIntervalBeforeRetry);
+                    await Task.Delay(_waitIntervalBeforeRetry, cancellationToken);
                     _waitIntervalBeforeRetry = _waitIntervalBeforeRetry * 2;
                 }
             }
 
+            _output.WriteLine($"Sending request '{method} - {url}' {_maxRetries + 1} attempt.");
+            result = await base.SendAsync(request, cancellationToken);
+            _output.WriteLine($"Request '{method} - {url}' ended with {result.StatusCode}.");
             return result;
         }
     }


### PR DESCRIPTION
I've seen issues in several tests on the analytics tab of Azure DevOps that point to this. Added retries to account for transient network failures.