### PR TITLE
Add support for port 0 in HttpSys

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestPortHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestPortHelper.cs
@@ -64,6 +64,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
         // GetNextPort doesn't check for HttpSys urlacls.
         public static int GetNextHttpSysPort(string scheme)
         {
+            if (scheme == "http")
+            {
+                return 0;
+            }
+
             while (NextPort < MaxPort)
             {
                 var port = NextPort++;

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestPortHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestPortHelper.cs
@@ -56,39 +56,5 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
                 }
             }
         }
-
-        private const int BasePort = 5001;
-        private const int MaxPort = 8000;
-        private static int NextPort = BasePort;
-
-        // GetNextPort doesn't check for HttpSys urlacls.
-        public static int GetNextHttpSysPort(string scheme)
-        {
-            if (scheme == "http")
-            {
-                return 0;
-            }
-
-            while (NextPort < MaxPort)
-            {
-                var port = NextPort++;
-
-                using (var server = new HttpListener())
-                {
-                    server.Prefixes.Add($"{scheme}://localhost:{port}/");
-                    try
-                    {
-                        server.Start();
-                        server.Stop();
-                        return port;
-                    }
-                    catch (HttpListenerException)
-                    {
-                    }
-                }
-            }
-            NextPort = BasePort;
-            throw new Exception("Failed to locate a free port.");
-        }
     }
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
                 }
                 else if (serverType == ServerType.HttpSys)
                 {
-                    return new UriBuilder(scheme, "localhost", TestPortHelper.GetNextHttpSysPort(scheme)).Uri;
+                    return new UriBuilder(scheme, "localhost", 0).Uri;
                 }
                 else
                 {

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
                 }
                 else if (serverType == ServerType.HttpSys)
                 {
+                    Debug.Assert(scheme == "http", "Https not supported");
                     return new UriBuilder(scheme, "localhost", 0).Uri;
                 }
                 else

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestUriHelper.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+
 namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
 {
     public static class TestUriHelper

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -73,7 +73,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             LogHelper.LogInfo(_logger, "Listening on prefix: " + uriPrefix);
             CheckDisposed();
-
             var statusCode = HttpApi.HttpAddUrlToUrlGroup(Id, uriPrefix, (ulong)contextId, 0);
 
             if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)

--- a/src/Servers/HttpSys/src/UrlPrefixCollection.cs
+++ b/src/Servers/HttpSys/src/UrlPrefixCollection.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                             throw new InvalidOperationException("Cannot bind to port 0 with https.");
                         }
 
-                        if (!FindHttpPortUnsynchronized(pair, urlPrefix))
+                        if (!FindHttpPortUnsynchronized(pair.Key, urlPrefix))
                         {
                             throw new HttpSysException(Marshal.GetLastWin32Error(), "Could not bind to port 0.");
                         }
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
-        private bool FindHttpPortUnsynchronized(KeyValuePair<int, UrlPrefix> pair, UrlPrefix urlPrefix)
+        private bool FindHttpPortUnsynchronized(int key, UrlPrefix urlPrefix)
         {
             for (var index = BasePortIndex; index < MaxPortIndex; index++)
             {
@@ -183,9 +183,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
                     Debug.Assert(port >= 5000 || port < 8000);
 
-                    var newPrefix = UrlPrefix.Create(urlPrefix.Scheme, urlPrefix.Host, index, urlPrefix.Path);
-                    _urlGroup.RegisterPrefix(newPrefix.FullPrefix, pair.Key);
-                    _prefixes[pair.Key] = newPrefix;
+                    var newPrefix = UrlPrefix.Create(urlPrefix.Scheme, urlPrefix.Host, port, urlPrefix.Path);
+                    _urlGroup.RegisterPrefix(newPrefix.FullPrefix, key);
+                    _prefixes[key] = newPrefix;
 
                     NextPortIndex = BasePortIndex + 1;
                     return true;

--- a/src/Servers/HttpSys/src/UrlPrefixCollection.cs
+++ b/src/Servers/HttpSys/src/UrlPrefixCollection.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.HttpSys.Internal;
 
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
@@ -24,10 +25,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private const int MaxPortIndex = 43000;
         private const int MaxRetries = 1000;
         private static int NextPortIndex;
-
-        private const int ErrorAccessDenied = 5;
-        private const int ErrorSharingViolation = 32;
-        private const int ErrorAlreadyRegistered = 183;
 
         internal UrlPrefixCollection()
         {
@@ -190,14 +187,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     _urlGroup.RegisterPrefix(newPrefix.FullPrefix, key);
                     _prefixes[key] = newPrefix;
 
-                    NextPortIndex = NextPortIndex++;
+                    NextPortIndex += index + 1;
                     return;
                 }
                 catch (HttpSysException ex)
                 {
-                    if ((ex.ErrorCode != ErrorSharingViolation
-                        && ex.ErrorCode != ErrorAlreadyRegistered
-                        && ex.ErrorCode != ErrorAccessDenied) || index == MaxRetries - 1)
+                    if ((ex.ErrorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_ACCESS_DENIED
+                        && ex.ErrorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SHARING_VIOLATION
+                        && ex.ErrorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_ALREADY_EXISTS) || index == MaxRetries - 1)
                     {
                         throw;
                     }

--- a/src/Servers/HttpSys/startvs.cmd
+++ b/src/Servers/HttpSys/startvs.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+%~dp0..\..\..\startvs.cmd %~dp0HttpSysServer.sln

--- a/src/Servers/HttpSys/test/FunctionalTests/MessagePumpTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/MessagePumpTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -114,7 +114,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 server.StartAsync(new DummyApplication(), CancellationToken.None).Wait();
 
-                Assert.Equal(Constants.DefaultServerAddress, server.Features.Get<IServerAddressesFeature>().Addresses.Single());
+                // Trailing slash is added when put in UrlPrefix.
+                Assert.StartsWith(Constants.DefaultServerAddress, server.Features.Get<IServerAddressesFeature>().Addresses.Single());
             }
         }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -21,11 +22,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     {
         // When tests projects are run in parallel, overlapping port ranges can cause a race condition when looking for free
         // ports during dynamic port allocation.
-        private const int BasePort = 5001;
-        private const int MaxPort = 8000;
         private const int BaseHttpsPort = 44300;
         private const int MaxHttpsPort = 44399;
-        private static int NextPort = BasePort;
         private static int NextHttpsPort = BaseHttpsPort;
         private static object PortLock = new object();
         internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
@@ -86,35 +84,26 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             lock (PortLock)
             {
-                while (NextPort < MaxPort)
-                {
-                    var port = NextPort++;
-                    var prefix = UrlPrefix.Create("http", "localhost", port, basePath);
-                    root = prefix.Scheme + "://" + prefix.Host + ":" + prefix.Port;
-                    baseAddress = prefix.ToString();
+                var prefix = UrlPrefix.Create("http", "localhost", "0", basePath);
 
-                    var builder = new WebHostBuilder()
-                        .UseHttpSys(options =>
-                        {
-                            options.UrlPrefixes.Add(prefix);
-                            configureOptions(options);
-                        })
-                        .Configure(appBuilder => appBuilder.Run(app));
-
-                    var host = builder.Build();
-
-
-                    try
+                var builder = new WebHostBuilder()
+                    .UseHttpSys(options =>
                     {
-                        host.Start();
-                        return host;
-                    }
-                    catch (HttpSysException)
-                    {
-                    }
+                        options.UrlPrefixes.Add(prefix);
+                        configureOptions(options);
+                    })
+                    .Configure(appBuilder => appBuilder.Run(app));
 
-                }
-                NextPort = BasePort;
+                var host = builder.Build();
+
+                host.Start();
+
+                var server = (MessagePump)host.Services.GetRequiredService<IServer>();
+                prefix = server.Listener.Options.UrlPrefixes.First(); // Has new port
+                root = prefix.Scheme + "://" + prefix.Host + ":" + prefix.Port;
+                baseAddress = prefix.ToString();
+
+                return host;
             }
             throw new Exception("Failed to locate a free port.");
         }
