### PR TITLE
Support attaching to an existing request queue in HTTP.SYS

### DIFF
--- a/src/Servers/HttpSys/HttpSysServer.sln
+++ b/src/Servers/HttpSys/HttpSysServer.sln
@@ -70,6 +70,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Hostin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Connections.Abstractions", "..\Connections.Abstractions\src\Microsoft.AspNetCore.Connections.Abstractions.csproj", "{00A88B8D-D539-45DD-B071-1E955AF89A4A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueueSharing", "samples\QueueSharing\QueueSharing.csproj", "{9B58DF76-DC6D-4728-86B7-40087BDDC897}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -304,6 +306,18 @@ Global
 		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|x86.ActiveCfg = Release|Any CPU
 		{00A88B8D-D539-45DD-B071-1E955AF89A4A}.Release|x86.Build.0 = Release|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Debug|x86.Build.0 = Debug|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Release|x86.ActiveCfg = Release|Any CPU
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,6 +343,7 @@ Global
 		{19DC60DE-C413-43A2-985E-0D0F20AD2302} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
 		{D93575B3-BFA3-4523-B060-D268D6A0A66B} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
 		{00A88B8D-D539-45DD-B071-1E955AF89A4A} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{9B58DF76-DC6D-4728-86B7-40087BDDC897} = {3A1E31E3-2794-4CA3-B8E2-253E96BDE514}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34B42B42-FA09-41AB-9216-14073990C504}

