### PR TITLE
[3.0 patch] Re-implement SameSite for 2019

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -17,6 +17,10 @@ Directory.Build.props checks this property using the following condition:
     <PackagesInPatch>
       Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
       @microsoft/signalr;
+      Microsoft.Net.Http.Headers;
+      Microsoft.AspNetCore.Http.Abstractions;
+      Microsoft.AspNetCore.Http.Features;
+      Microsoft.AspNetCore.CookiePolicy;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -20,8 +20,14 @@ namespace Microsoft.Net.Http.Headers
         private const string SecureToken = "secure";
         // RFC Draft: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00
         private const string SameSiteToken = "samesite";
+        private static readonly string SameSiteNoneToken = SameSiteMode.None.ToString().ToLower();
         private static readonly string SameSiteLaxToken = SameSiteMode.Lax.ToString().ToLower();
         private static readonly string SameSiteStrictToken = SameSiteMode.Strict.ToString().ToLower();
+
+        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
+        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+        internal static bool UseSameSite2016Compat;
+
         private const string HttpOnlyToken = "httponly";
         private const string SeparatorToken = "; ";
         private const string EqualsToken = "=";
@@ -35,6 +41,14 @@ namespace Microsoft.Net.Http.Headers
 
         private StringSegment _name;
         private StringSegment _value;
+
+        static SetCookieHeaderValue()
+        {
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.UseSameSite2016Compat", out var enabled))
+            {
+                UseSameSite2016Compat = enabled;
+            }
+        }
 
         private SetCookieHeaderValue()
         {
@@ -92,16 +106,17 @@ namespace Microsoft.Net.Http.Headers
 
         public bool Secure { get; set; }
 
-        public SameSiteMode SameSite { get; set; }
+        public SameSiteMode SameSite { get; set; } = UseSameSite2016Compat ? SameSiteMode.None : (SameSiteMode)(-1); // Unspecified
 
         public bool HttpOnly { get; set; }
 
-        // name="value"; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={Strict|Lax}; httponly
+        // name="value"; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={strict|lax|none}; httponly
         public override string ToString()
         {
             var length = _name.Length + EqualsToken.Length + _value.Length;
 
             string maxAge = null;
+            string sameSite = null;
 
             if (Expires.HasValue)
             {
@@ -129,9 +144,20 @@ namespace Microsoft.Net.Http.Headers
                 length += SeparatorToken.Length + SecureToken.Length;
             }
 
-            if (SameSite != SameSiteMode.None)
+            // Allow for Unspecified (-1) to skip SameSite
+            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
             {
-                var sameSite = SameSite == SameSiteMode.Lax ? SameSiteLaxToken : SameSiteStrictToken;
+                sameSite = SameSiteNoneToken;
+                length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
+            }
+            else if (SameSite == SameSiteMode.Lax)
+            {
+                sameSite = SameSiteLaxToken;
+                length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
+            }
+            else if (SameSite == SameSiteMode.Strict)
+            {
+                sameSite = SameSiteStrictToken;
                 length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
             }
 
@@ -180,9 +206,9 @@ namespace Microsoft.Net.Http.Headers
                     AppendSegment(ref span, SecureToken, null);
                 }
 
-                if (headerValue.SameSite != SameSiteMode.None)
+                if (sameSite != null)
                 {
-                    AppendSegment(ref span, SameSiteToken, headerValue.SameSite == SameSiteMode.Lax ? SameSiteLaxToken : SameSiteStrictToken);
+                    AppendSegment(ref span, SameSiteToken, sameSite);
                 }
 
                 if (headerValue.HttpOnly)
@@ -248,9 +274,18 @@ namespace Microsoft.Net.Http.Headers
                 AppendSegment(builder, SecureToken, null);
             }
 
