### PR TITLE
Prevent invalid access to ParameterView. Fixes #12622

### DIFF
--- a/src/Components/Components/src/CascadingValue.cs
+++ b/src/Components/Components/src/CascadingValue.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Components
 
             if (_subscribers != null && ChangeDetection.MayHaveChanged(previousValue, Value))
             {
-                NotifySubscribers();
+                NotifySubscribers(parameters.Lifetime);
             }
 
             return Task.CompletedTask;
@@ -168,11 +168,11 @@ namespace Microsoft.AspNetCore.Components
             _subscribers.Remove(subscriber);
         }
 
-        private void NotifySubscribers()
+        private void NotifySubscribers(ParameterViewLifetime lifetime)
         {
             foreach (var subscriber in _subscribers)
             {
-                subscriber.NotifyCascadingValueChanged();
+                subscriber.NotifyCascadingValueChanged(lifetime);
             }
         }
 

--- a/src/Components/Components/src/CascadingValue.cs
+++ b/src/Components/Components/src/CascadingValue.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Components
             _subscribers.Remove(subscriber);
         }
 
-        private void NotifySubscribers(ParameterViewLifetime lifetime)
+        private void NotifySubscribers(in ParameterViewLifetime lifetime)
         {
             foreach (var subscriber in _subscribers)
             {

--- a/src/Components/Components/src/ParameterView.cs
+++ b/src/Components/Components/src/ParameterView.cs
@@ -28,12 +28,12 @@ namespace Microsoft.AspNetCore.Components
         private readonly int _ownerIndex;
         private readonly IReadOnlyList<CascadingParameterState> _cascadingParametersOrNull;
 
-        internal ParameterView(ParameterViewLifetime lifetime, RenderTreeFrame[] frames, int ownerIndex)
+        internal ParameterView(in ParameterViewLifetime lifetime, RenderTreeFrame[] frames, int ownerIndex)
             : this(lifetime, frames, ownerIndex, null)
         {
         }
 
-        private ParameterView(ParameterViewLifetime lifetime, RenderTreeFrame[] frames, int ownerIndex, IReadOnlyList<CascadingParameterState> cascadingParametersOrNull)
+        private ParameterView(in ParameterViewLifetime lifetime, RenderTreeFrame[] frames, int ownerIndex, IReadOnlyList<CascadingParameterState> cascadingParametersOrNull)
         {
             _lifetime = lifetime;
             _frames = frames;

--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -519,8 +519,9 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             // comparisons it wants with the old values. Later we could choose to pass the
             // old parameter values if we wanted. By default, components always rerender
             // after any SetParameters call, which is safe but now always optimal for perf.
-            var oldParameters = new ParameterView(null, oldTree, oldComponentIndex);
-            var newParameters = new ParameterView(diffContext.BatchBuilder, newTree, newComponentIndex);
+            var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, oldTree, oldComponentIndex);
+            var newParametersLifetime = new ParameterViewLifetime(diffContext.BatchBuilder);
+            var newParameters = new ParameterView(newParametersLifetime, newTree, newComponentIndex);
             if (!newParameters.DefinitelyEquals(oldParameters))
             {
                 componentState.SetDirectParameters(newParameters);
@@ -893,7 +894,8 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             var childComponentState = frame.ComponentState;
 
             // Set initial parameters
-            var initialParameters = new ParameterView(diffContext.BatchBuilder, frames, frameIndex);
+            var initialParametersLifetime = new ParameterViewLifetime(diffContext.BatchBuilder);
+            var initialParameters = new ParameterView(initialParametersLifetime, frames, frameIndex);
             childComponentState.SetDirectParameters(initialParameters);
         }
 

--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -364,8 +364,8 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         // Handles the diff for attribute nodes only - this invariant is enforced by the caller.
         //
         // The diff for attributes is different because we allow attributes to appear in any order.
-        // Put another way, the attributes list of an element or  component is *conceptually* 
-        // unordered. This is a case where we can produce a more minimal diff by avoiding 
+        // Put another way, the attributes list of an element or  component is *conceptually*
+        // unordered. This is a case where we can produce a more minimal diff by avoiding
         // non-meaningful reorderings of attributes.
         private static void AppendAttributeDiffEntriesForRange(
             ref DiffContext diffContext,
@@ -519,8 +519,8 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             // comparisons it wants with the old values. Later we could choose to pass the
             // old parameter values if we wanted. By default, components always rerender
             // after any SetParameters call, which is safe but now always optimal for perf.
-            var oldParameters = new ParameterView(oldTree, oldComponentIndex);
-            var newParameters = new ParameterView(newTree, newComponentIndex);
+            var oldParameters = new ParameterView(null, oldTree, oldComponentIndex);
+            var newParameters = new ParameterView(diffContext.BatchBuilder, newTree, newComponentIndex);
             if (!newParameters.DefinitelyEquals(oldParameters))
             {
                 componentState.SetDirectParameters(newParameters);
@@ -893,7 +893,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             var childComponentState = frame.ComponentState;
 
             // Set initial parameters
-            var initialParameters = new ParameterView(frames, frameIndex);
+            var initialParameters = new ParameterView(diffContext.BatchBuilder, frames, frameIndex);
             childComponentState.SetDirectParameters(initialParameters);
         }
 
@@ -957,7 +957,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
         /// Exists only so that the various methods in this class can call each other without
         /// constantly building up long lists of parameters. Is private to this class, so the
         /// fact that it's a mutable struct is manageable.
-        /// 
+        ///
         /// Always pass by ref to avoid copying, and because the 'SiblingIndex' is mutable.
         /// </summary>
         private struct DiffContext

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public void NotifyCascadingValueChanged()
         {
             var directParams = _latestDirectParametersSnapshot != null
-                ? new ParameterView(_latestDirectParametersSnapshot.Buffer, 0)
+                ? new ParameterView(null, _latestDirectParametersSnapshot.Buffer, 0)
                 : ParameterView.Empty;
             var allParams = directParams.WithCascadingParameters(_cascadingParameters);
             var task = Component.SetParametersAsync(allParams);

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 _renderTreeBuilderPrevious.GetFrames(),
                 CurrentRenderTree.GetFrames());
             batchBuilder.UpdatedComponentDiffs.Append(diff);
+            batchBuilder.InvalidateParameterViews();
         }
 
         public bool TryDisposeInBatch(RenderBatchBuilder batchBuilder, out Exception exception)
@@ -156,10 +157,10 @@ namespace Microsoft.AspNetCore.Components.Rendering
             _renderer.AddToPendingTasks(Component.SetParametersAsync(parameters));
         }
 
-        public void NotifyCascadingValueChanged()
+        public void NotifyCascadingValueChanged(ParameterViewLifetime lifetime)
         {
             var directParams = _latestDirectParametersSnapshot != null
-                ? new ParameterView(null, _latestDirectParametersSnapshot.Buffer, 0)
+                ? new ParameterView(lifetime, _latestDirectParametersSnapshot.Buffer, 0)
                 : ParameterView.Empty;
             var allParams = directParams.WithCascadingParameters(_cascadingParameters);
             var task = Component.SetParametersAsync(allParams);

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -130,8 +130,8 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public void SetDirectParameters(ParameterView parameters)
         {
             // Note: We should be careful to ensure that the framework never calls
-            // IComponent.SetParameters directly elsewhere. We should only call it
-            // via ComponentState.SetParameters (or NotifyCascadingValueChanged below).
+            // IComponent.SetParametersAsync directly elsewhere. We should only call it
+            // via ComponentState.SetDirectParameters (or NotifyCascadingValueChanged below).
             // If we bypass this, the component won't receive the cascading parameters nor
             // will it update its snapshot of direct parameters.
 

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             _renderer.AddToPendingTasks(Component.SetParametersAsync(parameters));
         }
 
-        public void NotifyCascadingValueChanged(ParameterViewLifetime lifetime)
+        public void NotifyCascadingValueChanged(in ParameterViewLifetime lifetime)
         {
             var directParams = _latestDirectParametersSnapshot != null
                 ? new ParameterView(lifetime, _latestDirectParametersSnapshot.Buffer, 0)

--- a/src/Components/Components/src/Rendering/ParameterViewLifetime.cs
+++ b/src/Components/Components/src/Rendering/ParameterViewLifetime.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Components.Rendering
+{
+    internal readonly struct ParameterViewLifetime
+    {
+        private readonly RenderBatchBuilder _owner;
+        private readonly int _stamp;
+
+        public static readonly ParameterViewLifetime Unbound = default;
+
+        public ParameterViewLifetime(RenderBatchBuilder owner)
+        {
+            _owner = owner;
+            _stamp = owner.ParameterViewValidityStamp;
+        }
+
+        public void AssertNotExpired()
+        {
+            // _owner will be null if this instance is default(ParameterViewLifetime)
+            if (_owner != null && _owner.ParameterViewValidityStamp != _stamp)
+            {
+                throw new InvalidOperationException($"The {nameof(ParameterView)} instance can no longer be read because it has expired. {nameof(ParameterView)} can only be read synchronously and must not be stored for later use.");
+            }
+        }
+    }
+}

--- a/src/Components/Components/src/Rendering/ParameterViewLifetime.cs
+++ b/src/Components/Components/src/Rendering/ParameterViewLifetime.cs
@@ -20,7 +20,8 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
         public void AssertNotExpired()
         {
-            // _owner will be null if this instance is default(ParameterViewLifetime)
+            // If _owner is null, this instance is default(ParameterViewLifetime), which is
+            // the same as ParameterViewLifetime.Unbound. That means it never expires.
             if (_owner != null && _owner.ParameterViewValidityStamp != _stamp)
             {
                 throw new InvalidOperationException($"The {nameof(ParameterView)} instance can no longer be read because it has expired. {nameof(ParameterView)} can only be read synchronously and must not be stored for later use.");

--- a/src/Components/Components/src/Rendering/RenderBatchBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderBatchBuilder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Microsoft.AspNetCore.Components.RenderTree;
 
 namespace Microsoft.AspNetCore.Components.Rendering

--- a/src/Components/Components/src/Rendering/RenderBatchBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderBatchBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.AspNetCore.Components.RenderTree;
 
 namespace Microsoft.AspNetCore.Components.Rendering
@@ -15,6 +16,11 @@ namespace Microsoft.AspNetCore.Components.Rendering
     /// </summary>
     internal class RenderBatchBuilder : IDisposable
     {
+        // A value that, if changed, causes expiry of all ParameterView instances issued
+        // for this RenderBatchBuilder. This is to prevent invalid reads from arrays that
+        // may have been returned to the shared pool.
+        private int _parameterViewValidityStamp;
+
         // Primary result data
         public ArrayBuilder<RenderTreeDiff> UpdatedComponentDiffs { get; } = new ArrayBuilder<RenderTreeDiff>();
         public ArrayBuilder<int> DisposedComponentIds { get; } = new ArrayBuilder<int>();
@@ -30,6 +36,8 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
         // Scratch data structure for understanding attribute diffs.
         public Dictionary<string, int> AttributeDiffSet { get; } = new Dictionary<string, int>();
+
+        public int ParameterViewValidityStamp => _parameterViewValidityStamp;
 
         internal StackObjectPool<Dictionary<object, KeyedItemInfo>> KeyedItemInfoDictionaryPool { get; }
             = new StackObjectPool<Dictionary<object, KeyedItemInfo>>(maxPreservedItems: 10, () => new Dictionary<object, KeyedItemInfo>());
@@ -57,6 +65,22 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 ReferenceFramesBuffer.ToRange(),
                 DisposedComponentIds.ToRange(),
                 DisposedEventHandlerIds.ToRange());
+
+        public void InvalidateParameterViews()
+        {
+            // Wrapping is fine because all that matters is whether a snapshotted value matches
+            // the current one. There's no plausible case where it wraps around and happens to
+            // increment all the way back to a previously-snapshotted value on the exact same
+            // call that's checking the value.
+            if (_parameterViewValidityStamp == int.MaxValue)
+            {
+                _parameterViewValidityStamp = int.MinValue;
+            }
+            else
+            {
+                _parameterViewValidityStamp++;
+            }
+        }
 
         public void Dispose()
         {

--- a/src/Components/Components/test/CascadingParameterTest.cs
+++ b/src/Components/Components/test/CascadingParameterTest.cs
@@ -385,7 +385,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // It's no longer able to access anything in the ParameterView it just received
             var ex = Assert.Throws<InvalidOperationException>(nestedComponent.AttemptIllegalAccessToLastParameterView);
-            Assert.Equal("blah", ex.Message);
+            Assert.Equal($"The {nameof(ParameterView)} instance can no longer be read because it has expired. {nameof(ParameterView)} can only be read synchronously and must not be stored for later use.", ex.Message);
         }
 
         private static T FindComponent<T>(CapturedBatch batch, out int componentId)

--- a/src/Components/Components/test/CascadingParameterTest.cs
+++ b/src/Components/Components/test/CascadingParameterTest.cs
@@ -354,6 +354,40 @@ namespace Microsoft.AspNetCore.Components.Test
             Assert.Equal("The value of IsFixed cannot be changed dynamically.", ex.Message);
         }
 
+        [Fact]
+        public void ParameterViewSuppliedWithCascadingParametersCannotBeUsedAfterSynchronousReturn()
+        {
+            // Arrange
+            var providedValue = "Initial value";
+            var renderer = new TestRenderer();
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<CascadingValue<string>>(0);
+                builder.AddAttribute(1, "Value", providedValue);
+                builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+                {
+                    childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
+                    childBuilder.CloseComponent();
+                }));
+                builder.CloseComponent();
+            });
+
+            // Initial render; capture nested component
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+            var firstBatch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(firstBatch, out var nestedComponentId);
+
+            // Re-render CascadingValue with new value, so it gets a new ParameterView
+            providedValue = "Updated value";
+            component.TriggerRender();
+            Assert.Equal(2, renderer.Batches.Count);
+
+            // It's no longer able to access anything in the ParameterView it just received
+            var ex = Assert.Throws<InvalidOperationException>(nestedComponent.AttemptIllegalAccessToLastParameterView);
+            Assert.Equal("blah", ex.Message);
+        }
+
         private static T FindComponent<T>(CapturedBatch batch, out int componentId)
         {
             var componentFrame = batch.ReferenceFrames.Single(
@@ -378,6 +412,8 @@ namespace Microsoft.AspNetCore.Components.Test
 
         class CascadingParameterConsumerComponent<T> : AutoRenderComponent
         {
+            private ParameterView lastParameterView;
+
             public int NumSetParametersCalls { get; private set; }
             public int NumRenders { get; private set; }
 
@@ -386,6 +422,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             public override async Task SetParametersAsync(ParameterView parameters)
             {
+                lastParameterView = parameters;
                 NumSetParametersCalls++;
                 await base.SetParametersAsync(parameters);
             }
@@ -394,6 +431,13 @@ namespace Microsoft.AspNetCore.Components.Test
             {
                 NumRenders++;
                 builder.AddContent(0, $"CascadingParameter={CascadingParameter}; RegularParameter={RegularParameter}");
+            }
+
+            public void AttemptIllegalAccessToLastParameterView()
+            {
+                // You're not allowed to hold onto a ParameterView and access it later,
+                // so this should throw
+                lastParameterView.TryGetValue<object>("anything", out _);
             }
         }
 

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Components
                 }
                 builder.CloseComponent();
 
-                var view = new ParameterView(builder.GetFrames().Array, ownerIndex: 0);
+                var view = new ParameterView(null, builder.GetFrames().Array, ownerIndex: 0);
 
                 var cascadingParameters = new List<CascadingParameterState>();
                 foreach (var kvp in _keyValuePairs)

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Components
                 }
                 builder.CloseComponent();
 