--- a/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
+++ b/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
@@ -51,8 +51,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public int MaxAccepts { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public long? MaxConnections { get { throw null; } set { } }
         public long? MaxRequestBodySize { get { throw null; } set { } }
-        public Microsoft.AspNetCore.Server.HttpSys.RequestQueueMode Mode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public long RequestQueueLimit { get { throw null; } set { } }
+        public Microsoft.AspNetCore.Server.HttpSys.RequestQueueMode RequestQueueMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string RequestQueueName { get { throw null; } set { } }
         public bool ThrowWriteExceptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.HttpSys.TimeoutManager Timeouts { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
@@ -65,9 +65,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     public enum RequestQueueMode
     {
         Create = 0,
-        Controller = 1,
-        AttachToExisting = 2,
-        AttachOrCreate = 3,
+        Attach = 1,
+        CreateOrAttach = 2,
     }
     public sealed partial class TimeoutManager
     {

--- a/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
+++ b/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
@@ -51,6 +51,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public int MaxAccepts { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public long? MaxConnections { get { throw null; } set { } }
         public long? MaxRequestBodySize { get { throw null; } set { } }
+        public Microsoft.AspNetCore.Server.HttpSys.RequestQueueMode Mode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public long RequestQueueLimit { get { throw null; } set { } }
         public string RequestQueueName { get { throw null; } set { } }
         public bool ThrowWriteExceptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
@@ -60,6 +61,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     public partial interface IHttpSysRequestInfoFeature
     {
         System.Collections.Generic.IReadOnlyDictionary<int, System.ReadOnlyMemory<byte>> RequestInfo { get; }
+    }
+    public enum RequestQueueMode
+    {
+        Create = 0,
+        Controller = 1,
+        AttachToExisting = 2,
+        AttachOrCreate = 3,
     }
     public sealed partial class TimeoutManager
     {

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -21,10 +21,10 @@ namespace QueueSharing
             switch (key.KeyChar)
             {
                 case 'a':
-                    mode = RequestQueueMode.AttachToExisting;
+                    mode = RequestQueueMode.Attach;
                     break;
                 case 'o':
-                    mode = RequestQueueMode.AttachOrCreate;
+                    mode = RequestQueueMode.CreateOrAttach;
                     break;
                 case 'c':
                     mode = RequestQueueMode.Create;

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -40,7 +40,11 @@ namespace QueueSharing
                 {
                     webHost.UseHttpSys(options =>
                     {
-                        options.UrlPrefixes.Add("http://localhost:5000");
+                        // Skipping this to ensure the server works without any prefixes in attach mode.
+                        if (mode != RequestQueueMode.Attach)
+                        {
+                            options.UrlPrefixes.Add("http://localhost:5002");
+                        }
                         options.RequestQueueName = "QueueName";
                         options.RequestQueueMode = mode;
                         options.MaxAccepts = 1; // Better load rotation between instances.

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -14,26 +14,23 @@ namespace QueueSharing
     {
         public static void Main(string[] args)
         {
-            Console.Write("Create and (l)isten, (c)reate only, (a)ttach to existing, or attach (o)r create? ");
+            Console.Write("Create and (c)reate, (a)ttach to existing, or attach (o)r create? ");
             var key = Console.ReadKey();
             Console.WriteLine();
             var mode = RequestQueueMode.Create;
             switch (key.KeyChar)
             {
-                case 'c':
-                    mode = RequestQueueMode.Controller;
-                    break;
                 case 'a':
                     mode = RequestQueueMode.AttachToExisting;
                     break;
                 case 'o':
                     mode = RequestQueueMode.AttachOrCreate;
                     break;
-                case 'l':
+                case 'c':
                     mode = RequestQueueMode.Create;
                     break;
                 default:
-                    Console.WriteLine("Unknown option, defaulting to (l)isten.");
+                    Console.WriteLine("Unknown option, defaulting to (c)create.");
                     break;
             }
 

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -43,6 +43,7 @@ namespace QueueSharing
                         options.UrlPrefixes.Add("http://localhost:5000");
                         options.RequestQueueName = "QueueName";
                         options.RequestQueueMode = mode;
+                        options.MaxAccepts = 1; // Better load rotation between instances.
                     }).ConfigureServices(services =>
                     {
 

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -42,7 +42,7 @@ namespace QueueSharing
                     {
                         options.UrlPrefixes.Add("http://localhost:5000");
                         options.RequestQueueName = "QueueName";
-                        options.Mode = mode;
+                        options.RequestQueueMode = mode;
                     }).ConfigureServices(services =>
                     {
 

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Xml.Schema;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.HttpSys;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace QueueSharing
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.Write("Create and (l)isten, (c)reate only, (a)ttach to existing, or attach (o)r create? ");
+            var key = Console.ReadKey();
+            Console.WriteLine();
+            var mode = RequestQueueMode.Create;
+            switch (key.KeyChar)
+            {
+                case 'c':
+                    mode = RequestQueueMode.Controller;
+                    break;
+                case 'a':
+                    mode = RequestQueueMode.AttachToExisting;
+                    break;
+                case 'o':
+                    mode = RequestQueueMode.AttachOrCreate;
+                    break;
+                case 'l':
+                    mode = RequestQueueMode.Create;
+                    break;
+                default:
+                    Console.WriteLine("Unknown option, defaulting to (l)isten.");
+                    break;
+            }
+
+            var host = new HostBuilder()
+                .ConfigureLogging(factory => factory.AddConsole())
+                .ConfigureWebHost(webHost =>
+                {
+                    webHost.UseHttpSys(options =>
+                    {
+                        options.UrlPrefixes.Add("http://localhost:5000");
+                        options.RequestQueueName = "QueueName";
+                        options.Mode = mode;
+                    }).ConfigureServices(services =>
+                    {
+
+                    }).Configure(app =>
+                    {
+                        app.Run(async context =>
+                        {
+                            context.Response.ContentType = "text/plain";
+                            // There's a strong connection affinity between processes. Close the connection so the next request can be dispatched to a random instance.
+                            // It appears to be round robin based and switch instances roughly every 30 requests when using new connections.
+                            // This seems related to the default MaxAccepts (5 * processor count).
+                            // I'm told this connection affinity does not apply to HTTP/2.
+                            context.Response.Headers["Connection"] = "close";
+                            await context.Response.WriteAsync("Hello world from " + context.Request.Host + " at " + DateTime.Now);
+                        });
+                    });
+
+                })
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/src/Servers/HttpSys/samples/QueueSharing/QueueSharing.csproj
+++ b/src/Servers/HttpSys/samples/QueueSharing/QueueSharing.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
+    <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+</Project>

--- a/src/Servers/HttpSys/src/AuthenticationManager.cs
+++ b/src/Servers/HttpSys/src/AuthenticationManager.cs
@@ -32,6 +32,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
         }
 
+        /// <summary>
+        /// When attaching to an existing queue this setting must match the one used to create the queue.
+        /// </summary>
         public AuthenticationSchemes Schemes
         {
             get { return _authSchemes; }

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             // V2 initialization sequence:
             // 1. Create server session
             // 2. Create url group
-            // 3. Create request queue - Done in Start()
+            // 3. Create request queue
             // 4. Add urls to url group - Done in Start()
             // 5. Attach request queue to url group - Done in Start()
 
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
                 _urlGroup = new UrlGroup(_serverSession, Logger);
 
-                _requestQueue = new RequestQueue(_urlGroup, options.RequestQueueName, options.Mode, Logger);
+                _requestQueue = new RequestQueue(_urlGroup, options.RequestQueueName, options.RequestQueueMode, Logger);
 
                 _disconnectListener = new DisconnectListener(_requestQueue, Logger);
             }
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         return;
                     }
 
-                    // if we created the Q then set up the URL behaviors
+                    // If this instance created the queue then configure it.
                     if (_requestQueue.Created)
                     {
                         Options.Apply(UrlGroup, RequestQueue);
@@ -192,15 +192,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         return;
                     }
 
-                    // if we created the Q delete the URL prefixes
+                    // If this instance created the queue then remove the URL prefixes before shutting down.
                     if (_requestQueue.Created)
                     {
                         Options.UrlPrefixes.UnregisterAllPrefixes();
+                        _requestQueue.DetachFromUrlGroup();
                     }
 
                     _state = State.Stopped;
 
-                    _requestQueue.DetachFromUrlGroup();
                 }
             }
             catch (Exception exception)

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// Gets or sets the maximum number of concurrent connections to accept, -1 for infinite, or null to
         /// use the machine wide setting from the registry. The default value is null.
-        /// This settings do not apply when attaching to an existing queue.
+        /// This settings does not apply when attaching to an existing queue.
         /// </summary>
         public long? MaxConnections
         {
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         /// <summary>
         /// Gets or sets the maximum number of requests that will be queued up in Http.Sys.
-        /// This settings do not apply when attaching to an existing queue.
+        /// This settings does not apply when attaching to an existing queue.
         /// </summary>
         public long RequestQueueLimit
         {
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     throw new ArgumentOutOfRangeException(nameof(value), value, "The value must be greater than zero.");
                 }
 
-                if (_requestQueue != null && _requestQueue.Created)
+                if (_requestQueue != null)
                 {
                     _requestQueue.SetLengthLimit(_requestQueueLength);
                 }
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// Gets or sets a value that controls how http.sys reacts when rejecting requests due to throttling conditions - like when the request
         /// queue limit is reached. The default in http.sys is "Basic" which means http.sys is just resetting the TCP connection. IIS uses Limited
         /// as its default behavior which will result in sending back a 503 - Service Unavailable back to the client.
-        /// These settings do not apply when attaching to an existing queue.
+        /// This settings does not apply when attaching to an existing queue.
         /// </summary>
         public Http503VerbosityLevel Http503Verbosity
         {

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -49,9 +49,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         /// <summary>
-        /// Options for the creations of a HTTP.SYS Request Queue.
+        /// Indicates if this server instance is responsible for creating and configuring the request queue,
+        /// of if it should attach to an existing queue. The default is to create.
         /// </summary>
-        public RequestQueueMode Mode { get; set; }
+        public RequestQueueMode RequestQueueMode { get; set; }
 
         /// <summary>
         /// The maximum number of concurrent accepts.
@@ -68,6 +69,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// The url prefixes to register with Http.Sys. These may be modified at any time prior to disposing
         /// the listener.
+        /// When attached to an existing queue the prefixes are only used to compute PathBase for requests.
         /// </summary>
         public UrlPrefixCollection UrlPrefixes { get; } = new UrlPrefixCollection();
 
@@ -80,6 +82,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// Exposes the Http.Sys timeout configurations.  These may also be configured in the registry.
         /// These may be modified at any time prior to disposing the listener.
+        /// These settings do not apply when attaching to an existing queue.
         /// </summary>
         public TimeoutManager Timeouts { get; } = new TimeoutManager();
 
@@ -92,6 +95,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// Gets or sets the maximum number of concurrent connections to accept, -1 for infinite, or null to
         /// use the machine wide setting from the registry. The default value is null.
+        /// This settings do not apply when attaching to an existing queue.
         /// </summary>
         public long? MaxConnections
         {
@@ -114,6 +118,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         /// <summary>
         /// Gets or sets the maximum number of requests that will be queued up in Http.Sys.
+        /// This settings do not apply when attaching to an existing queue.
         /// </summary>
         public long RequestQueueLimit
         {
@@ -169,6 +174,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// Gets or sets a value that controls how http.sys reacts when rejecting requests due to throttling conditions - like when the request
         /// queue limit is reached. The default in http.sys is "Basic" which means http.sys is just resetting the TCP connection. IIS uses Limited
         /// as its default behavior which will result in sending back a 503 - Service Unavailable back to the client.
+        /// These settings do not apply when attaching to an existing queue.
         /// </summary>
         public Http503VerbosityLevel Http503Verbosity
         {
@@ -197,6 +203,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        // Not called when attaching to an existing queue.
         internal void Apply(UrlGroup urlGroup, RequestQueue requestQueue)
         {
             _urlGroup = urlGroup;

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -49,6 +49,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         /// <summary>
+        /// Options for the creations of a HTTP.SYS Request Queue.
+        /// </summary>
+        public RequestQueueMode Mode { get; set; }
+
+        /// <summary>
         /// The maximum number of concurrent accepts.
         /// </summary>
         public int MaxAccepts { get; set; } = DefaultMaxAccepts;

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             get => _requestQueueName;
             set
             {
-                if (value.Length > MaximumRequestQueueNameLength)
+                if (value?.Length > MaximumRequestQueueNameLength)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value),
                                                           value,

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     throw new ArgumentOutOfRangeException(nameof(value), value, "The value must be greater than zero.");
                 }
 
-                if (_requestQueue != null)
+                if (_requestQueue != null && _requestQueue.Created)
                 {
                     _requestQueue.SetLengthLimit(_requestQueueLength);
                 }

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -112,13 +112,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Listener.Options.UrlPrefixes.Add(value);
                 }
             }
-            else
+            else if (Listener.RequestQueue.Created)
             {
                 LogHelper.LogDebug(_logger, $"No listening endpoints were configured. Binding to {Constants.DefaultServerAddress} by default.");
 
                 _serverAddresses.Addresses.Add(Constants.DefaultServerAddress);
                 Listener.Options.UrlPrefixes.Add(Constants.DefaultServerAddress);
             }
+            // else // Attaching to an existing queue, don't add a default.
 
             // Can't call Start twice
             Contract.Assert(_application == null);

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -136,11 +136,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private void ActivateRequestProcessingLimits()
         {
-            if (_options.Mode == RequestQueueMode.Controller)
-            {
-                return;
-            }
-
             for (int i = _acceptorCounts; i < _maxAccepts; i++)
             {
                 ProcessRequestsWorker();

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -136,6 +136,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private void ActivateRequestProcessingLimits()
         {
+            if (_options.Mode == RequestQueueMode.Controller)
+            {
+                return;
+            }
+
             for (int i = _acceptorCounts; i < _maxAccepts; i++)
             {
                 ProcessRequestsWorker();

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         [DllImport(HTTPAPI, ExactSpelling = true, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern unsafe uint HttpCreateRequestQueue(HTTPAPI_VERSION version, string pName,
-            UnsafeNclNativeMethods.SECURITY_ATTRIBUTES pSecurityAttributes, uint flags, out HttpRequestQueueV2Handle pReqQueueHandle);
+            UnsafeNclNativeMethods.SECURITY_ATTRIBUTES pSecurityAttributes, HTTP_CREATE_REQUEST_QUEUE_FLAG flags, out HttpRequestQueueV2Handle pReqQueueHandle);
 
         [DllImport(HTTPAPI, ExactSpelling = true, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern unsafe uint HttpCloseRequestQueue(IntPtr pReqQueueHandle);

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -32,10 +32,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 flags = HttpApiTypes.HTTP_CREATE_REQUEST_QUEUE_FLAG.OpenExisting;
                 Created = false;
             }
-            else if (_mode == RequestQueueMode.Controller)
-            {
-                flags = HttpApiTypes.HTTP_CREATE_REQUEST_QUEUE_FLAG.Controller;
-            }
 
             HttpRequestQueueV2Handle requestQueueHandle = null;
 
@@ -72,8 +68,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
 
             // Disabling callbacks when IO operation completes synchronously (returns ErrorCodes.ERROR_SUCCESS)
-            if (_mode != RequestQueueMode.Controller &&
-                HttpSysListener.SkipIOCPCallbackOnSuccess &&
+            if (HttpSysListener.SkipIOCPCallbackOnSuccess &&
                 !UnsafeNclNativeMethods.SetFileCompletionNotificationModes(
                     requestQueueHandle,
                     UnsafeNclNativeMethods.FileCompletionNotificationModes.SkipCompletionPortOnSuccess |

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -97,12 +97,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             // Set the association between request queue and url group. After this, requests for registered urls will 
             // get delivered to this request queue.
 
-            // If we did not create then we skip this step
-            if (!Created)
-            {
-                return;
-            }
-
             var info = new HttpApiTypes.HTTP_BINDING_INFO();
             info.Flags = HttpApiTypes.HTTP_FLAGS.HTTP_PROPERTY_FLAG_PRESENT;
             info.RequestQueueHandle = Handle.DangerousGetHandle();
@@ -121,12 +115,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             // Note that this method may be called multiple times (Stop() and then Abort()). This
             // is fine since http.sys allows to set HttpServerBindingProperty multiple times for valid 
             // Url groups.
-
-            // If we did not create then we skip this step
-            if (!Created)
-            {
-                return;
-            }
 
             var info = new HttpApiTypes.HTTP_BINDING_INFO();
             info.Flags = HttpApiTypes.HTTP_FLAGS.NONE;

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             if (!Created)
             {
-                _logger.LogInformation("Attached to an existing request queue.");
+                _logger.LogInformation("Attached to an existing request queue '{requestQueueName}', some options do not apply.", requestQueueName);
             }
         }
 

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     HttpApi.Version,
                     requestQueueName,
                     null,
-                    (uint) flags,
+                    flags,
                     out requestQueueHandle);
 
             if (_mode == RequestQueueMode.AttachOrCreate && statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_FILE_NOT_FOUND)
@@ -50,7 +50,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 statusCode = HttpApi.HttpCreateRequestQueue(
                         HttpApi.Version,
                         requestQueueName,
-                        null, (uint) flags,
+                        null,
+                        flags,
                         out requestQueueHandle);
             }
 

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNetCore.HttpSys.Internal;
@@ -42,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             if (_mode == RequestQueueMode.CreateOrAttach && statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_ALREADY_EXISTS)
             {
-                // Tried to create, but it already exist so attach to it instead.
+                // Tried to create, but it already exists so attach to it instead.
                 Created = false;
                 flags = HttpApiTypes.HTTP_CREATE_REQUEST_QUEUE_FLAG.OpenExisting;
                 statusCode = HttpApi.HttpCreateRequestQueue(
@@ -87,7 +88,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         /// <summary>
-        /// Set true if we created queue instead of attaching to existing
+        /// True if this instace created the queue instead of attaching to an existing one.
         /// </summary>
         internal bool Created { get; }
 
@@ -96,6 +97,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal unsafe void AttachToUrlGroup()
         {
+            Debug.Assert(Created);
             CheckDisposed();
             // Set the association between request queue and url group. After this, requests for registered urls will 
             // get delivered to this request queue.
@@ -112,6 +114,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal unsafe void DetachFromUrlGroup()
         {
+            Debug.Assert(Created);
             CheckDisposed();
             // Break the association between request queue and url group. After this, requests for registered urls 
             // will get 503s.
@@ -132,6 +135,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // The listener must be active for this to work.
         internal unsafe void SetLengthLimit(long length)
         {
+            Debug.Assert(Created);
             CheckDisposed();
 
             var result = HttpApi.HttpSetRequestQueueProperty(Handle,
@@ -147,6 +151,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // The listener must be active for this to work.
         internal unsafe void SetRejectionVerbosity(Http503VerbosityLevel verbosity)
         {
+            Debug.Assert(Created);
             CheckDisposed();
 
             var result = HttpApi.HttpSetRequestQueueProperty(Handle,

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -79,6 +79,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     UnsafeNclNativeMethods.FileCompletionNotificationModes.SkipCompletionPortOnSuccess |
                     UnsafeNclNativeMethods.FileCompletionNotificationModes.SkipSetEventOnHandle))
             {
+                requestQueueHandle.Dispose();
                 throw new HttpSysException(Marshal.GetLastWin32Error());
             }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -11,8 +11,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpSys.Internal;
 
 namespace Microsoft.AspNetCore.Server.HttpSys

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -66,6 +66,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 PathBase = string.Empty;
                 Path = string.Empty;
             }
+            // TODO: How to make base paths work when the prefix is defined elsewhere? Loop and test?
+            else if (!RequestContext.Server.RequestQueue.Created || prefix == null)
+            {
+                PathBase = string.Empty;
+                Path = originalPath;
+            }
             // These paths are both unescaped already.
             else if (originalPath.Length == prefix.Path.Length - 1)
             {

--- a/src/Servers/HttpSys/src/RequestQueueMode.cs
+++ b/src/Servers/HttpSys/src/RequestQueueMode.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    public enum RequestQueueMode
+    {
+        Create = 0,
+        Controller,
+        AttachToExisting,
+        AttachOrCreate
+    }
+}

--- a/src/Servers/HttpSys/src/RequestQueueMode.cs
+++ b/src/Servers/HttpSys/src/RequestQueueMode.cs
@@ -1,17 +1,22 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
     public enum RequestQueueMode
     {
+        /// <summary>
+        /// Create a new queue. This will fail if there's an existing queue with the same name.
+        /// </summary>
         Create = 0,
-        Controller,
+        /// <summary>
+        /// Attach to an existing queue with the name given. This will fail if the queue does not already exist.
+        /// Most configuration options are ignored when attaching to an existing queue.
+        /// </summary>
         AttachToExisting,
+        /// <summary>
+        /// Attach to an existing queue with the given name if it exists, otherwise create it.
+        /// </summary>
         AttachOrCreate
     }
 }

--- a/src/Servers/HttpSys/src/RequestQueueMode.cs
+++ b/src/Servers/HttpSys/src/RequestQueueMode.cs
@@ -3,6 +3,10 @@
 
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
+    /// <summary>
+    /// Used to indicate if this server instance should create a new Http.Sys request queue
+    /// or attach to an existing one.
+    /// </summary>
     public enum RequestQueueMode
     {
         /// <summary>
@@ -16,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         Attach,
         /// <summary>
         /// Create a queue with the given name if it does not already exist, otherwise attach to the existing queue.
+        /// Most configuration options do not apply when attaching to an existing queue.
         /// </summary>
         CreateOrAttach
     }

--- a/src/Servers/HttpSys/src/RequestQueueMode.cs
+++ b/src/Servers/HttpSys/src/RequestQueueMode.cs
@@ -11,12 +11,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         Create = 0,
         /// <summary>
         /// Attach to an existing queue with the name given. This will fail if the queue does not already exist.
-        /// Most configuration options are ignored when attaching to an existing queue.
+        /// Most configuration options do not apply when attaching to an existing queue.
         /// </summary>
-        AttachToExisting,
+        Attach,
         /// <summary>
-        /// Attach to an existing queue with the given name if it exists, otherwise create it.
+        /// Create a queue with the given name if it does not already exist, otherwise attach to the existing queue.
         /// </summary>
-        AttachOrCreate
+        CreateOrAttach
     }
 }

--- a/src/Servers/HttpSys/src/TimeoutManager.cs
+++ b/src/Servers/HttpSys/src/TimeoutManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
     /// <summary>
     /// Exposes the Http.Sys timeout configurations.  These may also be configured in the registry.
+    /// These settings do not apply when attaching to an existing queue.
     /// </summary>
     public sealed class TimeoutManager
     {

--- a/src/Servers/HttpSys/src/UrlPrefix.cs
+++ b/src/Servers/HttpSys/src/UrlPrefix.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             Scheme = scheme;
             Host = host;
             Port = port;
+            HostAndPort = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", Host, Port);
             PortValue = portValue;
             Path = path;
             PathWithoutTrailingSlash = Path.Length > 1 ? Path[0..^1] : string.Empty;
@@ -145,14 +146,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             return Create(scheme, host, port, path);
         }
 
-        public bool IsHttps { get; private set; }
-        public string Scheme { get; private set; }
-        public string Host { get; private set; }
-        public string Port { get; private set; }
-        public int PortValue { get; private set; }
-        public string Path { get; private set; }
-        public string PathWithoutTrailingSlash { get; private set; }
-        public string FullPrefix { get; private set; }
+        public bool IsHttps { get; }
+        public string Scheme { get; }
+        public string Host { get; }
+        public string Port { get; }
+        internal string HostAndPort { get; }
+        public int PortValue { get; }
+        public string Path { get; }
+        internal string PathWithoutTrailingSlash { get; }
+        public string FullPrefix { get; }
 
         public override bool Equals(object obj)
         {

--- a/src/Servers/HttpSys/src/UrlPrefix.cs
+++ b/src/Servers/HttpSys/src/UrlPrefix.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             Port = port;
             PortValue = portValue;
             Path = path;
+            PathWithoutTrailingSlash = Path.Length > 1 ? Path[0..^1] : string.Empty;
             FullPrefix = string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}{3}", Scheme, Host, Port, Path);
         }
 
@@ -150,6 +151,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public string Port { get; private set; }
         public int PortValue { get; private set; }
         public string Path { get; private set; }
+        public string PathWithoutTrailingSlash { get; private set; }
         public string FullPrefix { get; private set; }
 
         public override bool Equals(object obj)

--- a/src/Servers/HttpSys/src/UrlPrefixCollection.cs
+++ b/src/Servers/HttpSys/src/UrlPrefixCollection.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
@@ -59,6 +61,30 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 return _prefixes.TryGetValue(id, out var prefix) ? prefix : null;
             }
+        }
+
+        internal bool TryMatchLongestPrefix(bool isHttps, string host, string originalPath, out string pathBase, out string remainingPath)
+        {
+            var originalPathString = new PathString(originalPath);
+            var found = false;
+            pathBase = null;
+            remainingPath = null;
+            lock (_prefixes)
+            {
+                foreach (var prefix in _prefixes.Values)
+                {
+                    if (isHttps == prefix.IsHttps
+                        && string.Equals(host, prefix.HostAndPort, StringComparison.OrdinalIgnoreCase)
+                        && originalPathString.StartsWithSegments(new PathString(prefix.PathWithoutTrailingSlash), StringComparison.OrdinalIgnoreCase, out var remainder)
+                        && (!found || remainder.Value.Length < remainingPath.Length)) // Longest match
+                    {
+                        found = true;
+                        pathBase = originalPath.Substring(0, prefix.PathWithoutTrailingSlash.Length); // Maintain the input casing
+                        remainingPath = remainder.Value;
+                    }
+                }
+            }
+            return found;
         }
 
         public void Clear()

--- a/src/Servers/HttpSys/src/UrlPrefixCollection.cs
+++ b/src/Servers/HttpSys/src/UrlPrefixCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections;
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             lock (_prefixes)
             {
-                return _prefixes[id];
+                return _prefixes.TryGetValue(id, out var prefix) ? prefix : null;
             }
         }
 

--- a/src/Servers/HttpSys/src/UrlPrefixCollection.cs
+++ b/src/Servers/HttpSys/src/UrlPrefixCollection.cs
@@ -73,6 +73,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 foreach (var prefix in _prefixes.Values)
                 {
+                    // The scheme, host, port, and start of path must match.
+                    // Note this does not currently handle prefixes with wildcard subdomains.
                     if (isHttps == prefix.IsHttps
                         && string.Equals(host, prefix.HostAndPort, StringComparison.OrdinalIgnoreCase)
                         && originalPathString.StartsWithSegments(new PathString(prefix.PathWithoutTrailingSlash), StringComparison.OrdinalIgnoreCase, out var remainder)

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
@@ -160,26 +160,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [ConditionalFact]
-        public async Task MultipleAuthTypes_KerberosAllowAnonymousButSpecify401_ChallengesAdded()
-        {
-            using var baseServer = Utilities.CreateHttpAuthServer(AuthenticationSchemes.Kerberos, AllowAnoymous, out var address);
-            using var server = Utilities.CreateServerOnExistingQueue(AuthenticationSchemes.Kerberos, AllowAnoymous, baseServer.Options.RequestQueueName);
-
-            Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
-
-            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
-            Assert.NotNull(context.User);
-            Assert.False(context.User.Identity.IsAuthenticated);
-            Assert.Equal(AuthenticationSchemes.Kerberos, context.Response.AuthenticationChallenges);
-            context.Response.StatusCode = 401;
-            context.Dispose();
-
-            var response = await responseTask;
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-            Assert.Equal("Kerberos", response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
-        }
-
         private async Task<HttpResponseMessage> SendRequestAsync(string uri, bool useDefaultCredentials = false)
         {
             HttpClientHandler handler = new HttpClientHandler();

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
@@ -45,7 +45,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationType.Digest)] // TODO: Not implemented
         [InlineData(AuthenticationSchemes.Basic)]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthType_RequireAuth_ChallengesAdded(AuthenticationSchemes authType)
         {
             using var baseServer = Utilities.CreateHttpAuthServer(authType, DenyAnoymous, out var address);
@@ -64,7 +63,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
         [InlineData(AuthenticationSchemes.Basic)]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthType_AllowAnonymousButSpecify401_ChallengesAdded(AuthenticationSchemes authType)
         {
             using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
@@ -1,0 +1,193 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.HttpSys.Listener
+{
+    public class AuthenticationOnExistingQueueTests
+    {
+        private static readonly bool AllowAnoymous = true;
+        private static readonly bool DenyAnoymous = false;
+
+        [ConditionalTheory]
+        [InlineData(AuthenticationSchemes.None)]
+        [InlineData(AuthenticationSchemes.Negotiate)]
+        [InlineData(AuthenticationSchemes.NTLM)]
+        // [InlineData(AuthenticationSchemes.Digest)]
+        [InlineData(AuthenticationSchemes.Basic)]
+        [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationSchemes.Digest |*/ AuthenticationSchemes.Basic)]
+        public async Task AuthTypes_AllowAnonymous_NoChallenge(AuthenticationSchemes authType)
+        {
+            using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+            
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.False(context.User.Identity.IsAuthenticated);
+            Assert.Equal(authType, context.Response.AuthenticationChallenges);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Empty(response.Headers.WwwAuthenticate);
+        }
+
+        [ConditionalTheory]
+        [InlineData(AuthenticationSchemes.Negotiate)]
+        [InlineData(AuthenticationSchemes.NTLM)]
+        // [InlineData(AuthenticationType.Digest)] // TODO: Not implemented
+        [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
+        public async Task AuthType_RequireAuth_ChallengesAdded(AuthenticationSchemes authType)
+        {
+            using var baseServer = Utilities.CreateHttpAuthServer(authType, DenyAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(authType, DenyAnoymous, baseServer.Options.RequestQueueName);
+
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+
+            var contextTask = server.AcceptAsync(Utilities.DefaultTimeout); // Fails when the server shuts down, the challenge happens internally.
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(authType.ToString(), response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        [ConditionalTheory]
+        [InlineData(AuthenticationSchemes.Negotiate)]
+        [InlineData(AuthenticationSchemes.NTLM)]
+        // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
+        [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
+        public async Task AuthType_AllowAnonymousButSpecify401_ChallengesAdded(AuthenticationSchemes authType)
+        {
+            using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+            
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.False(context.User.Identity.IsAuthenticated);
+            Assert.Equal(authType, context.Response.AuthenticationChallenges);
+            context.Response.StatusCode = 401;
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(authType.ToString(), response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        [ConditionalFact]
+        public async Task MultipleAuthTypes_AllowAnonymousButSpecify401_ChallengesAdded()
+        {
+            AuthenticationSchemes authType =
+                AuthenticationSchemes.Negotiate
+                | AuthenticationSchemes.NTLM
+                /* | AuthenticationSchemes.Digest TODO: Not implemented */
+                | AuthenticationSchemes.Basic;
+            using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+            
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.False(context.User.Identity.IsAuthenticated);
+            Assert.Equal(authType, context.Response.AuthenticationChallenges);
+            context.Response.StatusCode = 401;
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal("Negotiate, NTLM, basic", response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        [ConditionalTheory]
+        [InlineData(AuthenticationSchemes.Negotiate)]
+        [InlineData(AuthenticationSchemes.NTLM)]
+        // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
+        // [InlineData(AuthenticationSchemes.Basic)] // Doesn't work with default creds
+        [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationType.Digest |*/ AuthenticationSchemes.Basic)]
+        public async Task AuthTypes_AllowAnonymousButSpecify401_Success(AuthenticationSchemes authType)
+        {
+            using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+            
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.False(context.User.Identity.IsAuthenticated);
+            Assert.Equal(authType, context.Response.AuthenticationChallenges);
+            context.Response.StatusCode = 401;
+            context.Dispose();
+
+            context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.True(context.User.Identity.IsAuthenticated);
+            Assert.Equal(authType, context.Response.AuthenticationChallenges);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [ConditionalTheory]
+        [InlineData(AuthenticationSchemes.Negotiate)]
+        [InlineData(AuthenticationSchemes.NTLM)]
+        // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
+        // [InlineData(AuthenticationSchemes.Basic)] // Doesn't work with default creds
+        [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationType.Digest |*/ AuthenticationSchemes.Basic)]
+        public async Task AuthTypes_RequireAuth_Success(AuthenticationSchemes authType)
+        {
+            using var baseServer = Utilities.CreateHttpAuthServer(authType, DenyAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(authType, DenyAnoymous, baseServer.Options.RequestQueueName);
+
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.True(context.User.Identity.IsAuthenticated);
+            Assert.Equal(authType, context.Response.AuthenticationChallenges);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [ConditionalFact]
+        public async Task MultipleAuthTypes_KerberosAllowAnonymousButSpecify401_ChallengesAdded()
+        {
+            using var baseServer = Utilities.CreateHttpAuthServer(AuthenticationSchemes.Kerberos, AllowAnoymous, out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(AuthenticationSchemes.Kerberos, AllowAnoymous, baseServer.Options.RequestQueueName);
+
+            Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.NotNull(context.User);
+            Assert.False(context.User.Identity.IsAuthenticated);
+            Assert.Equal(AuthenticationSchemes.Kerberos, context.Response.AuthenticationChallenges);
+            context.Response.StatusCode = 401;
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal("Kerberos", response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        private async Task<HttpResponseMessage> SendRequestAsync(string uri, bool useDefaultCredentials = false)
+        {
+            HttpClientHandler handler = new HttpClientHandler();
+            handler.UseDefaultCredentials = useDefaultCredentials;
+            using HttpClient client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+            return await client.GetAsync(uri);
+        }
+    }
+}

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerOnExistingQueueTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerOnExistingQueueTests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.HttpSys.Listener
+{
+    public class ServerOnExistingQueueTests
+    {
+        [ConditionalFact]
+        public async Task Server_200OK_Success()
+        {
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+
+            var responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(string.Empty, response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_SendHelloWorld_Success()
+        {
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+
+            Task<string> responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            context.Response.ContentLength = 11;
+            await using (var writer = new StreamWriter(context.Response.Body))
+            {
+                await writer.WriteAsync("Hello World");
+            }
+
+            string response = await responseTask;
+            Assert.Equal("Hello World", response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_EchoHelloWorld_Success()
+        {
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+
+            var responseTask = SendRequestAsync(address, "Hello World");
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            string input = await new StreamReader(context.Request.Body).ReadToEndAsync();
+            Assert.Equal("Hello World", input);
+            context.Response.ContentLength = 11;
+            await using (var writer = new StreamWriter(context.Response.Body))
+            {
+                await writer.WriteAsync("Hello World");
+            }
+
+            var response = await responseTask;
+            Assert.Equal("Hello World", response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_ClientDisconnects_CallCanceled()
+        {
+            var interval = TimeSpan.FromSeconds(1);
+            var canceled = new ManualResetEvent(false);
+
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+            using var client = new HttpClient();
+
+            var responseTask = client.GetAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            var ct = context.DisconnectToken;
+            Assert.True(ct.CanBeCanceled, "CanBeCanceled");
+            Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
+            ct.Register(() => canceled.Set());
+
+            client.CancelPendingRequests();
+
+            Assert.True(canceled.WaitOne(interval), "canceled");
+            Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+
+            context.Dispose();
+        }
+
+        [ConditionalFact]
+        public async Task Server_TokenRegisteredAfterClientDisconnects_CallCanceled()
+        {
+            var interval = TimeSpan.FromSeconds(1);
+            var canceled = new ManualResetEvent(false);
+
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+            using var client = new HttpClient();
+            var responseTask = client.GetAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+
+            client.CancelPendingRequests();
+            await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+
+            var ct = context.DisconnectToken;
+            Assert.True(ct.CanBeCanceled, "CanBeCanceled");
+            ct.Register(() => canceled.Set());
+            Assert.True(ct.WaitHandle.WaitOne(interval));
+            Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
+
+            Assert.True(canceled.WaitOne(interval), "canceled");
+
+            context.Dispose();
+        }
+
+        [ConditionalFact]
+        public async Task Server_TokenRegisteredAfterResponseSent_Success()
+        {
+            var interval = TimeSpan.FromSeconds(1);
+            var canceled = new ManualResetEvent(false);
+
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+            using var client = new HttpClient();
+            var responseTask = client.GetAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            context.Dispose();
+
+            var response = await responseTask;
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
+
+            var ct = context.DisconnectToken;
+            Assert.False(ct.CanBeCanceled, "CanBeCanceled");
+            ct.Register(() => canceled.Set());
+            Assert.False(ct.WaitHandle.WaitOne(interval));
+            Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
+
+            Assert.False(canceled.WaitOne(interval), "canceled");
+        }
+
+        [ConditionalFact]
+        public async Task Server_Abort_CallCanceled()
+        {
+            var interval = TimeSpan.FromSeconds(1);
+            var canceled = new ManualResetEvent(false);
+
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+            
+            var responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            var ct = context.DisconnectToken;
+            Assert.True(ct.CanBeCanceled, "CanBeCanceled");
+            Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
+            ct.Register(() => canceled.Set());
+            context.Abort();
+            Assert.True(canceled.WaitOne(interval), "Aborted");
+            Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
+
+            await Assert.ThrowsAsync<HttpRequestException>(() => responseTask);
+        }
+
+        [ConditionalFact]
+        public async Task Server_ConnectionCloseHeader_CancellationTokenFires()
+        {
+            var interval = TimeSpan.FromSeconds(1);
+            var canceled = new ManualResetEvent(false);
+
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+            var responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            var ct = context.DisconnectToken;
+            Assert.True(ct.CanBeCanceled, "CanBeCanceled");
+            Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
+            ct.Register(() => canceled.Set());
+
+            context.Response.Headers["Connection"] = "close";
+
+            context.Response.ContentLength = 11;
+            await using (var writer = new StreamWriter(context.Response.Body))
+            {
+                await writer.WriteAsync("Hello World");
+            }
+
+            Assert.True(canceled.WaitOne(interval), "Disconnected");
+            Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
+
+            var response = await responseTask;
+            Assert.Equal("Hello World", response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_SetQueueLimit_Success()
+        {
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+            server.Options.RequestQueueLimit = 1001;
+            var responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(string.Empty, response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_HotAddPrefix_Success()
+        {
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+
+            var responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.Equal(string.Empty, context.Request.PathBase);
+            Assert.Equal("/", context.Request.Path);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(string.Empty, response);
+
+            address += "pathbase/";
+            server.Options.UrlPrefixes.Add(address);
+
+            responseTask = SendRequestAsync(address);
+
+            context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.Equal("/pathbase", context.Request.PathBase);
+            Assert.Equal("/", context.Request.Path);
+            context.Dispose();
+
+            response = await responseTask;
+            Assert.Equal(string.Empty, response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_HotRemovePrefix_Success()
+        {
+            using var baseServer = Utilities.CreateHttpServer(out var address);
+            using var server = Utilities.CreateServerOnExistingQueue(baseServer.Options.RequestQueueName);
+
+            address += "pathbase/";
+            server.Options.UrlPrefixes.Add(address);
+            var responseTask = SendRequestAsync(address);
+
+            var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.Equal("/pathbase", context.Request.PathBase);
+            Assert.Equal("/", context.Request.Path);
+            context.Dispose();
+
+            var response = await responseTask;
+            Assert.Equal(string.Empty, response);
+
+            Assert.True(server.Options.UrlPrefixes.Remove(address));
+
+            responseTask = SendRequestAsync(address);
+
+            context = await server.AcceptAsync(Utilities.DefaultTimeout);
+            Assert.Equal(string.Empty, context.Request.PathBase);
+            Assert.Equal("/pathbase/", context.Request.Path);
+            context.Dispose();
+
+            response = await responseTask;
+            Assert.Equal(string.Empty, response);
+        }
+
+        private async Task<string> SendRequestAsync(string uri)
+        {
+            using HttpClient client = new HttpClient();
+            return await client.GetStringAsync(uri);
+        }
+
+        private async Task<string> SendRequestAsync(string uri, string upload)
+        {
+            using HttpClient client = new HttpClient();
+            HttpResponseMessage response = await client.PostAsync(uri, new StringContent(upload));
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.HttpSys.Listener
@@ -20,6 +21,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         private static object PortLock = new object();
 
         internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
+
+        internal static HttpSysListener CreateHttpAuthServer(AuthenticationSchemes authType, bool allowAnonymous, out string baseAddress)
+        {
+            var listener = CreateHttpServer(out baseAddress);
+            listener.Options.Authentication.Schemes = authType;
+            listener.Options.Authentication.AllowAnonymous = allowAnonymous;
+            return listener;
+        }
 
         internal static HttpSysListener CreateHttpServer(out string baseAddress)
         {
@@ -43,16 +52,24 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     var prefix = UrlPrefix.Create("http", "localhost", port, basePath);
                     root = prefix.Scheme + "://" + prefix.Host + ":" + prefix.Port;
                     baseAddress = prefix.ToString();
-                    var listener = new HttpSysListener(new HttpSysOptions(), new LoggerFactory());
-                    listener.Options.UrlPrefixes.Add(prefix);
+                    var options = new HttpSysOptions();
+                    options.UrlPrefixes.Add(prefix);
+                    options.RequestQueueName = prefix.Port; // Convention for use with CreateServerOnExistingQueue
+                    var listener = new HttpSysListener(options, new LoggerFactory());
                     try
                     {
                         listener.Start();
                         return listener;
                     }
-                    catch (HttpSysException)
+                    catch (HttpSysException ex)
                     {
                         listener.Dispose();
+                        if (ex.ErrorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_ALREADY_EXISTS
+                            && ex.ErrorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SHARING_VIOLATION
+                            && ex.ErrorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_ACCESS_DENIED)
+                        {
+                            throw;
+                        }
                     }
                 }
                 NextPort = BasePort;
@@ -69,6 +86,23 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         {
             var listener = new HttpSysListener(new HttpSysOptions(), new LoggerFactory());
             listener.Options.UrlPrefixes.Add(UrlPrefix.Create(scheme, host, port, path));
+            listener.Start();
+            return listener;
+        }
+
+        internal static HttpSysListener CreateServerOnExistingQueue(string requestQueueName)
+        {
+            return CreateServerOnExistingQueue(AuthenticationSchemes.None, true, requestQueueName);
+        }
+
+        internal static HttpSysListener CreateServerOnExistingQueue(AuthenticationSchemes authScheme, bool allowAnonymos, string requestQueueName)
+        {
+            var options = new HttpSysOptions();
+            options.Mode = RequestQueueMode.AttachToExisting;
+            options.RequestQueueName = requestQueueName;
+            options.Authentication.Schemes = authScheme;
+            options.Authentication.AllowAnonymous = allowAnonymos;
+            var listener = new HttpSysListener(options, new LoggerFactory());
             listener.Start();
             return listener;
         }

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         internal static HttpSysListener CreateServerOnExistingQueue(AuthenticationSchemes authScheme, bool allowAnonymos, string requestQueueName)
         {
             var options = new HttpSysOptions();
-            options.RequestQueueMode = RequestQueueMode.AttachToExisting;
+            options.RequestQueueMode = RequestQueueMode.Attach;
             options.RequestQueueName = requestQueueName;
             options.Authentication.Schemes = authScheme;
             options.Authentication.AllowAnonymous = allowAnonymos;

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         internal static HttpSysListener CreateServerOnExistingQueue(AuthenticationSchemes authScheme, bool allowAnonymos, string requestQueueName)
         {
             var options = new HttpSysOptions();
-            options.Mode = RequestQueueMode.AttachToExisting;
+            options.RequestQueueMode = RequestQueueMode.AttachToExisting;
             options.RequestQueueName = requestQueueName;
             options.Authentication.Schemes = authScheme;
             options.Authentication.AllowAnonymous = allowAnonymos;

--- a/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }, options =>
             {
                 options.RequestQueueName = queueName;
-                options.Mode = RequestQueueMode.AttachToExisting;
+                options.RequestQueueMode = RequestQueueMode.AttachToExisting;
             }))
             {
                 var psi = new ProcessStartInfo("netsh", "http show servicestate view=requestq")

--- a/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }, options =>
             {
                 options.RequestQueueName = queueName;
-                options.RequestQueueMode = RequestQueueMode.AttachToExisting;
+                options.RequestQueueMode = RequestQueueMode.Attach;
             }))
             {
                 var psi = new ProcessStartInfo("netsh", "http show servicestate view=requestq")

--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -615,6 +615,16 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             HTTP_AUTH_ENABLE_KERBEROS = 0x00000010,
         }
 
+        [Flags]
+        internal enum HTTP_CREATE_REQUEST_QUEUE_FLAG : uint
+        {
+            None = 0,
+            // The HTTP_CREATE_REQUEST_QUEUE_FLAG_OPEN_EXISTING flag allows applications to open an existing request queue by name and retrieve the request queue handle. The pName parameter must contain a valid request queue name; it cannot be NULL.
+            OpenExisting = 1,
+            // The handle to the request queue created using this flag cannot be used to perform I/O operations. This flag can be set only when the request queue handle is created.
+            Controller = 2,
+        }
+
         internal static class HTTP_RESPONSE_HEADER_ID
         {
             private static string[] _strings =

--- a/src/Shared/HttpSys/NativeInterop/UnsafeNativeMethods.cs
+++ b/src/Shared/HttpSys/NativeInterop/UnsafeNativeMethods.cs
@@ -25,6 +25,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             internal const uint ERROR_SUCCESS = 0;
             internal const uint ERROR_FILE_NOT_FOUND = 2;
+            internal const uint ERROR_ACCESS_DENIED = 5;
+            internal const uint ERROR_SHARING_VIOLATION = 32;
             internal const uint ERROR_HANDLE_EOF = 38;
             internal const uint ERROR_NOT_SUPPORTED = 50;
             internal const uint ERROR_INVALID_PARAMETER = 87;

--- a/src/Shared/HttpSys/NativeInterop/UnsafeNativeMethods.cs
+++ b/src/Shared/HttpSys/NativeInterop/UnsafeNativeMethods.cs
@@ -24,9 +24,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         internal static class ErrorCodes
         {
             internal const uint ERROR_SUCCESS = 0;
+            internal const uint ERROR_FILE_NOT_FOUND = 2;
             internal const uint ERROR_HANDLE_EOF = 38;
             internal const uint ERROR_NOT_SUPPORTED = 50;
             internal const uint ERROR_INVALID_PARAMETER = 87;
+            internal const uint ERROR_INVALID_NAME = 123;
             internal const uint ERROR_ALREADY_EXISTS = 183;
             internal const uint ERROR_MORE_DATA = 234;
             internal const uint ERROR_OPERATION_ABORTED = 995;


### PR DESCRIPTION
Support attaching to an existing request queue in HTTP.SYS ( #5866).  This is an addendum to 
“https://github.com/aspnet/AspNetCore/issues/13461”.  

This is criticial (P0) functionality required by Office 365 in support of our new ASP.Net Core 3.X architecture for data access to Substrate Storage.  This is the storage that is mission critical for Office 365.