-            if (SameSite != SameSiteMode.None)
+            // Allow for Unspecified (-1) to skip SameSite
+            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
             {
-                AppendSegment(builder, SameSiteToken, SameSite == SameSiteMode.Lax ? SameSiteLaxToken : SameSiteStrictToken);
+                AppendSegment(builder, SameSiteToken, SameSiteNoneToken);
+            }
+            else if (SameSite == SameSiteMode.Lax)
+            {
+                AppendSegment(builder, SameSiteToken, SameSiteLaxToken);
+            }
+            else if (SameSite == SameSiteMode.Strict)
+            {
+                AppendSegment(builder, SameSiteToken, SameSiteStrictToken);
             }
 
             if (HttpOnly)
@@ -302,7 +337,7 @@ namespace Microsoft.Net.Http.Headers
             return MultipleValueParser.TryParseStrictValues(inputs, out parsedValues);
         }
 
-        // name=value; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={Strict|Lax}; httponly
+        // name=value; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={Strict|Lax|None}; httponly
         private static int GetSetCookieLength(StringSegment input, int startIndex, out SetCookieHeaderValue parsedValue)
         {
             Contract.Requires(startIndex >= 0);
@@ -437,25 +472,34 @@ namespace Microsoft.Net.Http.Headers
                 {
                     result.Secure = true;
                 }
-                // samesite-av = "SameSite" / "SameSite=" samesite-value
-                // samesite-value = "Strict" / "Lax"
+                // samesite-av = "SameSite=" samesite-value
+                // samesite-value = "Strict" / "Lax" / "None"
                 else if (StringSegment.Equals(token, SameSiteToken, StringComparison.OrdinalIgnoreCase))
                 {
                     if (!ReadEqualsSign(input, ref offset))
                     {
-                        result.SameSite = SameSiteMode.Strict;
+                        result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                     }
                     else
                     {
                         var enforcementMode = ReadToSemicolonOrEnd(input, ref offset);
 
-                        if (StringSegment.Equals(enforcementMode, SameSiteLaxToken, StringComparison.OrdinalIgnoreCase))
+                        if (StringSegment.Equals(enforcementMode, SameSiteStrictToken, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result.SameSite = SameSiteMode.Strict;
+                        }
+                        else if (StringSegment.Equals(enforcementMode, SameSiteLaxToken, StringComparison.OrdinalIgnoreCase))
                         {
                             result.SameSite = SameSiteMode.Lax;
                         }
+                        else if (!UseSameSite2016Compat
+                            && StringSegment.Equals(enforcementMode, SameSiteNoneToken, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result.SameSite = SameSiteMode.None;
+                        }
                         else
                         {
-                            result.SameSite = SameSiteMode.Strict;
+                            result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                         }
                     }
                 }

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Net.Http.Headers
 
         static SetCookieHeaderValue()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
             {
                 SuppressSameSiteNone = enabled;
             }

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Net.Http.Headers
 
         // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
         // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
-        internal static bool UseSameSite2016Compat;
+        internal static bool SuppressSameSiteNone;
 
         private const string HttpOnlyToken = "httponly";
         private const string SeparatorToken = "; ";
@@ -44,9 +44,9 @@ namespace Microsoft.Net.Http.Headers
 
         static SetCookieHeaderValue()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.UseSameSite2016Compat", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
             {
-                UseSameSite2016Compat = enabled;
+                SuppressSameSiteNone = enabled;
             }
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Net.Http.Headers
 
         public bool Secure { get; set; }
 
-        public SameSiteMode SameSite { get; set; } = UseSameSite2016Compat ? SameSiteMode.None : (SameSiteMode)(-1); // Unspecified
+        public SameSiteMode SameSite { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : (SameSiteMode)(-1); // Unspecified
 
         public bool HttpOnly { get; set; }
 
@@ -145,7 +145,7 @@ namespace Microsoft.Net.Http.Headers
             }
 
             // Allow for Unspecified (-1) to skip SameSite
-            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
+            if (SameSite == SameSiteMode.None && !SuppressSameSiteNone)
             {
                 sameSite = SameSiteNoneToken;
                 length += SeparatorToken.Length + SameSiteToken.Length + EqualsToken.Length + sameSite.Length;
@@ -275,7 +275,7 @@ namespace Microsoft.Net.Http.Headers
             }
 
             // Allow for Unspecified (-1) to skip SameSite
-            if (SameSite == SameSiteMode.None && !UseSameSite2016Compat)
+            if (SameSite == SameSiteMode.None && !SuppressSameSiteNone)
             {
                 AppendSegment(builder, SameSiteToken, SameSiteNoneToken);
             }
@@ -478,7 +478,7 @@ namespace Microsoft.Net.Http.Headers
                 {
                     if (!ReadEqualsSign(input, ref offset))
                     {
-                        result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
+                        result.SameSite = SuppressSameSiteNone ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                     }
                     else
                     {
@@ -492,14 +492,14 @@ namespace Microsoft.Net.Http.Headers
                         {
                             result.SameSite = SameSiteMode.Lax;
                         }
-                        else if (!UseSameSite2016Compat
+                        else if (!SuppressSameSiteNone
                             && StringSegment.Equals(enforcementMode, SameSiteNoneToken, StringComparison.OrdinalIgnoreCase))
                         {
                             result.SameSite = SameSiteMode.None;
                         }
                         else
                         {
-                            result.SameSite = UseSameSite2016Compat ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
+                            result.SameSite = SuppressSameSiteNone ? SameSiteMode.Strict : (SameSiteMode)(-1); // Unspecified
                         }
                     }
                 }

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -166,9 +166,9 @@ namespace Microsoft.Net.Http.Headers
                 length += SeparatorToken.Length + HttpOnlyToken.Length;
             }
 
-            return string.Create(length, (this, maxAge), (span, tuple) =>
+            return string.Create(length, (this, maxAge, sameSite), (span, tuple) =>
             {
-                var (headerValue, maxAgeValue) = tuple;
+                var (headerValue, maxAgeValue, sameSite) = tuple;
 
                 Append(ref span, headerValue._name);
                 Append(ref span, EqualsToken);

--- a/src/Http/Headers/test/SetCookieHeaderValueTest.cs
+++ b/src/Http/Headers/test/SetCookieHeaderValueTest.cs
@@ -314,9 +314,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_ToString_SameSite2016Compat()
+        public void SetCookieHeaderValue_ToString_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
 
             var input = new SetCookieHeaderValue("name", "value")
             {
@@ -325,7 +325,7 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal("name=value", input.ToString());
 
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             var input2 = new SetCookieHeaderValue("name", "value")
             {
@@ -347,9 +347,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_AppendToStringBuilder_SameSite2016Compat()
+        public void SetCookieHeaderValue_AppendToStringBuilder_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
 
             var builder = new StringBuilder();
             var input = new SetCookieHeaderValue("name", "value")
@@ -360,7 +360,7 @@ namespace Microsoft.Net.Http.Headers
             input.AppendToStringBuilder(builder);
             Assert.Equal("name=value", builder.ToString());
 
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             var builder2 = new StringBuilder();
             var input2 = new SetCookieHeaderValue("name", "value")
@@ -383,9 +383,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSite2016Compat()
+        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
             var header = SetCookieHeaderValue.Parse("name=value; samesite=none");
 
             var cookie = new SetCookieHeaderValue("name", "value")
@@ -395,7 +395,7 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal(cookie, header);
             Assert.Equal("name=value; samesite=strict", header.ToString());
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             var header2 = SetCookieHeaderValue.Parse("name=value; samesite=none");
 
@@ -418,9 +418,9 @@ namespace Microsoft.Net.Http.Headers
         }
 
         [Fact]
-        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSite2016Compat()
+        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSiteNoneCompat()
         {
-            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            SetCookieHeaderValue.SuppressSameSiteNone = true;
             Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header));
             var cookie = new SetCookieHeaderValue("name", "value")
             {
@@ -430,7 +430,7 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(cookie, header);
             Assert.Equal("name=value; samesite=strict", header.ToString());
 
-            SetCookieHeaderValue.UseSameSite2016Compat = false;
+            SetCookieHeaderValue.SuppressSameSiteNone = false;
 
             Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header2));
             var cookie2 = new SetCookieHeaderValue("name", "value")

--- a/src/Http/Headers/test/SetCookieHeaderValueTest.cs
+++ b/src/Http/Headers/test/SetCookieHeaderValueTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Net.Http.Headers
                 {
                     SameSite = SameSiteMode.None,
                 };
-                dataset.Add(header7, "name7=value7");
+                dataset.Add(header7, "name7=value7; samesite=none");
 
 
                 return dataset;
@@ -155,9 +155,20 @@ namespace Microsoft.Net.Http.Headers
                 {
                     SameSite = SameSiteMode.Strict
                 };
-                var string6a = "name6=value6; samesite";
-                var string6b = "name6=value6; samesite=Strict";
-                var string6c = "name6=value6; samesite=invalid";
+                var string6 = "name6=value6; samesite=Strict";
+
+                var header7 = new SetCookieHeaderValue("name7", "value7")
+                {
+                    SameSite = SameSiteMode.None
+                };
+                var string7 = "name7=value7; samesite=None";
+
+                var header8 = new SetCookieHeaderValue("name8", "value8")
+                {
+                    SameSite = (SameSiteMode)(-1) // Unspecified
+                };
+                var string8a = "name8=value8; samesite";
+                var string8b = "name8=value8; samesite=invalid";
 
                 dataset.Add(new[] { header1 }.ToList(), new[] { string1 });
                 dataset.Add(new[] { header1, header1 }.ToList(), new[] { string1, string1 });
@@ -170,9 +181,10 @@ namespace Microsoft.Net.Http.Headers
                 dataset.Add(new[] { header1, header2, header3, header4 }.ToList(), new[] { string.Join(",", string1, string2, string3, string4) });
                 dataset.Add(new[] { header5 }.ToList(), new[] { string5a });
                 dataset.Add(new[] { header5 }.ToList(), new[] { string5b });
-                dataset.Add(new[] { header6 }.ToList(), new[] { string6a });
-                dataset.Add(new[] { header6 }.ToList(), new[] { string6b });
-                dataset.Add(new[] { header6 }.ToList(), new[] { string6c });
+                dataset.Add(new[] { header6 }.ToList(), new[] { string6 });
+                dataset.Add(new[] { header7 }.ToList(), new[] { string7 });
+                dataset.Add(new[] { header8 }.ToList(), new[] { string8a });
+                dataset.Add(new[] { header8 }.ToList(), new[] { string8b });
 
                 return dataset;
             }
@@ -301,6 +313,28 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedValue, input.ToString());
         }
 
+        [Fact]
+        public void SetCookieHeaderValue_ToString_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+
+            var input = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            Assert.Equal("name=value", input.ToString());
+
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            var input2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            Assert.Equal("name=value; samesite=none", input2.ToString());
+        }
+
         [Theory]
         [MemberData(nameof(SetCookieHeaderDataSet))]
         public void SetCookieHeaderValue_AppendToStringBuilder(SetCookieHeaderValue input, string expectedValue)
@@ -310,6 +344,32 @@ namespace Microsoft.Net.Http.Headers
             input.AppendToStringBuilder(builder);
 
             Assert.Equal(expectedValue, builder.ToString());
+        }
+
+        [Fact]
+        public void SetCookieHeaderValue_AppendToStringBuilder_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+
+            var builder = new StringBuilder();
+            var input = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            input.AppendToStringBuilder(builder);
+            Assert.Equal("name=value", builder.ToString());
+
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            var builder2 = new StringBuilder();
+            var input2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            input2.AppendToStringBuilder(builder2);
+            Assert.Equal("name=value; samesite=none", builder2.ToString());
         }
 
         [Theory]
