### PR TITLE
Use Result instead of GetAwaiter().GetResult

### DIFF
--- a/src/Http/Http/src/Features/RequestServicesFeature.cs
+++ b/src/Http/Http/src/Features/RequestServicesFeature.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Http.Features
                     }
                     // If its a IValueTaskSource backed ValueTask,
                     // inform it its result has been read so it can reset
-                    vt.GetAwaiter().GetResult();
+                    vt.Result;
                     break;
                 case IDisposable disposable:
                     disposable.Dispose();

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
             // Make sure we only ever call GetResult once on the TryEnterAsync ValueTask b/c it resets.
             bool result;
 
-            if (waitInQueueTask.IsCompleted)
+            if (waitInQueueTask.IsCompletedSuccessfully)
             {
                 ConcurrencyLimiterEventSource.Log.QueueSkipped();
                 result = waitInQueueTask.Result;

--- a/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
+++ b/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Internal
             if (valueTask.IsCompletedSuccessfully)
             {
                 // Signal consumption to the IValueTaskSource
-                valueTask.GetAwaiter().GetResult();
+                valueTask.Result;
                 return Task.CompletedTask;
             }
             else


### PR DESCRIPTION
Same as #13614

@DylanDmitri I also changed `IsCompleted` to `IsCompletedSuccessfully` in `ConcurrencyLimiterMiddleware.cs` that you were working on, so we get a better exception in case it happened. Is it ok?