### PR TITLE
Improve performance for QueuePolicy in ConcurrencyLimiter

### DIFF
--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
@@ -19,15 +19,15 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 
         public QueuePolicy(IOptions<QueuePolicyOptions> options)
         {
-            QueuePolicyOptions queuePolicyOptions = options.Value;
+            var queuePolicyOptions = options.Value;
 
-            int maxConcurrentRequests = queuePolicyOptions.MaxConcurrentRequests;
+            var maxConcurrentRequests = queuePolicyOptions.MaxConcurrentRequests;
             if (maxConcurrentRequests <= 0)
             {
                 throw new ArgumentException(nameof(maxConcurrentRequests), "MaxConcurrentRequests must be a positive integer.");
             }
 
-            int requestQueueLimit = queuePolicyOptions.RequestQueueLimit;
+            var requestQueueLimit = queuePolicyOptions.RequestQueueLimit;
             if (requestQueueLimit < 0)
             {
                 throw new ArgumentException(nameof(requestQueueLimit), "The RequestQueueLimit cannot be a negative number.");
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
                 return new ValueTask<bool>(true);
             }
 
-            return AwaitSemaphore(task);
+            return SemaphoreAwaited(task);
         }
 
         public void OnExit()
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
             _serverSemaphore.Dispose();
         }
 
-        private async ValueTask<bool> AwaitSemaphore(Task task)
+        private async ValueTask<bool> SemaphoreAwaited(Task task)
         {
             await task;
 

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
@@ -10,31 +10,33 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 {
     internal class QueuePolicy : IQueuePolicy, IDisposable
     {
-        private readonly int _maxConcurrentRequests;
-        private readonly int _requestQueueLimit;
+        private readonly int _maxTotalRequest;
         private readonly SemaphoreSlim _serverSemaphore;
 
         private object _totalRequestsLock = new object();
+
+        private readonly static ValueTask<bool> _falseValueTask = new ValueTask<bool>(false);
+
         public int TotalRequests { get; private set; }
 
         public QueuePolicy(IOptions<QueuePolicyOptions> options)
         {
-            _maxConcurrentRequests = options.Value.MaxConcurrentRequests;
-            if (_maxConcurrentRequests <= 0)
+            if (options.Value.MaxConcurrentRequests <= 0)
             {
-                throw new ArgumentException(nameof(_maxConcurrentRequests), "MaxConcurrentRequests must be a positive integer.");
+                throw new ArgumentException(nameof(options.Value.MaxConcurrentRequests), "MaxConcurrentRequests must be a positive integer.");
             }
 
-            _requestQueueLimit = options.Value.RequestQueueLimit;
-            if (_requestQueueLimit < 0)
+            if (options.Value.RequestQueueLimit < 0)
             {
-                throw new ArgumentException(nameof(_requestQueueLimit), "The RequestQueueLimit cannot be a negative number.");
+                throw new ArgumentException(nameof(options.Value.RequestQueueLimit), "The RequestQueueLimit cannot be a negative number.");
             }
 
-            _serverSemaphore = new SemaphoreSlim(_maxConcurrentRequests);
+            _serverSemaphore = new SemaphoreSlim(options.Value.MaxConcurrentRequests);
+
+            _maxTotalRequest = options.Value.MaxConcurrentRequests + options.Value.RequestQueueLimit;
         }
 
-        public async ValueTask<bool> TryEnterAsync()
+        public ValueTask<bool> TryEnterAsync()
         {
             // a return value of 'false' indicates that the request is rejected
             // a return value of 'true' indicates that the request may proceed
@@ -42,17 +44,15 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 
             lock (_totalRequestsLock)
             {
-                if (TotalRequests >= _requestQueueLimit + _maxConcurrentRequests)
+                if (TotalRequests >= _maxTotalRequest)
                 {
-                    return false;
+                    return _falseValueTask;
                 }
 
                 TotalRequests++;
             }
 
-            await _serverSemaphore.WaitAsync();
-
-            return true;
+            return AwaitSemaphore();
         }
 
         public void OnExit()
@@ -68,6 +68,13 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
         public void Dispose()
         {
             _serverSemaphore.Dispose();
+        }
+
+        private async ValueTask<bool> AwaitSemaphore()
+        {
+            await _serverSemaphore.WaitAsync();
+
+            return true;
         }
     }
 }

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/StackPolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/StackPolicy.cs
@@ -21,8 +21,6 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 
         private readonly object _bufferLock = new Object();
 
-        private readonly static ValueTask<bool> _trueTask = new ValueTask<bool>(true);
-
         private int _freeServerSpots;
 
         public StackPolicy(IOptions<QueuePolicyOptions> options)
@@ -40,7 +38,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
                 if (_freeServerSpots > 0)
                 {
                     _freeServerSpots--;
-                    return _trueTask;
+                    return new ValueTask<bool>(true);
                 }
 
                 // if queue is full, cancel oldest request


### PR DESCRIPTION
 - Store `MaxTotalRequest` instead of `MaxConcurrentRequests` and `RequestQueueLimit` separately and calculating the sum in every request.
 - Make `TryEnterAsync` non async for the performance for when total request has reached to maximum