### PR TITLE
Remove Newtonsoft JSON.NET from Blazor WASM template

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Server/BlazorWasm-CSharp.Server.csproj
+++ b/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Server/BlazorWasm-CSharp.Server.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="$(TemplateBlazorPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(TemplateComponentsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Server/Startup.cs
+++ b/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Server/Startup.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Newtonsoft.Json.Serialization;
 using System.Linq;
 
 namespace BlazorWasm_CSharp.Server
@@ -14,7 +13,7 @@ namespace BlazorWasm_CSharp.Server
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().AddNewtonsoftJson();
+            services.AddMvc();
             services.AddResponseCompression(opts =>
             {
                 opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(


### PR DESCRIPTION
Addresses #13422 and #14039.
Closing original PR #14028 which was targeting the `master` branch in favour of this PR which correctly targets the `release/3.1` branch.
