### PR TITLE
Cleanup when SendAsync with Upload stream

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -316,12 +316,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                         _ = StreamResultsAsync(hubMethodInvocationMessage.InvocationId, connection, enumerable, scope, hubActivator, hub, cts, hubMethodInvocationMessage);
                     }
 
-                    else if (string.IsNullOrEmpty(hubMethodInvocationMessage.InvocationId))
-                    {
-                        // Send Async, no response expected
-                        invocation = ExecuteHubMethod(methodExecutor, hub, arguments);
-                    }
-
                     else
                     {
                         // Invoke Async, one reponse expected
@@ -350,7 +344,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                                 }
                             }
 
-                            await connection.WriteAsync(CompletionMessage.WithResult(hubMethodInvocationMessage.InvocationId, result));
+                            // Send Async, no response expected
+                            if (!string.IsNullOrEmpty(hubMethodInvocationMessage.InvocationId))
+                            {
+                                await connection.WriteAsync(CompletionMessage.WithResult(hubMethodInvocationMessage.InvocationId, result));
+                            }
                         }
                         invocation = ExecuteInvocation();
                     }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
                     else
                     {
-                        // Invoke Async, one reponse expected
+                        // Invoke or Send
                         async Task ExecuteInvocation()
                         {
                             object result;
@@ -344,9 +344,10 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                                 }
                             }
 
-                            // Send Async, no response expected
+                            // No InvocationId - Send Async, no response expected
                             if (!string.IsNullOrEmpty(hubMethodInvocationMessage.InvocationId))
                             {
+                                // Invoke Async, one reponse expected
                                 await connection.WriteAsync(CompletionMessage.WithResult(hubMethodInvocationMessage.InvocationId, result));
                             }
                         }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -3780,7 +3780,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             public int ReleaseCount;
             private IServiceProvider _serviceProvider;
-            public TaskCompletionSource<object> ReleaseTask;
+            public TaskCompletionSource<object> ReleaseTask = new TaskCompletionSource<object>();
             public TaskCompletionSource<object> CreateTask = new TaskCompletionSource<object>();
 
             public CustomHubActivator(IServiceProvider serviceProvider)
@@ -3792,7 +3792,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 ReleaseTask = new TaskCompletionSource<object>();
                 var hub = new DefaultHubActivator<THub>(_serviceProvider).Create();
-                CreateTask.SetResult(null);
+                CreateTask.TrySetResult(null);
                 return hub;
             }
 
@@ -3800,7 +3800,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 ReleaseCount++;
                 hub.Dispose();
-                ReleaseTask.SetResult(null);
+                ReleaseTask.TrySetResult(null);
                 CreateTask = new TaskCompletionSource<object>();
             }
         }


### PR DESCRIPTION
### Description
When using the new Client to Server streaming feature with `SendAsync` (a client API), the `Hub` and `IServiceScope` associated with the server side method invocation are not disposed properly and left to the GC to finalize.

### Customer impact
Customers could have logic they expect to run in Dispose/DisposeAsync of services they inject into the Hub which will not run.

### Regression
No. Client to Server streaming is a new feature in 3.0.

### Risk
Low. The test coverage in this area is good, we just missed this case. Added a new test to fix the gap.

cc @Pilchie 