### PR TITLE
3.1 - Fix Safari stack exceeded

### DIFF
--- a/src/Components/Blazor/Blazor/src/Http/WebAssemblyHttpMessageHandler.cs
+++ b/src/Components/Blazor/Blazor/src/Http/WebAssemblyHttpMessageHandler.cs
@@ -41,7 +41,10 @@ namespace Microsoft.AspNetCore.Blazor.Http
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<HttpResponseMessage>();
+            // There is a race condition on Safari as a result of using TaskCompletionSource that
+            // causes a stack exceeded error being thrown.  More information can be found here:
+            // https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/
+            var tcs = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
             cancellationToken.Register(() => tcs.TrySetCanceled());
 
             int id;

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -178,7 +178,18 @@ namespace Microsoft.AspNetCore.Components.RenderTree
 
                 // new work might be added before we check again as a result of waiting for all
                 // the child components to finish executing SetParametersAsync
-                await pendingWork;
+                // There is a race condition on Safari as a result of using TaskCompletionSource that
+                // causes a stack exceeded error being thrown.  See the corresponding modification in
+                // WebAssemblyHttpMessageHandler.   More information can be found here:
+                // https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/
+                var pendingWorkAsync = Task.Factory.StartNew(
+                    async () => {
+
+                            await pendingWork;
+
+                        },
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                await pendingWorkAsync;
             }
         }
 


### PR DESCRIPTION
Fix Unhandled Promise Rejection: RangeError: Maximum call stack size on Safari

There is a race condition on Safari as a result of using TaskCompletionSource that causes a stack exceeded error being thrown during Blazor startup.

Safari throws the following error:

```
[Error] Unhandled Promise Rejection: RangeError: Maximum call stack size exceeded.
    step (blazor.webassembly.js:2530)
    fulfilled (blazor.webassembly.js:2500)
    promiseReactionJob

```

- Modify `WebAssemblyHttpMessageHandler.cs` to create the TaskCompletionSource to run continuations asynchronously.
   - `TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);`

- Modify the `Renderer.cs` to process it's pending startup tasks to run continuations asynchronously to compliment the TaskCompetionSource of the Http response message.

The following link discusses the potential stack/race problem that can occur when using TaskCompletionSource:  https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/

Fixes https://github.com/mono/mono/issues/16986