### PR TITLE
Improve reliability of globalization E2E tests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             // Click the link to return back to the test page
             WaitUntilExists(By.ClassName("return-from-culture-setter")).Click();
 
-            // That should have triggered a redirect, wait for the main test selector to come up.
+            // That should have triggered a page load, so wait for the main test selector to come up.
             MountTestComponent<GlobalizationBindCases>();
             WaitUntilExists(By.Id("globalization-cases"));
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
@@ -41,16 +41,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void CanSetCultureAndParseCultueSensitiveNumbersAndDates(string culture)
         {
             var cultureInfo = CultureInfo.GetCultureInfo(culture);
-
-            var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
-            selector.SelectByValue(culture);
-
-            // That should have triggered a redirect, wait for the main test selector to come up.
-            MountTestComponent<GlobalizationBindCases>();
-            WaitUntilExists(By.Id("globalization-cases"));
-
-            var cultureDisplay = WaitUntilExists(By.Id("culture-name-display"));
-            Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
+            SetCulture(culture);
 
             // int
             var input = Browser.FindElement(By.Id("input_type_text_int"));
@@ -113,16 +104,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void CanSetCultureAndParseCultureInvariantNumbersAndDatesWithInputFields(string culture)
         {
             var cultureInfo = CultureInfo.GetCultureInfo(culture);
-
-            var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
-            selector.SelectByValue(culture);
-
-            // That should have triggered a redirect, wait for the main test selector to come up.
-            MountTestComponent<GlobalizationBindCases>();
-            WaitUntilExists(By.Id("globalization-cases"));
-
-            var cultureDisplay = WaitUntilExists(By.Id("culture-name-display"));
-            Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
+            SetCulture(culture);
 
             // int
             var input = Browser.FindElement(By.Id("input_type_number_int"));
@@ -179,16 +161,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void CanSetCultureAndParseCultureInvariantNumbersAndDatesWithFormComponents(string culture)
         {
             var cultureInfo = CultureInfo.GetCultureInfo(culture);
-
-            var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
-            selector.SelectByValue(culture);
-
-            // That should have triggered a redirect, wait for the main test selector to come up.
-            MountTestComponent<GlobalizationBindCases>();
-            WaitUntilExists(By.Id("globalization-cases"));
-
-            var cultureDisplay = WaitUntilExists(By.Id("culture-name-display"));
-            Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
+            SetCulture(culture);
 
             // int
             var input = Browser.FindElement(By.Id("inputnumber_int"));
@@ -246,6 +219,22 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             element.SendKeys(Keys.Control + "a");
             element.SendKeys(text);
+        }
+
+        private void SetCulture(string culture)
+        {
+            var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
+            selector.SelectByValue(culture);
+
+            // Click the link to return back to the test page
+            WaitUntilExists(By.ClassName("return-from-culture-setter")).Click();
+
+            // That should have triggered a redirect, wait for the main test selector to come up.
+            MountTestComponent<GlobalizationBindCases>();
+            WaitUntilExists(By.Id("globalization-cases"));
+
+            var cultureDisplay = WaitUntilExists(By.Id("culture-name-display"));
+            Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
         }
     }
 }

--- a/src/Components/test/E2ETest/ServerExecutionTests/LocalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/LocalizationTest.cs
@@ -40,7 +40,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
             selector.SelectByValue(culture);
 
-            // That should have triggered a redirect, wait for the main test selector to come up.
+            // Click the link to return back to the test page
+            WaitUntilExists(By.ClassName("return-from-culture-setter")).Click();
+
+            // That should have triggered a page load, so wait for the main test selector to come up.
             MountTestComponent<LocalizedText>();
 
             var cultureDisplay = WaitUntilExists(By.Id("culture-name-display"));

--- a/src/Components/test/testassets/BasicTestApp/CulturePicker.razor
+++ b/src/Components/test/testassets/BasicTestApp/CulturePicker.razor
@@ -12,7 +12,7 @@
     {
         // Included fragment to preserve choice of Blazor client or server.
         var redirect = new Uri(NavigationManager.Uri).GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped);
-        var query = $"?culture={Uri.EscapeDataString((string)e.Value)}&redirectUri={redirect}";
+        var query = $"?culture={Uri.EscapeDataString((string)e.Value)}&redirectUri={Uri.EscapeDataString(redirect)}";
         NavigationManager.NavigateTo("/Culture/SetCulture" + query, forceLoad: true);
     }
 }

--- a/src/Components/test/testassets/TestServer/Controllers/CultureController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/CultureController.cs
@@ -1,5 +1,8 @@
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Net.Http.Headers;
 
 namespace Components.TestServer.Controllers
 {
@@ -15,7 +18,10 @@ namespace Components.TestServer.Controllers
                     CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)));
             }
 
-            return LocalRedirect(redirectUri);
+            var htmlEncoder = HtmlEncoder.Default;
+            var html = $"<h1>Culture has been changed to {htmlEncoder.Encode(culture)}</h1>" +
+                $"<a class='return-from-culture-setter' href='{htmlEncoder.Encode(redirectUri)}'>Return to previous page</a>";
+            return Content(html, "text/html");
         }
     }
 }


### PR DESCRIPTION
Hopefully addresses https://github.com/aspnet/AspNetCore-Internal/issues/2992

These E2E tests go through a redirection flow to change the culture cookie. Previously they didn't wait for the redirection to tear down the old page before trying to grab the test selector element again. Normally redirections are very fast so this rarely fails, but if the old page wasn't torn down fast enough, you'd end up with a stale element exception.

The fix here is to make the tests explicitly wait for the redirection to happen. Instead of auto-redirecting back (which makes it hard to know something happened), the culture picker now displays some HTML saying it is done, and offers a link to continue. The E2E test now waits for this link to appear then clicks it.