### PR TITLE
Make BadHttpRequestException instantiable for testing

### DIFF
--- a/src/Servers/Kestrel/Core/src/BadHttpRequestException.cs
+++ b/src/Servers/Kestrel/Core/src/BadHttpRequestException.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             => throw GetException(reason, method.ToString().ToUpperInvariant());
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static BadHttpRequestException GetException(RequestRejectionReason reason)
+        public static BadHttpRequestException GetException(RequestRejectionReason reason)
         {
             BadHttpRequestException ex;
             switch (reason)
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static BadHttpRequestException GetException(RequestRejectionReason reason, string detail)
+        public static BadHttpRequestException GetException(RequestRejectionReason reason, string detail)
         {
             BadHttpRequestException ex;
             switch (reason)


### PR DESCRIPTION
`BadHttpRequestException` has no mechanism for instantiation.

Testing anything that `catch`es it is very difficult. Making the `static` initializer methods `public` allows easy instantiation of `BadHttpRequestException`s in testing rather than having to access a constructor or `GetException` method via reflection.