### PR TITLE
[TS] Add support for negotiateVersion and connectionToken

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -536,8 +536,11 @@ export class HttpConnection implements IConnection {
         }
         negotiateUrl += "negotiate";
         negotiateUrl += index === -1 ? "" : url.substring(index);
-        negotiateUrl += index === -1 ? "?" : "&";
-        negotiateUrl += "negotiateVersion=" + this.negotiateVersion;
+
+        if (negotiateUrl.indexOf("negotiateVersion") === -1) {
+            negotiateUrl += index === -1 ? "?" : "&";
+            negotiateUrl += "negotiateVersion=" + this.negotiateVersion;
+        }
         return negotiateUrl;
     }
 }

--- a/src/SignalR/clients/ts/signalr/tests/Common.ts
+++ b/src/SignalR/clients/ts/signalr/tests/Common.ts
@@ -15,10 +15,10 @@ export function eachTransport(action: (transport: HttpTransportType) => void) {
 
 export function eachEndpointUrl(action: (givenUrl: string, expectedUrl: string) => void) {
     const urls = [
-        [ "http://tempuri.org/endpoint/?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data" ],
-        [ "http://tempuri.org/endpoint?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data" ],
-        [ "http://tempuri.org/endpoint", "http://tempuri.org/endpoint/negotiate" ],
-        [ "http://tempuri.org/endpoint/", "http://tempuri.org/endpoint/negotiate" ],
+        [ "http://tempuri.org/endpoint/?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data&negotiateVersion=1" ],
+        [ "http://tempuri.org/endpoint?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data&negotiateVersion=1" ],
+        [ "http://tempuri.org/endpoint", "http://tempuri.org/endpoint/negotiate?negotiateVersion=1" ],
+        [ "http://tempuri.org/endpoint/", "http://tempuri.org/endpoint/negotiate?negotiateVersion=1" ],
     ];
 
     urls.forEach((t) => action(t[0], t[1]));

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -20,6 +20,7 @@ const commonOptions: IHttpConnectionOptions = {
 };
 
 const defaultConnectionId = "abc123";
+const defaultConnectionToken = "123abc";
 const defaultNegotiateResponse: INegotiateResponse = {
     availableTransports: [
         { transport: "WebSockets", transferFormats: ["Text", "Binary"] },
@@ -27,6 +28,8 @@ const defaultNegotiateResponse: INegotiateResponse = {
         { transport: "LongPolling", transferFormats: ["Text", "Binary"] },
     ],
     connectionId: defaultConnectionId,
+    connectionToken: defaultConnectionToken,
+    negotiateVersion: 1,
 };
 
 registerUnhandledRejectionHandler();
@@ -571,7 +574,7 @@ describe("HttpConnection", () => {
             let firstNegotiate = true;
             let firstPoll = true;
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate$/, () => {
+                .on("POST", /negotiate/, () => {
                     if (firstNegotiate) {
                         firstNegotiate = false;
                         return { url: "https://another.domain.url/chat" };
@@ -602,8 +605,8 @@ describe("HttpConnection", () => {
                 await connection.start(TransferFormat.Text);
 
                 expect(httpClient.sentRequests.length).toBe(4);
-                expect(httpClient.sentRequests[0].url).toBe("http://tempuri.org/negotiate");
-                expect(httpClient.sentRequests[1].url).toBe("https://another.domain.url/chat/negotiate");
+                expect(httpClient.sentRequests[0].url).toBe("http://tempuri.org/negotiate?negotiateVersion=1");
+                expect(httpClient.sentRequests[1].url).toBe("https://another.domain.url/chat/negotiate?negotiateVersion=1");
                 expect(httpClient.sentRequests[2].url).toMatch(/^https:\/\/another\.domain\.url\/chat\?id=0rge0d00-0040-0030-0r00-000q00r00e00/i);
                 expect(httpClient.sentRequests[3].url).toMatch(/^https:\/\/another\.domain\.url\/chat\?id=0rge0d00-0040-0030-0r00-000q00r00e00/i);
             } finally {
@@ -615,7 +618,7 @@ describe("HttpConnection", () => {
     it("fails to start if negotiate redirects more than 100 times", async () => {
         await VerifyLogger.run(async (logger) => {
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate$/, () => ({ url: "https://another.domain.url/chat" }));
+                .on("POST", /negotiate/, () => ({ url: "https://another.domain.url/chat" }));
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
@@ -637,7 +640,7 @@ describe("HttpConnection", () => {
             let firstNegotiate = true;
             let firstPoll = true;
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate$/, (r) => {
+                .on("POST", /negotiate/, (r) => {
                     if (firstNegotiate) {
                         firstNegotiate = false;
 
@@ -683,8 +686,8 @@ describe("HttpConnection", () => {
                 await connection.start(TransferFormat.Text);
 
                 expect(httpClient.sentRequests.length).toBe(4);
-                expect(httpClient.sentRequests[0].url).toBe("http://tempuri.org/negotiate");
-                expect(httpClient.sentRequests[1].url).toBe("https://another.domain.url/chat/negotiate");
+                expect(httpClient.sentRequests[0].url).toBe("http://tempuri.org/negotiate?negotiateVersion=1");
+                expect(httpClient.sentRequests[1].url).toBe("https://another.domain.url/chat/negotiate?negotiateVersion=1");
                 expect(httpClient.sentRequests[2].url).toMatch(/^https:\/\/another\.domain\.url\/chat\?id=0rge0d00-0040-0030-0r00-000q00r00e00/i);
                 expect(httpClient.sentRequests[3].url).toMatch(/^https:\/\/another\.domain\.url\/chat\?id=0rge0d00-0040-0030-0r00-000q00r00e00/i);
             } finally {
@@ -696,7 +699,7 @@ describe("HttpConnection", () => {
     it("throws error if negotiate response has error", async () => {
         await VerifyLogger.run(async (logger) => {
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate$/, () => ({ error: "Negotiate error." }));
+                .on("POST", /negotiate/, () => ({ error: "Negotiate error." }));
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -13,6 +13,7 @@ import { EventSourceConstructor, WebSocketConstructor } from "../src/Polyfills";
 import { eachEndpointUrl, eachTransport, VerifyLogger } from "./Common";
 import { TestHttpClient } from "./TestHttpClient";
 import { TestTransport } from "./TestTransport";
+import { TestEvent, TestWebSocket } from "./TestWebSocket";
 import { PromiseSource, registerUnhandledRejectionHandler, SyncPoint } from "./Utils";
 
 const commonOptions: IHttpConnectionOptions = {
@@ -876,7 +877,7 @@ describe("HttpConnection", () => {
         });
     });
 
-    it("missing negotiate version ignores connectionToken", async () => {
+    it("missing negotiateVersion ignores connectionToken", async () => {
         await VerifyLogger.run(async (logger) => {
             const availableTransport = { transport: "Custom", transferFormats: ["Text"] };
             const transport = {
@@ -1014,17 +1015,17 @@ describe("HttpConnection", () => {
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
                 httpClient: new TestHttpClient()
-                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=2", () => "{ \"connectionId\": \"42\" }")
+                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=42", () => "{ \"connectionId\": \"42\" }")
                     .on("GET", () => ""),
                 logger,
                 transport: fakeTransport,
             } as IHttpConnectionOptions;
 
-            const connection = new HttpConnection("http://tempuri.org?negotiateVersion=2", options);
+            const connection = new HttpConnection("http://tempuri.org?negotiateVersion=42", options);
             try {
                 const startPromise = connection.start(TransferFormat.Text);
 
-                expect(await connectUrl).toBe("http://tempuri.org?negotiateVersion=2&id=42");
+                expect(await connectUrl).toBe("http://tempuri.org?negotiateVersion=42&id=42");
 
                 await startPromise;
             } finally {
@@ -1032,6 +1033,95 @@ describe("HttpConnection", () => {
                 await connection.stop();
             }
         });
+    });
+
+    it("negotiateVersion query string not added if already present after redirect", async () => {
+        await VerifyLogger.run(async (logger) => {
+            const connectUrl = new PromiseSource<string>();
+            const fakeTransport: ITransport = {
+                connect(url: string): Promise<void> {
+                    connectUrl.resolve(url);
+                    return Promise.resolve();
+                },
+                send(): Promise<void> {
+                    return Promise.resolve();
+                },
+                stop(): Promise<void> {
+                    return Promise.resolve();
+                },
+                onclose: null,
+                onreceive: null,
+            };
+
+            const options: IHttpConnectionOptions = {
+                ...commonOptions,
+                httpClient: new TestHttpClient()
+                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=1", () => "{ \"url\": \"http://redirect.org\" }")
+                    .on("POST", "http://redirect.org/negotiate?negotiateVersion=1", () => "{ \"connectionId\": \"42\"}")
+                    .on("GET", () => ""),
+                logger,
+                transport: fakeTransport,
+            } as IHttpConnectionOptions;
+
+            const connection = new HttpConnection("http://tempuri.org", options);
+            try {
+                const startPromise = connection.start(TransferFormat.Text);
+
+                expect(await connectUrl).toBe("http://redirect.org?id=42");
+
+                await startPromise;
+            } finally {
+                (options.transport as ITransport).onclose!();
+                await connection.stop();
+            }
+        });
+    });
+
+    it("fallback changes connectionId property", async () => {
+        await VerifyLogger.run(async (logger) => {
+            const availableTransports = [{ transport: "WebSockets", transferFormats: ["Text"] }, { transport: "LongPolling", transferFormats: ["Text"] }];
+            let negotiateCount: number = 0;
+            let getCount: number = 0;
+            let connection: HttpConnection;
+            let connectionId: string | undefined;
+            const options: IHttpConnectionOptions = {
+                WebSocket: TestWebSocket,
+                ...commonOptions,
+                httpClient: new TestHttpClient()
+                    .on("POST", () =>  {
+                        negotiateCount++;
+                        return ({ connectionId: negotiateCount.toString(), connectionToken: "token", negotiateVersion: 1, availableTransports });
+                    })
+                    .on("GET", () => {
+                        getCount++;
+                        if (getCount === 1) {
+                            return new HttpResponse(200);
+                        }
+                        connectionId = connection.connectionId;
+                        return new HttpResponse(204);
+                    })
+                    .on("DELETE", () => new HttpResponse(202)),
+
+                logger,
+            } as IHttpConnectionOptions;
+
+            TestWebSocket.webSocketSet = new PromiseSource();
+
+            connection = new HttpConnection("http://tempuri.org", options);
+            const startPromise = connection.start(TransferFormat.Text);
+
+            await TestWebSocket.webSocketSet;
+            await TestWebSocket.webSocket.closeSet;
+            TestWebSocket.webSocket.onerror(new TestEvent());
+
+            try {
+                await startPromise;
+            } catch { }
+
+            expect(negotiateCount).toEqual(2);
+            expect(connectionId).toEqual("2");
+        },
+        "Failed to start the transport 'WebSockets': Error: There was an error with the transport.");
     });
 
     describe(".constructor", () => {
@@ -1082,7 +1172,7 @@ describe("HttpConnection", () => {
 
         it("uses WebSocket constructor from options if provided", async () => {
             await VerifyLogger.run(async (logger) => {
-                class TestWebSocket {
+                class BadConstructorWebSocket {
                     // The "_" prefix tell TypeScript not to worry about unused parameter, but tslint doesn't like it.
                     // tslint:disable-next-line:variable-name
                     constructor(_url: string, _protocols?: string | string[]) {
@@ -1092,7 +1182,7 @@ describe("HttpConnection", () => {
 
                 const options: IHttpConnectionOptions = {
                     ...commonOptions,
-                    WebSocket: TestWebSocket as WebSocketConstructor,
+                    WebSocket: BadConstructorWebSocket as WebSocketConstructor,
                     logger,
                     skipNegotiation: true,
                     transport: HttpTransportType.WebSockets,

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -575,7 +575,7 @@ describe("HttpConnection", () => {
             let firstNegotiate = true;
             let firstPoll = true;
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate/, () => {
+                .on("POST", /\/negotiate/, () => {
                     if (firstNegotiate) {
                         firstNegotiate = false;
                         return { url: "https://another.domain.url/chat" };
@@ -619,7 +619,7 @@ describe("HttpConnection", () => {
     it("fails to start if negotiate redirects more than 100 times", async () => {
         await VerifyLogger.run(async (logger) => {
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate/, () => ({ url: "https://another.domain.url/chat" }));
+                .on("POST", /\/negotiate/, () => ({ url: "https://another.domain.url/chat" }));
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
@@ -641,7 +641,7 @@ describe("HttpConnection", () => {
             let firstNegotiate = true;
             let firstPoll = true;
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate/, (r) => {
+                .on("POST", /\/negotiate/, (r) => {
                     if (firstNegotiate) {
                         firstNegotiate = false;
 
@@ -700,7 +700,7 @@ describe("HttpConnection", () => {
     it("throws error if negotiate response has error", async () => {
         await VerifyLogger.run(async (logger) => {
             const httpClient = new TestHttpClient()
-                .on("POST", /negotiate/, () => ({ error: "Negotiate error." }));
+                .on("POST", /\/negotiate/, () => ({ error: "Negotiate error." }));
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -21,6 +21,8 @@ const longPollingNegotiateResponse = {
         { transport: "LongPolling", transferFormats: ["Text", "Binary"] },
     ],
     connectionId: "abc123",
+    connectionToken: "123abc",
+    negotiateVersion: 1,
 };
 
 const commonHttpOptions: IHttpConnectionOptions = {
@@ -88,7 +90,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -104,7 +106,7 @@ describe("HubConnectionBuilder", () => {
             await expect(connection.start()).rejects.toThrow("The underlying connection was closed before the hub handshake could complete.");
             expect(connection.state).toBe(HubConnectionState.Disconnected);
 
-            expect((await pollSent.promise).url).toMatch(/http:\/\/example.com\?id=abc123.*/);
+            expect((await pollSent.promise).url).toMatch(/http:\/\/example.com\?id=123abc.*/);
         });
     });
 
@@ -125,7 +127,7 @@ describe("HubConnectionBuilder", () => {
             const pollCompleted = new PromiseSource<HttpResponse>();
             let negotiateRequest!: HttpRequest;
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     negotiateRequest = req;
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
@@ -219,7 +221,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -244,7 +246,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -274,7 +276,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -413,8 +415,8 @@ function createConnectionBuilder(logger?: ILogger): HubConnectionBuilder {
 function createTestClient(pollSent: PromiseSource<HttpRequest>, pollCompleted: Promise<HttpResponse>, negotiateResponse?: any): TestHttpClient {
     let firstRequest = true;
     return new TestHttpClient()
-        .on("POST", "http://example.com/negotiate", () => negotiateResponse || longPollingNegotiateResponse)
-        .on("GET", /http:\/\/example.com\?id=abc123&_=.*/, (req) => {
+        .on("POST", "http://example.com/negotiate?negotiateVersion=1", () => negotiateResponse || longPollingNegotiateResponse)
+        .on("GET", /http:\/\/example.com\?id=123abc&_=.*/, (req) => {
             if (firstRequest) {
                 firstRequest = false;
                 return new HttpResponse(200);


### PR DESCRIPTION
Follow up to https://github.com/aspnet/AspNetCore/pull/13389 for the TS client

Couple things I changed from the other clients implementations that I'll fix for them in a different PR:
* negotiateVersion is not included after negotiation occurs
* negotiateVersion is not added multiple times when redirecting (otherwise this would break the service scenario)
* connectionToken is not stored anywhere

Side-note: Fixed a bug where the connectionId property wasn't updated when fallback occurs.