### PR TITLE
Revert the ExecutionContext after processing requests

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -622,17 +622,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             TimeoutControl.SetTimeout(_keepAliveTicks, TimeoutReason.KeepAlive);
         }
 
-        protected override async Task ProcessRequestAsync<TContext>(IHttpApplication<TContext> application, TContext context)
+        protected override async ValueTask ProcessRequestAsync<TContext>(IHttpApplication<TContext> application, TContext context)
         {
             await application.ProcessRequestAsync(context);
         }
 
-        protected override async Task FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        protected override async ValueTask FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
         {
             await base.FireOnStartingMayAwait(onStarting);
         }
 
-        protected override async Task FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        protected override async ValueTask FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
         {
             await base.FireOnCompletedMayAwait(onCompleted);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
@@ -618,6 +620,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // Reset the features and timeout.
             Reset();
             TimeoutControl.SetTimeout(_keepAliveTicks, TimeoutReason.KeepAlive);
+        }
+
+        protected override async Task ProcessRequestAsync<TContext>(IHttpApplication<TContext> application, TContext context)
+        {
+            await application.ProcessRequestAsync(context);
+        }
+
+        protected override async Task FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        {
+            await base.FireOnStartingMayAwait(onStarting);
+        }
+
+        protected override async Task FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        {
+            await base.FireOnCompletedMayAwait(onCompleted);
         }
 
         protected override bool BeginRead(out ValueTask<ReadResult> awaitable)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -707,9 +707,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        protected virtual Task ProcessRequestAsync<TContext>(IHttpApplication<TContext> application, TContext context)
+        protected virtual ValueTask ProcessRequestAsync<TContext>(IHttpApplication<TContext> application, TContext context)
         {
-            return application.ProcessRequestAsync(context);
+            return new ValueTask(application.ProcessRequestAsync(context));
         }
 
         public void OnStarting(Func<object, Task> callback, object state)
@@ -735,13 +735,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _onCompleted.Push(new KeyValuePair<Func<object, Task>, object>(callback, state));
         }
 
-        protected Task FireOnStarting()
+        protected ValueTask FireOnStarting()
         {
             var onStarting = _onStarting;
 
             if (onStarting == null || onStarting.Count == 0)
             {
-                return Task.CompletedTask;
+                return default;
             }
             else
             {
@@ -749,7 +749,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        protected virtual Task FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        protected virtual ValueTask FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
         {
             try
             {
@@ -767,10 +767,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 ReportApplicationError(ex);
             }
 
-            return Task.CompletedTask;
+            return default;
         }
 
-        private async Task FireOnStartingAwaited(Task currentTask, Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        private async ValueTask FireOnStartingAwaited(Task currentTask, Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
         {
             try
             {
@@ -787,19 +787,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        protected Task FireOnCompleted()
+        protected ValueTask FireOnCompleted()
         {
             var onCompleted = _onCompleted;
 
             if (onCompleted == null || onCompleted.Count == 0)
             {
-                return Task.CompletedTask;
+                return default;
             }
 
             return FireOnCompletedMayAwait(onCompleted);
         }
 
-        protected virtual Task FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        protected virtual ValueTask FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
         {
             while (onCompleted.TryPop(out var entry))
             {
@@ -817,10 +817,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
 
-            return Task.CompletedTask;
+            return default;
         }
 
-        private async Task FireOnCompletedAwaited(Task currentTask, Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        private async ValueTask FireOnCompletedAwaited(Task currentTask, Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
         {
             try
             {
@@ -949,7 +949,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public async Task InitializeResponseAwaited(Task startingTask, int firstWriteByteCount)
+        public async Task InitializeResponseAwaited(ValueTask startingTask, int firstWriteByteCount)
         {
             await startingTask;
 
@@ -1434,7 +1434,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return Task.CompletedTask;
         }
 
-        private async Task CompleteAsyncAwaited(Task onStartingTask)
+        private async Task CompleteAsyncAwaited(ValueTask onStartingTask)
         {
             await onStartingTask;
 
@@ -1504,7 +1504,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return FirstWriteAsyncInternal(data, cancellationToken);
         }
 
-        private async ValueTask<FlushResult> FirstWriteAsyncAwaited(Task initializeTask, ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+        private async ValueTask<FlushResult> FirstWriteAsyncAwaited(ValueTask initializeTask, ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
         {
             await initializeTask;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -615,7 +615,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     KestrelEventSource.Log.RequestStart(this);
 
                     // Run the application code for this request
-                    await application.ProcessRequestAsync(context);
+                    await ProcessRequestAsync(application, context);
 
                     // Trigger OnStarting if it hasn't been called yet and the app hasn't
                     // already failed. If an OnStarting callback throws we can go through
@@ -707,6 +707,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
+        protected virtual Task ProcessRequestAsync<TContext>(IHttpApplication<TContext> application, TContext context)
+        {
+            return application.ProcessRequestAsync(context);
+        }
+
         public void OnStarting(Func<object, Task> callback, object state)
         {
             if (HasResponseStarted)
@@ -744,7 +749,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        private Task FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        protected virtual Task FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
         {
             try
             {
@@ -794,7 +799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return FireOnCompletedMayAwait(onCompleted);
         }
 
-        private Task FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        protected virtual Task FireOnCompletedMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
         {
             while (onCompleted.TryPop(out var entry))
             {

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -691,7 +691,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var original = _http1Connection.RequestAborted;
 
             // Only first write can be WriteAsyncAwaited
-            var startingTask = _http1Connection.InitializeResponseAwaited(Task.CompletedTask, 1);
+            var startingTask = _http1Connection.InitializeResponseAwaited(default, 1);
             await _http1Connection.WriteAsyncAwaited(startingTask, new ArraySegment<byte>(new[] { (byte)'h' }), default(CancellationToken));
             Assert.Equal(original, _http1Connection.RequestAborted);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -265,6 +265,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Equal(0, value);
                 local.Value++;
 
+                context.Response.OnStarting(() =>
+                {
+                    local.Value++;
+                    return Task.CompletedTask;
+                });
+
+                context.Response.OnCompleted(() =>
+                {
+                    local.Value++;
+                    return Task.CompletedTask;
+                });
+
                 context.Response.ContentLength = 1;
                 return context.Response.WriteAsync(value.ToString());
             }


### PR DESCRIPTION
- If user code modifies the ExecutionContext it could leak to the next http request. This happens because nothing reverts to the original on the way out. We piggy back on the async state machine logic to do this.
- Added a test

PS: I'm guessing this potentially regress the performance so this solution might not be the final one (depending on results).

Fixes #13991