### PR TITLE
Remove en-us locale from links in Blazor server-side project template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
@@ -7,7 +7,7 @@
 <div class="main">
     <div class="top-row px-4">
         <LoginDisplay />
-        <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
+        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.NoAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.NoAuth.razor
@@ -6,7 +6,7 @@
 
 <div class="main">
     <div class="top-row px-4">
-        <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
+        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">


### PR DESCRIPTION
Remove the "en-us" locale from the layout file used in the auth and no auth versions of the Blazor server-side project template.