### PR TITLE
Expose HttpSys RequestInfo extensibility 

### DIFF
--- a/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
+++ b/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
@@ -57,6 +57,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public Microsoft.AspNetCore.Server.HttpSys.TimeoutManager Timeouts { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Server.HttpSys.UrlPrefixCollection UrlPrefixes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
+    public partial interface IHttpSysRequestInfoFeature
+    {
+        System.Collections.Generic.IReadOnlyDictionary<int, System.ReadOnlyMemory<byte>> RequestInfo { get; }
+    }
     public sealed partial class TimeoutManager
     {
         internal TimeoutManager() { }

--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -547,7 +547,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         int ITlsHandshakeFeature.KeyExchangeStrength => Request.KeyExchangeStrength;
 
-        IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
+        IReadOnlyDictionary<int, ReadOnlyMemory<byte>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
 
         internal async Task OnResponseStart()
         {

--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -34,7 +34,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         IHttpUpgradeFeature,
         IHttpRequestIdentifierFeature,
         IHttpMaxRequestBodySizeFeature,
-        IHttpBodyControlFeature
+        IHttpBodyControlFeature,
+        IHttpSysRequestInfoFeature
     {
         private RequestContext _requestContext;
         private IFeatureCollection _features;
@@ -545,6 +546,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         ExchangeAlgorithmType ITlsHandshakeFeature.KeyExchangeAlgorithm => Request.KeyExchangeAlgorithm;
 
         int ITlsHandshakeFeature.KeyExchangeStrength => Request.KeyExchangeStrength;
+
+        IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
 
         internal async Task OnResponseStart()
         {

--- a/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
+++ b/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+// Note: This will also be useful for IIS in-proc.
+// Plan: Have Microsoft.AspNetCore.Server.IIS take a dependency on Microsoft.AspNetCore.Server.HttpSys and implement this interface.
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    /// <summary>
+    /// This exposes the Http.Sys HTTP_REQUEST_INFO extensibility point as opaque data for the caller to interperate.
+    /// https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_v2
+    /// https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_info
+    /// </summary>
+    public interface IHttpSysRequestInfoFeature
+    {
+        /// <summary>
+        /// A collection of the HTTP_REQUEST_INFO for the current request. The integer represents the identifying
+        /// HTTP_REQUEST_INFO_TYPE enum value. The Memory is opaque bytes that need to be interperted in the format
+        /// specified by the enum value.
+        /// </summary>
+        public IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> RequestInfo { get; }
+    }
+}

--- a/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
+++ b/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
@@ -20,6 +20,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// HTTP_REQUEST_INFO_TYPE enum value. The Memory is opaque bytes that need to be interperted in the format
         /// specified by the enum value.
         /// </summary>
-        public IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> RequestInfo { get; }
+        public IReadOnlyDictionary<int, ReadOnlyMemory<byte>> RequestInfo { get; }
     }
 }

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private AspNetCore.HttpSys.Internal.SocketAddress _localEndPoint;
         private AspNetCore.HttpSys.Internal.SocketAddress _remoteEndPoint;
 
-        private IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> _requestInfo;
+        private IReadOnlyDictionary<int, ReadOnlyMemory<byte>> _requestInfo;
 
         private bool _isDisposed = false;
 
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         public int KeyExchangeStrength { get; private set; }
 
-        public IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> RequestInfo
+        public IReadOnlyDictionary<int, ReadOnlyMemory<byte>> RequestInfo
         {
             get
             {

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -30,6 +31,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private AspNetCore.HttpSys.Internal.SocketAddress _localEndPoint;
         private AspNetCore.HttpSys.Internal.SocketAddress _remoteEndPoint;
+
+        private IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> _requestInfo;
 
         private bool _isDisposed = false;
 
@@ -251,6 +254,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public ExchangeAlgorithmType KeyExchangeAlgorithm { get; private set; }
 
         public int KeyExchangeStrength { get; private set; }
+
+        public IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> RequestInfo
+        {
+            get
+            {
+                if (_requestInfo == null)
+                {
+                    _requestInfo = _nativeRequestContext.GetRequestInfo();
+                }
+                return _requestInfo;
+            }
+        }
 
         private void GetTlsHandshakeResults()
         {

--- a/src/Servers/HttpSys/src/StandardFeatureCollection.cs
+++ b/src/Servers/HttpSys/src/StandardFeatureCollection.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             { typeof(RequestContext), ctx => ctx.RequestContext },
             { typeof(IHttpMaxRequestBodySizeFeature), _identityFunc },
             { typeof(IHttpBodyControlFeature), _identityFunc },
+            { typeof(IHttpSysRequestInfoFeature), _identityFunc },
         };
 
         private readonly FeatureContext _featureContext;

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -12,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -148,6 +151,46 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Assert.True(tlsFeature.HashStrength >= 0, "HashStrength"); // May be 0 for some algorithms
                     Assert.True(tlsFeature.KeyExchangeAlgorithm > ExchangeAlgorithmType.None, "KeyExchangeAlgorithm");
                     Assert.True(tlsFeature.KeyExchangeStrength > 0, "KeyExchangeStrength");
+                }
+                catch (Exception ex)
+                {
+                    await httpContext.Response.WriteAsync(ex.ToString());
+                }
+            }))
+            {
+                string response = await SendRequestAsync(address);
+                Assert.Equal(string.Empty, response);
+            }
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2)]
+        public async Task Https_ITlsHandshakeFeature_MatchesIHttpSysExtensionInfoFeature()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                try
+                {
+                    var tlsFeature = httpContext.Features.Get<ITlsHandshakeFeature>();
+                    var requestInfoFeature = httpContext.Features.Get<IHttpSysRequestInfoFeature>();
+                    Assert.NotNull(tlsFeature);
+                    Assert.NotNull(requestInfoFeature);
+                    Assert.True(requestInfoFeature.RequestInfo.Count > 0);
+                    var tlsInfo = requestInfoFeature.RequestInfo.Where(info => info.Key == (int)HttpApiTypes.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeSslProtocol).Single().Value;
+                    HttpApiTypes.HTTP_SSL_PROTOCOL_INFO tlsCopy;
+                    unsafe
+                    {
+                        using var handle = tlsInfo.Pin();
+                        tlsCopy = Marshal.PtrToStructure<HttpApiTypes.HTTP_SSL_PROTOCOL_INFO>((IntPtr)handle.Pointer);
+                    }
+
+                    // Assert.Equal(tlsFeature.Protocol, tlsCopy.Protocol); // These don't directly match because there's some value mapping that needs to happen.
+                    Assert.Equal(tlsFeature.CipherAlgorithm, tlsCopy.CipherType);
+                    Assert.Equal(tlsFeature.CipherStrength, (int)tlsCopy.CipherStrength);
+                    Assert.Equal(tlsFeature.HashAlgorithm, tlsCopy.HashType);
+                    Assert.Equal(tlsFeature.HashStrength, (int)tlsCopy.HashStrength);
+                    Assert.Equal(tlsFeature.KeyExchangeAlgorithm, tlsCopy.KeyExchangeType);
+                    Assert.Equal(tlsFeature.KeyExchangeStrength, (int)tlsCopy.KeyExchangeStrength);
                 }
                 catch (Exception ex)
                 {

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Assert.NotNull(tlsFeature);
                     Assert.NotNull(requestInfoFeature);
                     Assert.True(requestInfoFeature.RequestInfo.Count > 0);
-                    var tlsInfo = requestInfoFeature.RequestInfo.Where(info => info.Key == (int)HttpApiTypes.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeSslProtocol).Single().Value;
+                    var tlsInfo = requestInfoFeature.RequestInfo[(int)HttpApiTypes.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeSslProtocol];
                     HttpApiTypes.HTTP_SSL_PROTOCOL_INFO tlsCopy;
                     unsafe
                     {
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         tlsCopy = Marshal.PtrToStructure<HttpApiTypes.HTTP_SSL_PROTOCOL_INFO>((IntPtr)handle.Pointer);
                     }
 
-                    // Assert.Equal(tlsFeature.Protocol, tlsCopy.Protocol); // These don't directly match because there's some value mapping that needs to happen.
+                    // Assert.Equal(tlsFeature.Protocol, tlsCopy.Protocol); // These don't directly match because the native and managed enums use different values.
                     Assert.Equal(tlsFeature.CipherAlgorithm, tlsCopy.CipherType);
                     Assert.Equal(tlsFeature.CipherStrength, (int)tlsCopy.CipherStrength);
                     Assert.Equal(tlsFeature.HashAlgorithm, tlsCopy.HashType);

--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>HttpSys.FunctionalTests</TestGroupName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,10 +14,6 @@
   <PropertyGroup>
     <!--Imitate IIS Express so we can use it's cert bindings-->
     <PackageTags>214124cd-d05b-4309-9af9-9caa44b2b74a</PackageTags>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -15,6 +15,10 @@
     <PackageTags>214124cd-d05b-4309-9af9-9caa44b2b74a</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <ItemGroup>
     <HelixContent Include="$(RepoRoot)src\Servers\IIS\tools\TestCert.pfx" />
     <HelixContent Include="$(RepoRoot)src\Servers\IIS\tools\UpdateIISExpressCertificate.ps1" />

--- a/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
+++ b/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
@@ -498,14 +498,15 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         private IReadOnlyCollection<KeyValuePair<int, ReadOnlyMemory<byte>>> GetRequestInfo(IntPtr baseAddress, HttpApiTypes.HTTP_REQUEST_V2* nativeRequest)
         {
-            if (nativeRequest->RequestInfoCount == 0)
+            var count = nativeRequest->RequestInfoCount;
+            if (count == 0)
             {
                 return Array.Empty<KeyValuePair<int, ReadOnlyMemory<byte>>>();
             }
 
-            var list = new List<KeyValuePair<int, ReadOnlyMemory<byte>>>(nativeRequest->RequestInfoCount);
+            var list = new List<KeyValuePair<int, ReadOnlyMemory<byte>>>(count);
 
-            for (var i = 0; i < nativeRequest->RequestInfoCount; i++)
+            for (var i = 0; i < count; i++)
             {
                 var requestInfo = nativeRequest->pRequestInfo[i];
                 var offset = (long)requestInfo.pInfo - (long)baseAddress;


### PR DESCRIPTION
#13482 There are asks to expose data from the Http.Sys RequestInfo extensibility point. However, many of the extensions are still under development and don't meet our documentation requirements. We can mitigate this by exposing the raw bytes and letting the caller interpret them as needed.