### PR TITLE
HTTP2: Send remaining data and trailers together

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        public ValueTask<FlushResult> WriteDataAsync(int streamId, StreamOutputFlowControl flowControl, in ReadOnlySequence<byte> data, bool endStream)
+        public ValueTask<FlushResult> WriteDataAsync(int streamId, StreamOutputFlowControl flowControl, in ReadOnlySequence<byte> data, bool endStream, bool forceFlush)
         {
             // The Length property of a ReadOnlySequence can be expensive, so we cache the value.
             var dataLength = data.Length;
@@ -261,24 +261,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 // This cast is safe since if dataLength would overflow an int, it's guaranteed to be greater than the available flow control window.
                 flowControl.Advance((int)dataLength);
                 WriteDataUnsynchronized(streamId, data, dataLength, endStream);
-                return TimeFlushUnsynchronizedAsync();
-            }
-        }
 
-        public void WriteDataWithoutFlush(int streamId, StreamOutputFlowControl flowControl, in ReadOnlySequence<byte> data, bool endStream)
-        {
-            // The Length property of a ReadOnlySequence can be expensive, so we cache the value.
-            var dataLength = data.Length;
-
-            lock (_writeLock)
-            {
-                if (_completed || flowControl.IsAborted)
+                if (forceFlush)
                 {
-                    return;
+                    return TimeFlushUnsynchronizedAsync();
                 }
 
-                flowControl.Advance((int)dataLength);
-                WriteDataUnsynchronized(streamId, data, dataLength, endStream);
+                return default;
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        public void WriteData(int streamId, StreamOutputFlowControl flowControl, in ReadOnlySequence<byte> data, bool endStream)
+        public void WriteDataWithoutFlush(int streamId, StreamOutputFlowControl flowControl, in ReadOnlySequence<byte> data, bool endStream)
         {
             // The Length property of a ReadOnlySequence can be expensive, so we cache the value.
             var dataLength = data.Length;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -383,8 +383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                             }
                             else
                             {
-                                // Write data without flushing
-                                // This allows remaining content and trailers to be sent in the same packet
+                                // Writing remaining content without flushing allows content and trailers to be sent in the same packet
                                 _frameWriter.WriteDataWithoutFlush(_streamId, _flowControl, readResult.Buffer, endStream: false);
                             }
                         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -371,11 +371,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                     if (readResult.IsCompleted && _stream.ResponseTrailers?.Count > 0)
                     {
-                        var dataLength = readResult.Buffer.Length;
-
                         // Output is ending and there are trailers to write
                         // Write any remaining content then write trailers
-                        if (dataLength > 0)
+                        if (readResult.Buffer.Length > 0)
                         {
                             // Only flush if required (i.e. content length exceeds flow control availability)
                             // Writing remaining content without flushing allows content and trailers to be sent in the same packet

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -377,15 +377,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         // Write any remaining content then write trailers
                         if (dataLength > 0)
                         {
-                            if (dataLength > _flowControl.Available)
-                            {
-                                flushResult = await _frameWriter.WriteDataAsync(_streamId, _flowControl, readResult.Buffer, endStream: false);
-                            }
-                            else
-                            {
-                                // Writing remaining content without flushing allows content and trailers to be sent in the same packet
-                                _frameWriter.WriteDataWithoutFlush(_streamId, _flowControl, readResult.Buffer, endStream: false);
-                            }
+                            // Only flush if required (i.e. content length exceeds flow control availability)
+                            // Writing remaining content without flushing allows content and trailers to be sent in the same packet
+                            await _frameWriter.WriteDataAsync(_streamId, _flowControl, readResult.Buffer, endStream: false, forceFlush: false);
                         }
 
                         _stream.ResponseTrailers.SetReadOnly();
@@ -409,7 +403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         {
                             _stream.DecrementActiveClientStreamCount();
                         }
-                        flushResult = await _frameWriter.WriteDataAsync(_streamId, _flowControl, readResult.Buffer, endStream);
+                        flushResult = await _frameWriter.WriteDataAsync(_streamId, _flowControl, readResult.Buffer, endStream, forceFlush: true);
                     }
 
                     _pipeReader.AdvanceTo(readResult.Buffer.End);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -375,7 +375,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         // Write any remaining content then write trailers
                         if (readResult.Buffer.Length > 0)
                         {
-                            flushResult = await _frameWriter.WriteDataAsync(_streamId, _flowControl, readResult.Buffer, endStream: false);
+                            // Write data without flushing
+                            // This allows trailers and data to be sent together
+                            _frameWriter.WriteData(_streamId, _flowControl, readResult.Buffer, endStream: false);
                         }
 
                         _stream.ResponseTrailers.SetReadOnly();

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -385,7 +385,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                             {
                                 // Write data without flushing
                                 // This allows remaining content and trailers to be sent in the same packet
-                                _frameWriter.WriteData(_streamId, _flowControl, readResult.Buffer, endStream: false);
+                                _frameWriter.WriteDataWithoutFlush(_streamId, _flowControl, readResult.Buffer, endStream: false);
                             }
                         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -2047,7 +2047,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         //
 
         [Fact]
-        public async Task ResponseTrailers_WithLargeUnflushedData_DataSentWithTrailers()
+        public async Task ResponseTrailers_WithLargeUnflushedData_DataExceedsFlowControlAvailableAndNotSentWithTrailers()
         {
             const int FlowControlAvailable = 65535;
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -2045,6 +2045,58 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task ResponseTrailers_WithUnflushedData_DataSentWithTrailers()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                await context.Response.StartAsync();
+
+                var s = context.Response.BodyWriter.GetMemory(1);
+                s.Span[0] = byte.MaxValue;
+                context.Response.BodyWriter.Advance(1);
+
+                context.Response.AppendTrailer("CustomName", "Custom Value");
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+                withStreamId: 1);
+
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 1,
+                withFlags: (byte)Http2DataFrameFlags.NONE,
+                withStreamId: 1);
+
+            var trailersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 25,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+            _decodedHeaders.Clear();
+            _hpackDecoder.Decode(trailersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Single(_decodedHeaders);
+            Assert.Equal("Custom Value", _decodedHeaders["CustomName"]);
+        }
+
+        [Fact]
         public async Task ApplicationException_BeforeFirstWrite_Sends500()
         {
             var headers = new[]


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/11270

The test checks that the data is correct, but it doesn't verify that data and trailers were flushed together. What is the best way to check this using the current HTTP/2 test pattern?