### PR TITLE
Disable ref pack build in 3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,7 +91,7 @@
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
     <!-- Used to only produce targeting pack installers/packages once per major.minor. -->
-    <IsTargetingPackBuilding Condition="'$(AspNetCorePatchVersion)' == '0' AND '$(DotNetBuildFromSource)' != 'true'">false</IsTargetingPackBuilding>
+    <IsTargetingPackBuilding Condition="'$(AspNetCorePatchVersion)' != '0' OR '$(DotNetBuildFromSource)' == 'true'">false</IsTargetingPackBuilding>
 
     <!--
       Archives and installers using this prefix are intended for internal-use only.

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -85,7 +85,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </BuildDependsOn>
 
     <!-- No-op when in source build -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' != 'false' or '$(DotNetBuildFromSource)' == 'true'"/>
+    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'"/>
   </PropertyGroup>
 
   <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->

--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -85,7 +85,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </BuildDependsOn>
 
     <!-- No-op when in source build -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' != 'false' and '$(DotNetBuildFromSource)' == 'true'"/>
+    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' != 'false' or '$(DotNetBuildFromSource)' == 'true'"/>
   </PropertyGroup>
 
   <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNetCore
         }
 
         [Fact]
+        [Skip]
         public void PlatformManifestListsAllFiles()
         {
             var platformManifestPath = Path.Combine(_targetingPackRoot, "data", "PlatformManifest.txt");

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore
             _targetingPackRoot = Path.Combine(TestData.GetTestDataValue("TargetingPackLayoutRoot"), "packs", "Microsoft.AspNetCore.App.Ref", TestData.GetTestDataValue("TargetingPackVersion"));
         }
 
-        [Fact]
+        [Fact(Skip="https://github.com/aspnet/AspNetCore/issues/14832")]
         public void AssembliesAreReferenceAssemblies()
         {
             IEnumerable<string> dlls = Directory.GetFiles(_targetingPackRoot, "*.dll", SearchOption.AllDirectories);

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -55,8 +55,7 @@ namespace Microsoft.AspNetCore
             });
         }
 
-        [Fact]
-        [Skip]
+        [Fact(Skip="https://github.com/aspnet/AspNetCore/issues/14832")]
         public void PlatformManifestListsAllFiles()
         {
             var platformManifestPath = Path.Combine(_targetingPackRoot, "data", "PlatformManifest.txt");

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -49,7 +49,9 @@
 
     <!-- Build SharedFx Bundle Deb package -->
 
-    <Exec Command="$(DebianBuildScript) -i '$(IntermediateOutputPath)' -o '$(IntermediateOutputPath)out/' -C '$(PackageContentRoot)'" />
+    <Exec 
+      Condition="'$(IsTargetingPackBuilding)' != 'false'"
+      Command="$(DebianBuildScript) -i '$(IntermediateOutputPath)' -o '$(IntermediateOutputPath)out/' -C '$(PackageContentRoot)'" />
 
     <PropertyGroup>
       <BuildScriptOutputFileName>$(PackageId)_$(DebPackageVersion)-$(PackageRevision)_$(DebianPackageArch).deb</BuildScriptOutputFileName>

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -23,7 +23,7 @@
   <Target Name="Build" DependsOnTargets="DebBuild" />
   <Target Name="Pack" />
 
-  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)">
+  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)" Condition="'$(IsTargetingPackBuilding)' != 'false'">
     <!-- Generate debian_config.json. We can't simply use WriteLinesToFile because of https://github.com/Microsoft/msbuild/issues/1622. Use our custom GenerateFileFromTemplate task instead -->
     <PropertyGroup>
       <DebianConfigProperties>
@@ -49,9 +49,7 @@
 
     <!-- Build SharedFx Bundle Deb package -->
 
-    <Exec 
-      Condition="'$(IsTargetingPackBuilding)' != 'false'"
-      Command="$(DebianBuildScript) -i '$(IntermediateOutputPath)' -o '$(IntermediateOutputPath)out/' -C '$(PackageContentRoot)'" />
+    <Exec Command="$(DebianBuildScript) -i '$(IntermediateOutputPath)' -o '$(IntermediateOutputPath)out/' -C '$(PackageContentRoot)'" />
 
     <PropertyGroup>
       <BuildScriptOutputFileName>$(PackageId)_$(DebPackageVersion)-$(PackageRevision)_$(DebianPackageArch).deb</BuildScriptOutputFileName>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -32,7 +32,7 @@
   <Target Name="Build" DependsOnTargets="RpmBuild" />
   <Target Name="Pack" />
 
