### PR TITLE
Negotiate protocol versioning and ConnectionID split

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -69,6 +69,16 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
                 endpoints.MapHub<TestHub>("/default-nowebsockets", options => options.Transports = HttpTransportType.LongPolling | HttpTransportType.ServerSentEvents);
 
+                endpoints.MapHub<TestHub>("/negotiateProtocolVersion12", options =>
+                {
+                    options.MinimumProtocolVersion = 12;
+                });
+
+                endpoints.MapHub<TestHub>("/negotiateProtocolVersionNegative", options =>
+                {
+                    options.MinimumProtocolVersion = -1;
+                });
+
                 endpoints.MapGet("/generateJwtToken", context =>
                 {
                     return context.Response.WriteAsync(GenerateJwtToken());

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -359,7 +359,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     var httpHandler = new TestHttpMessageHandler();
 
                     var connectResponseTcs = new TaskCompletionSource<object>();
-                    httpHandler.OnGet("/?negotiateVersion=1&id=00000000-0000-0000-0000-000000000000", async (_, __) =>
+                    httpHandler.OnGet("/?id=00000000-0000-0000-0000-000000000000", async (_, __) =>
                     {
                         await connectResponseTcs.Task;
                         return ResponseUtils.CreateResponse(HttpStatusCode.Accepted);

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -359,7 +359,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     var httpHandler = new TestHttpMessageHandler();
 
                     var connectResponseTcs = new TaskCompletionSource<object>();
-                    httpHandler.OnGet("/?id=00000000-0000-0000-0000-000000000000", async (_, __) =>
+                    httpHandler.OnGet("/?negotiateVersion=1&id=00000000-0000-0000-0000-000000000000", async (_, __) =>
                     {
                         await connectResponseTcs.Task;
                         return ResponseUtils.CreateResponse(HttpStatusCode.Accepted);

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Negotiate.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Negotiate.cs
@@ -50,12 +50,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Theory]
-            [InlineData("http://fakeuri.org/", "http://fakeuri.org/negotiate")]
-            [InlineData("http://fakeuri.org/?q=1/0", "http://fakeuri.org/negotiate?q=1/0")]
-            [InlineData("http://fakeuri.org?q=1/0", "http://fakeuri.org/negotiate?q=1/0")]
-            [InlineData("http://fakeuri.org/endpoint", "http://fakeuri.org/endpoint/negotiate")]
-            [InlineData("http://fakeuri.org/endpoint/", "http://fakeuri.org/endpoint/negotiate")]
-            [InlineData("http://fakeuri.org/endpoint?q=1/0", "http://fakeuri.org/endpoint/negotiate?q=1/0")]
+            [InlineData("http://fakeuri.org/", "http://fakeuri.org/negotiate?negotiateVersion=1")]
+            [InlineData("http://fakeuri.org/?q=1/0", "http://fakeuri.org/negotiate?q=1/0&negotiateVersion=1")]
+            [InlineData("http://fakeuri.org?q=1/0", "http://fakeuri.org/negotiate?q=1/0&negotiateVersion=1")]
+            [InlineData("http://fakeuri.org/endpoint", "http://fakeuri.org/endpoint/negotiate?negotiateVersion=1")]
+            [InlineData("http://fakeuri.org/endpoint/", "http://fakeuri.org/endpoint/negotiate?negotiateVersion=1")]
+            [InlineData("http://fakeuri.org/endpoint?q=1/0", "http://fakeuri.org/endpoint/negotiate?q=1/0&negotiateVersion=1")]
             public async Task CorrectlyHandlesQueryStringWhenAppendingNegotiateToUrl(string requestedUrl, string expectedNegotiate)
             {
                 var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
@@ -101,6 +101,43 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                                 transferFormats = new[] { "Text" }
                             },
                         }
+                    })));
+                testHttpHandler.OnLongPoll(cancellationToken => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+                testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+                using (var noErrorScope = new VerifyNoErrorsScope())
+                {
+                    await WithConnectionAsync(
+                        CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                        async (connection) =>
+                        {
+                            await connection.StartAsync().OrTimeout();
+                            connectionId = connection.ConnectionId;
+                        });
+                }
+
+                Assert.Equal("0rge0d00-0040-0030-0r00-000q00r00e00", connectionId);
+            }
+
+            [Fact]
+            public async Task NegotiateCanHaveNewFields()
+            {
+                string connectionId = null;
+
+                var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+                testHttpHandler.OnNegotiate((request, cancellationToken) => ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                    JsonConvert.SerializeObject(new
+                    {
+                        connectionId = "0rge0d00-0040-0030-0r00-000q00r00e00",
+                        availableTransports = new object[]
+                        {
+                            new
+                            {
+                                transport = "LongPolling",
+                                transferFormats = new[] { "Text" }
+                            },
+                        },
+                        newField = "ignore this",
                     })));
                 testHttpHandler.OnLongPoll(cancellationToken => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
                 testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
@@ -172,10 +209,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         });
                 }
 
-                Assert.Equal("http://fakeuri.org/negotiate", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
-                Assert.Equal("https://another.domain.url/chat/negotiate", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
-                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
-                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
+                Assert.Equal("http://fakeuri.org/negotiate?negotiateVersion=1", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat/negotiate?negotiateVersion=1", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
                 Assert.Equal(5, testHttpHandler.ReceivedRequests.Count);
             }
 
@@ -278,10 +315,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         });
                 }
 
-                Assert.Equal("http://fakeuri.org/negotiate", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
-                Assert.Equal("https://another.domain.url/chat/negotiate", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
-                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
-                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
+                Assert.Equal("http://fakeuri.org/negotiate?negotiateVersion=1", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat/negotiate?negotiateVersion=1", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
                 // Delete request
                 Assert.Equal(5, testHttpHandler.ReceivedRequests.Count);
             }

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Negotiate.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Negotiate.cs
@@ -37,6 +37,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
+            public Task NegotiateResponseWithNegotiateVersionRequiresConnectionToken()
+            {
+                return RunInvalidNegotiateResponseTest<InvalidDataException>(ResponseUtils.CreateNegotiationContent(negotiateVersion: 1, connectionToken: null), "Invalid negotiation response received.");
+            }
+
+            [Fact]
             public Task ConnectionCannotBeStartedIfNoCommonTransportsBetweenClientAndServer()
             {
                 return RunInvalidNegotiateResponseTest<AggregateException>(ResponseUtils.CreateNegotiationContent(transportTypes: HttpTransportType.ServerSentEvents),
@@ -154,6 +160,87 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 }
 
                 Assert.Equal("0rge0d00-0040-0030-0r00-000q00r00e00", connectionId);
+            }
+
+            [Fact]
+            public async Task ConnectionIdGetsSetWithNegotiateProtocolGreaterThanZero()
+            {
+                string connectionId = null;
+
+                var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+                testHttpHandler.OnNegotiate((request, cancellationToken) => ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                    JsonConvert.SerializeObject(new
+                    {
+                        connectionId = "0rge0d00-0040-0030-0r00-000q00r00e00",
+                        negotiateVersion = 1,
+                        connectionToken = "different-id",
+                        availableTransports = new object[]
+                        {
+                            new
+                            {
+                                transport = "LongPolling",
+                                transferFormats = new[] { "Text" }
+                            },
+                        },
+                        newField = "ignore this",
+                    })));
+                testHttpHandler.OnLongPoll(cancellationToken => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+                testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+                using (var noErrorScope = new VerifyNoErrorsScope())
+                {
+                    await WithConnectionAsync(
+                        CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                        async (connection) =>
+                        {
+                            await connection.StartAsync().OrTimeout();
+                            connectionId = connection.ConnectionId;
+                        });
+                }
+
+                Assert.Equal("0rge0d00-0040-0030-0r00-000q00r00e00", connectionId);
+                Assert.Equal("http://fakeuri.org/negotiate?negotiateVersion=1", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
+                Assert.Equal("http://fakeuri.org/?negotiateVersion=1&id=different-id", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
+            }
+
+            [Fact]
+            public async Task ConnectionTokenFieldIsIgnoredForNegotiateIdLessThanOne()
+            {
+                string connectionId = null;
+
+                var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+                testHttpHandler.OnNegotiate((request, cancellationToken) => ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                    JsonConvert.SerializeObject(new
+                    {
+                        connectionId = "0rge0d00-0040-0030-0r00-000q00r00e00",
+                        connectionToken = "different-id",
+                        availableTransports = new object[]
+                        {
+                            new
+                            {
+                                transport = "LongPolling",
+                                transferFormats = new[] { "Text" }
+                            },
+                        },
+                        newField = "ignore this",
+                    })));
+                testHttpHandler.OnLongPoll(cancellationToken => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+                testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+                using (var noErrorScope = new VerifyNoErrorsScope())
+                {
+                    await WithConnectionAsync(
+                        CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                        async (connection) =>
+                        {
+                            await connection.StartAsync().OrTimeout();
+                            connectionId = connection.ConnectionId;
+                        });
+                }
+
+                Assert.Equal("0rge0d00-0040-0030-0r00-000q00r00e00", connectionId);
+                Assert.Equal("http://fakeuri.org/negotiate?negotiateVersion=1", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
+                Assert.Equal("http://fakeuri.org/?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
             }
 
             [Fact]

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/ResponseUtils.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/ResponseUtils.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         public static string CreateNegotiationContent(string connectionId = "00000000-0000-0000-0000-000000000000",
-            HttpTransportType? transportTypes = null)
+            HttpTransportType? transportTypes = null, string connectionToken = "connection-token", int negotiateVersion = 0)
         {
             var availableTransports = new List<object>();
 
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 });
             }
 
-            return JsonConvert.SerializeObject(new { connectionId, availableTransports });
+            return JsonConvert.SerializeObject(new { connectionId, availableTransports, connectionToken, negotiateVersion });
         }
     }
 }

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestHttpMessageHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -117,7 +120,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             });
             testHttpMessageHandler.OnRequest((request, next, cancellationToken) =>
             {
-                if (request.Method.Equals(HttpMethod.Delete) && request.RequestUri.PathAndQuery.StartsWith("/?id="))
+                if (request.Method.Equals(HttpMethod.Delete) && request.RequestUri.PathAndQuery.Contains("&id="))
                 {
                     deleteCts.Cancel();
                     return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Accepted));

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestHttpMessageHandler.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             });
             testHttpMessageHandler.OnRequest((request, next, cancellationToken) =>
             {
-                if (request.Method.Equals(HttpMethod.Delete) && request.RequestUri.PathAndQuery.Contains("&id="))
+                if (request.Method.Equals(HttpMethod.Delete) && request.RequestUri.PathAndQuery.Contains("id="))
                 {
                     deleteCts.Cancel();
                     return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Accepted));

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         // Not configurable on purpose, high enough that if we reach here, it's likely
         // a buggy server
         private static readonly int _maxRedirects = 100;
+        private static readonly int _protocolVersionNumber = 1;
         private static readonly Task<string> _noAccessToken = Task.FromResult<string>(null);
 
         private static readonly TimeSpan HttpClientTimeout = TimeSpan.FromSeconds(120);
@@ -428,8 +429,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                     urlBuilder.Path += "/";
                 }
                 urlBuilder.Path += "negotiate";
