### PR TITLE
Backport dotnet-watch test fix

### DIFF
--- a/src/Tools/dotnet-watch/src/DotNetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatcher.cs
@@ -85,10 +85,8 @@ namespace Microsoft.DotNet.Watcher
 
                     if (finishedTask == processTask)
                     {
-                        _reporter.Warn("Waiting for a file to change before restarting dotnet...");
-
                         // Now wait for a file to change before restarting process
-                        await fileSetWatcher.GetChangedFileAsync(cancellationToken);
+                        await fileSetWatcher.GetChangedFileAsync(cancellationToken, () => _reporter.Warn("Waiting for a file to change before restarting dotnet..."));
                     }
 
                     if (!string.IsNullOrEmpty(fileSetTask.Result))

--- a/src/Tools/dotnet-watch/src/Internal/FileSetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/Internal/FileSetWatcher.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             _fileWatcher = new FileWatcher(reporter);
         }
 
-        public async Task<string> GetChangedFileAsync(CancellationToken cancellationToken)
+        internal async Task<string> GetChangedFileAsync(CancellationToken cancellationToken, Action startedWatching)
         {
             foreach (var file in _fileSet)
             {
@@ -41,10 +41,16 @@ namespace Microsoft.DotNet.Watcher.Internal
             };
 
             _fileWatcher.OnFileChange += callback;
+            startedWatching();
             var changedFile = await tcs.Task;
             _fileWatcher.OnFileChange -= callback;
 
             return changedFile;
+        }
+
+        public Task<string> GetChangedFileAsync(CancellationToken cancellationToken)
+        {
+            return GetChangedFileAsync(cancellationToken, () => {});
         }
 
         public void Dispose()


### PR DESCRIPTION
Backport https://github.com/aspnet/AspNetCore/pull/9649 to fix flaky test(s)

Since this touches pubternal code I made a new version of the public function and made it internal and use that internally.

Also, since this change is only to fix some test flakiness and doesn't change product behavior I am not changing the patch.config as we don't need to produce a package with this change.