-                var view = new ParameterView(null, builder.GetFrames().Array, ownerIndex: 0);
+                var view = new ParameterView(ParameterViewLifetime.Unbound, builder.GetFrames().Array, ownerIndex: 0);
 
                 var cascadingParameters = new List<CascadingParameterState>();
                 foreach (var kvp in _keyValuePairs)

--- a/src/Components/Components/test/ParameterViewTest.cs
+++ b/src/Components/Components/test/ParameterViewTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Components
             {
                 RenderTreeFrame.ChildComponent(0, typeof(FakeComponent)).WithComponentSubtreeLength(1)
             };
-            var parameters = new ParameterView(frames, 0);
+            var parameters = new ParameterView(null, frames, 0);
 
             // Assert
             Assert.Empty(ToEnumerable(parameters));
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Components
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(1)
             };
-            var parameters = new ParameterView(frames, 0);
+            var parameters = new ParameterView(null, frames, 0);
 
             // Assert
             Assert.Empty(ToEnumerable(parameters));
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Components
                 // end of the owner's descendants
                 RenderTreeFrame.Attribute(3, "orphaned attribute", "value")
             };
-            var parameters = new ParameterView(frames, 0);
+            var parameters = new ParameterView(null, frames, 0);
 
             // Assert
             Assert.Collection(ToEnumerable(parameters),
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Components
                 RenderTreeFrame.Element(3, "child element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(4, "child attribute", "some value")
             };
-            var parameters = new ParameterView(frames, 0);
+            var parameters = new ParameterView(null, frames, 0);
 
             // Assert
             Assert.Collection(ToEnumerable(parameters),
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Components
             var attribute1Value = new object();
             var attribute2Value = new object();
             var attribute3Value = new object();
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "attribute 1", attribute1Value)
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Components
         public void CanTryGetNonExistingValue()
         {
             // Arrange
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Components
         public void CanTryGetExistingValueWithCorrectType()
         {
             // Arrange
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "my entry", "hello")
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var myEntryValue = new object();
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "my entry", myEntryValue),
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var myEntryValue = new object();
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(3),
                 RenderTreeFrame.Attribute(1, "my entry", myEntryValue),
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Components
         public void CanGetValueOrDefault_WithNonExistingValue()
         {
             // Arrange
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var explicitDefaultValue = new DateTime(2018, 3, 20);
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Components
         public void ThrowsIfTryGetExistingValueWithIncorrectType()
         {
             // Arrange
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "my entry", "hello")
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var entry2Value = new object();
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(3),
                 RenderTreeFrame.Attribute(0, "entry 1", "value 1"),
@@ -304,7 +304,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var myEntryValue = new object();
-            var parameters = new ParameterView(new[]
+            var parameters = new ParameterView(null, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "unrelated value", new object())

--- a/src/Components/Components/test/ParameterViewTest.cs
+++ b/src/Components/Components/test/ParameterViewTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Components
             {
                 RenderTreeFrame.ChildComponent(0, typeof(FakeComponent)).WithComponentSubtreeLength(1)
             };
-            var parameters = new ParameterView(null, frames, 0);
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, frames, 0);
 
             // Assert
             Assert.Empty(ToEnumerable(parameters));
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Components
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(1)
             };
-            var parameters = new ParameterView(null, frames, 0);
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, frames, 0);
 
             // Assert
             Assert.Empty(ToEnumerable(parameters));
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Components
                 // end of the owner's descendants
                 RenderTreeFrame.Attribute(3, "orphaned attribute", "value")
             };
