### PR TITLE
[Templates] Separate F# from C# tests, unskip tests, include reliability improvements

### DIFF
--- a/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
@@ -22,10 +22,19 @@ namespace Templates.Test
 
         public ITestOutputHelper Output { get; }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("F#")]
-        public async Task EmptyWebTemplateAsync(string languageOverride)
+        [Fact]
+        public async Task EmptyWebTemplateCSharp()
+        {
+            await EmtpyTemplateCore(languageOverride: null);
+        }
+
+        [Fact]
+        public async Task EmptyWebTemplateFSharp()
+        {
+            await EmtpyTemplateCore("F#");
+        }
+
+        private async Task EmtpyTemplateCore(string languageOverride)
         {
             Project = await ProjectFactory.GetOrCreateProject("empty" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);
 

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -25,11 +25,14 @@ namespace Templates.Test
         public ProjectFactoryFixture ProjectFactory { get; }
         public ITestOutputHelper Output { get; }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("F#", Skip = "https://github.com/aspnet/AspNetCore/issues/14022")]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2267", FlakyOn.All)]
-        public async Task MvcTemplate_NoAuthImplAsync(string languageOverride)
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/14022")]
+        public async Task MvcTemplate_NoAuthFSharp() => await MvcTemplateCore(languageOverride: "F#");
+
+        [Fact]
+        public async Task MvcTemplate_NoAuthCSharp() => await MvcTemplateCore(languageOverride: null);
+
+
+        private async Task MvcTemplateCore(string languageOverride)
         {
             Project = await ProjectFactory.GetOrCreateProject("mvcnoauth" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);
 
@@ -98,8 +101,7 @@ namespace Templates.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2267", FlakyOn.All)]
-        public async Task MvcTemplate_IndividualAuthImplAsync(bool useLocalDB)
+        public async Task MvcTemplate_IndividualAuth(bool useLocalDB)
         {
             Project = await ProjectFactory.GetOrCreateProject("mvcindividual" + (useLocalDB ? "uld" : ""), Output);
 

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -26,8 +26,7 @@ namespace Templates.Test
         public ITestOutputHelper Output { get; }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2327", FlakyOn.All)]
-        public async Task RazorPagesTemplate_NoAuthImplAsync()
+        public async Task RazorPagesTemplate_NoAuth()
         {
             Project = await ProjectFactory.GetOrCreateProject("razorpagesnoauth", Output);
 
@@ -95,10 +94,9 @@ namespace Templates.Test
         }
 
         [Theory]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2335", FlakyOn.All)]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task RazorPagesTemplate_IndividualAuthImplAsync(bool useLocalDB)
+        public async Task RazorPagesTemplate_IndividualAuth(bool useLocalDB)
         {
             Project = await ProjectFactory.GetOrCreateProject("razorpagesindividual" + (useLocalDB ? "uld" : ""), Output);
 

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -22,10 +22,13 @@ namespace Templates.Test
 
         public Project Project { get; set; }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("F#")]
-        public async Task WebApiTemplateAsync(string languageOverride)
+        [Fact]
+        public async Task WebApiTemplateFSharp() => await WebApiTemplateCore(languageOverride: "F#");
+
+        [Fact]
+        public async Task WebApiTemplateCSharp() => await WebApiTemplateCore(languageOverride: null);
+
+        private async Task WebApiTemplateCore(string languageOverride)
         {
             Project = await FactoryFixture.GetOrCreateProject("webapi" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);
 


### PR DESCRIPTION
* Separates F# from C# tests. These tests have very different runtime
  characteristics and should not be bundled together as the same test
  scenario. For example, we want to quickly separate F# specific issues
  from C# specific ones.
* Unskipping all skipped tests as the issue tracking their flakyness
  was closed.
* Adding reliability improvements to network requests.
  * Adds retries.