-  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)">
+  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)" Condition="'$(IsTargetingPackBuilding)' != 'false'">
     <!-- Create layout: Create changelog -->
     <PropertyGroup>
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -9,6 +9,7 @@
     <OutputName>$(Name)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <IsShipping>true</IsShipping>
+    <SkipCopyToArtifactsDirectory Condition="'$(IsTargetingPackBuilding)' == 'false'">true</SkipCopyToArtifactsDirectory>
     <ProjectGuid>0AC34F1B-8056-4FFB-A398-E6BB7D67B48D</ProjectGuid>
     <HarvestDirectoryAutoGenerateGuids>true</HarvestDirectoryAutoGenerateGuids>
     <HarvestDirectorySuppressSpecificWarnings>5150;5151</HarvestDirectorySuppressSpecificWarnings>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -63,7 +63,7 @@
   </Target>
 
   <Target Name="CopyToArtifactsDirectory"
-          Condition=" '$(IsShipping)' == 'true' "
+          Condition=" '$(IsShipping)' == 'true' AND '$(SkipCopyToArtifactsDirectory)' != 'true' "
           AfterTargets="Build">
     <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(InstallersOutputPath)$(PackageFileName)" />
     <ItemGroup>

--- a/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
+++ b/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
@@ -14,7 +14,7 @@
 
     <!-- Targeting pack version should be the one we just built, if we're building it. Otherwise we use the baseline version -->
     <PropertyGroup>
-      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' != 'false'">@(_TargetingPackVersionInfo->'%(PackageVersion)'</MicrosoftAspNetCoreAppRefPackageVersion>
+      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' != 'false'">@(TargetingPackVersionInfo.PackageVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
       <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' == 'false'">$(AspNetCoreBaselineVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
     </PropertyGroup>
 

--- a/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
+++ b/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
@@ -4,11 +4,19 @@
       DependsOnTargets="PrepareForTest"
       Condition="$(DesignTimeBuild) != true">
     <!-- The version of the shared framework. This is used in tests to ensure they run against the shared framework version we just built. -->
+    <!-- If we aren' building the targeting pack, use the baseline version -->
     <MSBuild Projects="$(RepoRoot)src\Framework\ref\Microsoft.AspNetCore.App.Ref.csproj"
         Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
+        SkipNonexistentProjects="false"
+        Condition="'$(IsTargetingPackBuilding)' != 'false'">
       <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackVersionInfo" />
     </MSBuild>
+
+    <!-- Targeting pack version should be the one we just built, if we're building it. Otherwise we use the baseline version -->
+    <PropertyGroup>
+      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' != 'false'">@(_TargetingPackVersionInfo->'%(PackageVersion)'</MicrosoftAspNetCoreAppRefPackageVersion>
+      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' == 'false'">$(AspNetCoreBaselineVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
+    </PropertyGroup>
 
     <!-- Runtime and Ref packs may have separate versions. -->
     <MSBuild Projects="$(RepoRoot)src\Framework\src\Microsoft.AspNetCore.App.Runtime.csproj"
@@ -25,7 +33,7 @@
         MicrosoftNETCoreAppRefPackageVersion=$(MicrosoftNETCoreAppRefPackageVersion);
         MicrosoftNETCorePlatformsPackageVersion=$(MicrosoftNETCorePlatformsPackageVersion);
         MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion);
-        MicrosoftAspNetCoreAppRefPackageVersion=@(_TargetingPackVersionInfo->'%(PackageVersion)');
+        MicrosoftAspNetCoreAppRefPackageVersion=$(MicrosoftAspNetCoreAppRefPackageVersion);
         MicrosoftAspNetCoreAppRuntimePackageVersion=@(_RuntimePackageVersionInfo->'%(PackageVersion)');
         SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers);
       </PropsProperties>


### PR DESCRIPTION
We should disable the build of the ref pack until the reference assembly versions are fixed (see https://github.com/aspnet/AspNetCore/pull/14538)

CC @dougbu @JunTaoLuo @nguerrera 