### PR TITLE
Adding LangVersion property to razorclasslib

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorClassLibrary-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorClassLibrary-CSharp.csproj.in
@@ -4,6 +4,7 @@
     <TargetFramework Condition="'$(SupportPagesAndViews)' == 'True'">netcoreapp5.0</TargetFramework>
     <TargetFramework Condition="'$(SupportPagesAndViews)' != 'True'">netstandard2.0</TargetFramework>
     <RazorLangVersion Condition="'$(SupportPagesAndViews)' != 'True'">3.0</RazorLangVersion>
+    <LangVersion Condition="'$(SupportPagesAndViews)' != 'True'">8.0</LangVersion>
     <AddRazorSupportForMvc Condition="'$(SupportPagesAndViews)' == 'True'">true</AddRazorSupportForMvc>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.RazorClassLibrary1</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Adding `LangVersion` to the `razorclasslib.csproj` template to prevent breaking builds from `nullable reference types not available` when importing `Microsoft.AspNetCore.Components.Web`. 

Addresses #13725
