### PR TITLE
WIP: Support global.json on arm64 as well

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
   "tools": {
     "dotnet": "5.0.100-alpha1-014696",
     "runtimes": {
-      "dotnet/x64": [
+      "dotnet": [
         "$(MicrosoftNETCoreAppRuntimeVersion)"
       ],
       "dotnet/x86": [


### PR DESCRIPTION
I am trying to get ASP.NET Core to build on linux/arm64 machines (not cross compiled on x86_64).

On such machines, global.json makes arcade download the arm64 SDK, then the x64 and/or x86 runtimes. Now there are two copies of hostfxr in the local SDK:

```
$ find .dotnet/host/
.dotnet/host/
.dotnet/host/fxr
.dotnet/host/fxr/5.0.0-alpha1.19415.3
.dotnet/host/fxr/5.0.0-alpha1.19415.3/libhostfxr.so
.dotnet/host/fxr/5.0.0-alpha1.19470.7
.dotnet/host/fxr/5.0.0-alpha1.19470.7/libhostfxr.so
```

One is an x64 binary, the other is the arm64 binary:

```
$ file .dotnet/host/fxr/5.0.0-alpha1.19415.3/libhostfxr.so
.dotnet/host/fxr/5.0.0-alpha1.19415.3/libhostfxr.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=824b0c0f19a62296726be7bd12cef294ee3732af, stripped
$ file .dotnet/host/fxr/5.0.0-alpha1.19470.7/libhostfxr.so
.dotnet/host/fxr/5.0.0-alpha1.19470.7/libhostfxr.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=511b71993bb9762f46d69f377145d622208165a5, stripped
```

Unfortunately, the higher version is the x64 binary. That can't be loaded or used on arm64. The ASP.NET Core build quickly runs into an error:

```
/home/omajid/.nuget/packages/microsoft.net.compilers.toolset/3.4.0-beta1-19456-03/tasks/netcoreapp2.1/Microsoft.CSharp.Core.targets(59,5): error : Failed to load �#|, error: /home/omajid/AspNetCore/.dotnet/host/fxr/5.0.0-alpha1.19470.7/libhostfxr.so: cannot open shared object file: No such file or directory [/home/omajid/AspNetCore/eng/tools/RepoTasks/RepoTasks.csproj]                       
```

This change removes architecture-specific download versions from global.json. This lets [arcade download the arch-appropriate version of .NET Core](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs) which then lets the build continue past this error.