### PR TITLE
[Helix] Use standard win10 helix queues

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,10 +1,4 @@
 <Project>
-  <ItemDefinitionGroup>
-    <HelixAvailableTargetQueue>
-      <EnableByDefault>true</EnableByDefault>
-    </HelixAvailableTargetQueue>
-  </ItemDefinitionGroup>
-
   <!-- this file is shared between Helix.proj and .csproj files -->
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailablePlatform Include="Windows" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -14,10 +14,9 @@
 
     <!-- x64 queues -->
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'x64'">
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.ClientRS4.VS2017.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" Platform="Windows" EnableByDefault="false" />
     <HelixAvailableTargetQueue Include="Ubuntu.1604.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Centos.7.Amd64.Open" Platform="Linux" />
@@ -40,7 +39,7 @@
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true'">
     <HelixAvailablePlatform Include="Windows" />
 
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.EnterpriseRS3.ASPNET.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -42,7 +42,7 @@ Usage: dotnet msbuild /t:Helix src/MyTestProject.csproj
 
     <ItemGroup>
       <!-- Include default queues based on platform -->
-      <_HelixProjectTargetQueue Include="%(HelixAvailableTargetQueue.Identity)" Condition="'%(HelixAvailableTargetQueue.Identity)' != '' AND '$(_SelectedPlatforms.Contains(%(Platform)))' == 'true' AND '%(EnableByDefault)' == 'true'" />
+      <_HelixProjectTargetQueue Include="%(HelixAvailableTargetQueue.Identity)" Condition="'%(HelixAvailableTargetQueue.Identity)' != '' AND '$(_SelectedPlatforms.Contains(%(Platform)))' == 'true'" />
 
       <_HelixApplicableTargetQueue Include="%(_HelixProjectTargetQueue.Identity)" Condition="'%(Identity)' == '$(HelixTargetQueue)'" />
     </ItemGroup>

--- a/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
+++ b/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.False(https);
         }
 
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, WindowsVersions.Win10, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
         [ConditionalFact]
         public void ParseAddressUnixPipe()
         {

--- a/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
+++ b/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
@@ -76,7 +76,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.False(https);
         }
 
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, WindowsVersions.Win10, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/FILEISSUE", Queues = "Windows.10.Amd64.Open")]
         [ConditionalFact]
         public void ParseAddressUnixPipe()
         {

--- a/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
+++ b/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
-        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/FILEISSUE", Queues = "Windows.10.Amd64.Open")]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/14382", Queues = "Windows.10.Amd64.Open")]
         [ConditionalFact]
         public void ParseAddressUnixPipe()
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 #else
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
 #endif
-        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/FILEISSUE", Queues = "Windows.10.Amd64.Open")]
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/14382", Queues = "Windows.10.Amd64.Open")]
         [ConditionalFact]
         [CollectDump]
         public async Task TestUnixDomainSocket()

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -21,11 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class UnixDomainSocketsTest : TestApplicationErrorLoggerLoggedTest
     {
-#if LIBUV
         [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Libuv does not support unix domain sockets on Windows.")]
-#else
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, WindowsVersions.Win10, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
-#endif
         [ConditionalFact]
         [CollectDump]
         public async Task TestUnixDomainSocket()

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -21,7 +21,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class UnixDomainSocketsTest : TestApplicationErrorLoggerLoggedTest
     {
+#if LIBUV
         [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Libuv does not support unix domain sockets on Windows.")]
+#else
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, WindowsVersions.Win10, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+#endif
         [ConditionalFact]
         [CollectDump]
         public async Task TestUnixDomainSocket()

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 #if LIBUV
         [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Libuv does not support unix domain sockets on Windows.")]
 #else
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, WindowsVersions.Win10, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
 #endif
         [ConditionalFact]
         [CollectDump]

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -24,8 +24,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 #if LIBUV
         [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Libuv does not support unix domain sockets on Windows.")]
 #else
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, WindowsVersions.Win10, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
 #endif
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/FILEISSUE", Queues = "Windows.10.Amd64.Open")]
         [ConditionalFact]
         [CollectDump]
         public async Task TestUnixDomainSocket()


### PR DESCRIPTION
Switching to the win10 queues that everyone else uses should result in a lot less waiting as the pools will be scaled and hot more often, our custom queues would take up to 45 minutes to setup a new machine from a cold queue