### PR TITLE
Don't call close if connect does not succeed

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -16,6 +16,7 @@ Directory.Build.props checks this property using the following condition:
   <PropertyGroup Condition=" '$(VersionPrefix)' == '3.0.1' ">
     <PackagesInPatch>
       Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+      @microsoft/signalr;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts
+++ b/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts
@@ -97,6 +97,8 @@ export class WebSocketTransport implements ITransport {
             };
 
             webSocket.onclose = (event: CloseEvent) => {
+                // Don't call close handler if connection was never established
+                // We'll reject the connect call instead
                 if (opened) {
                     this.close(event);
                 } else {

--- a/src/SignalR/clients/ts/signalr/tests/ServerSentEventsTransport.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/ServerSentEventsTransport.test.ts
@@ -59,10 +59,9 @@ describe("ServerSentEventsTransport", () => {
 
             TestEventSource.eventSource.onerror(new TestMessageEvent());
 
-            try {
-                await connectPromise;
-                expect(false).toBe(true);
-            } catch { }
+            await expect(connectPromise)
+                .rejects
+                .toEqual(new Error("Error occurred"));
             expect(closeCalled).toBe(false);
         });
     });


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/14075

#### Description
There is a race when falling back from WebSockets to other transports that will prevent fallback from working. This code was refactored in 3.0 which caused this regression. When a WebSocket connection failed to start, the WebSocket transport code would signal **both** that the connection failed to start **and** that the connection was closed. This would cause a race in the SignalR logic and if the wrong path wins the race, the connection is closed entirely instead of falling back to other transports.

#### Customer Impact
In situations where an intermediary (i.e. not the client, and not the app server) doesn't support WebSockets, the client may fail to connect where previously it would have fallen back to a different transport. Generally this wouldn't have a huge impact except that by default Azure App Service has an intermediary that doesn't support WebSockets. It can be enabled by users, but many customers don't enable it or don't wish to enable it. It is also a regression of a core functionality of SignalR (fallback) in 3.0.

#### Regression?
**Yes**, regression in 3.0 from the 2.2 behavior

#### Risk
Low, added test coverage to prevent this kind of issue in the future