### PR TITLE
TwoLetterISOLanguageName support in RouteDataRequestCultureProvider

### DIFF
--- a/src/Middleware/Localization.Routing/src/RouteDataRequestCultureProvider.cs
+++ b/src/Middleware/Localization.Routing/src/RouteDataRequestCultureProvider.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -66,9 +67,27 @@ namespace Microsoft.AspNetCore.Localization.Routing
                 culture = uiCulture;
             }
 
+            culture = TwoLetterISoToFullName(culture, false);
+            uiCulture = TwoLetterISoToFullName(uiCulture, true);
+
             var providerResultCulture = new ProviderCultureResult(culture, uiCulture);
 
             return Task.FromResult(providerResultCulture);
+        }
+        /// <summary>
+        /// Find the first culture name from the "Supported Cultures" match the culture parameter if it passed as the two-letter ISO language name 
+        /// EX: if culture = "en" then the function will find the first supported culture has two-letter ISO language name equals to "en" (case insensitive) may "en-US" or "en-GB" or etc. will be selected if it exists at first
+        /// </summary>
+        string TwoLetterISoToFullName(string culture, bool isUICulture)
+        {
+            System.Diagnostics.Debug.WriteLine($"{isUICulture} {this.Options?.SupportedUICultures?.Any()}");
+            if (culture.Length == 2 && this.Options != null)
+            {
+                var cultures = isUICulture ? this.Options.SupportedUICultures : this.Options.SupportedCultures;
+                culture = cultures?.Where(c => c.TwoLetterISOLanguageName.Equals(culture, StringComparison.OrdinalIgnoreCase))
+                    .Select(c => c.Name).FirstOrDefault() ?? culture;
+            }
+            return culture;
         }
     }
 }

--- a/src/Middleware/Localization.Routing/test/RouteDataRequestCultureProviderTest.cs
+++ b/src/Middleware/Localization.Routing/test/RouteDataRequestCultureProviderTest.cs
@@ -19,11 +19,15 @@ namespace Microsoft.AspNetCore.Localization.Routing
     {
         [Theory]
         [InlineData("{culture}/{ui-culture}/hello", "ar-SA/ar-YE/hello", "ar-SA", "ar-YE")]
+        [InlineData("{culture}/{ui-culture}/hello", "ar/ar/hello", "ar-SA", "ar-YE")]
         [InlineData("{CULTURE}/{UI-CULTURE}/hello", "ar-SA/ar-YE/hello", "ar-SA", "ar-YE")]
+        [InlineData("{CULTURE}/{UI-CULTURE}/hello", "ar/ar/hello", "ar-SA", "ar-YE")]
         [InlineData("{culture}/{ui-culture}/hello", "unsupported/unsupported/hello", "en-US", "en-US")]
         [InlineData("{culture}/hello", "ar-SA/hello", "ar-SA", "en-US")]
+        [InlineData("{culture}/hello", "ar/hello", "ar-SA", "ar-YE")]//
         [InlineData("hello", "hello", "en-US", "en-US")]
         [InlineData("{ui-culture}/hello", "ar-YE/hello", "en-US", "ar-YE")]
+        [InlineData("{ui-culture}/hello", "ar/hello", "ar-SA", "ar-YE")]//
         public async Task GetCultureInfo_FromRouteData(
             string routeTemplate,
             string requestUrl,


### PR DESCRIPTION
I needed to change the culture without specifying the country for example
when the URL like this
http://anydomain.com/ar/somepages
I need the system to select the first Arabic culture for example (ar-EG)

so I modified the RouteDataRequestCultureProvider to check if the culture is just two letters then select the first culture has the same TwoLetterISOLanguageName

Thanks