@@ -126,27 +115,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             lock (PortLock)
             {
-                while (NextPort < MaxPort)
-                {
+                var prefix = UrlPrefix.Create("http", "localhost", "0", basePath);
 
-                    var port = NextPort++;
-                    var prefix = UrlPrefix.Create("http", "localhost", port, basePath);
-                    root = prefix.Scheme + "://" + prefix.Host + ":" + prefix.Port;
-                    baseAddress = prefix.ToString();
+                var server = CreatePump();
+                server.Features.Get<IServerAddressesFeature>().Addresses.Add(prefix.ToString());
+                configureOptions(server.Listener.Options);
+                server.StartAsync(new DummyApplication(app), CancellationToken.None).Wait();
 
-                    var server = CreatePump();
-                    server.Features.Get<IServerAddressesFeature>().Addresses.Add(baseAddress);
-                    configureOptions(server.Listener.Options);
-                    try
-                    {
-                        server.StartAsync(new DummyApplication(app), CancellationToken.None).Wait();
-                        return server;
-                    }
-                    catch (HttpSysException)
-                    {
-                    }
-                }
-                NextPort = BasePort;
+                prefix = server.Listener.Options.UrlPrefixes.First(); // Has new port
+                root = prefix.Scheme + "://" + prefix.Host + ":" + prefix.Port;
+                baseAddress = prefix.ToString();
+
+                return server;
             }
             throw new Exception("Failed to locate a free port.");
         }
@@ -183,6 +163,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
             throw new Exception("Failed to locate a free port.");
         }
+
 
         internal static Task WithTimeout(this Task task) => task.TimeoutAfter(DefaultTimeout);
 

--- a/src/Servers/HttpSys/test/Tests/UrlPrefixTests.cs
+++ b/src/Servers/HttpSys/test/Tests/UrlPrefixTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Shared/HttpSys/NativeInterop/UnsafeNativeMethods.cs
+++ b/src/Shared/HttpSys/NativeInterop/UnsafeNativeMethods.cs
@@ -24,6 +24,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         internal static class ErrorCodes
         {
             internal const uint ERROR_SUCCESS = 0;
+            internal const uint ERROR_ACCESS_DENIED = 5;
+            internal const uint ERROR_SHARING_VIOLATION = 32;
             internal const uint ERROR_HANDLE_EOF = 38;
             internal const uint ERROR_NOT_SUPPORTED = 50;
             internal const uint ERROR_INVALID_PARAMETER = 87;


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2450 in master. Makes binding to port 0 a feature in HttpSys rather than a test only thing.