### PR TITLE
[release/3.0] Update gRPC package version to 2.23.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -231,7 +231,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>2.23.1</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>2.23.2</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0</IdentityServer4PackageVersion>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/14348

**Description**

Update Grpc.AspNetCore reference in gRPC template to 2.23.2.

**Customer impact**

Template currently references 2.23.1. This package is impacted by the NuGet deterministic issue, which could result in some gRPC runtime files not being deployed.

**Regression**

No

**Risk**

Low