### PR TITLE
Remove ConfigureAwait(false) when there is no await

### DIFF
--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Hosting
 
         public void Dispose()
         {
-            DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            DisposeAsync().GetAwaiter().GetResult();
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Http/Http/src/Features/RequestServicesFeature.cs
+++ b/src/Http/Http/src/Features/RequestServicesFeature.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Http.Features
 
         public void Dispose()
         {
-            DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            DisposeAsync().GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
There's no need to have `ConfigureAwait(false)` since there's no await.