### PR TITLE
Update Facebook API to 4.0

### DIFF
--- a/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
@@ -10,10 +10,10 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         public static readonly string DisplayName = "Facebook";
 
         // https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login
-        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v3.3/dialog/oauth";
+        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v4.0/dialog/oauth";
 
-        public static readonly string TokenEndpoint = "https://graph.facebook.com/v3.3/oauth/access_token";
+        public static readonly string TokenEndpoint = "https://graph.facebook.com/v4.0/oauth/access_token";
 
-        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v3.3/me";
+        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v4.0/me";
     }
 }

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/base/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v3.3/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v4.0/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v3.3/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v4.0/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/challenge");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v3.3/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v4.0/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=", location);


### PR DESCRIPTION
#4684 Every release we update our OAuth providers to make sure they're referencing the latest 3rd party API endpoints. Facebook is the only one that appears out of date this time. No behavior changes were observed when changing the version.