### PR TITLE
[mono][wasm] MacOSX Catalina Beta wasm workaround for booting mono wasm from Blazor.

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -26,7 +26,7 @@ export const monoPlatform: Platform = {
         init: () => { },
       };
       // Emscripten works by expecting the module config to be a global
-      // MacOSX Catalina initializes Module differently so needa workaround for now.
+      // MacOSX Catalina initializes Module differently so needs a workaround for now.
       addGlobalModuleScriptTagsToDocument(() => {
         window['Module'] = createEmscriptenModuleInstance(loadAssemblyUrls, resolve, reject);
         addScriptTagsToDocument();

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -218,6 +218,8 @@ function addGlobalModuleScriptTagsToDocument(callback: () => void) {
   const scriptElem = document.createElement('script');
 
   // This pollutes global but is needed so it can be called from the script.
+  // The callback is put in the global scope so that it can be run after the script is loaded. onload cannot be used in this case
+  // for non-file scripts
   window["__wasmmodulecallback__"] = callback;
   scriptElem.type="text/javascript"
   scriptElem.text = 'var Module = { onRuntimeInitialized: function () {  console.log("Initialized"); }}; window["__wasmmodulecallback__"](); window["__wasmmodulecallback__"] = null;';

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -217,7 +217,7 @@ function addGlobalModuleScriptTagsToDocument(callback: () => void) {
 
   const scriptElem = document.createElement('script');
 
-  // This polutes global but is needed so it can be called from the script.
+  // This pollutes global but is needed so it can be called from the script.
   window["__wasmmodulecallback__"] = callback;
   scriptElem.type="text/javascript"
   scriptElem.text = 'var Module = { onRuntimeInitialized: function () {  console.log("Initialized"); }}; window["__wasmmodulecallback__"](); window["__wasmmodulecallback__"] = null;';


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - MacOSX Catalina initializes WebAssembly `Module` differently and needs to be initialized before loading `mono.js`.

Modifications:

 - Add new method to MonoPlatform.ts `addGlobalModuleScriptTagsToDocument` 
   - Make sure we have the Module defined from the page as a `<script></script>` tag
   - When the `Module` is defined the regular Blazor mono webassembly setup is followed.
  - Boot start modified to call the new method `addGlobalModuleScriptTagsToDocument`.
 
After modification:

- New `<script></script>` is added to the page that defines the WebAssembly `Module` before the addition of the `<script></script>` tag to load `mono.js`.