@@ -322,6 +382,31 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedValue, header.ToString());
         }
 
+        [Fact]
+        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            var header = SetCookieHeaderValue.Parse("name=value; samesite=none");
+
+            var cookie = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.Strict,
+            };
+
+            Assert.Equal(cookie, header);
+            Assert.Equal("name=value; samesite=strict", header.ToString());
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            var header2 = SetCookieHeaderValue.Parse("name=value; samesite=none");
+
+            var cookie2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+            Assert.Equal(cookie2, header2);
+            Assert.Equal("name=value; samesite=none", header2.ToString());
+        }
+
         [Theory]
         [MemberData(nameof(SetCookieHeaderDataSet))]
         public void SetCookieHeaderValue_TryParse_AcceptsValidValues(SetCookieHeaderValue cookie, string expectedValue)
@@ -330,6 +415,31 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal(cookie, header);
             Assert.Equal(expectedValue, header.ToString());
+        }
+
+        [Fact]
+        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSite2016Compat()
+        {
+            SetCookieHeaderValue.UseSameSite2016Compat = true;
+            Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header));
+            var cookie = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.Strict,
+            };
+
+            Assert.Equal(cookie, header);
+            Assert.Equal("name=value; samesite=strict", header.ToString());
+
+            SetCookieHeaderValue.UseSameSite2016Compat = false;
+
+            Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header2));
+            var cookie2 = new SetCookieHeaderValue("name", "value")
+            {
+                SameSite = SameSiteMode.None,
+            };
+
+            Assert.Equal(cookie2, header2);
+            Assert.Equal("name=value; samesite=none", header2.ToString());
         }
 
         [Theory]

