### PR TITLE
Add CDN link

### DIFF
--- a/src/SignalR/README.md
+++ b/src/SignalR/README.md
@@ -41,6 +41,11 @@ Alternatively, if you don't want to create the .npmrc file run the following com
 npm install @aspnet/signalr --registry https://dotnet.myget.org/f/aspnetcore-dev/npm/
 ```
 
+Or simply include it from a CDN:
+```html
+<script src="https://cdn.jsdelivr.net/npm/@microsoft/signalr@3/dist/browser/signalr.min.js"></script>
+```
+
 We also have a MsgPack protocol library which is installed via:
 
 ```bash


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as an easier and faster option of using the project. Unlike cdnjs, jsDelivr pulls releases automatically from npm and doesn't require any config (also [it's faster](https://www.cdnperf.com/)).