### PR TITLE
[2.1] Re-implement SameSite for 2019 

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -40,6 +40,8 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.14' ">
     <PackagesInPatch>
+      Microsoft.Net.Http.Headers;
+      Microsoft.AspNetCore.CookiePolicy;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Net.Http.Headers
 
         // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
         // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
-        internal static bool UseSameSite2016Compat;
+        internal static bool SuppressSameSiteNone;
 
         private const string HttpOnlyToken = "httponly";
         private const string SeparatorToken = "; ";
@@ -42,9 +42,9 @@ namespace Microsoft.Net.Http.Headers
 
         static SetCookieHeaderValue()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.UseSameSite2016Compat", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
             {
-                UseSameSite2016Compat = enabled;
+                SuppressSameSiteNone = enabled;
             }
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.Net.Http.Headers
 
         public bool Secure { get; set; }
 
-        public SameSiteMode SameSite { get; set; } = UseSameSite2016Compat ? SameSiteMode.None : (SameSiteMode)(-1); // Unspecified
+        public SameSiteMode SameSite { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : (SameSiteMode)(-1); // Unspecified
 
         public bool HttpOnly { get; set; }
 
@@ -145,7 +145,7 @@ namespace Microsoft.Net.Http.Headers
             }
 
             // Allow for Unspecified (-1) to skip SameSite
-            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
+            if (SameSite == SameSiteMode.None && !SuppressSameSiteNone)
             {
                 sameSite = SameSiteNoneToken;
                 length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
@@ -261,7 +261,7 @@ namespace Microsoft.Net.Http.Headers
             }
 
             // Allow for Unspecified (-1) to skip SameSite
-            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
+            if (SameSite == SameSiteMode.None && !SuppressSameSiteNone)
             {
                 AppendSegment(builder, SameSiteToken, SameSiteNoneToken);
             }
@@ -464,7 +464,7 @@ namespace Microsoft.Net.Http.Headers
                 {
                     if (!ReadEqualsSign(input, ref offset))
                     {
-                        result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
+                        result.SameSite = SuppressSameSiteNone ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                     }
                     else
                     {
@@ -478,14 +478,14 @@ namespace Microsoft.Net.Http.Headers
                         {
                             result.SameSite = SameSiteMode.Lax;
                         }
-                        else if (!UseSameSite2016Compat
+                        else if (!SuppressSameSiteNone
                             && StringSegment.Equals(enforcementMode, SameSiteNoneToken, StringComparison.OrdinalIgnoreCase))
                         {
                             result.SameSite = SameSiteMode.None;
                         }
                         else
                         {
-                            result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
+                            result.SameSite = SuppressSameSiteNone ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                         }
                     }
                 }

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Net.Http.Headers
 
         static SetCookieHeaderValue()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
             {
                 SuppressSameSiteNone = enabled;
             }

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -19,8 +19,14 @@ namespace Microsoft.Net.Http.Headers
         private const string SecureToken = "secure";
         // RFC Draft: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00
         private const string SameSiteToken = "samesite";
+        private static readonly string SameSiteNoneToken = SameSiteMode.None.ToString().ToLower();
         private static readonly string SameSiteLaxToken = SameSiteMode.Lax.ToString().ToLower();
         private static readonly string SameSiteStrictToken = SameSiteMode.Strict.ToString().ToLower();
+
+        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
+        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+        internal static bool UseSameSite2016Compat;
+
         private const string HttpOnlyToken = "httponly";
         private const string SeparatorToken = "; ";
         private const string EqualsToken = "=";
@@ -33,6 +39,14 @@ namespace Microsoft.Net.Http.Headers
 
         private StringSegment _name;
         private StringSegment _value;
+
+        static SetCookieHeaderValue()
+        {
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.UseSameSite2016Compat", out var enabled))
+            {
+                UseSameSite2016Compat = enabled;
+            }
+        }
 
         private SetCookieHeaderValue()
         {
@@ -90,11 +104,11 @@ namespace Microsoft.Net.Http.Headers
 
         public bool Secure { get; set; }
 
-        public SameSiteMode SameSite { get; set; }
+        public SameSiteMode SameSite { get; set; } = UseSameSite2016Compat ? SameSiteMode.None : (SameSiteMode)(-1); // Unspecified
 
         public bool HttpOnly { get; set; }
 
-        // name="value"; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={Strict|Lax}; httponly
+        // name="value"; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={strict|lax|none}; httponly
         public override string ToString()
         {
             var length = _name.Length + EqualsToken.Length + _value.Length;
@@ -130,9 +144,20 @@ namespace Microsoft.Net.Http.Headers
                 length += SeparatorToken.Length + SecureToken.Length;
             }
 
-            if (SameSite != SameSiteMode.None)
+            // Allow for Unspecified (-1) to skip SameSite
+            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
             {
-                sameSite = SameSite == SameSiteMode.Lax ? SameSiteLaxToken : SameSiteStrictToken;
+                sameSite = SameSiteNoneToken;
+                length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
+            }
+            else if (SameSite == SameSiteMode.Lax)
+            {
+                sameSite = SameSiteLaxToken;
+                length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
+            }
+            else if (SameSite == SameSiteMode.Strict)
+            {
+                sameSite = SameSiteStrictToken;
                 length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
             }
 
@@ -172,7 +197,7 @@ namespace Microsoft.Net.Http.Headers
                 AppendSegment(ref sb, SecureToken, null);
             }
 
-            if (SameSite != SameSiteMode.None)
+            if (sameSite != null)
             {
                 AppendSegment(ref sb, SameSiteToken, sameSite);
             }
@@ -235,9 +260,18 @@ namespace Microsoft.Net.Http.Headers
                 AppendSegment(builder, SecureToken, null);
             }
 
