### PR TITLE
Fix null reference exception for Streaming null object (#14004)

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -265,7 +265,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                         for (var parameterPointer = 0; parameterPointer < arguments.Length; parameterPointer++)
                         {
                             if (hubMethodInvocationMessage.Arguments.Length > hubInvocationArgumentPointer &&
-                                descriptor.OriginalParameterTypes[parameterPointer].IsAssignableFrom(hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer].GetType()))
+                                (hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer] == null ||
+                                descriptor.OriginalParameterTypes[parameterPointer].IsAssignableFrom(hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer].GetType())))
                             {
                                 // The types match so it isn't a synthetic argument, just copy it into the arguments array
                                 arguments[parameterPointer] = hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer];

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -933,6 +933,36 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return channel.Reader;
         }
 
+        public ChannelReader<int> CancelableStreamNullableParameter(int x, string y, CancellationToken token)
+        {
+            var channel = Channel.CreateBounded<int>(10);
+
+            Task.Run(async () =>
+            {
+                _tcsService.StartedMethod.SetResult(x);
+                await token.WaitForCancellationAsync();
+                channel.Writer.TryComplete();
+                _tcsService.EndMethod.SetResult(y);
+            });
+
+            return channel.Reader;
+        }
+
+        public ChannelReader<int> StreamNullableParameter(int x, int? input)
+        {
+            var channel = Channel.CreateBounded<int>(10);
+
+            Task.Run(() =>
+            {
+                _tcsService.StartedMethod.SetResult(x);
+                channel.Writer.TryComplete();
+                _tcsService.EndMethod.SetResult(input);
+                return Task.CompletedTask;
+            });
+
+            return channel.Reader;
+        }
+
         public ChannelReader<int> CancelableStreamMiddleParameter(int ignore, CancellationToken token, int ignore2)
         {
             var channel = Channel.CreateBounded<int>(10);


### PR DESCRIPTION
#### Description
In 2.2 we added Server-to-client streaming as well as the ability to accept a CancellationToken in your streaming hub methods so you can observe when the stream has been canceled by the client.
There is a bug where if the user provides null as one of the values to an argument to the hub method then we will nullref and return an error to the client.

#### Customer Impact
This was a [customer reported issue](https://github.com/aspnet/AspNetCore/issues/13191).
If someone passes a null object (which is a valid scenario) to a streaming hub method that accepts a CancellationToken they will get a null ref on the server and the method will not be invoked.

#### Regression?
No, this has been a bug since the feature was introduced in 2.2.

#### Risk
Low, added test coverage to prevent this kind of issue in the future


@Pilchie I believe we need your approval for bug fixes