### PR TITLE
Use Result instead of GetAwaiter().GetResult when IsCompletetSuccessfully is true

### DIFF
--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
             // Make sure we only ever call GetResult once on the TryEnterAsync ValueTask b/c it resets.
             bool result;
 
-            if (waitInQueueTask.IsCompleted)
+            if (waitInQueueTask.IsCompletedSuccessfully)
             {
                 ConcurrencyLimiterEventSource.Log.QueueSkipped();
                 result = waitInQueueTask.Result;

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
             // Make sure we only ever call GetResult once on the TryEnterAsync ValueTask b/c it resets.
             bool result;
 
-            if (waitInQueueTask.IsCompletedSuccessfully)
+            if (waitInQueueTask.IsCompleted)
             {
                 ConcurrencyLimiterEventSource.Log.QueueSkipped();
                 result = waitInQueueTask.Result;

--- a/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
+++ b/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Internal
             if (valueTask.IsCompletedSuccessfully)
             {
                 // Signal consumption to the IValueTaskSource
-                valueTask.GetAwaiter().GetResult();
+                _ = valueTask.Result;
                 return Task.CompletedTask;
             }
             else


### PR DESCRIPTION
Same as #13614 