### PR TITLE
Pin SDK to preview 8

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -510,7 +510,9 @@ jobs:
       # The SDK version selected here is intentionally supposed to use the latest release
       # For the purpose of building Linux distros, we can't depend on features of the SDK
       # which may not exist in pre-built versions of the SDK
-      version: 3.0.x
+      # Pinning to preview 8 since preview 9 has breaking changes
+      # version: 3.0.x
+      version: 3.0.100-preview8-013656
       installationPath: $(DotNetCoreSdkDir)
       includePreviewVersions: true
   - script: ./eng/scripts/ci-source-build.sh --ci --configuration Release /p:BuildManaged=true /p:BuildNodeJs=false


### PR DESCRIPTION
We are seeing errors like 
```
error NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead. Learn more at https://aka.ms/deprecateIconUrl
```

in our Source Build steps. This occurred since we started to use the Preview 9 SDK which contains https://github.com/NuGet/NuGet.Client/pull/2916