### PR TITLE
Improve message when trusting the https development certificate

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/Diagnostics.cs
+++ b/src/Tools/dotnet-dev-certs/src/Diagnostics.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
+{
+    internal class Diagnostics : IDiagnostics
+    {
+        private readonly IReporter _reporter;
+
+        public Diagnostics(IReporter reporter)
+        {
+            _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+        }
+
+        public void Debug(string message)
+        {
+            _reporter.Verbose(message);
+        }
+
+        public void Debug(IEnumerable<string> messages)
+        {
+            foreach (var message in messages)
+            {
+                Debug(message);
+            }
+        }
+
+        public void Warn(string message)
+        {
+            _reporter.Warn(message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            _reporter.Error(message);
+            while (exception != null)
+            {
+                _reporter.Error("Exception message: " + exception.Message);
+                exception = exception.InnerException;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Only display the "Trusting the HTTPS development certificate" warning when we are actually trusting the certificate.

Before this commit, running `dotnet dev-certs https --trust` would _always_ display the "Trusting the HTTPS development certificate" message with a conditional "if the certificate was not previously trusted".

After this commit, the message is not displayed if the certificate is already trusted. Additionally, on macOS, the command with the actual temporary certificate path is displayed instead of using a `<<certificate>>` placeholder. This will help the user to better diagnose problems.