### PR TITLE
[Templates] Allow configuring the LogLevel in exceptions

### DIFF
--- a/src/ProjectTemplates/test/e2eTestSettings.ci.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.ci.json
@@ -4,5 +4,7 @@
   "DefaultWaitTimeoutInSeconds": 120,
   // This value is balanced between completing the build fast enough upon failure and giving
   // each E2E test a fair chance to pass even in the event that a separate test has failed already.
-  "DefaultAfterFailureWaitTimeoutInSeconds": 120
+  "DefaultAfterFailureWaitTimeoutInSeconds": 120,
+  // Capture all the logs from the browser when an exception occurs.
+  "BrowserLogLevel": "All"
 }

--- a/src/ProjectTemplates/test/e2eTestSettings.json
+++ b/src/ProjectTemplates/test/e2eTestSettings.json
@@ -1,4 +1,6 @@
 {
   "DefaultWaitTimeoutInSeconds": 20,
-  "ScreenShotsPath": "../../screenshots"
+  "ScreenShotsPath": "../../screenshots",
+  // Capture all the logs from the browser when an exception occurs.
+  "BrowserLogLevel": "All"
 }

--- a/src/Shared/E2ETesting/E2ETestOptions.cs
+++ b/src/Shared/E2ETesting/E2ETestOptions.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
+using OpenQA.Selenium;
 
 namespace Microsoft.AspNetCore.E2ETesting
 {
@@ -56,5 +57,7 @@ namespace Microsoft.AspNetCore.E2ETesting
         public string ScreenShotsPath { get; set; }
 
         public double DefaultAfterFailureWaitTimeoutInSeconds { get; set; } = 3;
+
+        public LogLevel BrowserLogLevel { get; set; } = LogLevel.Severe;
     }
 }

--- a/src/Shared/E2ETesting/WaitAssert.cs
+++ b/src/Shared/E2ETesting/WaitAssert.cs
@@ -84,9 +84,10 @@ namespace Microsoft.AspNetCore.E2ETesting
 
                 var fileId = $"{Guid.NewGuid():N}.png";
                 var screenShotPath = Path.Combine(Path.GetFullPath(E2ETestOptions.Instance.ScreenShotsPath), fileId);
-                var errors = driver.GetBrowserLogs(LogLevel.Severe);
+                var errors = driver.GetBrowserLogs(E2ETestOptions.Instance.BrowserLogLevel);
 
                 TakeScreenShot(driver, screenShotPath);
+
                 var exceptionInfo = lastException != null ? ExceptionDispatchInfo.Capture(lastException) :
                     CaptureException(assertion);
 


### PR DESCRIPTION
* Allows configuring the LogLevel during assertions to capture all relevant information when an assertion fails.