### PR TITLE
[release/2.2] Backport memory leak fix from 3.0

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -78,6 +78,7 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.8' ">
     <PackagesInPatch>
+      Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore
         {
             using (var scope = _services.CreateScope())
             {
+                var context = scope.ServiceProvider.GetRequiredService<TContext>();	
                 // Put logger in a local such that `this` isn't captured.
                 var logger = _logger;
                 return context.DataProtectionKeys.AsNoTracking().Select(key => TryParseKeyXml(key.Xml, logger)).ToList().AsReadOnly();

--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
@@ -42,8 +42,9 @@ namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore
         {
             using (var scope = _services.CreateScope())
             {
-                var context = scope.ServiceProvider.GetRequiredService<TContext>();
-                return context.DataProtectionKeys.AsNoTracking().Select(key => TryParseKeyXml(key.Xml)).ToList().AsReadOnly();
+                // Put logger in a local such that `this` isn't captured.
+                var logger = _logger;
+                return context.DataProtectionKeys.AsNoTracking().Select(key => TryParseKeyXml(key.Xml, logger)).ToList().AsReadOnly();
             }
         }
 
@@ -65,7 +66,7 @@ namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore
             }
         }
 
-        private XElement TryParseKeyXml(string xml)
+        private static XElement TryParseKeyXml(string xml, ILogger logger)
         {
             try
             {
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore
             }
             catch (Exception e)
             {
-                _logger?.LogExceptionWhileParsingKeyXml(xml, e);
+                logger?.LogExceptionWhileParsingKeyXml(xml, e);
                 return null;
             }
         }


### PR DESCRIPTION
Same as https://github.com/aspnet/AspNetCore/pull/13743, but for 2.2.

**Description**
Customers using the Microsoft.AspNetCore.DataProtection.EntityFrameworkCore package would silently hit a memory leak every time EntityFrameworkCoreXmlRepository.GetAllElements is called. Specifically, both the Logger and Services would leak each time this is called. 

**Customer impact**
In 2.2, customers will see increased memory usage everytime they call EntityFrameworkCoreXmlRepository.GetAllElements due to a memory leak.

**Regression**
No. This behavior has existed since the release of 2.2.

**Risk**
Low. This changes the call to TryParseKeyXml from an instance method to static.

@Pilchie can you take this to ship room It's the same change as above, but minimized for 2.2.
