### PR TITLE
Add -Force to Expand-Archive

### DIFF
--- a/eng/helix/content/InstallNode.ps1
+++ b/eng/helix/content/InstallNode.ps1
@@ -48,9 +48,10 @@ Write-Host "Extracting to $tempDir"
 
 if (Get-Command -Name 'Microsoft.PowerShell.Archive\Expand-Archive' -ErrorAction Ignore) {
     # Use built-in commands where possible as they are cross-plat compatible
-    Microsoft.PowerShell.Archive\Expand-Archive -Path "nodejs.zip" -DestinationPath $tempDir
+    Microsoft.PowerShell.Archive\Expand-Archive -Path "nodejs.zip" -DestinationPath $tempDir -Force
 }
 else {
+    Remove-Item $tempDir -Recurse -ErrorAction Ignore
     # Fallback to old approach for old installations of PowerShell
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("nodejs.zip", $tempDir)


### PR DESCRIPTION
As noted in [the console spew of this test](https://helix.dot.net/api/2019-06-17/jobs/82bbddae-4a56-4002-b3ee-a8768311a92b/workitems/Microsoft.AspNetCore.SpaServices.Extensions.Tests-netcoreapp3.0/console) , it's quite possible for Node to be unpacked, but not on the path (generally on a helix machine it's because your parent process was created before the previous guy who unzipped Node and put it on the path ran, so only after reboot would you see the effect you want.)

Summary of the changes (Less than 80 chars)
 - Add Force argument to Expand-Archive cmdlet
 - Delete the folder if it exists in the fallback path, since otherwise this .NET API will throw.

Addresses test failure