--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Http
 
         static CookieBuilder()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
             {
                 SuppressSameSiteNone = enabled;
             }

--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -11,7 +11,19 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public class CookieBuilder
     {
+        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
+        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+        internal static bool SuppressSameSiteNone;
+
         private string _name;
+
+        static CookieBuilder()
+        {
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            {
+                SuppressSameSiteNone = enabled;
+            }
+        }
 
         /// <summary>
         /// The name of the cookie.
@@ -49,12 +61,12 @@ namespace Microsoft.AspNetCore.Http
         public virtual bool HttpOnly { get; set; }
 
         /// <summary>
-        /// The SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.None"/>
+        /// The SameSite attribute of the cookie. The default value is -1 (Unspecified)
         /// </summary>
         /// <remarks>
         /// Determines the value that will set on <seealso cref="CookieOptions.SameSite"/>.
         /// </remarks>
-        public virtual SameSiteMode SameSite { get; set; } = SameSiteMode.None;
+        public virtual SameSiteMode SameSite { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : (SameSiteMode)(-1);
 
         /// <summary>
         /// The policy that will be used to determine <seealso cref="CookieOptions.Secure"/>.

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Http
 
         static CookieOptions()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
             {
                 SuppressSameSiteNone = enabled;
             }

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -10,6 +10,18 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public class CookieOptions
     {
+        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
+        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+        internal static bool SuppressSameSiteNone;
+
+        static CookieOptions()
+        {
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            {
+                SuppressSameSiteNone = enabled;
+            }
+        }
+
         /// <summary>
         /// Creates a default cookie with a path of '/'.
         /// </summary>
@@ -43,10 +55,10 @@ namespace Microsoft.AspNetCore.Http
         public bool Secure { get; set; }
 
         /// <summary>
-        /// Gets or sets the value for the SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.None"/>
+        /// Gets or sets the value for the SameSite attribute of the cookie. The default value is -1 (Unspecified)
         /// </summary>
         /// <returns>The <see cref="SameSiteMode"/> representing the enforcement mode of the cookie.</returns>
-        public SameSiteMode SameSite { get; set; } = SameSiteMode.None;
+        public SameSiteMode SameSite { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : (SameSiteMode)(-1);
 
         /// <summary>
         /// Gets or sets a value that indicates whether a cookie is accessible by client-side script.

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/OpenIdConnectSample.csproj
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/OpenIdConnectSample.csproj
@@ -14,7 +14,9 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <Reference Include="Microsoft.AspNetCore.CookiePolicy" />
     <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -32,9 +32,32 @@ namespace OpenIdConnectSample
         public IConfiguration Configuration { get; set; }
         public IWebHostEnvironment Environment { get; }
 
+        private void CheckSameSite(HttpContext httpContext, CookieOptions options)
+        {
+            if (options.SameSite > (SameSiteMode)(-1))
+            {
+                var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
+                // TODO: Use your User Agent library of choice here.
+                if (userAgent.Contains("CPU iPhone OS 12") // Also covers iPod touch
+                    || userAgent.Contains("iPad; CPU OS 12")
+                    // Safari 12 and 13 are both broken on Mojave
+                    || userAgent.Contains("Macintosh; Intel Mac OS X 10_14"))
+                {
+                    options.SameSite = (SameSiteMode)(-1);
+                }
+            }
+        }
+
         public void ConfigureServices(IServiceCollection services)
         {
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+            });
 
             services.AddAuthentication(sharedOptions =>
             {
@@ -84,6 +107,7 @@ namespace OpenIdConnectSample
         public void Configure(IApplicationBuilder app, IOptionsMonitor<OpenIdConnectOptions> optionsMonitor)
         {
             app.UseDeveloperExceptionPage();
+            app.UseCookiePolicy(); // Before UseAuthentication or anything else that writes cookies.
             app.UseAuthentication();
 
             app.Run(async context =>

--- a/src/Security/Authentication/WsFederation/samples/WsFedSample/WsFedSample.csproj
+++ b/src/Security/Authentication/WsFederation/samples/WsFedSample/WsFedSample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Security/Authentication/test/CookieTests.cs
+++ b/src/Security/Authentication/test/CookieTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             Assert.Contains(" path=/foo", setCookie1);
             Assert.Contains(" domain=another.com", setCookie1);
             Assert.Contains(" secure", setCookie1);
-            Assert.DoesNotContain(" samesite", setCookie1);
+            Assert.Contains(" samesite=none", setCookie1);
             Assert.Contains(" httponly", setCookie1);
 
             var server2 = CreateServer(o =>

--- a/src/Security/Authentication/test/Microsoft.AspNetCore.Authentication.Test.csproj
+++ b/src/Security/Authentication/test/Microsoft.AspNetCore.Authentication.Test.csproj
@@ -49,6 +49,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.WsFederation" />
     <Reference Include="Microsoft.AspNetCore.HttpOverrides" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectChallengeTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectChallengeTests.cs
@@ -437,6 +437,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             var server = settings.CreateTestServer();
             var transaction = await server.SendAsync(ChallengeEndpoint);
 
+            Assert.Contains("samesite=none", transaction.SetCookie.First());
             var challengeCookies = SetCookieHeaderValue.ParseList(transaction.SetCookie);
             var nonceCookie = challengeCookies.Where(cookie => cookie.Name.StartsWith(OpenIdConnectDefaults.CookieNoncePrefix, StringComparison.Ordinal)).Single();
             Assert.True(nonceCookie.Expires.HasValue);

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -12,10 +12,22 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class CookiePolicyOptions
     {
+        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
+        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+        internal static bool SuppressSameSiteNone;
+
+        static CookiePolicyOptions()
+        {
+            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            {
+                SuppressSameSiteNone = enabled;
+            }
+        }
+
         /// <summary>
         /// Affects the cookie's same site attribute.
         /// </summary>
-        public SameSiteMode MinimumSameSitePolicy { get; set; } = SameSiteMode.None;
+        public SameSiteMode MinimumSameSitePolicy { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : (SameSiteMode)(-1);
 
         /// <summary>
         /// Affects whether cookies must be HttpOnly.

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Builder
 
         static CookiePolicyOptions()
         {
-            if (AppContext.TryGetSwitch("Microsoft.Net.Http.Headers.SetCookieHeaderValue.SuppressSameSiteNone", out var enabled))
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
             {
                 SuppressSameSiteNone = enabled;
             }

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -115,7 +115,8 @@ namespace Microsoft.AspNetCore.CookiePolicy
         private bool CheckPolicyRequired()
         {
             return !CanTrack
-                || Options.MinimumSameSitePolicy != SameSiteMode.None
+                || (CookiePolicyOptions.SuppressSameSiteNone && Options.MinimumSameSitePolicy != SameSiteMode.None)
+                || (!CookiePolicyOptions.SuppressSameSiteNone && Options.MinimumSameSitePolicy != (SameSiteMode)(-1)) // Unspecified
                 || Options.HttpOnly != HttpOnlyPolicy.None
                 || Options.Secure != CookieSecurePolicy.None;
         }
@@ -241,27 +242,13 @@ namespace Microsoft.AspNetCore.CookiePolicy
                 default:
                     throw new InvalidOperationException();
             }
-            switch (Options.MinimumSameSitePolicy)
+
+            if (options.SameSite < Options.MinimumSameSitePolicy)
             {
-                case SameSiteMode.None:
-                    break;
-                case SameSiteMode.Lax:
-                    if (options.SameSite == SameSiteMode.None)
-                    {
-                        options.SameSite = SameSiteMode.Lax;
-                        _logger.CookieSameSiteUpgraded(key, "lax");
-                    }
-                    break;
-                case SameSiteMode.Strict:
-                    if (options.SameSite != SameSiteMode.Strict)
-                    {
-                        options.SameSite = SameSiteMode.Strict;
-                        _logger.CookieSameSiteUpgraded(key, "strict");
-                    }
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unrecognized {nameof(SameSiteMode)} value {Options.MinimumSameSitePolicy.ToString()}");
+                options.SameSite = Options.MinimumSameSitePolicy;
+                _logger.CookieSameSiteUpgraded(key, Options.MinimumSameSitePolicy.ToString());
             }
+
             switch (Options.HttpOnly)
             {
                 case HttpOnlyPolicy.Always:

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -223,12 +223,12 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             Assert.Equal("yes", consentCookie.Value);
             Assert.True(consentCookie.Expires.HasValue);
             Assert.True(consentCookie.Expires.Value > DateTimeOffset.Now + TimeSpan.FromDays(364));
-            Assert.Equal(Net.Http.Headers.SameSiteMode.None, consentCookie.SameSite);
+            Assert.Equal((Net.Http.Headers.SameSiteMode)(-1), consentCookie.SameSite);
             Assert.NotNull(consentCookie.Expires);
             var testCookie = cookies[1];
             Assert.Equal("Test", testCookie.Name);
             Assert.Equal("Value", testCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.None, testCookie.SameSite);
+            Assert.Equal((Net.Http.Headers.SameSiteMode)(-1), testCookie.SameSite);
             Assert.Null(testCookie.Expires);
         }
 
@@ -400,12 +400,12 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var testCookie = cookies[0];
             Assert.Equal("Test", testCookie.Name);
             Assert.Equal("Value1", testCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.None, testCookie.SameSite);
+            Assert.Equal((Net.Http.Headers.SameSiteMode)(-1), testCookie.SameSite);
             Assert.Null(testCookie.Expires);
             var consentCookie = cookies[1];
             Assert.Equal(".AspNet.Consent", consentCookie.Name);
             Assert.Equal("", consentCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.None, consentCookie.SameSite);
+            Assert.Equal((Net.Http.Headers.SameSiteMode)(-1), consentCookie.SameSite);
             Assert.NotNull(consentCookie.Expires);
         }
 
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var testCookie = cookies[0];
             Assert.Equal("Test", testCookie.Name);
             Assert.Equal("", testCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.None, testCookie.SameSite);
+            Assert.Equal((Net.Http.Headers.SameSiteMode)(-1), testCookie.SameSite);
             Assert.NotNull(testCookie.Expires);
         }
 
@@ -576,7 +576,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var consentCookie = cookies[0];
             Assert.Equal(".AspNet.Consent", consentCookie.Name);
             Assert.Equal("yes", consentCookie.Value);
-            Assert.Equal(Net.Http.Headers.SameSiteMode.None, consentCookie.SameSite);
+            Assert.Equal((Net.Http.Headers.SameSiteMode)(-1), consentCookie.SameSite);
             Assert.NotNull(consentCookie.Expires);
 
             cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers["ManualCookie"]);

--- a/src/Security/CookiePolicy/test/CookiePolicyTests.cs
+++ b/src/Security/CookiePolicy/test/CookiePolicyTests.cs
@@ -39,8 +39,8 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
         private RequestDelegate SameSiteCookieAppends = context =>
         {
             context.Response.Cookies.Append("A", "A");
-            context.Response.Cookies.Append("B", "B", new CookieOptions { SameSite = Http.SameSiteMode.None });
-            context.Response.Cookies.Append("C", "C", new CookieOptions());
+            context.Response.Cookies.Append("B", "B", new CookieOptions());
+            context.Response.Cookies.Append("C", "C", new CookieOptions { SameSite = Http.SameSiteMode.None });
             context.Response.Cookies.Append("D", "D", new CookieOptions { SameSite = Http.SameSiteMode.Lax });
             context.Response.Cookies.Append("E", "E", new CookieOptions { SameSite = Http.SameSiteMode.Strict });
             return Task.FromResult(0);
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
         }
 
         [Fact]
-        public async Task SameSiteNoneLeavesItAlone()
+        public async Task SameSiteNoneSetsItAlways()
         {
             await RunTest("/sameSiteNone",
                 new CookiePolicyOptions
@@ -210,9 +210,30 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                 transaction =>
                 {
                     Assert.NotNull(transaction.SetCookie);
+                    Assert.Equal("A=A; path=/; samesite=none", transaction.SetCookie[0]);
+                    Assert.Equal("B=B; path=/; samesite=none", transaction.SetCookie[1]);
+                    Assert.Equal("C=C; path=/; samesite=none", transaction.SetCookie[2]);
+                    Assert.Equal("D=D; path=/; samesite=lax", transaction.SetCookie[3]);
+                    Assert.Equal("E=E; path=/; samesite=strict", transaction.SetCookie[4]);
+                }));
+        }
+
+        [Fact]
+        public async Task SameSiteUnspecifiedLeavesItAlone()
+        {
+            await RunTest("/sameSiteNone",
+                new CookiePolicyOptions
+                {
+                    MinimumSameSitePolicy = (Http.SameSiteMode)(-1)
+                },
+                SameSiteCookieAppends,
+                new RequestTest("http://example.com/sameSiteNone",
+                transaction =>
+                {
+                    Assert.NotNull(transaction.SetCookie);
                     Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
                     Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
-                    Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+                    Assert.Equal("C=C; path=/; samesite=none", transaction.SetCookie[2]);
                     Assert.Equal("D=D; path=/; samesite=lax", transaction.SetCookie[3]);
                     Assert.Equal("E=E; path=/; samesite=strict", transaction.SetCookie[4]);
                 }));

--- a/src/Security/CookiePolicy/test/Microsoft.AspNetCore.CookiePolicy.Test.csproj
+++ b/src/Security/CookiePolicy/test/Microsoft.AspNetCore.CookiePolicy.Test.csproj
@@ -13,6 +13,7 @@
     <Reference Include="Microsoft.AspNetCore.CookiePolicy" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cherry pick of #13858 but expanded to account for the 3.0 defaults change from Lax to None. This preserves the old behavior of None for most components using a default value by witching them to -1 (Unspecified). E.g. `new CookieOptions()` excludes samesite like before unless you explicitly set it.