### PR TITLE
Reduce bound checks in Kestrel.Core and HttpSys

### DIFF
--- a/src/Servers/HttpSys/src/Helpers.cs
+++ b/src/Servers/HttpSys/src/Helpers.cs
@@ -117,8 +117,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 }
             }
 
-            header[8] = (byte)'\r';
+            // hoist the bound check
             header[9] = (byte)'\n';
+            header[8] = (byte)'\r';
 
             return new ArraySegment<byte>(header, offset, header.Length - offset);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -458,7 +458,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // Advance examined before possibly throwing, so we don't risk examining less than the previous call to ParseChunkedSuffix.
             examined = suffixBuffer.End;
 
-            if (suffixSpan[0] == '\r' && suffixSpan[1] == '\n')
+            // index 1 first, to elide the bound check for index 0
+            if (suffixSpan[1] == '\n' && suffixSpan[0] == '\r')
             {
                 consumed = suffixBuffer.End;
                 AddAndCheckConsumedBytes(2);
@@ -486,7 +487,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // Advance examined before possibly throwing, so we don't risk examining less than the previous call to ParseChunkedTrailer.
             examined = trailerBuffer.End;
 
-            if (trailerSpan[0] == '\r' && trailerSpan[1] == '\n')
+            // index 1 first, to elide the bound check for index 0
+            if (trailerSpan[1] == '\n' && trailerSpan[0] == '\r')
             {
                 consumed = trailerBuffer.End;
                 AddAndCheckConsumedBytes(2);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -190,8 +190,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     // Fast path, we're still looking at the same span
                     if (span.Length >= 2)
                     {
-                        ch1 = span[0];
+                        // index 1 first, to elide the bound check for index 0
                         ch2 = span[1];
+                        ch1 = span[0];
                     }
                     else if (reader.TryRead(out ch1)) // Possibly split across spans
                     {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Bitshifter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Bitshifter.cs
@@ -14,16 +14,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt24BigEndian(ReadOnlySpan<byte> source)
         {
-            return (uint)((source[0] << 16) | (source[1] << 8) | source[2]);
+            return (uint)(source[2] | (source[1] << 8) | (source[0] << 16));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt24BigEndian(Span<byte> destination, uint value)
         {
             Debug.Assert(value <= 0xFF_FF_FF, value.ToString());
-            destination[0] = (byte)((value & 0xFF_00_00) >> 16);
-            destination[1] = (byte)((value & 0x00_FF_00) >> 8);
             destination[2] = (byte)(value & 0x00_00_FF);
+            destination[1] = (byte)((value & 0x00_FF_00) >> 8);
+            destination[0] = (byte)((value & 0xFF_00_00) >> 16);
         }
 
         // Drops the highest order bit

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/HPack/HPackEncoder.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/HPack/HPackEncoder.cs
@@ -70,11 +70,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack
                     buffer[0] = (byte)(0x80 | StaticTable.Instance.StatusIndex[statusCode]);
                     return 1;
                 default:
+                    // index 1 first, to elide the bound check for index 0
+                    var statusBytes = StatusCodes.ToStatusBytes(statusCode);
+                    buffer[1] = (byte)statusBytes.Length;
+
                     // Send as Literal Header Field Without Indexing - Indexed Name
                     buffer[0] = 0x08;
 
-                    var statusBytes = StatusCodes.ToStatusBytes(statusCode);
-                    buffer[1] = (byte)statusBytes.Length;
                     ((Span<byte>)statusBytes).CopyTo(buffer.Slice(2));
 
                     return 2 + statusBytes.Length;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -621,8 +621,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             Bitshifter.WriteUInt24BigEndian(buffer, (uint)frame.PayloadLength);
             buffer = buffer.Slice(3);
 
-            buffer[0] = (byte)frame.Type;
+            // index 1 first, to elide the bound check for index 0
             buffer[1] = frame.Flags;
+            buffer[0] = (byte)frame.Type;
             buffer = buffer.Slice(2);
 
             Bitshifter.WriteUInt31BigEndian(buffer, (uint)frame.StreamId, preserveHighestBit: false);


### PR DESCRIPTION
For Span / array access write the highest constant index first, so the JIT will emit only one bound check, instead of a bound check for each access.

For instance `Bitshifter.ReadUInt24BigEndian`.
<details>
  <summary>before</summary>

```asm
; Assembly listing for method Program:Do(struct):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00    ] (  3,  3   )  struct (16) [rsp+0x08]   do-not-enreg[XSB] addr-exposed
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;* V02 tmp1         [V02    ] (  0,  0   )  struct (16) zero-ref    ld-addr-op "Inlining Arg"
;  V03 tmp2         [V03,T01] (  4,  4   )   byref  ->  rdi         V02._pointer(offs=0x00) P-INDEP "field V02._pointer (fldOffset=0x0)"
;  V04 tmp3         [V04,T02] (  4,  4   )     int  ->  rax         V02._length(offs=0x08) P-INDEP "field V02._length (fldOffset=0x8)"
;  V05 tmp4         [V05,T00] (  3,  6   )   byref  ->  rax         "BlockOp address local"
;
; Lcl frame size = 24

G_M56184_IG01:
       4883EC18             sub      rsp, 24
       90                   nop      
       48897C2408           mov      bword ptr [rsp+08H], rdi
       4889742410           mov      qword ptr [rsp+10H], rsi

G_M56184_IG02:
       488D442408           lea      rax, bword ptr [rsp+08H]
       488B38               mov      rdi, bword ptr [rax]
       8B4008               mov      eax, dword ptr [rax+8]
       83F800               cmp      eax, 0
       7625                 jbe      SHORT G_M56184_IG04
       400FB637             movzx    rsi, byte  ptr [rdi]
       C1E610               shl      esi, 16
       83F801               cmp      eax, 1
       7619                 jbe      SHORT G_M56184_IG04
       0FB65701             movzx    rdx, byte  ptr [rdi+1]
       C1E208               shl      edx, 8
       0BD6                 or       edx, esi
       83F802               cmp      eax, 2
       760B                 jbe      SHORT G_M56184_IG04
       0FB64702             movzx    rax, byte  ptr [rdi+2]
       0BC2                 or       eax, edx

G_M56184_IG03:
       4883C418             add      rsp, 24
       C3                   ret      

G_M56184_IG04:		;; bbWeight=0   
       E8D72B4579           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 74, prolog size 5, perf score 30.40, (MethodHash=e1472488) for method Program:Do(struct):int
; ============================================================
```
</details>

<details>
  <summary>after</summary>

```asm
; Assembly listing for method Program:Do(struct):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00    ] (  3,  3   )  struct (16) [rsp+0x08]   do-not-enreg[XSB] addr-exposed
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;* V02 tmp1         [V02    ] (  0,  0   )  struct (16) zero-ref    ld-addr-op "Inlining Arg"
;  V03 tmp2         [V03,T01] (  4,  4   )   byref  ->  rdi         V02._pointer(offs=0x00) P-INDEP "field V02._pointer (fldOffset=0x0)"
;  V04 tmp3         [V04,T02] (  2,  2   )     int  ->  rax         V02._length(offs=0x08) P-INDEP "field V02._length (fldOffset=0x8)"
;  V05 tmp4         [V05,T00] (  3,  6   )   byref  ->  rax         "BlockOp address local"
;
; Lcl frame size = 24

G_M56184_IG01:
       4883EC18             sub      rsp, 24
       90                   nop      
       48897C2408           mov      bword ptr [rsp+08H], rdi
       4889742410           mov      qword ptr [rsp+10H], rsi

G_M56184_IG02:
       488D442408           lea      rax, bword ptr [rsp+08H]
       488B38               mov      rdi, bword ptr [rax]
       8B4008               mov      eax, dword ptr [rax+8]
       83F802               cmp      eax, 2
       761C                 jbe      SHORT G_M56184_IG04
       0FB64702             movzx    rax, byte  ptr [rdi+2]
       400FB67701           movzx    rsi, byte  ptr [rdi+1]
       C1E608               shl      esi, 8
       0BC6                 or       eax, esi
       400FB63F             movzx    rdi, byte  ptr [rdi]
       C1E710               shl      edi, 16
       0BC7                 or       eax, edi

G_M56184_IG03:
       4883C418             add      rsp, 24
       C3                   ret      

G_M56184_IG04:		;; bbWeight=0   
       E8E06B4479           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 65, prolog size 5, perf score 27.00, (MethodHash=e1472488) for method Program:Do(struct):int
; ============================================================
```
</details>

I didn't run any explicit benchmarks, because the win should be obvious.