### PR TITLE
HttpSys GoAway

### DIFF
--- a/src/Servers/HttpSys/samples/SelfHostServer/SelfHostServer.csproj
+++ b/src/Servers/HttpSys/samples/SelfHostServer/SelfHostServer.csproj
@@ -1,9 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <!--Imitate IIS Express so we can use it's cert bindings-->
+    <PackageTags>214124cd-d05b-4309-9af9-9caa44b2b74a</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/HttpSys/samples/SelfHostServer/Startup.cs
+++ b/src/Servers/HttpSys/samples/SelfHostServer/Startup.cs
@@ -37,6 +37,8 @@ namespace SelfHostServer
                 .UseHttpSys(options =>
                 {
                     options.UrlPrefixes.Add("http://localhost:5000");
+                    // This is a pre-configured IIS express port. See the PackageTags in the csproj.
+                    options.UrlPrefixes.Add("https://localhost:44319");
                     options.Authentication.Schemes = AuthenticationSchemes.None;
                     options.Authentication.AllowAnonymous = true;
                 })

--- a/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
@@ -12,11 +11,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Minimum support for Windows 7 is assumed.
         internal static readonly bool IsWin8orLater;
 
+        public static bool SupportsGoAway { get; }
+
         static ComNetOS()
         {
             var win8Version = new Version(6, 2);
 
             IsWin8orLater = (Environment.OSVersion.Version >= win8Version);
+
+            var win1019H2Version = new Version(10, 0, 18363);
+            // Win10 1909 (19H2) or later
+            SupportsGoAway = (Environment.OSVersion.Version >= win1019H2Version);
         }
+
     }
 }

--- a/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Minimum support for Windows 7 is assumed.
         internal static readonly bool IsWin8orLater;
 
-        public static bool SupportsGoAway { get; }
+        internal static bool SupportsGoAway { get; }
 
         static ComNetOS()
         {

--- a/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
@@ -11,18 +11,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Minimum support for Windows 7 is assumed.
         internal static readonly bool IsWin8orLater;
 
-        internal static bool SupportsGoAway { get; }
-
         static ComNetOS()
         {
             var win8Version = new Version(6, 2);
 
             IsWin8orLater = (Environment.OSVersion.Version >= win8Version);
-
-            var win1019H2Version = new Version(10, 0, 18363);
-            // Win10 1909 (19H2) or later
-            SupportsGoAway = (Environment.OSVersion.Version >= win1019H2Version);
         }
-
     }
 }

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -417,6 +416,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Headers.Append(HttpKnownHeaderNames.Connection, Constants.Close);
                 }
                 flags = HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_DISCONNECT;
+                if (responseCloseSet && requestVersion >= Constants.V2 && ComNetOS.SupportsGoAway)
+                {
+                    flags |= HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_GOAWAY;
+                }
             }
 
             Headers.IsReadOnly = true;

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -17,7 +17,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 {
     internal sealed class Response
     {
-        private static bool? SupportsGoAway;
+        // Support is assumed until we get an error and turn it off.
+        private static bool SupportsGoAway = true;
 
         private ResponseState _responseState;
         private string _reasonPhrase;
@@ -443,7 +444,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Headers.Append(HttpKnownHeaderNames.Connection, Constants.Close);
                 }
                 flags = HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_DISCONNECT;
-                if (responseCloseSet && requestVersion >= Constants.V2 && SupportsGoAway != false)
+                if (responseCloseSet && requestVersion >= Constants.V2 && SupportsGoAway)
                 {
                     flags |= HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_GOAWAY;
                 }

--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -602,6 +602,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             HTTP_INITIALIZE_SERVER = 0x00000001,
             HTTP_INITIALIZE_CBT = 0x00000004,
             HTTP_SEND_RESPONSE_FLAG_OPAQUE = 0x00000040,
+            HTTP_SEND_RESPONSE_FLAG_GOAWAY = 0x00000100,
         }
 
         [Flags]


### PR DESCRIPTION
#13356 We have a customer that needs to trigger an HTTP/2 GoAway via Http.Sys so that their load balancer can redirect traffic. Http.Sys added a response flag we can set for this, but only on 1909.

My test app did have to add a manifest for the OS version check to work:
https://stackoverflow.com/questions/33328739/system-environment-osversion-returns-wrong-version (not sure how it worked on my other machine without this.)

I verified this manually using wireshark. Post preview1 we have a work item to add helix queues that support new windows builds (https://github.com/aspnet/AspNetCore-Internal/issues/3170). Stephen also has a branch with tools that will allow us to write unit tests at the protocol/frame level (https://github.com/aspnet/AspNetCore/pull/14582).