### PR TITLE
Move most helix queues to a daily scheduled run

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -583,27 +583,6 @@ stages:
         path: artifacts/log/
         publishOnError: true
       
-  # Helix ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Helix_arm64
-      jobDisplayName: "Tests: Helix ARM64"
-      agentOs: Linux
-      timeoutInMinutes: 180
-      steps:
-      - script: ./restore.sh -ci
-        displayName: Restore
-      - script: ./build.sh -ci --arch arm64 -test --no-build-nodejs -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildAllProjects=true /p:BuildNative=true -bl
-        displayName: Run build.sh helix arm64 target
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-      installNodeJs: false
-      artifacts:
-      - name: Helix_arm64_logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-
   # Source build
   - job: Source_Build
     displayName: 'Test: Linux Source Build'

--- a/.azure/pipelines/helix-daily.yml
+++ b/.azure/pipelines/helix-daily.yml
@@ -1,0 +1,45 @@
+# Uses Scheduled Triggers, which aren't supported in YAML yet.
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=vsts&tabs=yaml#scheduled
+
+# Daily Helix Tests for ASP.NET Core
+
+jobs:
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Helix_x64_daily
+    jobDisplayName: 'Tests: Helix x64 Daily'
+    agentOs: Windows
+    timeoutInMinutes: 240
+    steps:
+    - script: .\restore.cmd -ci
+      displayName: Restore
+    - script: .\build.cmd -ci -NoRestore -test -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildAllProjects=true /p:BuildNative=true -bl
+      displayName: Run build.cmd helix target
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+    artifacts:
+    - name: Helix_logs
+      path: artifacts/log/
+      publishOnError: true
+
+# Helix ARM64
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Helix_arm64_daily
+    jobDisplayName: "Tests: Helix ARM64 Daily"
+    agentOs: Linux
+    timeoutInMinutes: 180
+    steps:
+    - script: ./restore.sh -ci
+      displayName: Restore
+    - script: ./build.sh -ci --arch arm64 -test --no-build-nodejs -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildAllProjects=true /p:BuildNative=true -bl
+      displayName: Run build.sh helix arm64 target
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+    installNodeJs: false
+    artifacts:
+    - name: Helix_arm64_logs
+      path: artifacts/log/
+      publishOnError: true
+      includeForks: true
+

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -6,14 +6,23 @@
     <HelixAvailablePlatform Include="Linux" />
   </ItemGroup>
 
-  <!-- required for green PR queues -->
-
-  <!-- x64 queues -->
+  <!-- required for green PR queues  -->
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsRequiredCheck)' == 'true'">
     <HelixAvailableTargetQueue Include="Ubuntu.1604.Amd64.Open" Platform="Linux" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'arm64' AND '$(IsRequiredCheck)' == 'true'">
+  <!-- daily scheduled only queues -->
+  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
+    <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="OSX.1014.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="Centos.7.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="Debian.8.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="(Fedora.28.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-09ca40b-20190508143249" Platform="Linux" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
     <!-- arm64 queues -->
     <HelixAvailableTargetQueue Include="(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036" Platform="Linux" />
 
@@ -23,17 +32,11 @@
     -->
   </ItemGroup>
   
-  <!-- non required queues -->
+  <!-- non required queues run on every PR -->
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsRequiredCheck)' != 'true'">
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Centos.7.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Debian.8.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="(Fedora.28.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-09ca40b-20190508143249" Platform="Linux" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true' AND '$(IsRequiredCheck)' != 'true'">


### PR DESCRIPTION
Ubuntu 1604 x64 only required PR check
Windows queues are non required PR checks
Adds back OSX.1014
TODO: Add additional arm queues and OSX flavors

All other helix queues (including arm) are moved to a scheduled daily run