+                var uri = Utils.AppendQueryString(urlBuilder.Uri, $"negotiateVersion={_protocolVersionNumber}");
 
-                using (var request = new HttpRequestMessage(HttpMethod.Post, urlBuilder.Uri))
+                using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
                 {
                     // Corefx changed the default version and High Sierra curlhandler tries to upgrade request
                     request.Version = new Version(1, 1);
@@ -466,7 +468,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 throw new FormatException("Invalid connection id.");
             }
 
-            return Utils.AppendQueryString(url, "id=" + connectionId);
+            return Utils.AppendQueryString(url, $"negotiateVersion={_protocolVersionNumber}&id=" + connectionId);
         }
 
         private async Task StartTransport(Uri connectUrl, HttpTransportType transportType, TransferFormat transferFormat, CancellationToken cancellationToken)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -42,7 +42,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private readonly HttpConnectionOptions _httpConnectionOptions;
         private ITransport _transport;
         private readonly ITransportFactory _transportFactory;
-        private string _connectionToken;
         private string _connectionId;
         private readonly ConnectionLogScope _logScope;
         private readonly ILoggerFactory _loggerFactory;
@@ -343,7 +342,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
 
                 // This should only need to happen once
-                var connectUrl = CreateConnectUrl(uri, _connectionToken);
+                var connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionToken);
 
                 // We're going to search for the transfer format as a string because we don't want to parse
                 // all the transfer formats in the negotiation response, and we want to allow transfer formats
@@ -384,10 +383,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                             if (negotiationResponse == null)
                             {
                                 negotiationResponse = await GetNegotiationResponseAsync(uri, cancellationToken);
-                                connectUrl = CreateConnectUrl(uri, _connectionToken);
+                                connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionToken);
                             }
 
-                            Log.StartingTransport(_logger, transportType, connectUrl);
+                            Log.StartingTransport(_logger, transportType, uri);
                             await StartTransport(connectUrl, transportType, transferFormat, cancellationToken);
                             break;
                         }
@@ -430,7 +429,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                     urlBuilder.Path += "/";
                 }
                 urlBuilder.Path += "negotiate";
-                var uri = Utils.AppendQueryString(urlBuilder.Uri, $"negotiateVersion={_protocolVersionNumber}");
+                Uri uri;
+                if (urlBuilder.Query.Contains("negotiateVersion"))
+                {
+                    uri = urlBuilder.Uri;
+                }
+                else
+                {
+                    uri = Utils.AppendQueryString(urlBuilder.Uri, $"negotiateVersion={_protocolVersionNumber}");
+                }
 
                 using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
                 {
@@ -469,7 +476,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 throw new FormatException("Invalid connection id.");
             }
 
-            return Utils.AppendQueryString(url, $"negotiateVersion={_protocolVersionNumber}&id=" + connectionId);
+            return Utils.AppendQueryString(url, $"id={connectionId}");
         }
 
         private async Task StartTransport(Uri connectUrl, HttpTransportType transportType, TransferFormat transferFormat, CancellationToken cancellationToken)
@@ -613,14 +620,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             // If the negotiationVersion is greater than zero then we know that the negotiation response contains a
             // connectionToken that will be required to conenct. Otherwise we just set the connectionId and the
             // connectionToken on the client to the same value.
-            if (negotiationResponse.Version > 0)
+            _connectionId = negotiationResponse.ConnectionId;
+            if (negotiationResponse.Version == 0)
             {
-                _connectionId = negotiationResponse.ConnectionId;
-                _connectionToken = negotiationResponse.ConnectionToken;
-            }
-            else
-            {
-                _connectionToken = _connectionId = negotiationResponse.ConnectionId;
+                negotiationResponse.ConnectionToken = _connectionId;
             }
 
             _logScope.ConnectionId = _connectionId;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private readonly HttpConnectionOptions _httpConnectionOptions;
         private ITransport _transport;
         private readonly ITransportFactory _transportFactory;
+        private string _connectionToken;
         private string _connectionId;
         private readonly ConnectionLogScope _logScope;
         private readonly ILoggerFactory _loggerFactory;
@@ -342,7 +343,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
 
                 // This should only need to happen once
-                var connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionId);
+                var connectUrl = CreateConnectUrl(uri, _connectionToken);
 
                 // We're going to search for the transfer format as a string because we don't want to parse
                 // all the transfer formats in the negotiation response, and we want to allow transfer formats
@@ -383,7 +384,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                             if (negotiationResponse == null)
                             {
                                 negotiationResponse = await GetNegotiationResponseAsync(uri, cancellationToken);
-                                connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionId);
+                                connectUrl = CreateConnectUrl(uri, _connectionToken);
                             }
 
                             Log.StartingTransport(_logger, transportType, connectUrl);
