### PR TITLE
Use static data ReadOnlySpan<byte> optimize GeneratedId

### DIFF
--- a/src/Servers/Kestrel/shared/CorrelationIdGenerator.cs
+++ b/src/Servers/Kestrel/shared/CorrelationIdGenerator.cs
@@ -25,42 +25,42 @@ namespace Microsoft.AspNetCore.Connections
         {
             return string.Create(13, id, (buffer, value) =>
             {
-                Span<byte> targetBytes = MemoryMarshal.Cast<char, byte>(buffer);
+                Span<byte> bufferBytes = MemoryMarshal.Cast<char, byte>(buffer);
 
                 // ReadOnlySpan<byte> doesn't support long index, have to use pointer to avoid cast long to int.
-                fixed (byte* bp = s_encode32Bytes)
+                fixed (byte* encode32Bytes = s_encode32Bytes)
                 {
                     if (BitConverter.IsLittleEndian)
                     {
-                        targetBytes[24] = bp[value & 31];
-                        targetBytes[22] = bp[(value >> 5) & 31];
-                        targetBytes[20] = bp[(value >> 10) & 31];
-                        targetBytes[18] = bp[(value >> 15) & 31];
-                        targetBytes[16] = bp[(value >> 20) & 31];
-                        targetBytes[14] = bp[(value >> 25) & 31];
-                        targetBytes[12] = bp[(value >> 30) & 31];
-                        targetBytes[10] = bp[(value >> 35) & 31];
-                        targetBytes[8] = bp[(value >> 40) & 31];
-                        targetBytes[6] = bp[(value >> 45) & 31];
-                        targetBytes[4] = bp[(value >> 50) & 31];
-                        targetBytes[2] = bp[(value >> 55) & 31];
-                        targetBytes[0] = bp[(value >> 60) & 31];
+                        bufferBytes[24] = encode32Bytes[value & 31];
+                        bufferBytes[22] = encode32Bytes[(value >> 5) & 31];
+                        bufferBytes[20] = encode32Bytes[(value >> 10) & 31];
+                        bufferBytes[18] = encode32Bytes[(value >> 15) & 31];
+                        bufferBytes[16] = encode32Bytes[(value >> 20) & 31];
+                        bufferBytes[14] = encode32Bytes[(value >> 25) & 31];
+                        bufferBytes[12] = encode32Bytes[(value >> 30) & 31];
+                        bufferBytes[10] = encode32Bytes[(value >> 35) & 31];
+                        bufferBytes[8] = encode32Bytes[(value >> 40) & 31];
+                        bufferBytes[6] = encode32Bytes[(value >> 45) & 31];
+                        bufferBytes[4] = encode32Bytes[(value >> 50) & 31];
+                        bufferBytes[2] = encode32Bytes[(value >> 55) & 31];
+                        bufferBytes[0] = encode32Bytes[(value >> 60) & 31];
                     }
                     else
                     {
-                        targetBytes[25] = bp[value & 31];
-                        targetBytes[23] = bp[(value >> 5) & 31];
-                        targetBytes[21] = bp[(value >> 10) & 31];
-                        targetBytes[19] = bp[(value >> 15) & 31];
-                        targetBytes[17] = bp[(value >> 20) & 31];
-                        targetBytes[15] = bp[(value >> 25) & 31];
-                        targetBytes[13] = bp[(value >> 30) & 31];
-                        targetBytes[11] = bp[(value >> 35) & 31];
-                        targetBytes[9] = bp[(value >> 40) & 31];
-                        targetBytes[7] = bp[(value >> 45) & 31];
-                        targetBytes[5] = bp[(value >> 50) & 31];
-                        targetBytes[3] = bp[(value >> 55) & 31];
-                        targetBytes[1] = bp[(value >> 60) & 31];
+                        bufferBytes[25] = encode32Bytes[value & 31];
+                        bufferBytes[23] = encode32Bytes[(value >> 5) & 31];
+                        bufferBytes[21] = encode32Bytes[(value >> 10) & 31];
+                        bufferBytes[19] = encode32Bytes[(value >> 15) & 31];
+                        bufferBytes[17] = encode32Bytes[(value >> 20) & 31];
+                        bufferBytes[15] = encode32Bytes[(value >> 25) & 31];
+                        bufferBytes[13] = encode32Bytes[(value >> 30) & 31];
+                        bufferBytes[11] = encode32Bytes[(value >> 35) & 31];
+                        bufferBytes[9] = encode32Bytes[(value >> 40) & 31];
+                        bufferBytes[7] = encode32Bytes[(value >> 45) & 31];
+                        bufferBytes[5] = encode32Bytes[(value >> 50) & 31];
+                        bufferBytes[3] = encode32Bytes[(value >> 55) & 31];
+                        bufferBytes[1] = encode32Bytes[(value >> 60) & 31];
                     }
                 }
             });

--- a/src/Servers/Kestrel/shared/CorrelationIdGenerator.cs
+++ b/src/Servers/Kestrel/shared/CorrelationIdGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Microsoft.AspNetCore.Connections
@@ -9,7 +10,9 @@ namespace Microsoft.AspNetCore.Connections
     internal static class CorrelationIdGenerator
     {
         // Base32 encoding - in ascii sort order for easy text based sorting
-        private static readonly char[] s_encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV".ToCharArray();
+        // s_encode32Bytes: 0123456789ABCDEFGHIJKLMNOPQRSTUV
+        // use this optimization: https://github.com/dotnet/roslyn/pull/24621
+        private static ReadOnlySpan<byte> s_encode32Bytes => new byte[] { (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5', (byte)'6', (byte)'7', (byte)'8', (byte)'9', (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G', (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N', (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U', (byte)'V' };
 
         // Seed the _lastConnectionId for this application instance with
         // the number of 100-nanosecond intervals that have elapsed since 12:00:00 midnight, January 1, 0001
@@ -18,25 +21,48 @@ namespace Microsoft.AspNetCore.Connections
 
         public static string GetNextId() => GenerateId(Interlocked.Increment(ref _lastId));
 
-        private static string GenerateId(long id)
+        private unsafe static string GenerateId(long id)
         {
             return string.Create(13, id, (buffer, value) =>
             {
-                char[] encode32Chars = s_encode32Chars;
+                Span<byte> targetBytes = MemoryMarshal.Cast<char, byte>(buffer);
 
-                buffer[12] = encode32Chars[value & 31];
-                buffer[11] = encode32Chars[(value >> 5) & 31];
-                buffer[10] = encode32Chars[(value >> 10) & 31];
-                buffer[9] = encode32Chars[(value >> 15) & 31];
-                buffer[8] = encode32Chars[(value >> 20) & 31];
-                buffer[7] = encode32Chars[(value >> 25) & 31];
-                buffer[6] = encode32Chars[(value >> 30) & 31];
-                buffer[5] = encode32Chars[(value >> 35) & 31];
-                buffer[4] = encode32Chars[(value >> 40) & 31];
-                buffer[3] = encode32Chars[(value >> 45) & 31];
-                buffer[2] = encode32Chars[(value >> 50) & 31];
-                buffer[1] = encode32Chars[(value >> 55) & 31];
-                buffer[0] = encode32Chars[(value >> 60) & 31];
+                // ReadOnlySpan<byte> doesn't support long index, have to use pointer to avoid cast long to int.
+                fixed (byte* bp = s_encode32Bytes)
+                {
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        targetBytes[24] = bp[value & 31];
+                        targetBytes[22] = bp[(value >> 5) & 31];
+                        targetBytes[20] = bp[(value >> 10) & 31];
+                        targetBytes[18] = bp[(value >> 15) & 31];
+                        targetBytes[16] = bp[(value >> 20) & 31];
+                        targetBytes[14] = bp[(value >> 25) & 31];
+                        targetBytes[12] = bp[(value >> 30) & 31];
+                        targetBytes[10] = bp[(value >> 35) & 31];
+                        targetBytes[8] = bp[(value >> 40) & 31];
+                        targetBytes[6] = bp[(value >> 45) & 31];
+                        targetBytes[4] = bp[(value >> 50) & 31];
+                        targetBytes[2] = bp[(value >> 55) & 31];
+                        targetBytes[0] = bp[(value >> 60) & 31];
+                    }
+                    else
+                    {
+                        targetBytes[25] = bp[value & 31];
+                        targetBytes[23] = bp[(value >> 5) & 31];
+                        targetBytes[21] = bp[(value >> 10) & 31];
+                        targetBytes[19] = bp[(value >> 15) & 31];
+                        targetBytes[17] = bp[(value >> 20) & 31];
+                        targetBytes[15] = bp[(value >> 25) & 31];
+                        targetBytes[13] = bp[(value >> 30) & 31];
+                        targetBytes[11] = bp[(value >> 35) & 31];
+                        targetBytes[9] = bp[(value >> 40) & 31];
+                        targetBytes[7] = bp[(value >> 45) & 31];
+                        targetBytes[5] = bp[(value >> 50) & 31];
+                        targetBytes[3] = bp[(value >> 55) & 31];
+                        targetBytes[1] = bp[(value >> 60) & 31];
+                    }
+                }
             });
         }
     }


### PR DESCRIPTION
Use static data ReadOnlySpan<byte> optimize GeneratedId, gain a little performance improve and eliminate initial char array in the heap. 
https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static/

Summary of the changes (Less than 80 chars)
 - Use `ReadOnlySpan<byte>` avoid static char array allocation in the heap.  
 - Improve performance a little. 

I have created a benchmark:  https://gist.github.com/Ruikuan/1066fb7af4deb0f6d50319ef1d98717b , result:

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i7-3720QM CPU 2.60GHz (Ivy Bridge), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
```

|            Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| GenerateId_Origin | 18.19 ns | 0.1217 ns | 0.1079 ns |  1.00 | 0.0153 |     - |     - |      48 B |
|        GenerateId | 16.50 ns | 0.0786 ns | 0.0697 ns |  0.91 | 0.0153 |     - |     - |      48 B |


Other:
* `GenerateId` is `unsafe` again.
* I don't have a big endian computer, so I can't test the big endian part myself.