### PR TITLE
Diagnostics Exception Page: Color-blindness Improvement

### DIFF
--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.css
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.css
@@ -96,6 +96,12 @@ body .location {
         background-color: #fbfbfb;
     }
 
+#stackpage .frame .source .highlight {
+    border-left: 3px solid red;
+    margin-left: -3px;
+    font-weight: bold;
+}
+
 #stackpage .frame .source .highlight li span {
     color: #FF0000;
 }

--- a/src/Shared/ErrorPage/Views/ErrorPage.css
+++ b/src/Shared/ErrorPage/Views/ErrorPage.css
@@ -98,6 +98,12 @@ body .location {
         background-color: #fbfbfb;
     }
 
+#stackpage .frame .source .highlight {
+    border-left: 3px solid red;
+    margin-left: -3px;
+    font-weight: bold;
+}
+
 #stackpage .frame .source .highlight li span {
     color: #FF0000;
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Add visual cue to highlighted code when exception is thrown.

---

I have a coworker who is colorblind and he works in .net core almost everyday. My focus is more of ux/front-end/design so I don't work in .net core as often, however I noticed one day that my coworker was having trouble trying to find an error when an exception was thrown - turns out he couldn't see the highlighted red text, to him it looked black.

I'm using a color blind simulator called Glassbrick in the screencasts. 

### Current Views

**Exception page before suggested change:**
![AspNetCoreExceptionView--Default](https://user-images.githubusercontent.com/1302542/66075692-2bef4900-e52a-11e9-8161-b50f634b853e.gif)
**Exception page before suggested change** (_Color Blind Simulation - Deuteranomaly_):
![AspNetCoreExceptionView--DefaultDeuteranomaly](https://user-images.githubusercontent.com/1302542/66075960-b172f900-e52a-11e9-88b0-75f413f582c0.gif)
**Exception page before suggested change** (_Color Blind Simulation - Protanomaly_):
![AspNetCoreExceptionView--DefaultProtanomaly](https://user-images.githubusercontent.com/1302542/66076202-470e8880-e52b-11e9-967b-c8eb62c358c1.gif)
**Exception page before suggested change** (_Color Blind Simulation - Tritanomaly_):
![AspNetCoreExceptionView--DefaultTritanomaly](https://user-images.githubusercontent.com/1302542/66076298-7f15cb80-e52b-11e9-9d75-ddbb035b0d2f.gif)

### Suggested Pull Request Views

**Exception page after suggested change:**
![AspNetCoreExceptionView--Adjustment](https://user-images.githubusercontent.com/1302542/66076419-c8661b00-e52b-11e9-86be-3fde5082ebe3.gif)
**Exception page after suggested change** (_Color Blind Simulation - Deuteranomaly_):
![AspNetCoreExceptionView--AdjustmentDeuteranomaly](https://user-images.githubusercontent.com/1302542/66076505-f0ee1500-e52b-11e9-84f0-6fbc68906630.gif)
**Exception page after suggested change** (_Color Blind Simulation - Protanomaly_):
![AspNetCoreExceptionView--AdjustmentProtanomaly](https://user-images.githubusercontent.com/1302542/66076552-13802e00-e52c-11e9-9e1a-6d13ab4f7269.gif)
**Exception page after suggested change** (_Color Blind Simulation - Tritanomaly_):
![AspNetCoreExceptionView--AdjustmentTritanomaly](https://user-images.githubusercontent.com/1302542/66076617-36aadd80-e52c-11e9-9bbf-8ef53f082fd2.gif)
