### PR TITLE
[UserSecrets Tooling] Adds user-secrets edit CLI command

### DIFF
--- a/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
+++ b/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Extensions.SecretManager.Tools
             app.Command("list", c => ListCommand.Configure(c, options));
             app.Command("clear", c => ClearCommand.Configure(c, options));
             app.Command("init", c => InitCommandFactory.Configure(c, options));
+            app.Command("edit", c => EditCommand.Configure(c));
 
             // Show help information if no subcommand/option was specified.
             app.OnExecute(() => app.ShowHelp());

--- a/src/Tools/dotnet-user-secrets/src/Internal/EditCommand.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/EditCommand.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace Microsoft.Extensions.SecretManager.Tools.Internal
+{
+    internal class EditCommand : ICommand
+    {
+        public void Execute(CommandContext context)
+        {
+            Process.Start(context.SecretStore.SecretsFilePath);
+        }
+
+        internal static void Configure(CommandLineApplication command)
+        {
+            command.Description = "Opens secrets file in default editor";
+            command.HelpOption();
+        }
+    }
+}

--- a/src/Tools/dotnet-user-secrets/src/Internal/SecretsStore.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/SecretsStore.cs
@@ -19,20 +19,20 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
     /// </summary>
     public class SecretsStore
     {
-        private readonly string _secretsFilePath;
+        public readonly string SecretsFilePath;
         private IDictionary<string, string> _secrets;
 
         public SecretsStore(string userSecretsId, IReporter reporter)
         {
             Ensure.NotNull(userSecretsId, nameof(userSecretsId));
 
-            _secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+            SecretsFilePath = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
 
             // workaround bug in configuration
-            var secretDir = Path.GetDirectoryName(_secretsFilePath);
+            var secretDir = Path.GetDirectoryName(SecretsFilePath);
             Directory.CreateDirectory(secretDir);
 
-            reporter.Verbose(Resources.FormatMessage_Secret_File_Path(_secretsFilePath));
+            reporter.Verbose(Resources.FormatMessage_Secret_File_Path(SecretsFilePath));
             _secrets = Load(userSecretsId);
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
 
         public virtual void Save()
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(_secretsFilePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(SecretsFilePath));
 
             var contents = new JObject();
             if (_secrets != null)
@@ -75,13 +75,13 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
                 }
             }
 
-            File.WriteAllText(_secretsFilePath, contents.ToString(), Encoding.UTF8);
+            File.WriteAllText(SecretsFilePath, contents.ToString(), Encoding.UTF8);
         }
 
         protected virtual IDictionary<string, string> Load(string userSecretsId)
         {
             return new ConfigurationBuilder()
-                .AddJsonFile(_secretsFilePath, optional: true)
+                .AddJsonFile(SecretsFilePath, optional: true)
                 .Build()
                 .AsEnumerable()
                 .Where(i => i.Value != null)


### PR DESCRIPTION
Currently when working with user-secrets using full VS we have this helpful option:
![image](https://user-images.githubusercontent.com/2963600/66397651-8e3dc300-e9dc-11e9-9a3b-1333ef69174a.png)
which opens up `secrets.json` for user to edit. However any other IDE requires additional extension for that feature.
This PR is a proposal for `dotnet user-secrets edit` which would open `secrets.json` with editor of user's choice (similar to `kubectl edit ...`)