### PR TITLE
Allow opt out of HttpSys client cert negotiation 

### DIFF
--- a/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
+++ b/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
@@ -26,6 +26,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         Negotiate = 8,
         Kerberos = 16,
     }
+    public enum ClientCertificateMode
+    {
+        NoCertificate = 0,
+        AllowCertificate = 1,
+        DynamicCertificate = 2,
+    }
     public enum Http503VerbosityLevel : long
     {
         Basic = (long)0,
@@ -46,6 +52,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public HttpSysOptions() { }
         public bool AllowSynchronousIO { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.HttpSys.AuthenticationManager Authentication { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMode ClientCertificateMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool EnableResponseCaching { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.HttpSys.Http503VerbosityLevel Http503Verbosity { get { throw null; } set { } }
         public int MaxAccepts { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
+++ b/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.netcoreapp.cs
@@ -26,11 +26,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         Negotiate = 8,
         Kerberos = 16,
     }
-    public enum ClientCertificateMode
+    public enum ClientCertificateMethod
     {
         NoCertificate = 0,
         AllowCertificate = 1,
-        DynamicCertificate = 2,
+        AllowRenegotation = 2,
     }
     public enum Http503VerbosityLevel : long
     {
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public HttpSysOptions() { }
         public bool AllowSynchronousIO { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.HttpSys.AuthenticationManager Authentication { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMode ClientCertificateMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod ClientCertificateMethod { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool EnableResponseCaching { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Server.HttpSys.Http503VerbosityLevel Http503Verbosity { get { throw null; } set { } }
         public int MaxAccepts { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Servers/HttpSys/src/ClientCertificateMethod.cs
+++ b/src/Servers/HttpSys/src/ClientCertificateMethod.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
     /// <summary>
-    /// Describes the client certificate negotiation methods a HTTPS connection.
+    /// Describes the client certificate negotiation method for HTTPS connections.
     /// </summary>
-    public enum ClientCertificateMode
+    public enum ClientCertificateMethod
     {
         /// <summary>
         /// A client certificate will not be populated on the request.
@@ -21,6 +21,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// The TLS session can be renegotiated to request a client certificate.
         /// </summary>
-        DynamicCertificate
+        AllowRenegotation
     }
 }

--- a/src/Servers/HttpSys/src/ClientCertificateMode.cs
+++ b/src/Servers/HttpSys/src/ClientCertificateMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    /// <summary>
+    /// Describes the client certificate negotiation methods a HTTPS connection.
+    /// </summary>
+    public enum ClientCertificateMode
+    {
+        /// <summary>
+        /// A client certificate will not be populated on the request.
+        /// </summary>
+        NoCertificate = 0,
+
+        /// <summary>
+        /// A client certificate will be populated if already present at the start of a request.
+        /// </summary>
+        AllowCertificate,
+
+        /// <summary>
+        /// The TLS session can be renegotiated to request a client certificate.
+        /// </summary>
+        DynamicCertificate
+    }
+}

--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -316,7 +316,17 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (IsNotInitialized(Fields.ClientCertificate))
                 {
-                    _clientCert = Request.GetClientCertificateAsync().Result; // TODO: Sync;
+                    var mode = _requestContext.Server.Options.ClientCertificateMode;
+                    if (mode == ClientCertificateMode.AllowCertificate)
+                    {
+                        _clientCert = Request.ClientCertificate;
+                    }
+                    else if (mode == ClientCertificateMode.DynamicCertificate)
+                    {
+                        _clientCert = Request.GetClientCertificateAsync().Result; // TODO: Sync;
+                    }
+                    // else if (mode == ClientCertificateMode.NoCertificate) // No-op
+
                     SetInitialized(Fields.ClientCertificate);
                 }
                 return _clientCert;

--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -316,16 +316,16 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (IsNotInitialized(Fields.ClientCertificate))
                 {
-                    var mode = _requestContext.Server.Options.ClientCertificateMode;
-                    if (mode == ClientCertificateMode.AllowCertificate)
+                    var method = _requestContext.Server.Options.ClientCertificateMethod;
+                    if (method == ClientCertificateMethod.AllowCertificate)
                     {
                         _clientCert = Request.ClientCertificate;
                     }
-                    else if (mode == ClientCertificateMode.DynamicCertificate)
+                    else if (method == ClientCertificateMethod.AllowRenegotation)
                     {
-                        _clientCert = Request.GetClientCertificateAsync().Result; // TODO: Sync;
+                        _clientCert = Request.GetClientCertificateAsync().Result; // TODO: Sync over async;
                     }
-                    // else if (mode == ClientCertificateMode.NoCertificate) // No-op
+                    // else if (method == ClientCertificateMethod.NoCertificate) // No-op
 
                     SetInitialized(Fields.ClientCertificate);
                 }

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -55,11 +55,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public RequestQueueMode RequestQueueMode { get; set; }
 
         /// <summary>
-        /// Indicates how client certificates should be populated. The default is to allow dynamic renegotation.
+        /// Indicates how client certificates should be populated. The default is to allow renegotation.
         /// This does not change the netsh 'clientcertnegotiation' binding option which will need to be enabled for
-        /// ClientCertificateMode.AllowCertificate to resolve a certificate.
+        /// ClientCertificateMethod.AllowCertificate to resolve a certificate.
         /// </summary>
-        public ClientCertificateMode ClientCertificateMode { get; set; } = ClientCertificateMode.DynamicCertificate;
+        public ClientCertificateMethod ClientCertificateMethod { get; set; } = ClientCertificateMethod.AllowRenegotation;
 
         /// <summary>
         /// The maximum number of concurrent accepts.

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -55,6 +55,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public RequestQueueMode RequestQueueMode { get; set; }
 
         /// <summary>
+        /// Indicates how client certificates should be populated. The default is to allow dynamic renegotation.
+        /// This does not change the netsh 'clientcertnegotiation' binding option which will need to be enabled for
+        /// ClientCertificateMode.AllowCertificate to resolve a certificate.
+        /// </summary>
+        public ClientCertificateMode ClientCertificateMode { get; set; } = ClientCertificateMode.DynamicCertificate;
+
+        /// <summary>
         /// The maximum number of concurrent accepts.
         /// </summary>
         public int MaxAccepts { get; set; } = DefaultMaxAccepts;


### PR DESCRIPTION
#14806 @avparuch

Background:
Http.Sys has a unique capability not surfaced in other servers, the ability to renegotiate the TLS connection during a request to get a client certificate. This has been the standard behavior all the way back to HttpSys's origins in [HttpListener](https://referencesource.microsoft.com/#System/net/System/Net/HttpListenerRequest.cs,605). This can be useful because it means you can delay prompting for a cert until the user performs an action that requires it.  However it also has some side effects like high latency and a potential protocol deadlock on POST requests if the TCP windows are full. Renegotiation is also not supported on HTTP/2.

In HttpSys it is not great that we trigger IO during a sync API call where people aren't expecting it (HttpContext.Connection.ClientCertificate). An async version is available (GetClientCertificateAsync).

The odd thing is that Http.Sys provides a simpler way to get the client certificate that was never implemented by HttpListener or HttpSys. If the client certificate has already been negotiated for a connection then it will be directly included in the request structure, no additional API calls or renegotiation is required. Clients rarely volunteer a certificate unless prompted, so it does require enabling the `clientcertnegotiation` option on the netsh binding to get the client cert at the start of the connection. This is the same approach IIS and Kestrel use.

Change:
I've added ClientCertificateMode to let you control the behavior of HttpContext.Connection.ClientCertificate for HttpSys. The the old behavior is still the default for compat reasons, but I'll file an issue to change that in 5.0. If you change the setting to AllowCertificate then it will only populate certs if they're present in the request structure. For NoCertificate it will always return null.
HttpContext.Connection.GetClientCertificateAsync will maintain the old behavior regardless of the new option. We should also change this in 5.0 to prefer the request cert before attempting a renegotiation (needs testing).

Testing: There are only some skipped manual tests for client certs because they are not constantly available on machines. Also the netsh `clientcertnegotiation` setting is machine state can't be changed during a test so the new Allow mode would never return a cert. Verified manually and we have a customer waiting to test previews.