-            var parameters = new ParameterView(null, frames, 0);
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, frames, 0);
 
             // Assert
             Assert.Collection(ToEnumerable(parameters),
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Components
                 RenderTreeFrame.Element(3, "child element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(4, "child attribute", "some value")
             };
-            var parameters = new ParameterView(null, frames, 0);
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, frames, 0);
 
             // Assert
             Assert.Collection(ToEnumerable(parameters),
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Components
             var attribute1Value = new object();
             var attribute2Value = new object();
             var attribute3Value = new object();
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "attribute 1", attribute1Value)
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Components
         public void CanTryGetNonExistingValue()
         {
             // Arrange
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Components
         public void CanTryGetExistingValueWithCorrectType()
         {
             // Arrange
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "my entry", "hello")
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var myEntryValue = new object();
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "my entry", myEntryValue),
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var myEntryValue = new object();
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(3),
                 RenderTreeFrame.Attribute(1, "my entry", myEntryValue),
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Components
         public void CanGetValueOrDefault_WithNonExistingValue()
         {
             // Arrange
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var explicitDefaultValue = new DateTime(2018, 3, 20);
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Components
         public void ThrowsIfTryGetExistingValueWithIncorrectType()
         {
             // Arrange
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "my entry", "hello")
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var entry2Value = new object();
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(3),
                 RenderTreeFrame.Attribute(0, "entry 1", "value 1"),
@@ -304,7 +304,7 @@ namespace Microsoft.AspNetCore.Components
         {
             // Arrange
             var myEntryValue = new object();
-            var parameters = new ParameterView(null, new[]
+            var parameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
             {
                 RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
                 RenderTreeFrame.Attribute(1, "unrelated value", new object())

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -4491,7 +4491,7 @@ namespace Microsoft.AspNetCore.Components.Test
             {
                 CapturedParameterView = parameters;
 
-                // Return a task that never completes to show that access is forbidded
+                // Return a task that never completes to show that access is forbidden
                 // after the synchronous return, not just after the returned task completes
                 return new TaskCompletionSource<object>().Task;
             }

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -3720,11 +3720,17 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert
             var capturingComponent = (ParameterViewIllegalCapturingComponent)renderer.GetCurrentRenderTreeFrames(rootComponentId).Array[0].Component;
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-            {
-                // TODO: check other types of access too
-                capturingComponent.CapturedParameterView.TryGetValue<object>("anything", out _);
-            });
+            var parameterView = capturingComponent.CapturedParameterView;
+
+            // All public APIs on capturingComponent should be electrified now
+            // Internal APIs don't have to be, because we won't call them at the wrong time
+            Assert.Throws<InvalidOperationException>(() => parameterView.GetEnumerator());
+            Assert.Throws<InvalidOperationException>(() => parameterView.GetValueOrDefault<object>("anything"));
+            Assert.Throws<InvalidOperationException>(() => parameterView.SetParameterProperties(new object()));
+            Assert.Throws<InvalidOperationException>(() => parameterView.ToDictionary());
+            var ex = Assert.Throws<InvalidOperationException>(() => parameterView.TryGetValue<object>("anything", out _));
+
+            // It's enough to assert about one of the messages
             Assert.Equal($"The {nameof(ParameterView)} instance can no longer be read because it has expired. {nameof(ParameterView)} can only be read synchronously and must not be stored for later use.", ex.Message);
         }
 

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -270,7 +270,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorComponents
             // Assert
             Assert.Equal(expectedHtml, result);
         }
-        
+
         [Fact]
         public void RenderComponentAsync_MarksSelectedOptionsAsSelected()
         {
@@ -668,18 +668,19 @@ namespace Microsoft.AspNetCore.Mvc.RazorComponents
 
             public Task SetParametersAsync(ParameterView parameters)
             {
-                _renderHandle.Render(CreateRenderFragment(parameters));
+                var content = parameters.GetValueOrDefault<string>("Value");
+                _renderHandle.Render(CreateRenderFragment(content));
                 return Task.CompletedTask;
             }
 
-            private RenderFragment CreateRenderFragment(ParameterView parameters)
+            private RenderFragment CreateRenderFragment(string content)
             {
                 return RenderFragment;
 
                 void RenderFragment(RenderTreeBuilder rtb)
                 {
                     rtb.OpenElement(1, "span");
-                    rtb.AddContent(2, parameters.GetValueOrDefault<string>("Value"));
+                    rtb.AddContent(2, content);
                     rtb.CloseElement();
                 }
             }


### PR DESCRIPTION
`ParameterView` provides a view over a `RenderTreeFrame` array. It's what we pass into components' `SetParametersAsync` lifecycle method so they can update themselves.

However, the underlying storage comes from a shared pool, so it's vital that people don't hold onto references of it and then start reading from it at an arbitrary time in the future. To enforce this rule, this PR makes it throw if you try to read from it after the end of its safe lifetime.

This would have been really trivial if `ParameterView` was a class, as we could have just mutated it to say "you're disposed now". But it's not - it's a `readonly struct` - so the only way it can know about its own expiry is by holding a reference to a reference-typed thing that can mutate when expiry should happen.

So, the implementation here is putting a "version"-type field on `RenderBatchBuilder` that changes after every synchronous render-and-diff operation. This means as soon as you yield the thread from a lifecycle method, the `ParameterView` becomes electrified. You can't read from it either asynchronously later in the same method, or arbitrarily in the future if you store the reference on your component class.
