### PR TITLE
Small improvement to HttpsConnectionMiddleware

### DIFF
--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -78,13 +78,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
             _options = options;
             _logger = loggerFactory?.CreateLogger<HttpsConnectionMiddleware>();
         }
-        public Task OnConnectionAsync(ConnectionContext context)
+        public async Task OnConnectionAsync(ConnectionContext context)
         {
-            return Task.Run(() => InnerOnConnectionAsync(context));
-        }
+            await Task.Yield();
 
-        private async Task InnerOnConnectionAsync(ConnectionContext context)
-        {
             bool certificateRequired;
             var feature = new Core.Internal.TlsConnectionFeature();
             context.Features.Set<ITlsConnectionFeature>(feature);


### PR DESCRIPTION
- Dispatch using `Task.Yield` instead of `Task.Run`. `Task.Yield` no longer allocates a work item or delegate (it just queues the async state machine itself to the thread pool queue) and doesn't break causality when looking at dumps while Task.Run does.