### PR TITLE
Add hubType to HubInvocationContext

### DIFF
--- a/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp.cs
+++ b/src/SignalR/server/Core/ref/Microsoft.AspNetCore.SignalR.Core.netcoreapp.cs
@@ -176,9 +176,11 @@ namespace Microsoft.AspNetCore.SignalR
     public partial class HubInvocationContext
     {
         public HubInvocationContext(Microsoft.AspNetCore.SignalR.HubCallerContext context, string hubMethodName, object[] hubMethodArguments) { }
+        public HubInvocationContext(Microsoft.AspNetCore.SignalR.HubCallerContext context, System.Type hubType, string hubMethodName, object[] hubMethodArguments) { }
         public Microsoft.AspNetCore.SignalR.HubCallerContext Context { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<object> HubMethodArguments { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string HubMethodName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Type HubType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public abstract partial class HubLifetimeManager<THub> where THub : Microsoft.AspNetCore.SignalR.Hub
     {

--- a/src/SignalR/server/Core/src/HubInvocationContext.cs
+++ b/src/SignalR/server/Core/src/HubInvocationContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 
@@ -11,6 +12,18 @@ namespace Microsoft.AspNetCore.SignalR
     /// </summary>
     public class HubInvocationContext
     {
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="HubInvocationContext"/> class.
+        /// </summary>
+        /// <param name="context">Context for the active Hub connection and caller.</param>
+        /// <param name="hubType">The type of the Hub.</param>
+        /// <param name="hubMethodName">The name of the Hub method being invoked.</param>
+        /// <param name="hubMethodArguments">The arguments provided by the client.</param>
+        public HubInvocationContext(HubCallerContext context, Type hubType, string hubMethodName, object[] hubMethodArguments): this(context, hubMethodName, hubMethodArguments)
+        {
+            HubType = hubType;
+        }
+
         /// <summary>
         /// Instantiates a new instance of the <see cref="HubInvocationContext"/> class.
         /// </summary>
@@ -28,6 +41,11 @@ namespace Microsoft.AspNetCore.SignalR
         /// Gets the context for the active Hub connection and caller.
         /// </summary>
         public HubCallerContext Context { get; }
+
+        /// <summary>
+        /// Gets the Hub type.
+        /// </summary>
+        public Type HubType { get; }
 
         /// <summary>
         /// Gets the name of the Hub method being invoked.

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -494,7 +494,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 return TaskCache.True;
             }
 
-            return IsHubMethodAuthorizedSlow(provider, hubConnectionContext.User, policies, new HubInvocationContext(hubConnectionContext.HubCallerContext, hubMethodName, hubMethodArguments));
+            return IsHubMethodAuthorizedSlow(provider, hubConnectionContext.User, policies, new HubInvocationContext(hubConnectionContext.HubCallerContext, typeof(THub), hubMethodName, hubMethodArguments));
         }
 
         private static async Task<bool> IsHubMethodAuthorizedSlow(IServiceProvider provider, ClaimsPrincipal principal, IList<IAuthorizeData> policies, HubInvocationContext resource)

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2215,6 +2215,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 Assert.NotNull(context.Resource);
                 var resource = Assert.IsType<HubInvocationContext>(context.Resource);
+                Assert.Equal(typeof(MethodHub), resource.HubType);
                 Assert.Equal(nameof(MethodHub.MultiParamAuthMethod), resource.HubMethodName);
                 Assert.Equal(2, resource.HubMethodArguments?.Count);
                 Assert.Equal("Hello", resource.HubMethodArguments[0]);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Just added the `HubName` property to the `HubInvocationContext`

Addresses #14344

/cc: @anurse 