-            if (SameSite != SameSiteMode.None)
+            // Allow for Unspecified (-1) to skip SameSite
+            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
             {
-                AppendSegment(builder, SameSiteToken, SameSite == SameSiteMode.Lax ? SameSiteLaxToken : SameSiteStrictToken);
+                AppendSegment(builder, SameSiteToken, SameSiteNoneToken);
+            }
+            else if (SameSite == SameSiteMode.Lax)
+            {
+                AppendSegment(builder, SameSiteToken, SameSiteLaxToken);
+            }
+            else if (SameSite == SameSiteMode.Strict)
+            {
+                AppendSegment(builder, SameSiteToken, SameSiteStrictToken);
             }
 
             if (HttpOnly)
@@ -289,7 +323,7 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.TryParseStrictValues(inputs, out parsedValues);
         }
 
-        // name=value; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={Strict|Lax}; httponly
+        // name=value; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={Strict|Lax|None}; httponly
         private static int GetSetCookieLength(StringSegment input, int startIndex, out SetCookieHeaderValue parsedValue)
         {
             Contract.Requires(startIndex >= 0);
@@ -424,25 +458,34 @@ namespace Microsoft.Net.Http.Headers
                 {
                     result.Secure = true;
                 }
-                // samesite-av = "SameSite" / "SameSite=" samesite-value
-                // samesite-value = "Strict" / "Lax"
+                // samesite-av = "SameSite=" samesite-value
+                // samesite-value = "Strict" / "Lax" / "None"
                 else if (StringSegment.Equals(token, SameSiteToken, StringComparison.OrdinalIgnoreCase))
                 {
                     if (!ReadEqualsSign(input, ref offset))
                     {
-                        result.SameSite = SameSiteMode.Strict;
+                        result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                     }
                     else
                     {
                         var enforcementMode = ReadToSemicolonOrEnd(input, ref offset);
 
-                        if (StringSegment.Equals(enforcementMode, SameSiteLaxToken, StringComparison.OrdinalIgnoreCase))
+                        if (StringSegment.Equals(enforcementMode, SameSiteStrictToken, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result.SameSite = SameSiteMode.Strict;
+                        }
+                        else if (StringSegment.Equals(enforcementMode, SameSiteLaxToken, StringComparison.OrdinalIgnoreCase))
                         {
                             result.SameSite = SameSiteMode.Lax;
                         }
+                        else if (!UseSameSite2016Compat
+                            && StringSegment.Equals(enforcementMode, SameSiteNoneToken, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result.SameSite = SameSiteMode.None;
+                        }
                         else
                         {
-                            result.SameSite = SameSiteMode.Strict;
+                            result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                         }
                     }
                 }

--- a/src/Http/Headers/test/SetCookieHeaderValueTest.cs
+++ b/src/Http/Headers/test/SetCookieHeaderValueTest.cs
@@ -314,9 +314,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_ToString_SameSite2016Compat()
+        public void SetCookieHeaderValue_ToString_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
 
             var input = new SetCookieHeaderValue("name", "value")
             {
@@ -325,7 +325,7 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal("name=value", input.ToString());
 
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             var input2 = new SetCookieHeaderValue("name", "value")
             {
@@ -347,9 +347,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_AppendToStringBuilder_SameSite2016Compat()
+        public void SetCookieHeaderValue_AppendToStringBuilder_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
 
             var builder = new StringBuilder();
             var input = new SetCookieHeaderValue("name", "value")
@@ -360,7 +360,7 @@ namespace Microsoft.Net.Http.Headers
             input.AppendToStringBuilder(builder);
             Assert.Equal("name=value", builder.ToString());
 
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             var builder2 = new StringBuilder();
             var input2 = new SetCookieHeaderValue("name", "value")
@@ -383,9 +383,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSite2016Compat()
+        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
             var header = SetCookieHeaderValue.Parse("name=value; samesite=none");
 
             var cookie = new SetCookieHeaderValue("name", "value")
@@ -395,7 +395,7 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal(cookie, header);
             Assert.Equal("name=value; samesite=strict", header.ToString());
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             var header2 = SetCookieHeaderValue.Parse("name=value; samesite=none");
 
@@ -418,9 +418,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSite2016Compat()
+        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
             Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header));
             var cookie = new SetCookieHeaderValue("name", "value")
             {
@@ -430,7 +430,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(cookie, header);
             Assert.Equal("name=value; samesite=strict", header.ToString());
 
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header2));
             var cookie2 = new SetCookieHeaderValue("name", "value")

--- a/src/Http/Headers/test/SetCookieHeaderValueTest.cs
+++ b/src/Http/Headers/test/SetCookieHeaderValueTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Net.Http.Headers
                 {
                     SameSite = SameSiteMode.None,
                 };
-                dataset.Add(header7, "name7=value7");
+                dataset.Add(header7, "name7=value7; samesite=none");
 
 
                 return dataset;
@@ -155,9 +155,20 @@ namespace Microsoft.Net.Http.Headers
                 {
                     SameSite = SameSiteMode.Strict
                 };
-                var string6a = "name6=value6; samesite";
-                var string6b = "name6=value6; samesite=Strict";
-                var string6c = "name6=value6; samesite=invalid";
+                var string6 = "name6=value6; samesite=Strict";
+
+                var header7 = new SetCookieHeaderValue("name7", "value7")
+                {
+                    SameSite = SameSiteMode.None
+                };
+                var string7 = "name7=value7; samesite=None";
+
+                var header8 = new SetCookieHeaderValue("name8", "value8")
+                {
+                    SameSite = (SameSiteMode)(-1) // Unspecified
+                };
+                var string8a = "name8=value8; samesite";
+                var string8b = "name8=value8; samesite=invalid";
 
                 dataset.Add(new[] { header1 }.ToList(), new[] { string1 });
                 dataset.Add(new[] { header1, header1 }.ToList(), new[] { string1, string1 });
@@ -170,9 +181,10 @@ namespace Microsoft.Net.Http.Headers
                 dataset.Add(new[] { header1, header2, header3, header4 }.ToList(), new[] { string.Join(",", string1, string2, string3, string4) });
                 dataset.Add(new[] { header5 }.ToList(), new[] { string5a });
                 dataset.Add(new[] { header5 }.ToList(), new[] { string5b });
-                dataset.Add(new[] { header6 }.ToList(), new[] { string6a });
-                dataset.Add(new[] { header6 }.ToList(), new[] { string6b });
-                dataset.Add(new[] { header6 }.ToList(), new[] { string6c });
+                dataset.Add(new[] { header6 }.ToList(), new[] { string6 });
+                dataset.Add(new[] { header7 }.ToList(), new[] { string7 });
+                dataset.Add(new[] { header8 }.ToList(), new[] { string8a });
+                dataset.Add(new[] { header8 }.ToList(), new[] { string8b });
 
                 return dataset;
             }
@@ -301,6 +313,28 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedValue, input.ToString());
         }
 
