### PR TITLE
Add support for negotiateVersion query string parameter

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -58,7 +58,7 @@ public class HubConnection {
     private TransportEnum transportEnum = TransportEnum.ALL;
     private String connectionId;
     private String connectionToken;
-    private int negotiateVersion = 1;
+    private final int negotiateVersion = 1;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
 
     /**
@@ -342,12 +342,7 @@ public class HubConnection {
         });
 
         stopError = null;
-        String urlWithQS;
-        if (baseUrl.contains("?")) {
-            urlWithQS = baseUrl + "&negotiateVersion=" + negotiateVersion;
-        } else {
-            urlWithQS = baseUrl + "?negotiateVersion=" + negotiateVersion;
-        }
+        String urlWithQS = Utils.appendQueryString(baseUrl, "negotiateVersion=" + negotiateVersion);
         Single<NegotiateResponse> negotiate = null;
         if (!skipNegotiate) {
             negotiate = tokenCompletable.andThen(Single.defer(() -> startNegotiate(urlWithQS, 0)));
@@ -462,21 +457,13 @@ public class HubConnection {
                 }
 
                 String finalUrl = url;
-                if (url.contains("?")) {
-                    finalUrl = url + "&id=" + this.connectionToken;
-                } else {
-                    finalUrl = url + "?id=" + this.connectionToken;
-                }
+                finalUrl = Utils.appendQueryString(url, "id=" + this.connectionToken);
 
                 response.setFinalUrl(finalUrl);
                 return Single.just(response);
             }
             String redirectUrl = "";
-            if (response.getRedirectUrl().contains("?")) {
-                redirectUrl = response.getRedirectUrl() + "&negotiateVersion=" + negotiateVersion;
-            } else {
-                redirectUrl = response.getRedirectUrl() + "?negotiateVersion=" + negotiateVersion;
-            }
+            redirectUrl = Utils.appendQueryString(response.getRedirectUrl(), "negotiateVersion=" + negotiateVersion);
             return startNegotiate(redirectUrl, negotiateAttempts + 1);
         });
     }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -57,6 +57,7 @@ public class HubConnection {
     private Map<String, Observable> streamMap = new ConcurrentHashMap<>();
     private TransportEnum transportEnum = TransportEnum.ALL;
     private String connectionId;
+    private String connectionToken; // Use this!
     private int negotiateVersion = 1;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
 
@@ -385,6 +386,7 @@ public class HubConnection {
                         try {
                             hubConnectionState = HubConnectionState.CONNECTED;
                             this.connectionId = negotiateResponse.getConnectionId();
+                            this.connectionToken = negotiateResponse.getConnectionToken();
                             logger.info("HubConnection started.");
                             resetServerTimeout();
                             //Don't send pings if we're using long polling.
@@ -455,23 +457,23 @@ public class HubConnection {
                 }
 
                 String finalUrl = url;
-                if (response.getConnectionId() != null) {
+                if (response.getConnectionToken() != null) {
                     if (url.contains("?")) {
-                        finalUrl = url + "&id=" + response.getConnectionId();
+                        finalUrl = url + "&id=" + response.getConnectionToken();
                     } else {
-                        finalUrl = url + "?id=" + response.getConnectionId();
+                        finalUrl = url + "?id=" + response.getConnectionToken();
                     }
                 }
                 response.setFinalUrl(finalUrl);
                 return Single.just(response);
             }
-            String redirecturl = "";
+            String redirectUrl = "";
             if (response.getRedirectUrl().contains("?")) {
-                redirecturl = response.getRedirectUrl() + "&negotiateVersion=" + negotiateVersion;
+                redirectUrl = response.getRedirectUrl() + "&negotiateVersion=" + negotiateVersion;
             } else {
-                redirecturl = response.getRedirectUrl() + "?negotiateVersion=" + negotiateVersion;
+                redirectUrl = response.getRedirectUrl() + "?negotiateVersion=" + negotiateVersion;
             }
-            return startNegotiate(redirecturl, negotiateAttempts + 1);
+            return startNegotiate(redirectUrl, negotiateAttempts + 1);
         });
     }
 
@@ -533,6 +535,7 @@ public class HubConnection {
             handshakeResponseSubject.onComplete();
             redirectAccessTokenProvider = null;
             connectionId = null;
+            connectionToken = null;
             transportEnum = TransportEnum.ALL;
             this.localHeaders.clear();
             this.streamMap.clear();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -57,7 +57,7 @@ public class HubConnection {
     private Map<String, Observable> streamMap = new ConcurrentHashMap<>();
     private TransportEnum transportEnum = TransportEnum.ALL;
     private String connectionId;
-    private String connectionToken; // Use this!
+    private String connectionToken;
     private int negotiateVersion = 1;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
 
@@ -385,7 +385,6 @@ public class HubConnection {
                         hubConnectionStateLock.lock();
                         try {
                             hubConnectionState = HubConnectionState.CONNECTED;
-
                             logger.info("HubConnection started.");
                             resetServerTimeout();
                             //Don't send pings if we're using long polling.

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -456,14 +456,13 @@ public class HubConnection {
                     this.connectionToken = this.connectionId = response.getConnectionId();
                 }
 
-                String finalUrl = url;
-                finalUrl = Utils.appendQueryString(url, "id=" + this.connectionToken);
+                String finalUrl = Utils.appendQueryString(url, "id=" + this.connectionToken);
 
                 response.setFinalUrl(finalUrl);
                 return Single.just(response);
             }
-            String redirectUrl = "";
-            redirectUrl = Utils.appendQueryString(response.getRedirectUrl(), "negotiateVersion=" + negotiateVersion);
+
+            String redirectUrl = redirectUrl = Utils.appendQueryString(response.getRedirectUrl(), "negotiateVersion=" + negotiateVersion);
             return startNegotiate(redirectUrl, negotiateAttempts + 1);
         });
     }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -462,7 +462,7 @@ public class HubConnection {
                 return Single.just(response);
             }
 
-            String redirectUrl = redirectUrl = Utils.appendQueryString(response.getRedirectUrl(), "negotiateVersion=" + negotiateVersion);
+            String redirectUrl = Utils.appendQueryString(response.getRedirectUrl(), "negotiateVersion=" + negotiateVersion);
             return startNegotiate(redirectUrl, negotiateAttempts + 1);
         });
     }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -385,8 +385,7 @@ public class HubConnection {
                         hubConnectionStateLock.lock();
                         try {
                             hubConnectionState = HubConnectionState.CONNECTED;
-                            this.connectionId = negotiateResponse.getConnectionId();
-                            this.connectionToken = negotiateResponse.getConnectionToken();
+
                             logger.info("HubConnection started.");
                             resetServerTimeout();
                             //Don't send pings if we're using long polling.
@@ -456,14 +455,20 @@ public class HubConnection {
                     throw new RuntimeException("There were no compatible transports on the server.");
                 }
 
-                String finalUrl = url;
-                if (response.getConnectionToken() != null) {
-                    if (url.contains("?")) {
-                        finalUrl = url + "&id=" + response.getConnectionToken();
-                    } else {
-                        finalUrl = url + "?id=" + response.getConnectionToken();
-                    }
+                if (response.getVersion() > 0) {
+                    this.connectionId = response.getConnectionId();
+                    this.connectionToken = response.getConnectionToken();
+                } else {
+                    this.connectionToken = this.connectionId = response.getConnectionId();
                 }
+
+                String finalUrl = url;
+                if (url.contains("?")) {
+                    finalUrl = url + "&id=" + this.connectionToken;
+                } else {
+                    finalUrl = url + "?id=" + this.connectionToken;
+                }
+
                 response.setFinalUrl(finalUrl);
                 return Single.just(response);
             }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Negotiate.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Negotiate.java
@@ -10,7 +10,7 @@ class Negotiate {
         // Check if we have a query string. If we do then we ignore it for now.
         int queryStringIndex = url.indexOf('?');
         if (queryStringIndex > 0) {
-            negotiateUrl = url.substring(0, url.indexOf('?'));
+            negotiateUrl = url.substring(0, queryStringIndex);
         } else {
             negotiateUrl = url;
         }
@@ -24,7 +24,7 @@ class Negotiate {
 
         // Add the query string back if it existed.
         if (queryStringIndex > 0) {
-            negotiateUrl += url.substring(url.indexOf('?'));
+            negotiateUrl += url.substring(queryStringIndex);
         }
 
         return negotiateUrl;

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
@@ -11,6 +11,7 @@ import com.google.gson.stream.JsonReader;
 
 class NegotiateResponse {
     private String connectionId;
+    private String connectionToken;
     private Set<String> availableTransports = new HashSet<>();
     private String redirectUrl;
     private String accessToken;
@@ -33,6 +34,9 @@ class NegotiateResponse {
                         return;
                     case "negotiateVersion":
                         this.version = reader.nextInt();
+                        break;
+                    case "connectionToken":
+                        this.connectionToken = reader.nextString();
                         break;
                     case "url":
                         this.redirectUrl = reader.nextString();
@@ -112,6 +116,10 @@ class NegotiateResponse {
 
     public int getVersion() {
         return version;
+    }
+
+    public String getConnectionToken() {
+        return connectionToken;
     }
 
     public void setFinalUrl(String url) {

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
@@ -16,6 +16,7 @@ class NegotiateResponse {
     private String accessToken;
     private String error;
     private String finalUrl;
+    private int version;
 
     public NegotiateResponse(JsonReader reader) {
         try {
@@ -30,6 +31,9 @@ class NegotiateResponse {
                     case "ProtocolVersion":
                         this.error = "Detected an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.";
                         return;
+                    case "negotiateVersion":
+                        this.version = reader.nextInt();
+                        break;
                     case "url":
                         this.redirectUrl = reader.nextString();
                         break;
@@ -104,6 +108,10 @@ class NegotiateResponse {
 
     public String getFinalUrl() {
         return finalUrl;
+    }
+
+    public int getVersion() {
+        return version;
     }
 
     public void setFinalUrl(String url) {

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Utils.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Utils.java
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+class Utils {
+    public static String appendQueryString(String original, String queryStringValue) {
+        if (original.contains("?")) {
+            return original + "&" + queryStringValue;
+        } else {
+            return  original + "?" + queryStringValue;
+        }
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
@@ -1,4 +1,3 @@
-
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1700,7 +1700,7 @@ class HubConnectionTest {
     }
 
     @Test
-    public void    negotiateSentOnStart() {
+    public void negotiateSentOnStart() {
         TestHttpClient client = new TestHttpClient()
         .on("POST", (req) -> Single.just(new HttpResponse(404, "", "")));
 
@@ -1782,7 +1782,7 @@ class HubConnectionTest {
                                 "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
                                 "\"negotiateVersion\": 1," +
                                 "\"connectionToken\":\"connection-token-value\"," +
-                                 "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+                                "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
         MockTransport transport = new MockTransport(true);
         HubConnection hubConnection = HubConnectionBuilder
@@ -1803,7 +1803,7 @@ class HubConnectionTest {
     }
 
         @Test
-        public void connectionTokenIsIgnoredIsNegotiateVersionIsNotPresentInNegotiateResponse() {
+        public void connectionTokenIsIgnoredIfNegotiateVersionIsNotPresentInNegotiateResponse() {
             TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                     (req) -> Single.just(new HttpResponse(200, "",
                             "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1807,7 +1807,8 @@ class HubConnectionTest {
             TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                     (req) -> Single.just(new HttpResponse(200, "",
                             "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
-                                    "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+                            "\"connectionToken\":\"connection-token-value\"," +
+                            "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
             MockTransport transport = new MockTransport(true);
             HubConnection hubConnection = HubConnectionBuilder

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1700,7 +1700,7 @@ class HubConnectionTest {
     }
 
     @Test
-    public void negotiateSentOnStart() {
+    public void    negotiateSentOnStart() {
         TestHttpClient client = new TestHttpClient()
         .on("POST", (req) -> Single.just(new HttpResponse(404, "", "")));
 
@@ -1714,12 +1714,12 @@ class HubConnectionTest {
 
         List<HttpRequest> sentRequests = client.getSentRequests();
         assertEquals(1, sentRequests.size());
-        assertEquals("http://example.com/negotiate", sentRequests.get(0).getUrl());
+        assertEquals("http://example.com/negotiate?negotiateVersion=1", sentRequests.get(0).getUrl());
     }
 
     @Test
     public void negotiateThatRedirectsForeverFailsAfter100Tries() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://example.com\"}")));
 
         HubConnection hubConnection = HubConnectionBuilder
@@ -1752,7 +1752,7 @@ class HubConnectionTest {
 
     @Test
     public void connectionIdIsAvailableAfterStart() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
@@ -1777,7 +1777,7 @@ class HubConnectionTest {
 
     @Test
     public void afterSuccessfulNegotiateConnectsWithWebsocketsTransport() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
@@ -1798,7 +1798,7 @@ class HubConnectionTest {
 
     @Test
     public void afterSuccessfulNegotiateConnectsWithLongPollingTransport() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
@@ -1891,7 +1891,7 @@ class HubConnectionTest {
 
     @Test
     public void receivingServerSentEventsTransportFromNegotiateFails() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]}]}")));
@@ -1911,7 +1911,7 @@ class HubConnectionTest {
 
     @Test
     public void negotiateThatReturnsErrorThrowsFromStart() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"error\":\"Test error.\"}")));
 
         MockTransport transport = new MockTransport(true);
@@ -1928,7 +1928,7 @@ class HubConnectionTest {
 
     @Test
     public void DetectWhenTryingToConnectToClassicSignalRServer() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"Url\":\"/signalr\"," +
                         "\"ConnectionToken\":\"X97dw3uxW4NPPggQsYVcNcyQcuz4w2\"," +
                         "\"ConnectionId\":\"05265228-1e2c-46c5-82a1-6a5bcc3f0143\"," +
@@ -1954,9 +1954,9 @@ class HubConnectionTest {
 
     @Test
     public void negotiateRedirectIsFollowed()  {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
-                .on("POST", "http://testexample.com/negotiate",
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
@@ -1978,11 +1978,11 @@ class HubConnectionTest {
         AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> {
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> {
                     beforeRedirectToken.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
                 })
-                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                     token.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                             + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
@@ -2018,7 +2018,7 @@ class HubConnectionTest {
     public void accessTokenProviderIsUsedForNegotiate() {
         AtomicReference<String> token = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             token.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2043,8 +2043,8 @@ class HubConnectionTest {
     public void accessTokenProviderIsOverriddenFromRedirectNegotiate() {
         AtomicReference<String> token = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-            .on("POST", "http://example.com/negotiate", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}")))
-            .on("POST", "http://testexample.com/negotiate", (req) -> {
+            .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}")))
+            .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                 token.set(req.getHeaders().get("Authorization"));
                 return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
@@ -2060,7 +2060,7 @@ class HubConnectionTest {
 
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        assertEquals("http://testexample.com/?id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
+        assertEquals("http://testexample.com/?negotiateVersion=1&id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
         hubConnection.stop();
         assertEquals("Bearer newToken", token.get());
     }
@@ -2071,11 +2071,11 @@ class HubConnectionTest {
         AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> {
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> {
                     beforeRedirectToken.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
                 })
-                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                     token.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                             + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
@@ -2112,7 +2112,7 @@ class HubConnectionTest {
         AtomicInteger redirectCount = new AtomicInteger();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> {
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> {
                     if (redirectCount.get() == 0) {
                         redirectCount.incrementAndGet();
                         redirectToken.set(req.getHeaders().get("Authorization"));
@@ -2122,7 +2122,7 @@ class HubConnectionTest {
                         return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"secondRedirectToken\"}"));
                     }
                 })
-                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                     token.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                             + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
@@ -2189,7 +2189,7 @@ class HubConnectionTest {
     public void userAgentHeaderIsSet() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("User-Agent"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2213,7 +2213,7 @@ class HubConnectionTest {
     public void userAgentHeaderCanBeOverwritten() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("User-Agent"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2237,7 +2237,7 @@ class HubConnectionTest {
     public void userAgentCanBeCleared() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("User-Agent"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2260,7 +2260,7 @@ class HubConnectionTest {
     public void headersAreSetAndSentThroughBuilder() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("ExampleHeader"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2285,7 +2285,7 @@ class HubConnectionTest {
     public void headersAreNotClearedWhenConnectionIsRestarted() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2315,12 +2315,12 @@ class HubConnectionTest {
         AtomicReference<String> afterRedirectHeader = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             beforeRedirectHeader.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"redirectToken\"}\"}"));
                         })
-                .on("POST", "http://testexample.com/negotiate",
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             afterRedirectHeader.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2358,7 +2358,7 @@ class HubConnectionTest {
     public void sameHeaderSetTwiceGetsOverwritten() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("ExampleHeader"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2403,8 +2403,8 @@ class HubConnectionTest {
     public void hubConnectionCanBeStartedAfterBeingStoppedAndRedirected()  {
         MockTransport mockTransport = new MockTransport();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
-                .on("POST", "http://testexample.com/negotiate", (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                         + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
         HubConnection hubConnection = HubConnectionBuilder
@@ -2426,7 +2426,7 @@ class HubConnectionTest {
     @Test
     public void non200FromNegotiateThrowsError() {
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> Single.just(new HttpResponse(500, "Internal server error", "")));
 
         MockTransport transport = new MockTransport();

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
@@ -56,4 +56,13 @@ class NegotiateResponseTest {
         NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
     }
+
+    @Test
+    public void NegotiateResponseWithNegotiateVersion() {
+        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                "\"negotiateVersion\": 99}";
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals(99, negotiateResponse.getVersion());
+    }
 }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
@@ -15,8 +15,9 @@ import com.google.gson.stream.JsonReader;
 class NegotiateResponseTest {
     @Test
     public void VerifyNegotiateResponse() {
-        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\"" +
-                "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}," +
+        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                "\"negotiateVersion\": 99, \"connectionToken\":\"connection-token-value\"," +
+                "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}," +
                 "{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]}," +
                 "{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}";
         NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
@@ -26,6 +27,8 @@ class NegotiateResponseTest {
         assertNull(negotiateResponse.getAccessToken());
         assertNull(negotiateResponse.getRedirectUrl());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals("connection-token-value", negotiateResponse.getConnectionToken());
+        assertEquals(99, negotiateResponse.getVersion());
     }
 
     @Test
@@ -63,6 +66,16 @@ class NegotiateResponseTest {
                 "\"negotiateVersion\": 99}";
         NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals(99, negotiateResponse.getVersion());
+    }
+
+    @Test
+    public void NegotiateResponseWithConnectionToken() {
+        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                "\"negotiateVersion\": 99, \"connectionToken\":\"connection-token-value\"}";
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals("connection-token-value", negotiateResponse.getConnectionToken());
         assertEquals(99, negotiateResponse.getVersion());
     }
 }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/UserAgentTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/UserAgentTest.java
@@ -30,17 +30,17 @@ public class UserAgentTest {
     }
 
     @Test
-    public void verifyJavaVendor(){
+    public void verifyJavaVendor() {
         assertEquals(System.getProperty("java.vendor"), UserAgentHelper.getJavaVendor());
     }
 
     @Test
-    public void verifyJavaVersion(){
+    public void verifyJavaVersion() {
         assertEquals(System.getProperty("java.version"), UserAgentHelper.getJavaVersion());
     }
 
     @Test
-    public void checkUserAgentString(){
+    public void checkUserAgentString() {
         String userAgent = UserAgentHelper.createUserAgentString();
         assertNotNull(userAgent);
 


### PR DESCRIPTION
Follow up on the `negotiateVersion` changes from https://github.com/aspnet/AspNetCore/pull/13389 for the Java client.
I'll probably just leave this as a draft until the connectionToken change https://github.com/aspnet/AspNetCore/pull/13773 goes and make the necessary changes in this branch as well.