### PR TITLE
Merge Pass SubProtocols from TestHost WebSocketClient (#14666)

### DIFF
--- a/src/Hosting/TestHost/src/WebSocketClient.cs
+++ b/src/Hosting/TestHost/src/WebSocketClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
 using System.Threading;
@@ -76,6 +77,7 @@ namespace Microsoft.AspNetCore.TestHost
                 request.Headers.Add("Upgrade", new string[] { "websocket" });
                 request.Headers.Add("Sec-WebSocket-Version", new string[] { "13" });
                 request.Headers.Add("Sec-WebSocket-Key", new string[] { CreateRequestKey() });
+                request.Headers.Add("Sec-WebSocket-Protocol", SubProtocols.ToArray());
                 request.Body = Stream.Null;
 
                 // WebSocket

--- a/src/Hosting/TestHost/src/WebSocketClient.cs
+++ b/src/Hosting/TestHost/src/WebSocketClient.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.TestHost
 {
@@ -73,11 +74,15 @@ namespace Microsoft.AspNetCore.TestHost
                     request.PathBase = _pathBase;
                 }
                 request.QueryString = QueryString.FromUriComponent(uri);
-                request.Headers.Add("Connection", new string[] { "Upgrade" });
-                request.Headers.Add("Upgrade", new string[] { "websocket" });
-                request.Headers.Add("Sec-WebSocket-Version", new string[] { "13" });
-                request.Headers.Add("Sec-WebSocket-Key", new string[] { CreateRequestKey() });
-                request.Headers.Add("Sec-WebSocket-Protocol", SubProtocols.ToArray());
+                request.Headers.Add(HeaderNames.Connection, new string[] { "Upgrade" });
+                request.Headers.Add(HeaderNames.Upgrade, new string[] { "websocket" });
+                request.Headers.Add(HeaderNames.SecWebSocketVersion, new string[] { "13" });
+                request.Headers.Add(HeaderNames.SecWebSocketKey, new string[] { CreateRequestKey() });
+                if (SubProtocols.Any())
+                {
+                    request.Headers.Add(HeaderNames.SecWebSocketProtocol, SubProtocols.ToArray());
+                }
+
                 request.Body = Stream.Null;
 
                 // WebSocket

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -173,12 +173,7 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 if (ctx.WebSockets.IsWebSocketRequest)
                 {
-                    Assert.False(ctx.Request.Headers.ContainsKey(HeaderNames.SecWebSocketProtocol))
-                    {
-                        // no subprotocols were specified by client but subprotocol header is present
-                        return;
-                    }
-
+                    Assert.False(ctx.Request.Headers.ContainsKey(HeaderNames.SecWebSocketProtocol));
                     var websocket = await ctx.WebSockets.AcceptWebSocketAsync();
                     var receiveArray = new byte[1024];
                     while (true)

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 if (ctx.WebSockets.IsWebSocketRequest)
                 {
-                    if (ctx.Request.Headers.ContainsKey(HeaderNames.SecWebSocketProtocol))
+                    Assert.False(ctx.Request.Headers.ContainsKey(HeaderNames.SecWebSocketProtocol))
                     {
                         // no subprotocols were specified by client but subprotocol header is present
                         return;

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -232,6 +232,58 @@ namespace Microsoft.AspNetCore.TestHost
             clientSocket.Dispose();
         }
 
+[Fact]
+public async Task WebSocketSubProtocolsWorks()
+{
+    // Arrange
+    RequestDelegate appDelegate = async ctx =>
+    {
+        if (ctx.WebSockets.IsWebSocketRequest)
+        {
+            if (ctx.WebSockets.WebSocketRequestedProtocols.Contains("alpha") &&
+                ctx.WebSockets.WebSocketRequestedProtocols.Contains("bravo"))
+            {
+                // according to rfc6455, the "server needs to include the same field and one of the selected subprotocol values"
+                // however, this isn't enforced by either our server or client so it's possible to accept an arbitrary protocol.
+                // Done here to demonstrate not "correct" behaviour, simply to show it's possible. Other clients may not allow this.
+                var websocket = await ctx.WebSockets.AcceptWebSocketAsync("charlie");
+                await websocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Normal Closure", CancellationToken.None);
+            }
+            else
+            {
+                var subprotocols = ctx.WebSockets.WebSocketRequestedProtocols.Any()
+                    ? string.Join(", ", ctx.WebSockets.WebSocketRequestedProtocols)
+                    : "<none>";
+                var closeReason = "Unexpected subprotocols: " + subprotocols;
+                var websocket = await ctx.WebSockets.AcceptWebSocketAsync();
+                await websocket.CloseAsync(WebSocketCloseStatus.InternalServerError, closeReason, CancellationToken.None);
+            }
+        }
+    };
+    var builder = new WebHostBuilder()
+        .Configure(app =>
+        {
+            app.Run(appDelegate);
+        });
+    var server = new TestServer(builder);
+
+    // Act
+    var client = server.CreateWebSocketClient();
+    client.SubProtocols.Add("alpha");
+    client.SubProtocols.Add("bravo");
+    var clientSocket = await client.ConnectAsync(new Uri("wss://localhost"), CancellationToken.None);
+    var buffer = new byte[1024];
+    var result = await clientSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+    // Assert
+    Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+    Assert.Equal("Normal Closure", result.CloseStatusDescription);
+    Assert.Equal(WebSocketState.CloseReceived, clientSocket.State);
+    Assert.Equal("charlie", clientSocket.SubProtocol);
+
+    clientSocket.Dispose();
+}
+
         [ConditionalFact]
         public async Task WebSocketAcceptThrowsWhenCancelled()
         {


### PR DESCRIPTION
 - Use `SubProtocols` property on TestHost's `WebSocketClient` to populate `Sec-WebSocket-Protocol` header

Addresses #14666
