### PR TITLE
[Templates] Capture traces for run processes

### DIFF
--- a/src/ProjectTemplates/test/Helpers/Project.cs
+++ b/src/ProjectTemplates/test/Helpers/Project.cs
@@ -205,9 +205,9 @@ namespace Templates.Test.Helpers
             {
                 ["ASPNETCORE_URLS"] = _urls,
                 ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                ["ASPNETCORE_Logging__LogLevel__Default"] = "Debug",
-                ["ASPNETCORE_Logging__LogLevel__System"] = "Debug",
-                ["ASPNETCORE_Logging__LogLevel__Microsoft"] = "Debug",
+                ["ASPNETCORE_Logging__Console__LogLevel__Default"] = "Debug",
+                ["ASPNETCORE_Logging__Console__LogLevel__System"] = "Debug",
+                ["ASPNETCORE_Logging__Console__LogLevel__Microsoft"] = "Debug",
                 ["ASPNETCORE_Logging__Console__IncludeScopes"] = "true",
             };
 
@@ -220,9 +220,9 @@ namespace Templates.Test.Helpers
             var environment = new Dictionary<string, string>
             {
                 ["ASPNETCORE_URLS"] = _urls,
-                ["ASPNETCORE_Logging__LogLevel__Default"] = "Debug",
-                ["ASPNETCORE_Logging__LogLevel__System"] = "Debug",
-                ["ASPNETCORE_Logging__LogLevel__Microsoft"] = "Debug",
+                ["ASPNETCORE_Logging__Console__LogLevel__Default"] = "Debug",
+                ["ASPNETCORE_Logging__Console__LogLevel__System"] = "Debug",
+                ["ASPNETCORE_Logging__Console__LogLevel__Microsoft"] = "Debug",
                 ["ASPNETCORE_Logging__Console__IncludeScopes"] = "true",
             };
 

--- a/src/ProjectTemplates/test/Helpers/Project.cs
+++ b/src/ProjectTemplates/test/Helpers/Project.cs
@@ -205,7 +205,10 @@ namespace Templates.Test.Helpers
             {
                 ["ASPNETCORE_URLS"] = _urls,
                 ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                ["ASPNETCORE_Kestrel__EndpointDefaults__Protocols"] = "Http1"
+                ["ASPNETCORE_Logging__LogLevel__Default"] = "Debug",
+                ["ASPNETCORE_Logging__LogLevel__System"] = "Debug",
+                ["ASPNETCORE_Logging__LogLevel__Microsoft"] = "Debug",
+                ["ASPNETCORE_Logging__Console__IncludeScopes"] = "true",
             };
 
             var projectDll = Path.Combine(TemplateBuildDir, $"{ProjectName}.dll");
@@ -217,7 +220,10 @@ namespace Templates.Test.Helpers
             var environment = new Dictionary<string, string>
             {
                 ["ASPNETCORE_URLS"] = _urls,
-                ["ASPNETCORE_Kestrel__EndpointDefaults__Protocols"] = "Http1"
+                ["ASPNETCORE_Logging__LogLevel__Default"] = "Debug",
+                ["ASPNETCORE_Logging__LogLevel__System"] = "Debug",
+                ["ASPNETCORE_Logging__LogLevel__Microsoft"] = "Debug",
+                ["ASPNETCORE_Logging__Console__IncludeScopes"] = "true",
             };
 
             var projectDll = $"{ProjectName}.dll";

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -297,7 +297,6 @@ namespace Templates.Test.SpaTemplateTest
                 browser.Equal("Weather forecast", () => browser.FindElement(By.TagName("h1")).Text);
 
                 // Asynchronously loads and displays the table of weather forecasts
-                Assert.False(true, "Ensure logs are captured.");
                 browser.Exists(By.CssSelector("table>tbody>tr"));
                 browser.Equal(5, () => browser.FindElements(By.CssSelector("p+table>tbody>tr")).Count);
             }

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -297,7 +297,8 @@ namespace Templates.Test.SpaTemplateTest
                 browser.Equal("Weather forecast", () => browser.FindElement(By.TagName("h1")).Text);
 
                 // Asynchronously loads and displays the table of weather forecasts
-                browser.Exists(By.CssSelector("table>tbody>tr"), TimeSpan.FromSeconds(10));
+                Assert.False(true, "Ensure logs are captured.");
+                browser.Exists(By.CssSelector("table>tbody>tr"));
                 browser.Equal(5, () => browser.FindElements(By.CssSelector("p+table>tbody>tr")).Count);
             }
 


### PR DESCRIPTION
* Turns on the debugging level in the Console to Debug so that we can reason about test failures in template tests.