### PR TITLE
[3.0] Update gRPC template to use 2.23.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -225,7 +225,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>0.2.23-pre1</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>2.23.1</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0</IdentityServer4PackageVersion>


### PR DESCRIPTION
**Description**

Update Grpc.AspNetCore reference in gRPC template to 2.23.0.

**Customer impact**

Template now references a non-preview gRPC package.
Template will reference gRPC package with bug fixes since preview 9.

**Regression**

No

**Risk**

Low

---

Note that there is a just discovered issue in 2.23.0 so it might be updated to 2.23.1. What day is the deadline for RC changes?