### PR TITLE
Handle exceptions thrown by PEReader

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -173,6 +173,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 var exceptionDetailProvider = new ExceptionDetailsProvider(
                     HostingEnvironment.ContentRootFileProvider,
+                    Logger,
                     sourceCodeLineCount: 6);
 
                 model.ErrorDetails = exceptionDetailProvider.GetDetails(exception);

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -270,6 +270,7 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     var exceptionDetailProvider = new ExceptionDetailsProvider(
                         hostingEnv.ContentRootFileProvider,
+                        logger,
                         sourceCodeLineCount: 6);
 
                     model.ErrorDetails = exceptionDetailProvider.GetDetails(ex);

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             _logger = loggerFactory.CreateLogger<DeveloperExceptionPageMiddleware>();
             _fileProvider = _options.FileProvider ?? hostingEnvironment.ContentRootFileProvider;
             _diagnosticSource = diagnosticSource;
-            _exceptionDetailsProvider = new ExceptionDetailsProvider(_fileProvider, _options.SourceCodeLineCount);
+            _exceptionDetailsProvider = new ExceptionDetailsProvider(_fileProvider, _logger, _options.SourceCodeLineCount);
             _exceptionHandler = DisplayException;
 
             foreach (var filter in filters.Reverse())

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionDetailsProviderTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionDetailsProviderTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.Internal
             using (var provider = new PhysicalFileProvider(rootPath))
             {
                 // Act
-                var exceptionDetailProvider = new ExceptionDetailsProvider(provider, sourceCodeLineCount: 6);
+                var exceptionDetailProvider = new ExceptionDetailsProvider(provider, logger: null, sourceCodeLineCount: 6);
                 var stackFrame = exceptionDetailProvider.GetStackFrameSourceCodeInfo(
                     "func1",
                     absoluteFilePath,
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Internal
             using (var provider = new PhysicalFileProvider(rootPath))
             {
                 // Act
-                var exceptionDetailProvider = new ExceptionDetailsProvider(provider, sourceCodeLineCount: 6);
+                var exceptionDetailProvider = new ExceptionDetailsProvider(provider, logger: null, sourceCodeLineCount: 6);
                 var stackFrame = exceptionDetailProvider.GetStackFrameSourceCodeInfo(
                     "func1",
                     relativePath,
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Internal
                 baseNamespace: $"{typeof(ExceptionDetailsProviderTest).GetTypeInfo().Assembly.GetName().Name}.Resources");
 
             // Act
-            var exceptionDetailProvider = new ExceptionDetailsProvider(provider, sourceCodeLineCount: 6);
+            var exceptionDetailProvider = new ExceptionDetailsProvider(provider, logger: null, sourceCodeLineCount: 6);
             var stackFrame = exceptionDetailProvider.GetStackFrameSourceCodeInfo(
                 "func1",
                 relativePath,
@@ -259,7 +259,8 @@ namespace Microsoft.Extensions.Internal
             // Act
             var exceptionDetailProvider = new ExceptionDetailsProvider(
                 new PhysicalFileProvider(Directory.GetCurrentDirectory()),
-               sourceCodeLineCount: 6);
+                logger: null,
+                sourceCodeLineCount: 6);
 
             exceptionDetailProvider.ReadFrameContent(
                 stackFrame,

--- a/src/Servers/IIS/IIS/src/StartupHook.cs
+++ b/src/Servers/IIS/IIS/src/StartupHook.cs
@@ -81,6 +81,7 @@ internal class StartupHook
 
             var exceptionDetailProvider = new ExceptionDetailsProvider(
                 new PhysicalFileProvider(contentRoot),
+                logger: null,
                 sourceCodeLineCount: 6);
 
             // The startup hook is only present when detailed errors are allowed, so

--- a/src/Shared/StackTrace/ExceptionDetails/LoggerExtensions.cs
+++ b/src/Shared/StackTrace/ExceptionDetails/LoggerExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.StackTrace.Sources
+{
+    internal static class LoggerExtensions
+    {
+        private static readonly Action<ILogger, Exception> _failedToReadStackFrameInfo;
+
+        static LoggerExtensions()
+        {
+            _failedToReadStackFrameInfo = LoggerMessage.Define(
+                logLevel: LogLevel.Debug,
+                eventId: new EventId(1, "FailedToReadStackTraceInfo"),
+                formatString: "Failed to read stack trace information for exception.");
+        }
+
+        public static void FailedToReadStackTraceInfo(this ILogger logger, Exception exception)
+        {
+            _failedToReadStackFrameInfo(logger, exception);
+        }
+    }
+}

--- a/src/Shared/StackTrace/ExceptionDetails/LoggerExtensions.cs
+++ b/src/Shared/StackTrace/ExceptionDetails/LoggerExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.StackTrace.Sources
         {
             _failedToReadStackFrameInfo = LoggerMessage.Define(
                 logLevel: LogLevel.Debug,
-                eventId: new EventId(1, "FailedToReadStackTraceInfo"),
+                eventId: new EventId(0, "FailedToReadStackTraceInfo"),
                 formatString: "Failed to read stack trace information for exception.");
         }
 

--- a/src/Shared/test/Shared.Tests/StackTraceHelperTest.cs
+++ b/src/Shared/test/Shared.Tests/StackTraceHelperTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Internal
             }
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             Assert.Collection(stackFrames,
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => GenericMethod<string>(null));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => MethodWithOutParameter(out var value));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => MethodWithGenericOutParameter("Test", out int value));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => MethodWithRefParameter(ref value));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -113,7 +113,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => MethodWithGenericRefParameter(ref value));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -128,7 +128,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => MethodWithNullableParameter(value));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -142,7 +142,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => new GenericClass<int>().Throw(0));
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -175,7 +175,7 @@ namespace Microsoft.Extensions.Internal
             }
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
             var methodNames = stackFrames.Select(stackFrame => stackFrame.MethodDisplayInfo.ToString()).ToArray();
 
             // Assert
@@ -189,7 +189,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => InvokeMethodOnTypeWithStackTraceHiddenAttribute());
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => InvokeStaticMethodOnTypeWithStackTraceHiddenAttribute());
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -219,7 +219,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(() => new TypeWithMethodWithStackTraceHiddenAttribute().Throw());
 
             // Act
-            var stackFrames = StackTraceHelper.GetFrames(exception);
+            var stackFrames = StackTraceHelper.GetFrames(exception, out _);
 
             // Assert
             var methods = stackFrames.Select(frame => frame.MethodDisplayInfo.ToString()).ToArray();
@@ -237,7 +237,7 @@ namespace Microsoft.Extensions.Internal
             var exception = Record.Exception(action);
 
             // Act
-            var frames = StackTraceHelper.GetFrames(exception).ToArray();
+            var frames = StackTraceHelper.GetFrames(exception, out _).ToArray();
 
             // Assert
             var frame = frames[0];


### PR DESCRIPTION
If the `PEReader` fails to read the debug directory from the assembly, the `GetMetadataReader` will now return `null` and short-circuit in `PopulateStackFrame`.

Fixes #14609