+        [Fact]
+        public void SetCookieHeaderValue_ToString_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+
+            var input = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            Assert.Equal("name=value", input.ToString());
+
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            var input2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            Assert.Equal("name=value; samesite=none", input2.ToString());
+        }
+
         [Theory]
         [MemberData(nameof(SetCookieHeaderDataSet))]
         public void SetCookieHeaderValue_AppendToStringBuilder(SetCookieHeaderValue input, string expectedValue)
@@ -310,6 +344,32 @@ namespace Microsoft.Net.Http.Headers
             input.AppendToStringBuilder(builder);
 
             Assert.Equal(expectedValue, builder.ToString());
+        }
+
+        [Fact]
+        public void SetCookieHeaderValue_AppendToStringBuilder_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+
+            var builder = new StringBuilder();
+            var input = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            input.AppendToStringBuilder(builder);
+            Assert.Equal("name=value", builder.ToString());
+
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            var builder2 = new StringBuilder();
+            var input2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            input2.AppendToStringBuilder(builder2);
+            Assert.Equal("name=value; samesite=none", builder2.ToString());
         }
 
         [Theory]
@@ -322,6 +382,31 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedValue, header.ToString());
         }
 
+        [Fact]
+        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            var header = SetCookieHeaderValue.Parse("name=value; samesite=none");
+
+            var cookie = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.Strict,
+            };
+
+            Assert.Equal(cookie, header);
+            Assert.Equal("name=value; samesite=strict", header.ToString());
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            var header2 = SetCookieHeaderValue.Parse("name=value; samesite=none");
+
+            var cookie2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+            Assert.Equal(cookie2, header2);
+            Assert.Equal("name=value; samesite=none", header2.ToString());
+        }
+
         [Theory]
         [MemberData(nameof(SetCookieHeaderDataSet))]
         public void SetCookieHeaderValue_TryParse_AcceptsValidValues(SetCookieHeaderValue cookie, string expectedValue)