@@ -609,7 +610,19 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private async Task<NegotiationResponse> GetNegotiationResponseAsync(Uri uri, CancellationToken cancellationToken)
         {
             var negotiationResponse = await NegotiateAsync(uri, _httpClient, _logger, cancellationToken);
-            _connectionId = negotiationResponse.ConnectionId;
+            // If the negotiationVersion is greater than zero then we know that the negotiation response contains a
+            // connectionToken that will be required to conenct. Otherwise we just set the connectionId and the
+            // connectionToken on the client to the same value.
+            if (negotiationResponse.Version > 0)
+            {
+                _connectionId = negotiationResponse.ConnectionId;
+                _connectionToken = negotiationResponse.ConnectionToken;
+            }
+            else
+            {
+                _connectionToken = _connectionId = negotiationResponse.ConnectionId;
+            }
+
             _logScope.ConnectionId = _connectionId;
             return negotiationResponse;
         }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -57,7 +57,6 @@ public class HubConnection {
     private Map<String, Observable> streamMap = new ConcurrentHashMap<>();
     private TransportEnum transportEnum = TransportEnum.ALL;
     private String connectionId;
-    private String connectionToken;
     private final int negotiateVersion = 1;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
 
@@ -262,7 +261,7 @@ public class HubConnection {
         HttpRequest request = new HttpRequest();
         request.addHeaders(this.localHeaders);
 
-        return httpClient.post(Negotiate.resolveNegotiateUrl(url), request).map((response) -> {
+        return httpClient.post(Negotiate.resolveNegotiateUrl(url, this.negotiateVersion), request).map((response) -> {
             if (response.getStatusCode() != 200) {
                 throw new RuntimeException(String.format("Unexpected status code returned from negotiate: %d %s.",
                         response.getStatusCode(), response.getStatusText()));
@@ -341,12 +340,11 @@ public class HubConnection {
         });
 
         stopError = null;
-        String urlWithQS = Utils.appendQueryString(baseUrl, "negotiateVersion=" + negotiateVersion);
         Single<NegotiateResponse> negotiate = null;
         if (!skipNegotiate) {
-            negotiate = tokenCompletable.andThen(Single.defer(() -> startNegotiate(urlWithQS, 0)));
+            negotiate = tokenCompletable.andThen(Single.defer(() -> startNegotiate(baseUrl, 0)));
         } else {
-            negotiate = tokenCompletable.andThen(Single.defer(() -> Single.just(new NegotiateResponse(urlWithQS))));
+            negotiate = tokenCompletable.andThen(Single.defer(() -> Single.just(new NegotiateResponse(baseUrl))));
         }
 
         CompletableSubject start = CompletableSubject.create();
@@ -448,21 +446,21 @@ public class HubConnection {
                     throw new RuntimeException("There were no compatible transports on the server.");
                 }
 
+                String connectionToken = "";
                 if (response.getVersion() > 0) {
                     this.connectionId = response.getConnectionId();
-                    this.connectionToken = response.getConnectionToken();
+                    connectionToken = response.getConnectionToken();
                 } else {
-                    this.connectionToken = this.connectionId = response.getConnectionId();
+                    connectionToken = this.connectionId = response.getConnectionId();
                 }
 
-                String finalUrl = Utils.appendQueryString(url, "id=" + this.connectionToken);
+                String finalUrl = Utils.appendQueryString(url, "id=" + connectionToken);
 
                 response.setFinalUrl(finalUrl);
                 return Single.just(response);
             }
 
-            String redirectUrl = Utils.appendQueryString(response.getRedirectUrl(), "negotiateVersion=" + negotiateVersion);
-            return startNegotiate(redirectUrl, negotiateAttempts + 1);
+            return startNegotiate(response.getRedirectUrl(), negotiateAttempts + 1);
         });
     }
 
@@ -524,7 +522,6 @@ public class HubConnection {
             handshakeResponseSubject.onComplete();
             redirectAccessTokenProvider = null;
             connectionId = null;
-            connectionToken = null;
             transportEnum = TransportEnum.ALL;
             this.localHeaders.clear();
             this.streamMap.clear();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Negotiate.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Negotiate.java
@@ -4,7 +4,7 @@
 package com.microsoft.signalr;
 
 class Negotiate {
-    public static String resolveNegotiateUrl(String url) {
+    public static String resolveNegotiateUrl(String url, int negotiateVersion) {
         String negotiateUrl = "";
 
         // Check if we have a query string. If we do then we ignore it for now.
@@ -15,7 +15,7 @@ class Negotiate {
             negotiateUrl = url;
         }
 
-        //Check if the url ends in a /
+        // Check if the url ends in a /
         if (negotiateUrl.charAt(negotiateUrl.length() - 1) != '/') {
             negotiateUrl += "/";
         }
@@ -25,6 +25,10 @@ class Negotiate {
         // Add the query string back if it existed.
         if (queryStringIndex > 0) {
             negotiateUrl += url.substring(queryStringIndex);
+        }
+
+        if (!url.contains("negotiateVersion")) {
+            negotiateUrl = Utils.appendQueryString(negotiateUrl, "negotiateVersion=" + negotiateVersion);
         }
 
         return negotiateUrl;

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Negotiate.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Negotiate.java
@@ -10,7 +10,7 @@ class Negotiate {
         // Check if we have a query string. If we do then we ignore it for now.
         int queryStringIndex = url.indexOf('?');
         if (queryStringIndex > 0) {
-            negotiateUrl = url.substring(0, url.indexOf('?'));
+            negotiateUrl = url.substring(0, queryStringIndex);
         } else {
             negotiateUrl = url;
         }
@@ -24,7 +24,7 @@ class Negotiate {
 
         // Add the query string back if it existed.
         if (queryStringIndex > 0) {
-            negotiateUrl += url.substring(url.indexOf('?'));
+            negotiateUrl += url.substring(queryStringIndex);
         }
 
         return negotiateUrl;

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/NegotiateResponse.java
@@ -11,11 +11,13 @@ import com.google.gson.stream.JsonReader;
 
 class NegotiateResponse {
     private String connectionId;
+    private String connectionToken;
     private Set<String> availableTransports = new HashSet<>();
     private String redirectUrl;
     private String accessToken;
     private String error;
     private String finalUrl;
+    private int version;
 
     public NegotiateResponse(JsonReader reader) {
         try {
@@ -30,6 +32,12 @@ class NegotiateResponse {
                     case "ProtocolVersion":
                         this.error = "Detected an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.";
                         return;
+                    case "negotiateVersion":
+                        this.version = reader.nextInt();
+                        break;
+                    case "connectionToken":
+                        this.connectionToken = reader.nextString();
+                        break;
                     case "url":
                         this.redirectUrl = reader.nextString();
                         break;
@@ -104,6 +112,14 @@ class NegotiateResponse {
 
     public String getFinalUrl() {
         return finalUrl;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public String getConnectionToken() {
+        return connectionToken;
     }
 
     public void setFinalUrl(String url) {

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Utils.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Utils.java
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+class Utils {
+    public static String appendQueryString(String original, String queryStringValue) {
+        if (original.contains("?")) {
+            return original + "&" + queryStringValue;
+        } else {
+            return  original + "?" + queryStringValue;
+        }
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1796,36 +1796,62 @@ class HubConnectionTest {
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
-        assertEquals("http://example.com?negotiateVersion=1&id=connection-token-value", transport.getUrl());
+        assertEquals("http://example.com?id=connection-token-value", transport.getUrl());
         hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
     }
 
-        @Test
-        public void connectionTokenIsIgnoredIfNegotiateVersionIsNotPresentInNegotiateResponse() {
-            TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
-                    (req) -> Single.just(new HttpResponse(200, "",
-                            "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
-                            "\"connectionToken\":\"connection-token-value\"," +
-                            "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+    @Test
+    public void connectionTokenIsIgnoredIfNegotiateVersionIsNotPresentInNegotiateResponse() {
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                (req) -> Single.just(new HttpResponse(200, "",
+                        "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                        "\"connectionToken\":\"connection-token-value\"," +
+                        "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
-            MockTransport transport = new MockTransport(true);
-            HubConnection hubConnection = HubConnectionBuilder
-                    .create("http://example.com")
-                    .withTransportImplementation(transport)
-                    .withHttpClient(client)
-                    .build();
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .build();
 
-            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
-            assertNull(hubConnection.getConnectionId());
-            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-            assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-            assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
-            assertEquals("http://example.com?negotiateVersion=1&id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
-            hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
-            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
-            assertNull(hubConnection.getConnectionId());
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertNull(hubConnection.getConnectionId());
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
+        assertEquals("http://example.com?id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertNull(hubConnection.getConnectionId());
+    }
+
+    @Test
+    public void negotiateVersionIsNotAddedIfAlreadyPresent() {
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=42",
+                (req) -> Single.just(new HttpResponse(200, "",
+                        "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                        "\"connectionToken\":\"connection-token-value\"," +
+                        "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com?negotiateVersion=42")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .build();
+
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertNull(hubConnection.getConnectionId());
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
+        assertEquals("http://example.com?negotiateVersion=42&id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertNull(hubConnection.getConnectionId());
     }
 
     @Test
@@ -2115,7 +2141,7 @@ class HubConnectionTest {
 
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        assertEquals("http://testexample.com/?negotiateVersion=1&id=connection-token-value", transport.getUrl());
+        assertEquals("http://testexample.com/?id=connection-token-value", transport.getUrl());
         hubConnection.stop();
         assertEquals("Bearer newToken", token.get());
     }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -1714,12 +1714,12 @@ class HubConnectionTest {
 
         List<HttpRequest> sentRequests = client.getSentRequests();
         assertEquals(1, sentRequests.size());
-        assertEquals("http://example.com/negotiate", sentRequests.get(0).getUrl());
+        assertEquals("http://example.com/negotiate?negotiateVersion=1", sentRequests.get(0).getUrl());
     }
 
     @Test
     public void negotiateThatRedirectsForeverFailsAfter100Tries() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://example.com\"}")));
 
         HubConnection hubConnection = HubConnectionBuilder
@@ -1752,7 +1752,7 @@ class HubConnectionTest {
 
     @Test
     public void connectionIdIsAvailableAfterStart() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
@@ -1776,8 +1776,61 @@ class HubConnectionTest {
     }
 
     @Test
+    public void connectionTokenAppearsInQSConnectionIdIsOnConnectionInstance() {
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                (req) -> Single.just(new HttpResponse(200, "",
+                                "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                                "\"negotiateVersion\": 1," +
+                                "\"connectionToken\":\"connection-token-value\"," +
+                                "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+
+        MockTransport transport = new MockTransport(true);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .build();
+
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertNull(hubConnection.getConnectionId());
+        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
+        assertEquals("http://example.com?negotiateVersion=1&id=connection-token-value", transport.getUrl());
+        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertNull(hubConnection.getConnectionId());
+    }
+
+        @Test
+        public void connectionTokenIsIgnoredIfNegotiateVersionIsNotPresentInNegotiateResponse() {
+            TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                    (req) -> Single.just(new HttpResponse(200, "",
+                            "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                            "\"connectionToken\":\"connection-token-value\"," +
+                            "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+
+            MockTransport transport = new MockTransport(true);
+            HubConnection hubConnection = HubConnectionBuilder
+                    .create("http://example.com")
+                    .withTransportImplementation(transport)
+                    .withHttpClient(client)
+                    .build();
+
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+            assertNull(hubConnection.getConnectionId());
+            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+            assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
+            assertEquals("http://example.com?negotiateVersion=1&id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
+            hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+            assertNull(hubConnection.getConnectionId());
+    }
+
+    @Test
     public void afterSuccessfulNegotiateConnectsWithWebsocketsTransport() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
@@ -1798,7 +1851,7 @@ class HubConnectionTest {
 
     @Test
     public void afterSuccessfulNegotiateConnectsWithLongPollingTransport() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
@@ -1891,7 +1944,7 @@ class HubConnectionTest {
 
     @Test
     public void receivingServerSentEventsTransportFromNegotiateFails() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",
                         "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                 + "availableTransports\":[{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]}]}")));
@@ -1911,7 +1964,7 @@ class HubConnectionTest {
 
     @Test
     public void negotiateThatReturnsErrorThrowsFromStart() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"error\":\"Test error.\"}")));
 
         MockTransport transport = new MockTransport(true);
@@ -1928,7 +1981,7 @@ class HubConnectionTest {
 
     @Test
     public void DetectWhenTryingToConnectToClassicSignalRServer() {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"Url\":\"/signalr\"," +
                         "\"ConnectionToken\":\"X97dw3uxW4NPPggQsYVcNcyQcuz4w2\"," +
                         "\"ConnectionId\":\"05265228-1e2c-46c5-82a1-6a5bcc3f0143\"," +
@@ -1954,9 +2007,9 @@ class HubConnectionTest {
 
     @Test
     public void negotiateRedirectIsFollowed()  {
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate",
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
-                .on("POST", "http://testexample.com/negotiate",
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                 + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
@@ -1978,11 +2031,11 @@ class HubConnectionTest {
         AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> {
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> {
                     beforeRedirectToken.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
                 })
-                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                     token.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                             + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
@@ -2018,7 +2071,7 @@ class HubConnectionTest {
     public void accessTokenProviderIsUsedForNegotiate() {
         AtomicReference<String> token = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             token.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2043,11 +2096,13 @@ class HubConnectionTest {
     public void accessTokenProviderIsOverriddenFromRedirectNegotiate() {
         AtomicReference<String> token = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-            .on("POST", "http://example.com/negotiate", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}")))
-            .on("POST", "http://testexample.com/negotiate", (req) -> {
+            .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}")))
+            .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                 token.set(req.getHeaders().get("Authorization"));
-                return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
-                + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\","
+                        + "\"connectionToken\":\"connection-token-value\","
+                        + "\"negotiateVersion\":1,"
+                        + "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
             });
 
         MockTransport transport = new MockTransport(true);
@@ -2060,7 +2115,7 @@ class HubConnectionTest {
 
         hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        assertEquals("http://testexample.com/?id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
+        assertEquals("http://testexample.com/?negotiateVersion=1&id=connection-token-value", transport.getUrl());
         hubConnection.stop();
         assertEquals("Bearer newToken", token.get());
     }
@@ -2071,14 +2126,14 @@ class HubConnectionTest {
         AtomicReference<String> beforeRedirectToken = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> {
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> {
                     beforeRedirectToken.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"));
                 })
-                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                     token.set(req.getHeaders().get("Authorization"));
-                    return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
-                            + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
+                    return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\","
+                            + "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
                 });
 
         MockTransport transport = new MockTransport(true);
@@ -2112,7 +2167,7 @@ class HubConnectionTest {
         AtomicInteger redirectCount = new AtomicInteger();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> {
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> {
                     if (redirectCount.get() == 0) {
                         redirectCount.incrementAndGet();
                         redirectToken.set(req.getHeaders().get("Authorization"));
@@ -2122,7 +2177,7 @@ class HubConnectionTest {
                         return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"secondRedirectToken\"}"));
                     }
                 })
-                .on("POST", "http://testexample.com/negotiate", (req) -> {
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                     token.set(req.getHeaders().get("Authorization"));
                     return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                             + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"));
@@ -2189,7 +2244,7 @@ class HubConnectionTest {
     public void headersAreSetAndSentThroughBuilder() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("ExampleHeader"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2214,7 +2269,7 @@ class HubConnectionTest {
     public void headersAreNotClearedWhenConnectionIsRestarted() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2244,12 +2299,12 @@ class HubConnectionTest {
         AtomicReference<String> afterRedirectHeader = new AtomicReference<>();
 
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             beforeRedirectHeader.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\",\"accessToken\":\"redirectToken\"}\"}"));
                         })
-                .on("POST", "http://testexample.com/negotiate",
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             afterRedirectHeader.set(req.getHeaders().get("Authorization"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2287,7 +2342,7 @@ class HubConnectionTest {
     public void sameHeaderSetTwiceGetsOverwritten() {
         AtomicReference<String> header = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> {
                             header.set(req.getHeaders().get("ExampleHeader"));
                             return Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
@@ -2332,8 +2387,8 @@ class HubConnectionTest {
     public void hubConnectionCanBeStartedAfterBeingStoppedAndRedirected()  {
         MockTransport mockTransport = new MockTransport();
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
-                .on("POST", "http://testexample.com/negotiate", (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                         + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
 
         HubConnection hubConnection = HubConnectionBuilder
@@ -2355,7 +2410,7 @@ class HubConnectionTest {
     @Test
     public void non200FromNegotiateThrowsError() {
         TestHttpClient client = new TestHttpClient()
-                .on("POST", "http://example.com/negotiate",
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                         (req) -> Single.just(new HttpResponse(500, "Internal server error", "")));
 
         MockTransport transport = new MockTransport();

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/NegotiateResponseTest.java
@@ -15,8 +15,9 @@ import com.google.gson.stream.JsonReader;
 class NegotiateResponseTest {
     @Test
     public void VerifyNegotiateResponse() {
-        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\"" +
-                "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}," +
+        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                "\"negotiateVersion\": 99, \"connectionToken\":\"connection-token-value\"," +
+                "\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}," +
                 "{\"transport\":\"ServerSentEvents\",\"transferFormats\":[\"Text\"]}," +
                 "{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}";
         NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
@@ -26,6 +27,8 @@ class NegotiateResponseTest {
         assertNull(negotiateResponse.getAccessToken());
         assertNull(negotiateResponse.getRedirectUrl());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals("connection-token-value", negotiateResponse.getConnectionToken());
+        assertEquals(99, negotiateResponse.getVersion());
     }
 
     @Test
@@ -55,5 +58,24 @@ class NegotiateResponseTest {
                 "\"extra\":[\"something\"]}";
         NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+    }
+
+    @Test
+    public void NegotiateResponseWithNegotiateVersion() {
+        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                "\"negotiateVersion\": 99}";
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals(99, negotiateResponse.getVersion());
+    }
+
+    @Test
+    public void NegotiateResponseWithConnectionToken() {
+        String stringNegotiateResponse = "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\"," +
+                "\"negotiateVersion\": 99, \"connectionToken\":\"connection-token-value\"}";
+        NegotiateResponse negotiateResponse = new NegotiateResponse(new JsonReader(new StringReader(stringNegotiateResponse)));
+        assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", negotiateResponse.getConnectionId());
+        assertEquals("connection-token-value", negotiateResponse.getConnectionToken());
+        assertEquals(99, negotiateResponse.getVersion());
     }
 }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/ResolveNegotiateUrlTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/ResolveNegotiateUrlTest.java
@@ -14,17 +14,18 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ResolveNegotiateUrlTest {
     private static Stream<Arguments> protocols() {
         return Stream.of(
-                Arguments.of("http://example.com/hub/", "http://example.com/hub/negotiate"),
-                Arguments.of("http://example.com/hub", "http://example.com/hub/negotiate"),
-                Arguments.of("http://example.com/endpoint?q=my/Data", "http://example.com/endpoint/negotiate?q=my/Data"),
-                Arguments.of("http://example.com/endpoint/?q=my/Data", "http://example.com/endpoint/negotiate?q=my/Data"),
-                Arguments.of("http://example.com/endpoint/path/more?q=my/Data", "http://example.com/endpoint/path/more/negotiate?q=my/Data"));
+                Arguments.of("http://example.com/hub/", 0, "http://example.com/hub/negotiate?negotiateVersion=0"),
+                Arguments.of("http://example.com/hub", 1, "http://example.com/hub/negotiate?negotiateVersion=1"),
+                Arguments.of("http://example.com/endpoint?q=my/Data", 0, "http://example.com/endpoint/negotiate?q=my/Data&negotiateVersion=0"),
+                Arguments.of("http://example.com/endpoint/?q=my/Data", 1, "http://example.com/endpoint/negotiate?q=my/Data&negotiateVersion=1"),
+                Arguments.of("http://example.com/endpoint/path/more?q=my/Data", 0, "http://example.com/endpoint/path/more/negotiate?q=my/Data&negotiateVersion=0"),
+                Arguments.of("http://example.com/hub/?negotiateVersion=2", 0, "http://example.com/hub/negotiate?negotiateVersion=2"));
     }
 
     @ParameterizedTest
     @MethodSource("protocols")
-    public void checkNegotiateUrl(String url, String resolvedUrl) {
-        String urlResult = Negotiate.resolveNegotiateUrl(url);
+    public void checkNegotiateUrl(String url, int negotiateVersion, String resolvedUrl) {
+        String urlResult = Negotiate.resolveNegotiateUrl(url, negotiateVersion);
         assertEquals(resolvedUrl, urlResult);
     }
 }

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -23,6 +23,8 @@ const enum ConnectionState {
 /** @private */
 export interface INegotiateResponse {
     connectionId?: string;
+    connectionToken?: string;
+    negotiateVersion?: number;
     availableTransports?: IAvailableTransport[];
     url?: string;
     accessToken?: string;
@@ -69,6 +71,8 @@ export class HttpConnection implements IConnection {
     public connectionId?: string;
     public onreceive: ((data: string | ArrayBuffer) => void) | null;
     public onclose: ((e?: Error) => void) | null;
+
+    private readonly negotiateVersion: number = 1;
 
     constructor(url: string, options: IHttpConnectionOptions = {}) {
         Arg.isRequired(url, "url");
@@ -272,8 +276,6 @@ export class HttpConnection implements IConnection {
                     throw new Error("Negotiate redirection limit exceeded.");
                 }
 
-                this.connectionId = negotiateResponse.connectionId;
-
                 await this.createTransport(url, this.options.transport, negotiateResponse, transferFormat);
             }
 
@@ -322,32 +324,41 @@ export class HttpConnection implements IConnection {
                 return Promise.reject(new Error(`Unexpected status code returned from negotiate ${response.statusCode}`));
             }
 
-            return JSON.parse(response.content as string) as INegotiateResponse;
+            const negotiateResponse = JSON.parse(response.content as string) as INegotiateResponse;
+            if (!negotiateResponse.negotiateVersion || negotiateResponse.negotiateVersion < 1) {
+                // Negotiate version 0 doesn't use connectionToken
+                // So we set it equal to connectionId so all our logic can use connectionToken without being aware of the negotiate version
+                negotiateResponse.connectionToken = negotiateResponse.connectionId;
+            }
+            return negotiateResponse;
         } catch (e) {
             this.logger.log(LogLevel.Error, "Failed to complete negotiation with the server: " + e);
             return Promise.reject(e);
         }
     }
 
-    private createConnectUrl(url: string, connectionId: string | null | undefined) {
-        if (!connectionId) {
+    private createConnectUrl(url: string, connectionToken: string | null | undefined) {
+        if (!connectionToken) {
             return url;
         }
-        return url + (url.indexOf("?") === -1 ? "?" : "&") + `id=${connectionId}`;
+
+        return url + (url.indexOf("?") === -1 ? "?" : "&") + `id=${connectionToken}`;
     }
 
     private async createTransport(url: string, requestedTransport: HttpTransportType | ITransport | undefined, negotiateResponse: INegotiateResponse, requestedTransferFormat: TransferFormat): Promise<void> {
-        let connectUrl = this.createConnectUrl(url, negotiateResponse.connectionId);
+        let connectUrl = this.createConnectUrl(url, negotiateResponse.connectionToken);
         if (this.isITransport(requestedTransport)) {
             this.logger.log(LogLevel.Debug, "Connection was provided an instance of ITransport, using that directly.");
             this.transport = requestedTransport;
             await this.startTransport(connectUrl, requestedTransferFormat);
 
+            this.connectionId = negotiateResponse.connectionId;
             return;
         }
 
         const transportExceptions: any[] = [];
         const transports = negotiateResponse.availableTransports || [];
+        let negotiate: INegotiateResponse | undefined = negotiateResponse;
         for (const endpoint of transports) {
             const transportOrError = this.resolveTransportOrError(endpoint, requestedTransport, requestedTransferFormat);
             if (transportOrError instanceof Error) {
@@ -355,20 +366,21 @@ export class HttpConnection implements IConnection {
                 transportExceptions.push(`${endpoint.transport} failed: ${transportOrError}`);
             } else if (this.isITransport(transportOrError)) {
                 this.transport = transportOrError;
-                if (!negotiateResponse.connectionId) {
+                if (!negotiate) {
                     try {
-                        negotiateResponse = await this.getNegotiationResponse(url);
+                        negotiate = await this.getNegotiationResponse(url);
                     } catch (ex) {
                         return Promise.reject(ex);
                     }
-                    connectUrl = this.createConnectUrl(url, negotiateResponse.connectionId);
+                    connectUrl = this.createConnectUrl(url, negotiate.connectionToken);
                 }
                 try {
                     await this.startTransport(connectUrl, requestedTransferFormat);
+                    this.connectionId = negotiate.connectionId;
                     return;
                 } catch (ex) {
                     this.logger.log(LogLevel.Error, `Failed to start the transport '${endpoint.transport}': ${ex}`);
-                    negotiateResponse.connectionId = undefined;
+                    negotiate = undefined;
                     transportExceptions.push(`${endpoint.transport} failed: ${ex}`);
 
                     if (this.connectionState !== ConnectionState.Connecting) {
@@ -504,7 +516,7 @@ export class HttpConnection implements IConnection {
 
         // Setting the url to the href propery of an anchor tag handles normalization
         // for us. There are 3 main cases.
-        // 1. Relative  path normalization e.g "b" -> "http://localhost:5000/a/b"
+        // 1. Relative path normalization e.g "b" -> "http://localhost:5000/a/b"
         // 2. Absolute path normalization e.g "/a/b" -> "http://localhost:5000/a/b"
         // 3. Networkpath reference normalization e.g "//localhost:5000/a/b" -> "http://localhost:5000/a/b"
         const aTag = window.document.createElement("a");
@@ -522,6 +534,11 @@ export class HttpConnection implements IConnection {
         }
         negotiateUrl += "negotiate";
         negotiateUrl += index === -1 ? "" : url.substring(index);
+
+        if (negotiateUrl.indexOf("negotiateVersion") === -1) {
+            negotiateUrl += index === -1 ? "?" : "&";
+            negotiateUrl += "negotiateVersion=" + this.negotiateVersion;
+        }
         return negotiateUrl;
     }
 }

--- a/src/SignalR/clients/ts/signalr/tests/Common.ts
+++ b/src/SignalR/clients/ts/signalr/tests/Common.ts
@@ -15,10 +15,10 @@ export function eachTransport(action: (transport: HttpTransportType) => void) {
 
 export function eachEndpointUrl(action: (givenUrl: string, expectedUrl: string) => void) {
     const urls = [
-        [ "http://tempuri.org/endpoint/?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data" ],
-        [ "http://tempuri.org/endpoint?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data" ],
-        [ "http://tempuri.org/endpoint", "http://tempuri.org/endpoint/negotiate" ],
-        [ "http://tempuri.org/endpoint/", "http://tempuri.org/endpoint/negotiate" ],
+        [ "http://tempuri.org/endpoint/?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data&negotiateVersion=1" ],
+        [ "http://tempuri.org/endpoint?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data&negotiateVersion=1" ],
+        [ "http://tempuri.org/endpoint", "http://tempuri.org/endpoint/negotiate?negotiateVersion=1" ],
+        [ "http://tempuri.org/endpoint/", "http://tempuri.org/endpoint/negotiate?negotiateVersion=1" ],
     ];
 
     urls.forEach((t) => action(t[0], t[1]));

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -21,6 +21,8 @@ const longPollingNegotiateResponse = {
         { transport: "LongPolling", transferFormats: ["Text", "Binary"] },
     ],
     connectionId: "abc123",
+    connectionToken: "123abc",
+    negotiateVersion: 1,
 };
 
 const commonHttpOptions: IHttpConnectionOptions = {
@@ -88,7 +90,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -104,7 +106,7 @@ describe("HubConnectionBuilder", () => {
             await expect(connection.start()).rejects.toThrow("The underlying connection was closed before the hub handshake could complete.");
             expect(connection.state).toBe(HubConnectionState.Disconnected);
 
-            expect((await pollSent.promise).url).toMatch(/http:\/\/example.com\?id=abc123.*/);
+            expect((await pollSent.promise).url).toMatch(/http:\/\/example.com\?id=123abc.*/);
         });
     });
 
@@ -125,7 +127,7 @@ describe("HubConnectionBuilder", () => {
             const pollCompleted = new PromiseSource<HttpResponse>();
             let negotiateRequest!: HttpRequest;
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     negotiateRequest = req;
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
@@ -219,7 +221,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -244,7 +246,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -274,7 +276,7 @@ describe("HubConnectionBuilder", () => {
             const pollSent = new PromiseSource<HttpRequest>();
             const pollCompleted = new PromiseSource<HttpResponse>();
             const testClient = createTestClient(pollSent, pollCompleted.promise)
-                .on("POST", "http://example.com?id=abc123", (req) => {
+                .on("POST", "http://example.com?id=123abc", (req) => {
                     // Respond from the poll with the handshake response
                     pollCompleted.resolve(new HttpResponse(204, "No Content", "{}"));
                     return new HttpResponse(202);
@@ -413,8 +415,8 @@ function createConnectionBuilder(logger?: ILogger): HubConnectionBuilder {
 function createTestClient(pollSent: PromiseSource<HttpRequest>, pollCompleted: Promise<HttpResponse>, negotiateResponse?: any): TestHttpClient {
     let firstRequest = true;
     return new TestHttpClient()
-        .on("POST", "http://example.com/negotiate", () => negotiateResponse || longPollingNegotiateResponse)
-        .on("GET", /http:\/\/example.com\?id=abc123&_=.*/, (req) => {
+        .on("POST", "http://example.com/negotiate?negotiateVersion=1", () => negotiateResponse || longPollingNegotiateResponse)
+        .on("GET", /http:\/\/example.com\?id=123abc&_=.*/, (req) => {
             if (firstRequest) {
                 firstRequest = false;
                 return new HttpResponse(200);

--- a/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netcoreapp.cs
+++ b/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netcoreapp.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public string AccessToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IList<Microsoft.AspNetCore.Http.Connections.AvailableTransport> AvailableTransports { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string ConnectionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string ConnectionToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Url { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netcoreapp.cs
+++ b/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netcoreapp.cs
@@ -36,5 +36,6 @@ namespace Microsoft.AspNetCore.Http.Connections
         public string ConnectionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Url { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }

--- a/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netstandard2.0.cs
+++ b/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netstandard2.0.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public string AccessToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IList<Microsoft.AspNetCore.Http.Connections.AvailableTransport> AvailableTransports { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string ConnectionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string ConnectionToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Url { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netstandard2.0.cs
+++ b/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.netstandard2.0.cs
@@ -36,5 +36,6 @@ namespace Microsoft.AspNetCore.Http.Connections
         public string ConnectionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Url { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
 }

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Http.Connections
     {
         private const string ConnectionIdPropertyName = "connectionId";
         private static JsonEncodedText ConnectionIdPropertyNameBytes = JsonEncodedText.Encode(ConnectionIdPropertyName);
+        private const string ConnectionTokenPropertyName = "connectionToken";
+        private static JsonEncodedText ConnectionTokenPropertyNameBytes = JsonEncodedText.Encode(ConnectionTokenPropertyName);
         private const string UrlPropertyName = "url";
         private static JsonEncodedText UrlPropertyNameBytes = JsonEncodedText.Encode(UrlPropertyName);
         private const string AccessTokenPropertyName = "accessToken";
@@ -69,6 +71,11 @@ namespace Microsoft.AspNetCore.Http.Connections
                 if (!string.IsNullOrEmpty(response.ConnectionId))
                 {
                     writer.WriteString(ConnectionIdPropertyNameBytes, response.ConnectionId);
+                }
+
+                if (response.Version > 0 && !string.IsNullOrEmpty(response.ConnectionToken))
+                {
+                    writer.WriteString(ConnectionTokenPropertyNameBytes, response.ConnectionToken);
                 }
 
                 writer.WriteStartArray(AvailableTransportsPropertyNameBytes);
@@ -127,6 +134,7 @@ namespace Microsoft.AspNetCore.Http.Connections
                 reader.EnsureObjectStart();
 
                 string connectionId = null;
+                string connectionToken = null;
                 string url = null;
                 string accessToken = null;
                 List<AvailableTransport> availableTransports = null;
@@ -150,6 +158,10 @@ namespace Microsoft.AspNetCore.Http.Connections
                             else if (reader.ValueTextEquals(ConnectionIdPropertyNameBytes.EncodedUtf8Bytes))
                             {
                                 connectionId = reader.ReadAsString(ConnectionIdPropertyName);
+                            }
+                            else if (reader.ValueTextEquals(ConnectionTokenPropertyNameBytes.EncodedUtf8Bytes))
+                            {
+                                connectionToken = reader.ReadAsString(ConnectionTokenPropertyName);
                             }
                             else if (reader.ValueTextEquals(NegotiateVersionPropertyNameBytes.EncodedUtf8Bytes))
                             {
@@ -202,6 +214,14 @@ namespace Microsoft.AspNetCore.Http.Connections
                         throw new InvalidDataException($"Missing required property '{ConnectionIdPropertyName}'.");
                     }
 
+                    if (version > 0)
+                    {
+                        if (connectionToken == null)
+                        {
+                            throw new InvalidDataException($"Missing required property '{ConnectionTokenPropertyName}'.");
+                        }
+                    }
+
                     if (availableTransports == null)
                     {
                         throw new InvalidDataException($"Missing required property '{AvailableTransportsPropertyName}'.");
@@ -211,6 +231,7 @@ namespace Microsoft.AspNetCore.Http.Connections
                 return new NegotiationResponse
                 {
                     ConnectionId = connectionId,
+                    ConnectionToken = connectionToken,
                     Url = url,
                     AccessToken = accessToken,
                     AvailableTransports = availableTransports,

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public string Url { get; set; }
         public string AccessToken { get; set; }
         public string ConnectionId { get; set; }
+        public int Version { get; set; }
         public IList<AvailableTransport> AvailableTransports { get; set; }
         public string Error { get; set; }
     }

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public string Url { get; set; }
         public string AccessToken { get; set; }
         public string ConnectionId { get; set; }
+        public string ConnectionToken { get; set; }
         public int Version { get; set; }
         public IList<AvailableTransport> AvailableTransports { get; set; }
         public string Error { get; set; }

--- a/src/SignalR/common/Http.Connections/ref/Microsoft.AspNetCore.Http.Connections.netcoreapp.cs
+++ b/src/SignalR/common/Http.Connections/ref/Microsoft.AspNetCore.Http.Connections.netcoreapp.cs
@@ -53,6 +53,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public long ApplicationMaxBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IList<Microsoft.AspNetCore.Authorization.IAuthorizeData> AuthorizationData { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Http.Connections.LongPollingOptions LongPolling { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public int MinimumProtocolVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public long TransportMaxBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Http.Connections.HttpTransportType Transports { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Http.Connections.WebSocketOptions WebSockets { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -57,5 +57,11 @@ namespace Microsoft.AspNetCore.Http.Connections
         /// Gets or sets the maximum buffer size of the application writer.
         /// </summary>
         public long ApplicationMaxBufferSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum protocol verison supported by the server.
+        /// The default value is 0, the lowest possible protocol version.
+        /// </summary>
+        public int MinimumProtocolVersion { get; set; } = 0;
     }
 }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -48,11 +48,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         /// Creates the DefaultConnectionContext without Pipes to avoid upfront allocations.
         /// The caller is expected to set the <see cref="Transport"/> and <see cref="Application"/> pipes manually.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="connectionId"></param>
+        /// <param name="connectionToken"></param>
         /// <param name="logger"></param>
-        public HttpConnectionContext(string id, ILogger logger)
+        public HttpConnectionContext(string connectionId, string connectionToken, ILogger logger)
         {
-            ConnectionId = id;
+            ConnectionId = connectionId;
+            ConnectionToken = connectionToken;
             LastSeenUtc = DateTime.UtcNow;
 
             // The default behavior is that both formats are supported.
@@ -74,8 +76,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             Features.Set<IConnectionInherentKeepAliveFeature>(this);
         }
 
-        public HttpConnectionContext(string id, IDuplexPipe transport, IDuplexPipe application, ILogger logger = null)
-            : this(id, logger)
+        internal HttpConnectionContext(string id, IDuplexPipe transport, IDuplexPipe application, ILogger logger = null)
+            : this(id, null, logger)
         {
             Transport = transport;
             Application = application;
@@ -112,6 +114,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         public HttpConnectionStatus Status { get; set; } = HttpConnectionStatus.Inactive;
 
         public override string ConnectionId { get; set; }
+
+        internal string ConnectionToken { get; set; }
 
         public override IFeatureCollection Features { get; }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.Log.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.Log.cs
@@ -52,6 +52,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             private static readonly Action<ILogger, string, Exception> _failedToReadHttpRequestBody =
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(14, "FailedToReadHttpRequestBody"), "Connection {TransportConnectionId} failed to read the HTTP request body.");
 
+            private static readonly Action<ILogger, int, Exception> _negotiateProtocolVersionMismatch =
+                LoggerMessage.Define<int>(LogLevel.Debug, new EventId(15, "NegotiateProtocolVersionMismatch"), "The client requested version '{clientProtocolVersion}', but the server does not support this version.");
+
+            private static readonly Action<ILogger, string, Exception> _invalidNegotiateProtocolVersion =
+               LoggerMessage.Define<string>(LogLevel.Debug, new EventId(16, "InvalidNegotiateProtocolVersion"), "The client requested an invalid protocol version '{queryStringVersionValue}'");
+
             public static void ConnectionDisposed(ILogger logger, string connectionId)
             {
                 _connectionDisposed(logger, connectionId, null);
@@ -120,6 +126,16 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             public static void FailedToReadHttpRequestBody(ILogger logger, string connectionId, Exception ex)
             {
                 _failedToReadHttpRequestBody(logger, connectionId, ex);
+            }
+
+            public static void NegotiateProtocolVersionMismatch(ILogger logger, int clientProtocolVersion)
+            {
+                _negotiateProtocolVersionMismatch(logger, clientProtocolVersion, null);
+            }
+
+            public static void InvalidNegotiateProtocolVersion(ILogger logger, string requestedProtocolVersion)
+            {
+                _invalidNegotiateProtocolVersion(logger, requestedProtocolVersion, null);
             }
         }
     }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -59,7 +59,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             // Create the log scope and attempt to pass the Connection ID to it so as many logs as possible contain
             // the Connection ID metadata. If this is the negotiate request then the Connection ID for the scope will
             // be set a little later.
-            var logScope = new ConnectionLogScope(GetConnectionId(context));
+
+            HttpConnectionContext connectionContext = null;
+            var connectionToken = GetConnectionToken(context);
+            if (connectionToken != null)
+            {
+                _manager.TryGetConnection(GetConnectionToken(context), out connectionContext);
+            }
+
+            var logScope = new ConnectionLogScope(connectionContext?.ConnectionId);
             using (_logger.BeginScope(logScope))
             {
                 if (HttpMethods.IsPost(context.Request.Method))
@@ -279,13 +287,29 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         private async Task ProcessNegotiate(HttpContext context, HttpConnectionDispatcherOptions options, ConnectionLogScope logScope)
         {
             context.Response.ContentType = "application/json";
+            string error = null;
+            int clientProtocolVersion = 0;
+            if (context.Request.Query.TryGetValue("NegotiateVersion", out var queryStringVersion))
+            {
+                // Set the negotiate response to the protocol we use.
+                var queryStringVersionValue = queryStringVersion.ToString();
+                if (!int.TryParse(queryStringVersionValue, out clientProtocolVersion))
+                {
+                    error = $"The client requested an invalid protocol version '{queryStringVersionValue}'";
+                    Log.InvalidNegotiateProtocolVersion(_logger, queryStringVersionValue);
+                }
+            }
 
             // Establish the connection
-            var connection = CreateConnection(options);
+            HttpConnectionContext connection = null;
+            if (error == null)
+            {
+                connection = CreateConnection(options, clientProtocolVersion);
+            }
 
             // Set the Connection ID on the logging scope so that logs from now on will have the
             // Connection ID metadata set.
-            logScope.ConnectionId = connection.ConnectionId;
+            logScope.ConnectionId = connection?.ConnectionId;
 
             // Don't use thread static instance here because writer is used with async
             var writer = new MemoryBufferWriter();
@@ -293,7 +317,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             try
             {
                 // Get the bytes for the connection id
-                WriteNegotiatePayload(writer, connection.ConnectionId, context, options);
+                WriteNegotiatePayload(writer, connection?.ConnectionId, connection?.ConnectionToken, context, options, clientProtocolVersion, error);
 
                 Log.NegotiationRequest(_logger);
 
@@ -307,38 +331,34 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             }
         }
 
-        private void WriteNegotiatePayload(IBufferWriter<byte> writer, string connectionId, HttpContext context, HttpConnectionDispatcherOptions options)
+        private void WriteNegotiatePayload(IBufferWriter<byte> writer, string connectionId, string connectionToken, HttpContext context, HttpConnectionDispatcherOptions options,
+            int clientProtocolVersion, string error)
         {
             var response = new NegotiationResponse();
 
-            if (context.Request.Query.TryGetValue("NegotiateVersion", out var queryStringVersion))
+            if (!string.IsNullOrEmpty(error))
             {
-                // Set the negotiate response to the protocol we use.
-                var queryStringVersionValue = queryStringVersion.ToString();
-                if (int.TryParse(queryStringVersionValue, out var clientProtocolVersion))
+                response.Error = error;
+                NegotiateProtocol.WriteResponse(response, writer);
+                return;
+            }
+
+            if (clientProtocolVersion > 0)
+            {
+                if (clientProtocolVersion < options.MinimumProtocolVersion)
                 {
-                    if (clientProtocolVersion < options.MinimumProtocolVersion)
-                    {
-                        response.Error = $"The client requested version '{clientProtocolVersion}', but the server does not support this version.";
-                        Log.NegotiateProtocolVersionMismatch(_logger, clientProtocolVersion);
-                        NegotiateProtocol.WriteResponse(response, writer);
-                        return;
-                    }
-                    else if (clientProtocolVersion > _protocolVersion)
-                    {
-                        response.Version = _protocolVersion;
-                    }
-                    else
-                    {
-                        response.Version = clientProtocolVersion;
-                    }
+                    response.Error = $"The client requested version '{clientProtocolVersion}', but the server does not support this version.";
+                    Log.NegotiateProtocolVersionMismatch(_logger, clientProtocolVersion);
+                    NegotiateProtocol.WriteResponse(response, writer);
+                    return;
+                }
+                else if (clientProtocolVersion > _protocolVersion)
+                {
+                    response.Version = _protocolVersion;
                 }
                 else
                 {
-                    response.Error = $"The client requested an invalid protocol version '{queryStringVersionValue}'";
-                    Log.InvalidNegotiateProtocolVersion(_logger, queryStringVersionValue);
-                    NegotiateProtocol.WriteResponse(response, writer);
-                    return;
+                    response.Version = clientProtocolVersion;
                 }
             }
             else if (options.MinimumProtocolVersion > 0)
@@ -350,6 +370,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             }
 
             response.ConnectionId = connectionId;
+            response.ConnectionToken = connectionToken;
             response.AvailableTransports = new List<AvailableTransport>();
 
             if ((options.Transports & HttpTransportType.WebSockets) != 0 && ServerHasWebSockets(context.Features))
@@ -375,7 +396,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             return features.Get<IHttpWebSocketFeature>() != null;
         }
 
-        private static string GetConnectionId(HttpContext context) => context.Request.Query["id"];
+        private static string GetConnectionToken(HttpContext context) => context.Request.Query["id"];
 
         private async Task ProcessSend(HttpContext context, HttpConnectionDispatcherOptions options)
         {
@@ -648,9 +669,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         private async Task<HttpConnectionContext> GetConnectionAsync(HttpContext context)
         {
-            var connectionId = GetConnectionId(context);
+            var connectionToken = GetConnectionToken(context);
 
-            if (StringValues.IsNullOrEmpty(connectionId))
+            if (StringValues.IsNullOrEmpty(connectionToken))
             {
                 // There's no connection ID: bad request
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -659,7 +680,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 return null;
             }
 
-            if (!_manager.TryGetConnection(connectionId, out var connection))
+            if (!_manager.TryGetConnection(connectionToken, out var connection))
             {
                 // No connection with that ID: Not Found
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -674,15 +695,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         // This is only used for WebSockets connections, which can connect directly without negotiating
         private async Task<HttpConnectionContext> GetOrCreateConnectionAsync(HttpContext context, HttpConnectionDispatcherOptions options)
         {
-            var connectionId = GetConnectionId(context);
+            var connectionToken = GetConnectionToken(context);
             HttpConnectionContext connection;
 
             // There's no connection id so this is a brand new connection
-            if (StringValues.IsNullOrEmpty(connectionId))
+            if (StringValues.IsNullOrEmpty(connectionToken))
             {
                 connection = CreateConnection(options);
             }
-            else if (!_manager.TryGetConnection(connectionId, out connection))
+            else if (!_manager.TryGetConnection(connectionToken, out connection))
             {
                 // No connection with that ID: Not Found
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -693,12 +714,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             return connection;
         }
 
-        private HttpConnectionContext CreateConnection(HttpConnectionDispatcherOptions options)
+        private HttpConnectionContext CreateConnection(HttpConnectionDispatcherOptions options, int clientProtocolVersion = 0)
         {
             var transportPipeOptions = new PipeOptions(pauseWriterThreshold: options.TransportMaxBufferSize, resumeWriterThreshold: options.TransportMaxBufferSize / 2, readerScheduler: PipeScheduler.ThreadPool, useSynchronizationContext: false);
             var appPipeOptions = new PipeOptions(pauseWriterThreshold: options.ApplicationMaxBufferSize, resumeWriterThreshold: options.ApplicationMaxBufferSize / 2, readerScheduler: PipeScheduler.ThreadPool, useSynchronizationContext: false);
-
-            return _manager.CreateConnection(transportPipeOptions, appPipeOptions);
+            return _manager.CreateConnection(transportPipeOptions, appPipeOptions, clientProtocolVersion);
         }
 
         private class EmptyServiceProvider : IServiceProvider

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
     public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     {
         [Fact]
-        public async Task NegotiateReservesConnectionIdAndReturnsIt()
+        public async Task NegotiateVersionZeroReservesConnectionIdAndReturnsIt()
         {
             using (StartVerifiableLog())
             {
@@ -54,8 +54,35 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions());
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
                 var connectionId = negotiateResponse.Value<string>("connectionId");
-                Assert.True(manager.TryGetConnection(connectionId, out var connectionContext));
+                var connectionToken = negotiateResponse.Value<string>("connectionToken");
+                Assert.Null(connectionToken);
+                Assert.NotNull(connectionId);
+            }
+        }
+
+        [Fact]
+        public async Task NegotiateReservesConnectionTokenAndConnectionIdAndReturnsIt()
+        {
+            using (StartVerifiableLog())
+            {
+                var manager = CreateConnectionManager(LoggerFactory);
+                var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
+                var context = new DefaultHttpContext();
+                var services = new ServiceCollection();
+                services.AddSingleton<TestConnectionHandler>();
+                services.AddOptions();
+                var ms = new MemoryStream();
+                context.Request.Path = "/foo";
+                context.Request.Method = "POST";
+                context.Response.Body = ms;
+                context.Request.QueryString = new QueryString("?negotiateVersion=1");
+                await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions());
+                var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
+                var connectionId = negotiateResponse.Value<string>("connectionId");
+                var connectionToken = negotiateResponse.Value<string>("connectionToken");
+                Assert.True(manager.TryGetConnection(connectionToken, out var connectionContext));
                 Assert.Equal(connectionId, connectionContext.ConnectionId);
+                Assert.NotEqual(connectionId, connectionToken);
             }
         }
 
@@ -74,12 +101,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Path = "/foo";
                 context.Request.Method = "POST";
                 context.Response.Body = ms;
+                context.Request.QueryString = new QueryString("?negotiateVersion=1");
                 var options = new HttpConnectionDispatcherOptions { TransportMaxBufferSize = 4, ApplicationMaxBufferSize = 4 };
                 await dispatcher.ExecuteNegotiateAsync(context, options);
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
-                var connectionId = negotiateResponse.Value<string>("connectionId");
-                context.Request.QueryString = context.Request.QueryString.Add("id", connectionId);
-                Assert.True(manager.TryGetConnection(connectionId, out var connection));
+                var connectionToken = negotiateResponse.Value<string>("connectionToken");
+                context.Request.QueryString = context.Request.QueryString.Add("id", connectionToken);
+                Assert.True(manager.TryGetConnection(connectionToken, out var connection));
                 // Fake actual connection after negotiate to populate the pipes on the connection
                 await dispatcher.ExecuteAsync(context, options, c => Task.CompletedTask);
 
@@ -111,7 +139,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Method = "POST";
                 context.Response.Body = ms;
                 context.Request.QueryString = new QueryString("?negotiateVersion=Invalid");
-
                 var options = new HttpConnectionDispatcherOptions { TransportMaxBufferSize = 4, ApplicationMaxBufferSize = 4 };
                 await dispatcher.ExecuteNegotiateAsync(context, options);
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
@@ -140,7 +167,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Method = "POST";
                 context.Response.Body = ms;
                 context.Request.QueryString = new QueryString("");
-
                 var options = new HttpConnectionDispatcherOptions { TransportMaxBufferSize = 4, ApplicationMaxBufferSize = 4, MinimumProtocolVersion = 1 };
                 await dispatcher.ExecuteNegotiateAsync(context, options);
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
@@ -183,7 +209,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -224,6 +251,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Path = "/foo";
                 context.Request.Method = "POST";
                 context.Response.Body = ms;
+                context.Request.QueryString = new QueryString("?negotiateVersion=1");
                 await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { Transports = transports });
 
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
@@ -262,6 +290,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Method = "GET";
                     var values = new Dictionary<string, StringValues>();
                     values["id"] = "unknown";
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
                     SetTransport(context, transportType);
@@ -298,6 +327,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
                     values["id"] = "unknown";
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -334,7 +364,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -373,6 +404,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
                     values["id"] = connection.ConnectionId;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -412,7 +444,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "GET";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -473,7 +506,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "GET";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -539,7 +573,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -602,6 +637,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
                     values["id"] = connection.ConnectionId;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -671,7 +707,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "GET";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     values["another"] = "value";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
@@ -719,8 +756,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     var connectionHttpContext = connection.GetHttpContext();
                     Assert.NotNull(connectionHttpContext);
 
-                    Assert.Equal(2, connectionHttpContext.Request.Query.Count);
-                    Assert.Equal(connection.ConnectionId, connectionHttpContext.Request.Query["id"]);
+                    Assert.Equal(3, connectionHttpContext.Request.Query.Count);
                     Assert.Equal("value", connectionHttpContext.Request.Query["another"]);
 
                     Assert.Equal(3, connectionHttpContext.Request.Headers.Count);
@@ -764,6 +800,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     services.AddSingleton<TestConnectionHandler>();
                     context.Request.Path = "/foo";
                     context.Request.Method = "GET";
+                    context.Request.QueryString = new QueryString("?negotiateVersion=1");
 
                     SetTransport(context, transportType);
 
@@ -806,7 +843,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
 
@@ -833,6 +871,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     services.AddSingleton<TestConnectionHandler>();
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
+                    context.Request.QueryString = new QueryString("?negotiateVersion=1");
 
                     var builder = new ConnectionBuilder(services.BuildServiceProvider());
                     builder.UseConnectionHandler<TestConnectionHandler>();
@@ -904,6 +943,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
 
                 var context = MakeRequest("/foo", connection);
+
                 SetTransport(context, HttpTransportType.ServerSentEvents);
 
                 var services = new ServiceCollection();
@@ -915,7 +955,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-                var exists = manager.TryGetConnection(connection.ConnectionId, out _);
+                var exists = manager.TryGetConnection(connection.ConnectionToken, out _);
                 Assert.False(exists);
             }
         }
@@ -1279,7 +1319,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 await task;
 
                 Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
-                var exists = manager.TryGetConnection(connection.ConnectionId, out _);
+                var exists = manager.TryGetConnection(connection.ConnectionToken, out _);
                 Assert.False(exists);
             }
         }
@@ -1320,7 +1360,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 await task;
 
                 Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
-                var exists = manager.TryGetConnection(connection.ConnectionId, out _);
+                var exists = manager.TryGetConnection(connection.ConnectionToken, out _);
                 Assert.False(exists);
             }
         }
@@ -1422,10 +1462,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Method = "GET";
                 context.RequestServices = sp;
                 var values = new Dictionary<string, StringValues>();
-                values["id"] = connection.ConnectionId;
+                values["id"] = connection.ConnectionToken;
+                values["negotiateVersion"] = "1";
                 var qs = new QueryCollection(values);
                 context.Request.Query = qs;
-
                 var builder = new ConnectionBuilder(sp);
                 builder.UseConnectionHandler<TestConnectionHandler>();
                 var app = builder.Build();
@@ -1510,7 +1550,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 // Issue the delete request
                 var deleteContext = new DefaultHttpContext();
                 deleteContext.Request.Path = "/foo";
-                deleteContext.Request.QueryString = new QueryString($"?id={connection.ConnectionId}");
+                deleteContext.Request.QueryString = new QueryString($"?id={connection.ConnectionToken}");
                 deleteContext.Request.Method = "DELETE";
                 var ms = new MemoryStream();
                 deleteContext.Response.Body = ms;
@@ -1553,7 +1593,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 // Issue the delete request and make sure the poll completes
                 var deleteContext = new DefaultHttpContext();
                 deleteContext.Request.Path = "/foo";
-                deleteContext.Request.QueryString = new QueryString($"?id={connection.ConnectionId}");
+                deleteContext.Request.QueryString = new QueryString($"?id={connection.ConnectionToken}");
                 deleteContext.Request.Method = "DELETE";
 
                 Assert.False(pollTask.IsCompleted);
@@ -1571,7 +1611,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 Assert.Equal("text/plain", deleteContext.Response.ContentType);
 
                 // Verify the connection was removed from the manager
-                Assert.False(manager.TryGetConnection(connection.ConnectionId, out _));
+                Assert.False(manager.TryGetConnection(connection.ConnectionToken, out _));
             }
         }
 
@@ -1601,7 +1641,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 // Issue the delete request and make sure the poll completes
                 var deleteContext = new DefaultHttpContext();
                 deleteContext.Request.Path = "/foo";
-                deleteContext.Request.QueryString = new QueryString($"?id={connection.ConnectionId}");
+                deleteContext.Request.QueryString = new QueryString($"?id={connection.ConnectionToken}");
                 deleteContext.Request.Method = "DELETE";
 
                 await dispatcher.ExecuteAsync(deleteContext, options, app).OrTimeout();
@@ -1619,7 +1659,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 await connection.DisposeAndRemoveTask.OrTimeout();
 
                 // Verify the connection was removed from the manager
-                Assert.False(manager.TryGetConnection(connection.ConnectionId, out _));
+                Assert.False(manager.TryGetConnection(connection.ConnectionToken, out _));
             }
         }
 
@@ -1639,6 +1679,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Path = "/foo";
                 context.Request.Method = "POST";
                 context.Response.Body = ms;
+                context.Request.QueryString = new QueryString("?negotiateVersion=1");
                 await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { Transports = HttpTransportType.WebSockets });
 
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
@@ -1695,7 +1736,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
                     var buffer = Encoding.UTF8.GetBytes("Hello, world");
@@ -1751,7 +1793,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
                     var buffer = Encoding.UTF8.GetBytes("Hello, world");
@@ -1804,7 +1847,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     context.Request.Path = "/foo";
                     context.Request.Method = "POST";
                     var values = new Dictionary<string, StringValues>();
-                    values["id"] = connection.ConnectionId;
+                    values["id"] = connection.ConnectionToken;
+                    values["negotiateVersion"] = "1";
                     var qs = new QueryCollection(values);
                     context.Request.Query = qs;
                     var buffer = Encoding.UTF8.GetBytes("Hello, world");
@@ -1866,7 +1910,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 await pollTask.OrTimeout();
 
                 Assert.Equal(StatusCodes.Status500InternalServerError, pollContext.Response.StatusCode);
-                Assert.False(manager.TryGetConnection(connection.ConnectionId, out var _));
+                Assert.False(manager.TryGetConnection(connection.ConnectionToken, out var _));
             }
         }
 
@@ -1889,7 +1933,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Path = "/foo";
                 context.Request.Method = "GET";
                 var values = new Dictionary<string, StringValues>();
-                values["id"] = connection.ConnectionId;
+                values["id"] = connection.ConnectionToken;
+                values["negotiateVersion"] = "1";
                 var qs = new QueryCollection(values);
                 context.Request.Query = qs;
 
@@ -1911,14 +1956,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             }
         }
 
-        private static DefaultHttpContext MakeRequest(string path, ConnectionContext connection, string format = null)
+        private static DefaultHttpContext MakeRequest(string path, HttpConnectionContext connection, string format = null)
         {
             var context = new DefaultHttpContext();
             context.Features.Set<IHttpResponseFeature>(new ResponseFeature());
             context.Request.Path = path;
             context.Request.Method = "GET";
             var values = new Dictionary<string, StringValues>();
-            values["id"] = connection.ConnectionId;
+            values["id"] = connection.ConnectionToken;
+            values["negotiateVersion"] = "1";
             if (format != null)
             {
                 values["format"] = format;

--- a/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
+++ b/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
@@ -13,12 +13,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
     public class NegotiateProtocolTests
     {
         [Theory]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null)]
-        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0], null, null)]
-        [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null)]
-        [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token")]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null)]
-        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken)
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 0)]
+        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0], null, null, 0)]
+        [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null, 0)]
+        [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token", 0)]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0)]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0)]
+        [InlineData("{\"negotiateVersion\":123,\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 123)]
+        [InlineData("{\"negotiateVersion\":123,\"negotiateVersion\":321,\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 321)]
+        [InlineData("{\"ignore\":123,\"negotiateVersion\":123,\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 123)]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[],\"negotiateVersion\":123}", "123", new string[0], null, null, 123)]
+        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken, int version)
         {
             var responseData = Encoding.UTF8.GetBytes(json);
             var response = NegotiateProtocol.ParseResponse(responseData);
@@ -27,6 +32,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             Assert.Equal(availableTransports?.Length, response.AvailableTransports?.Count);
             Assert.Equal(url, response.Url);
             Assert.Equal(accessToken, response.AccessToken);
+            Assert.Equal(version, response.Version);
 
             if (response.AvailableTransports != null)
             {
@@ -82,7 +88,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 string json = Encoding.UTF8.GetString(writer.ToArray());
 
-                Assert.Equal("{\"availableTransports\":[]}", json);
+                Assert.Equal("{\"negotiateVersion\":0,\"availableTransports\":[]}", json);
             }
         }
 
@@ -101,7 +107,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 string json = Encoding.UTF8.GetString(writer.ToArray());
 
-                Assert.Equal("{\"availableTransports\":[{\"transport\":null,\"transferFormats\":[]}]}", json);
+                Assert.Equal("{\"negotiateVersion\":0,\"availableTransports\":[{\"transport\":null,\"transferFormats\":[]}]}", json);
             }
         }
     }

--- a/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
+++ b/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
@@ -18,8 +18,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null, 0, null)]
         [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token", 0, null)]
         [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0, null)]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0, null)]
-        [InlineData("{\"negotiateVersion\":123,\"connectionId\":\"123\",\"connectionToken\":\"789\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 123, "789")]
         [InlineData("{\"negotiateVersion\":123,\"negotiateVersion\":321, \"connectionToken\":\"789\",\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 321, "789")]
         [InlineData("{\"ignore\":123,\"negotiateVersion\":123, \"connectionToken\":\"789\",\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 123, "789")]
         [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[],\"negotiateVersion\":123, \"connectionToken\":\"789\"}", "123", new string[0], null, null, 123, "789")]

--- a/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
+++ b/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
@@ -13,17 +13,20 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
     public class NegotiateProtocolTests
     {
         [Theory]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 0)]
-        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0], null, null, 0)]
-        [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null, 0)]
-        [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token", 0)]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0)]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0)]
-        [InlineData("{\"negotiateVersion\":123,\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 123)]
-        [InlineData("{\"negotiateVersion\":123,\"negotiateVersion\":321,\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 321)]
-        [InlineData("{\"ignore\":123,\"negotiateVersion\":123,\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 123)]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[],\"negotiateVersion\":123}", "123", new string[0], null, null, 123)]
-        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken, int version)
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 0, null)]
+        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0], null, null, 0, null)]
+        [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null, 0, null)]
+        [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token", 0, null)]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0, null)]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 0, null)]
+        [InlineData("{\"negotiateVersion\":123,\"connectionId\":\"123\",\"connectionToken\":\"789\",\"availableTransports\":[{\"\\u0074ransport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null, 123, "789")]
+        [InlineData("{\"negotiateVersion\":123,\"negotiateVersion\":321, \"connectionToken\":\"789\",\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 321, "789")]
+        [InlineData("{\"ignore\":123,\"negotiateVersion\":123, \"connectionToken\":\"789\",\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null, 123, "789")]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[],\"negotiateVersion\":123, \"connectionToken\":\"789\"}", "123", new string[0], null, null, 123, "789")]
+        [InlineData("{\"connectionId\":\"123\",\"connectionToken\":\"789\",\"availableTransports\":[]}", "123", new string[0], null, null, 0, "789")]
+        [InlineData("{\"connectionToken\":\"789\",\"connectionId\":\"123\",\"availableTransports\":[],\"negotiateVersion\":123}", "123", new string[0], null, null, 123, "789")]
+        [InlineData("{\"connectionToken\":\"789\",\"connectionId\":\"123\",\"availableTransports\":[],\"negotiateVersion\":123, \"connectionToken\":\"987\"}", "123", new string[0], null, null, 123, "987")]
+        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken, int version, string connectionToken)
         {
             var responseData = Encoding.UTF8.GetBytes(json);
             var response = NegotiateProtocol.ParseResponse(responseData);
@@ -33,6 +36,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             Assert.Equal(url, response.Url);
             Assert.Equal(accessToken, response.AccessToken);
             Assert.Equal(version, response.Version);
+            Assert.Equal(connectionToken, response.ConnectionToken);
 
             if (response.AvailableTransports != null)
             {
@@ -50,6 +54,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         [InlineData("{\"connectionId\":\"123\",\"availableTransports\":null}", "Unexpected JSON Token Type 'Null'. Expected a JSON Array.")]
         [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transferFormats\":[]}]}", "Missing required property 'transport'.")]
         [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\"}]}", "Missing required property 'transferFormats'.")]
+        [InlineData("{\"connectionId\":\"123\",\"negotiateVersion\":123,\"availableTransports\":[]}", "Missing required property 'connectionToken'.")]
         public void ParsingNegotiateResponseMessageThrowsForInvalid(string payload, string expectedMessage)
         {
             var responseData = Encoding.UTF8.GetBytes(payload);


### PR DESCRIPTION
Backport the Negotiate versioning and ConnectionID split

- [x] SignalR Negotiate protocol versioning https://github.com/aspnet/AspNetCore/pull/13389
- [x] SignalR ConnectionToken/ConnectionAddress feature https://github.com/aspnet/AspNetCore/pull/13773
- [x] Add support for negotiateVersion query string parameter https://github.com/aspnet/AspNetCore/pull/13880
- [x] [TS] Add support for negotiateVersion and connectionToken https://github.com/aspnet/AspNetCore/pull/14157
- [x] C# and Java client negotiateVersion cleanup https://github.com/aspnet/AspNetCore/pull/14196

Manual Testing:
- [x] 3.0 JS client + 3.1 server
- [x] 3.0 Java client + 3.1 server
- [x] 3.0 C# client + 3.1 server
- [x] 3.1 JS client + 3.0 server
- [x] 3.1 Java client + 3.0 server
- [x] 3.1 C# client + 3.0 server
- [x] 2.1 JS client + 3.1 server
- [x] 2.1 C# client + 3.1 server
- [x] 2.2 JS client + 3.1 server
- [x] 2.2 Java client + 3.1 server
- [x] 2.2 C# client + 3.1 server
- [x] 3.1 client + 3.1 server + SignalR Service
- [x] 3.0 client + 3.1 server + SignalR Service