### PR TITLE
Use dynamically compiled factory instead of Activator.CreateInstance in TypedClientBuilder

### DIFF
--- a/src/SignalR/perf/Microbenchmarks/TypedClientBuilderBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/TypedClientBuilderBenchmark.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.SignalR.Internal;
+
+namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
+{
+    public class TypedClientBuilderBenchmark
+    {
+        private static readonly IClientProxy Dummy = new DummyProxy();
+
+        [Benchmark]
+        public ITestClient Build()
+        {
+            return TypedClientBuilder<ITestClient>.Build(Dummy);
+        }
+
+        public interface ITestClient { }
+
+        private class DummyProxy : IClientProxy
+        {
+            public Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs
+++ b/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         private static readonly PropertyInfo CancellationTokenNoneProperty = typeof(CancellationToken).GetProperty("None", BindingFlags.Public | BindingFlags.Static);
 
+        private static readonly ConstructorInfo ObjectConstructor = typeof(object).GetConstructors().Single();
+
         private static readonly Type[] ParameterTypes = new Type[] { typeof(IClientProxy) };
 
         public static T Build(IClientProxy proxy)
@@ -93,7 +95,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
             // Call object constructor
             generator.Emit(OpCodes.Ldarg_0);
-            generator.Emit(OpCodes.Call, typeof(object).GetConstructors().Single());
+            generator.Emit(OpCodes.Call, ObjectConstructor);
 
             // Assign constructor argument to the proxyField
             generator.Emit(OpCodes.Ldarg_0); // type

--- a/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs
+++ b/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs
@@ -56,6 +56,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
             var ctor = BuildConstructor(type, proxyField);
 
+            // Because a constructor doesn't return anything, it can't be wrapped in a
+            // delegate directly, so we emit a factory method that just takes the IClientProxy,
+            // invokes the constructor (using newobj) and returns the new instance of type T.
             BuildFactoryMethod(type, ctor);
 
             foreach (var method in GetAllInterfaceMethods(typeof(T)))


### PR DESCRIPTION
This should shave off some milliseconds every time a typed client is constructed :smile:

There's already tests covering these paths, but I added an extra benchmark, shown below.

## Before

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10.0.17134
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical cores and 4 physical cores
.NET Core SDK=5.0.100-alpha1-013788
  [Host]     : .NET Core 5.0.0-alpha1.19404.5 (CoreCLR 5.0.19.40302, CoreFX 5.0.19.38102), 64bit RyuJIT
  Job-FBDBIV : .NET Core 5.0.0-alpha1.19404.5 (CoreCLR 5.0.19.40302, CoreFX 5.0.19.38102), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET 5.0  RunStrategy=Throughput  

```
| Method |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
|------- |---------:|---------:|---------:|------------:|-------:|----------:|
|  Build | 692.2 ns | 15.00 ns | 17.27 ns | 1,444,691.6 | 0.0095 |     408 B |

## After

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10.0.17134
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical cores and 4 physical cores
.NET Core SDK=5.0.100-alpha1-013788
  [Host]     : .NET Core 5.0.0-alpha1.19404.5 (CoreCLR 5.0.19.40302, CoreFX 5.0.19.38102), 64bit RyuJIT
  Job-TKTSZD : .NET Core 5.0.0-alpha1.19404.5 (CoreCLR 5.0.19.40302, CoreFX 5.0.19.38102), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET 5.0  RunStrategy=Throughput  

```
| Method |     Mean |     Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|------- |---------:|----------:|----------:|-------------:|-------:|----------:|
|  Build | 14.88 ns | 0.3769 ns | 0.4032 ns | 67,220,764.5 | 0.0006 |      24 B |