@@ -330,6 +415,31 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal(cookie, header);
             Assert.Equal(expectedValue, header.ToString());
+        }
+
+        [Fact]
+        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header));
+            var cookie = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.Strict,
+            };
+
+            Assert.Equal(cookie, header);
+            Assert.Equal("name=value; samesite=strict", header.ToString());
+
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header2));
+            var cookie2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            Assert.Equal(cookie2, header2);
+            Assert.Equal("name=value; samesite=none", header2.ToString());
         }
 
         [Theory]

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/OpenIdConnectSample.csproj
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/OpenIdConnectSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
@@ -21,6 +21,7 @@
     <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Microsoft.Extensions.Logging.Debug" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/OpenIdConnectSample.csproj
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/OpenIdConnectSample.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <Reference Include="Microsoft.AspNetCore.CookiePolicy" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Https" />

--- a/src/Security/Authentication/test/CookieTests.cs
+++ b/src/Security/Authentication/test/CookieTests.cs
@@ -649,7 +649,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             Assert.Contains(" path=/foo", setCookie1);
             Assert.Contains(" domain=another.com", setCookie1);
             Assert.Contains(" secure", setCookie1);
-            Assert.DoesNotContain(" samesite", setCookie1);
+            Assert.Contains(" samesite=none", setCookie1);
             Assert.Contains(" httponly", setCookie1);
 
             var server2 = CreateServer(o =>

--- a/src/Security/Authentication/test/Microsoft.AspNetCore.Authentication.Test.csproj
+++ b/src/Security/Authentication/test/Microsoft.AspNetCore.Authentication.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
@@ -39,6 +39,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.Twitter" />
     <Reference Include="Microsoft.AspNetCore.Authentication.WsFederation" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectChallengeTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectChallengeTests.cs
@@ -376,6 +376,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             var server = settings.CreateTestServer();
             var transaction = await server.SendAsync(ChallengeEndpoint);
 
+            Assert.Contains("samesite=none", transaction.SetCookie.First());
             var challengeCookies = SetCookieHeaderValue.ParseList(transaction.SetCookie);
             var nonceCookie = challengeCookies.Where(cookie => cookie.Name.StartsWith(OpenIdConnectDefaults.CookieNoncePrefix, StringComparison.Ordinal)).Single();
             Assert.True(nonceCookie.Expires.HasValue);

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -12,6 +12,18 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class CookiePolicyOptions
     {
+        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
+        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+        internal static bool SuppressSameSiteNone;
+
+        static CookiePolicyOptions()
+        {
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
+            {
+                SuppressSameSiteNone = enabled;
+            }
+        }
+
         /// <summary>
         /// Affects the cookie's same site attribute.
         /// </summary>

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -115,7 +115,8 @@ namespace Microsoft.AspNetCore.CookiePolicy
         private bool CheckPolicyRequired()
         {
             return !CanTrack
-                || Options.MinimumSameSitePolicy != SameSiteMode.None
+                || (CookiePolicyOptions.SuppressSameSiteNone && Options.MinimumSameSitePolicy != SameSiteMode.None)
+                || (!CookiePolicyOptions.SuppressSameSiteNone && Options.MinimumSameSitePolicy != (SameSiteMode)(-1))
                 || Options.HttpOnly != HttpOnlyPolicy.None
                 || Options.Secure != CookieSecurePolicy.None;
         }
@@ -241,26 +242,10 @@ namespace Microsoft.AspNetCore.CookiePolicy
                 default:
                     throw new InvalidOperationException();
             }
-            switch (Options.MinimumSameSitePolicy)
+            if (options.SameSite < Options.MinimumSameSitePolicy)
             {
-                case SameSiteMode.None:
-                    break;
-                case SameSiteMode.Lax:
-                    if (options.SameSite == SameSiteMode.None)
-                    {
-                        options.SameSite = SameSiteMode.Lax;
-                        _logger.CookieSameSiteUpgraded(key, "lax");
-                    }
-                    break;
-                case SameSiteMode.Strict:
-                    if (options.SameSite != SameSiteMode.Strict)
-                    {
-                        options.SameSite = SameSiteMode.Strict;
-                        _logger.CookieSameSiteUpgraded(key, "strict");
-                    }
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unrecognized {nameof(SameSiteMode)} value {Options.MinimumSameSitePolicy.ToString()}");
+                options.SameSite = Options.MinimumSameSitePolicy;
+                _logger.CookieSameSiteUpgraded(key, Options.MinimumSameSitePolicy.ToString());
             }
             switch (Options.HttpOnly)
             {

--- a/src/Security/CookiePolicy/test/Microsoft.AspNetCore.CookiePolicy.Test.csproj
+++ b/src/Security/CookiePolicy/test/Microsoft.AspNetCore.CookiePolicy.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
@@ -13,6 +13,7 @@
     <Reference Include="Microsoft.AspNetCore.CookiePolicy" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Security.sln
+++ b/src/Security/Security.sln
@@ -102,6 +102,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server.IISIntegration", "..\Servers\IIS\IISIntegration\src\Microsoft.AspNetCore.Server.IISIntegration.csproj", "{81D0E81F-4711-4C7B-BBD4-E168102D0D7D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Http.Headers", "..\Http\Headers\src\Microsoft.Net.Http.Headers.csproj", "{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -248,6 +250,10 @@ Global
 		{81D0E81F-4711-4C7B-BBD4-E168102D0D7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81D0E81F-4711-4C7B-BBD4-E168102D0D7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81D0E81F-4711-4C7B-BBD4-E168102D0D7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -298,6 +304,7 @@ Global
 		{707CBFB4-4D35-479E-9BAF-39B4DA9782DE} = {A3766414-EB5C-40F7-B031-121804ED5D0A}
 		{AFE880E8-2E9E-46FD-BE87-DFC8192E7B2D} = {A3766414-EB5C-40F7-B031-121804ED5D0A}
 		{81D0E81F-4711-4C7B-BBD4-E168102D0D7D} = {A3766414-EB5C-40F7-B031-121804ED5D0A}
+		{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE} = {A3766414-EB5C-40F7-B031-121804ED5D0A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABF8089E-43D0-4010-84A7-7A9DCFE49357}


### PR DESCRIPTION
2.1 patch for #12125. Similar patches are in flight for System.Web and Microsoft.Owin.

Issue: Chrome is redefining how the SameSite cookie property works in a non-backwards compatible way. Cross site components like OpenIdConnect authentication must opt-out by sending a new "None" value or they won't work anymore.

Customer impact: Customers using OpenIdConnect to log into their web sites will break without this patch starting in January (Chrome 80).

Risk: Medium. The SameSite changes are known to be incompatible with older OSs and browsers, especially iOS 12 and OSX Mojave (latest - 1). These represent a small but influential portion of the web client user base. Updating to the latest OS version addresses the incompatibility. 

Mitigations: 
A) This patch includes an AppContext switch to revert everything to the old behavior. "Microsoft.AspNetCore.SuppressSameSiteNone"
B) `(SameSiteMode)(-1)` can be used to exclude the SameSite attribute for cookies on a case by case basis.
C) We're providing browser sniffing samples and guidance to account for the incompatibilities in some old clients.

@blowdart 