### PR TITLE
Unflake InteropReliabilityTests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -22,7 +22,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
-    [Flaky("https://github.com/aspnet/AspNetCore/issues/13086", FlakyOn.All)]
     public class InteropReliabilityTests : IClassFixture<AspNetSiteServerFixture>, IDisposable
     {
         private static readonly TimeSpan DefaultLatencyTimeout = TimeSpan.FromSeconds(30);
@@ -264,7 +263,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore/issues/13086", FlakyOn.AzP.Windows)]
         public async Task ContinuesWorkingAfterInvalidAsyncReturnCallback()
         {
             // Arrange
@@ -279,11 +277,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.NotEqual(default, call);
 
             var id = call.AsyncHandle;
-            await Client.HubConnection.InvokeAsync(
+            await Client.ExpectRenderBatch(() => Client.HubConnection.InvokeAsync(
                 "EndInvokeJSFromDotNet",
                 id,
                 true,
-                $"[{id}, true, \"{{\"]");
+                $"[{id}, true, \"{{\"]"));
 
             var text = Assert.Single(
                 Client.FindElementById("errormessage-malformed").Children.OfType<TextNode>(),
@@ -308,15 +306,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.NotEqual(default, call);
 
             var id = call.AsyncHandle;
-            await Client.HubConnection.InvokeAsync(
+            await Client.ExpectRenderBatch(() => Client.HubConnection.InvokeAsync(
                 "EndInvokeJSFromDotNet",
-                id++,
+                id,
                 true,
-                $"[{id}, true, null]");
+                $"[{id}, true, null]"));
 
             Assert.Single(
                 Client.FindElementById("errormessage-success").Children.OfType<TextNode>(),
-                e => "" == e.TextContent);
+                e => "Success" == e.TextContent);
 
             Assert.Contains((LogLevel.Debug, "EndInvokeJSSucceeded"), logEvents);
         }

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -586,7 +586,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             sink.MessageLogged += (wc) => logEvents.Add((wc.LogLevel, wc.EventId.Name, wc.Exception));
 
             // Act
-            await Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: false);
+            await Client.ExpectCircuitError(() =>
+                Client.ClickAsync("event-handler-throw-sync", expectRenderBatch: false));
 
             Assert.Contains(
                 logEvents,

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ReliabilityComponent.razor
@@ -116,6 +116,7 @@
             var result = await JSRuntime.InvokeAsync<object>(
                 "sendSuccessCallbackReturn",
                 Array.Empty<object>());
+            errorSuccess = "Success";
         }
         catch (Exception e)
         {


### PR DESCRIPTION
This is a continuation of https://github.com/aspnet/AspNetCore/pull/13226. There are a few more cases where `InteropReliabilityTests` interacts with the client without waiting for an explicit outcome. Those tests show up in the CI analytics as unreliable.

I'm removing the `[Flaky]` attributes here because we have reason to believe they shouldn't be flaky any more, and if we don't remove it now, we don't (yet) have any system for knowing it's time to remove it in the future.