### PR TITLE
Add "allowReconnect" to SignalR CloseMessages

### DIFF
--- a/src/Components/Server/src/BlazorPack/BlazorPackHubProtocol.cs
+++ b/src/Components/Server/src/BlazorPack/BlazorPackHubProtocol.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Components.Server.BlazorPack
                     message = PingMessage.Instance;
                     return true;
                 case HubProtocolConstants.CloseMessageType:
-                    message = CreateCloseMessage(ref reader);
+                    message = CreateCloseMessage(ref reader, itemCount);
                     return true;
                 default:
                     // Future protocol changes can add message types, old clients can ignore them
@@ -196,10 +196,23 @@ namespace Microsoft.AspNetCore.Components.Server.BlazorPack
             return ApplyHeaders(headers, new CancelInvocationMessage(invocationId));
         }
 
-        private static CloseMessage CreateCloseMessage(ref MessagePackReader reader)
+        private static CloseMessage CreateCloseMessage(ref MessagePackReader reader, int itemCount)
         {
             var error = ReadString(ref reader, "error");
-            return new CloseMessage(error);
+            var allowReconnect = false;
+
+            if (itemCount > 2)
+            {
+                allowReconnect = ReadBoolean(ref reader, "allowReconnect");
+            }
+
+            // An empty string is still an error
+            if (error == null && !allowReconnect)
+            {
+                return CloseMessage.Empty;
+            }
+
+            return new CloseMessage(error, allowReconnect);
         }
 
         private static Dictionary<string, string> ReadHeaders(ref MessagePackReader reader)
@@ -515,7 +528,7 @@ namespace Microsoft.AspNetCore.Components.Server.BlazorPack
 
         private void WriteCloseMessage(CloseMessage message, ref MessagePackWriter writer)
         {
-            writer.WriteArrayHeader(2);
+            writer.WriteArrayHeader(3);
             writer.Write(HubProtocolConstants.CloseMessageType);
             if (string.IsNullOrEmpty(message.Error))
             {
@@ -525,6 +538,8 @@ namespace Microsoft.AspNetCore.Components.Server.BlazorPack
             {
                 writer.Write(message.Error);
             }
+
+            writer.Write(message.AllowReconnect);
         }
 
         private void WritePingMessage(PingMessage _, ref MessagePackWriter writer)
@@ -557,6 +572,17 @@ namespace Microsoft.AspNetCore.Components.Server.BlazorPack
             }
 
             return destination;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadBoolean(ref MessagePackReader reader, string field)
+        {
+            if (reader.End || reader.NextMessagePackType != MessagePackType.Boolean)
+            {
+                ThrowInvalidDataException(field, "Boolean");
+            }
+
+            return reader.ReadBoolean();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1165,7 +1165,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                                     }
 
                                     // Stopping being true indicates the client shouldn't try to reconnect even if automatic reconnects are enabled.
-                                    if (closeMessage.PreventAutomaticReconnect)
+                                    if (!closeMessage.AllowAutomaticReconnect)
                                     {
                                         connectionState.Stopping = true;
                                     }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1165,7 +1165,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                                     }
 
                                     // Stopping being true indicates the client shouldn't try to reconnect even if automatic reconnects are enabled.
-                                    if (!closeMessage.AllowAutomaticReconnect)
+                                    if (!closeMessage.AllowReconnect)
                                     {
                                         connectionState.Stopping = true;
                                     }
@@ -1645,7 +1645,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             public CancellationToken UploadStreamToken { get; set; }
 
             // Indicates the connection is stopping AND the client should NOT attempt to reconnect even if automatic reconnects are enabled.
-            // This means either HubConnection.DisposeAsync/StopAsync was called OR a CloseMessage with AllowAutomaticReconnects set to false was received.
+            // This means either HubConnection.DisposeAsync/StopAsync was called OR a CloseMessage with AllowReconnects set to false was received.
             public bool Stopping
             {
                 get => _stopping;

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
-            public async Task CannotBeInducedByCloseMessageWithAllowAutoReconnectOmmitted()
+            public async Task CannotBeInducedByCloseMessageWithAllowAutoReconnectOmitted()
             {
                 bool ExpectedErrors(WriteContext writeContext)
                 {

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
-            public async Task CanBeInducedByCloseMessageWithAllowAutoReconnectSet()
+            public async Task CanBeInducedByCloseMessageWithAllowReconnectSet()
             {
                 bool ExpectedErrors(WriteContext writeContext)
                 {
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
-            public async Task CannotBeInducedByCloseMessageWithAllowAutoReconnectOmitted()
+            public async Task CannotBeInducedByCloseMessageWithAllowReconnectOmitted()
             {
                 bool ExpectedErrors(WriteContext writeContext)
                 {

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
@@ -124,6 +124,7 @@ export class MessagePackHubProtocol implements IHubProtocol {
 
         return {
             // Close messages have no headers.
+            allowReconnect: properties.length >= 3 ? properties[2] : undefined,
             error: properties[1],
             type: MessageType.Close,
         } as HubMessage;

--- a/src/SignalR/clients/ts/signalr/src/IHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/IHubProtocol.ts
@@ -131,6 +131,9 @@ export interface CloseMessage extends HubMessageBase {
      * If this property is undefined, the connection was closed normally and without error.
      */
     readonly error?: string;
+
+    /** If true, clients with automatic reconnects enabled should attempt to reconnect after receiving the CloseMessage. Otherwise, they should not. */
+    readonly allowReconnect?: boolean;
 }
 
 /** A hub message sent to request that a streaming invocation be canceled. */

--- a/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import { DefaultReconnectPolicy } from "../src/DefaultReconnectPolicy";
 import { HubConnection, HubConnectionState } from "../src/HubConnection";
 import { IConnection } from "../src/IConnection";
 import { HubMessage, IHubProtocol, MessageType } from "../src/IHubProtocol";
 import { ILogger, LogLevel } from "../src/ILogger";
-import { IRetryPolicy } from "../src/IRetryPolicy";
 import { TransferFormat } from "../src/ITransport";
 import { JsonHubProtocol } from "../src/JsonHubProtocol";
 import { NullLogger } from "../src/Loggers";
@@ -18,8 +16,8 @@ import { VerifyLogger } from "./Common";
 import { TestConnection } from "./TestConnection";
 import { delayUntil, PromiseSource, registerUnhandledRejectionHandler } from "./Utils";
 
-function createHubConnection(connection: IConnection, logger?: ILogger | null, protocol?: IHubProtocol | null, reconnectPolicy?: IRetryPolicy) {
-    return HubConnection.create(connection, logger || NullLogger.instance, protocol || new JsonHubProtocol(), reconnectPolicy);
+function createHubConnection(connection: IConnection, logger?: ILogger | null, protocol?: IHubProtocol | null) {
+    return HubConnection.create(connection, logger || NullLogger.instance, protocol || new JsonHubProtocol());
 }
 
 registerUnhandledRejectionHandler();
@@ -827,62 +825,6 @@ describe("HubConnection", () => {
                     // allowReconnect Should have no effect since auto reconnect is disabled by default.
                     connection.receive({
                         allowReconnect: true,
-                        error: "Error!",
-                        type: MessageType.Close,
-                    });
-
-                    expect(isClosed).toEqual(true);
-                    expect(closeError!.message).toEqual("Server returned an error on close: Error!");
-                } finally {
-                    await hubConnection.stop();
-                }
-            });
-        });
-
-        it("reconnect on close message if allowReconnect is true and auto reconnect is enabled", async () => {
-            await VerifyLogger.run(async (logger) => {
-                const connection = new TestConnection();
-                const hubConnection = createHubConnection(connection, logger, null, new DefaultReconnectPolicy());
-                try {
-                    let isReconnecting = false;
-                    let reconnectingError: Error | undefined;
-
-                    hubConnection.onreconnecting((e) => {
-                        isReconnecting = true;
-                        reconnectingError = e;
-                    });
-
-                    await hubConnection.start();
-
-                    connection.receive({
-                        allowReconnect: true,
-                        error: "Error!",
-                        type: MessageType.Close,
-                    });
-
-                    expect(isReconnecting).toEqual(true);
-                    expect(reconnectingError!.message).toEqual("Server returned an error on close: Error!");
-                } finally {
-                    await hubConnection.stop();
-                }
-            });
-        });
-
-        it("stop on close message if allowReconnect is missing and auto reconnect is enabled", async () => {
-            await VerifyLogger.run(async (logger) => {
-                const connection = new TestConnection();
-                const hubConnection = createHubConnection(connection, logger, null, new DefaultReconnectPolicy());
-                try {
-                    let isClosed = false;
-                    let closeError: Error | undefined;
-                    hubConnection.onclose((e) => {
-                        isClosed = true;
-                        closeError = e;
-                    });
-
-                    await hubConnection.start();
-
-                    connection.receive({
                         error: "Error!",
                         type: MessageType.Close,
                     });

--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         private static JsonEncodedText TypePropertyNameBytes = JsonEncodedText.Encode(TypePropertyName);
         private const string ErrorPropertyName = "error";
         private static JsonEncodedText ErrorPropertyNameBytes = JsonEncodedText.Encode(ErrorPropertyName);
-        private const string AllowAutomaticReconnectPropertyName = "allowReconnect";
-        private static JsonEncodedText AllowAutomaticReconnectPropertyNameBytes = JsonEncodedText.Encode(AllowAutomaticReconnectPropertyName);
+        private const string AllowReconnectPropertyName = "allowReconnect";
+        private static JsonEncodedText AllowReconnectPropertyNameBytes = JsonEncodedText.Encode(AllowReconnectPropertyName);
         private const string TargetPropertyName = "target";
         private static JsonEncodedText TargetPropertyNameBytes = JsonEncodedText.Encode(TargetPropertyName);
         private const string ArgumentsPropertyName = "arguments";
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 ExceptionDispatchInfo argumentBindingException = null;
                 Dictionary<string, string> headers = null;
                 var completed = false;
-                var allowAutomaticReconnect = false;
+                var allowReconnect = false;
 
                 var reader = new Utf8JsonReader(input, isFinalBlock: true, state: default);
 
@@ -189,9 +189,9 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                             {
                                 error = reader.ReadAsString(ErrorPropertyName);
                             }
-                            else if (reader.ValueTextEquals(AllowAutomaticReconnectPropertyNameBytes.EncodedUtf8Bytes))
+                            else if (reader.ValueTextEquals(AllowReconnectPropertyNameBytes.EncodedUtf8Bytes))
                             {
-                                allowAutomaticReconnect = reader.ReadAsBoolean(AllowAutomaticReconnectPropertyName);
+                                allowReconnect = reader.ReadAsBoolean(AllowReconnectPropertyName);
                             }
                             else if (reader.ValueTextEquals(ResultPropertyNameBytes.EncodedUtf8Bytes))
                             {
@@ -379,7 +379,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                     case HubProtocolConstants.PingMessageType:
                         return PingMessage.Instance;
                     case HubProtocolConstants.CloseMessageType:
-                        return BindCloseMessage(error, allowAutomaticReconnect);
+                        return BindCloseMessage(error, allowReconnect);
                     case null:
                         throw new InvalidDataException($"Missing required property '{TypePropertyName}'.");
                     default:
@@ -552,9 +552,9 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 writer.WriteString(ErrorPropertyNameBytes, message.Error);
             }
 
-            if (message.AllowAutomaticReconnect)
+            if (message.AllowReconnect)
             {
-                writer.WriteBoolean(AllowAutomaticReconnectPropertyNameBytes, false);
+                writer.WriteBoolean(AllowReconnectPropertyNameBytes, true);
             }
         }
 
@@ -734,15 +734,15 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             return arguments ?? Array.Empty<object>();
         }
 
-        private CloseMessage BindCloseMessage(string error, bool allowAutomaticReconnect)
+        private CloseMessage BindCloseMessage(string error, bool allowReconnect)
         {
             // An empty string is still an error
-            if (error == null && !allowAutomaticReconnect)
+            if (error == null && !allowReconnect)
             {
                 return CloseMessage.Empty;
             }
 
-            return new CloseMessage(error, allowAutomaticReconnect);
+            return new CloseMessage(error, allowReconnect);
         }
 
         private HubMessage ApplyHeaders(HubMessage message, Dictionary<string, string> headers)

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -264,20 +264,20 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         private static CloseMessage CreateCloseMessage(byte[] input, ref int offset, int itemCount)
         {
             var error = ReadString(input, ref offset, "error");
-            var preventAutomaticReconnect = true;
+            var allowAutomaticReconnect = true;
 
             if (itemCount > 2)
             {
-                preventAutomaticReconnect = ReadBoolean(input, ref offset, "preventReconnect");
+                allowAutomaticReconnect = ReadBoolean(input, ref offset, "allowReconnect");
             }
 
             // An empty string is still an error
-            if (error == null && preventAutomaticReconnect)
+            if (error == null && !allowAutomaticReconnect)
             {
                 return CloseMessage.Empty;
             }
 
-            return new CloseMessage(error, preventAutomaticReconnect);
+            return new CloseMessage(error, allowAutomaticReconnect);
         }
 
         private static Dictionary<string, string> ReadHeaders(byte[] input, ref int offset)
@@ -557,7 +557,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 MessagePackBinary.WriteString(packer, message.Error);
             }
 
-            MessagePackBinary.WriteBoolean(packer, message.PreventAutomaticReconnect);
+            MessagePackBinary.WriteBoolean(packer, message.AllowAutomaticReconnect);
         }
 
         private void WritePingMessage(PingMessage pingMessage, Stream packer)

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -264,20 +264,20 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         private static CloseMessage CreateCloseMessage(byte[] input, ref int offset, int itemCount)
         {
             var error = ReadString(input, ref offset, "error");
-            var allowAutomaticReconnect = true;
+            var allowReconnect = false;
 
             if (itemCount > 2)
             {
-                allowAutomaticReconnect = ReadBoolean(input, ref offset, "allowReconnect");
+                allowReconnect = ReadBoolean(input, ref offset, "allowReconnect");
             }
 
             // An empty string is still an error
-            if (error == null && !allowAutomaticReconnect)
+            if (error == null && !allowReconnect)
             {
                 return CloseMessage.Empty;
             }
 
-            return new CloseMessage(error, allowAutomaticReconnect);
+            return new CloseMessage(error, allowReconnect);
         }
 
         private static Dictionary<string, string> ReadHeaders(byte[] input, ref int offset)
@@ -557,7 +557,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 MessagePackBinary.WriteString(packer, message.Error);
             }
 
-            MessagePackBinary.WriteBoolean(packer, message.AllowAutomaticReconnect);
+            MessagePackBinary.WriteBoolean(packer, message.AllowReconnect);
         }
 
         private void WritePingMessage(PingMessage pingMessage, Stream packer)

--- a/src/SignalR/common/Shared/JsonUtils.cs
+++ b/src/SignalR/common/Shared/JsonUtils.cs
@@ -114,6 +114,19 @@ namespace Microsoft.AspNetCore.Internal
             }
         }
 
+        public static bool ReadAsBoolean(JsonTextReader reader, string propertyName)
+        {
+            reader.Read();
+
+            if (reader.TokenType != JsonToken.Boolean || reader.Value == null)
+            {
+                throw new InvalidDataException($"Expected '{propertyName}' to be of type {JTokenType.Boolean}.");
+            }
+
+            // REVIEW: I'm trying to keep this similar to ReadAsInt32, but why not just call reader.ReadAsBoolean() and verify it's not null?
+            return Convert.ToBoolean(reader.Value, CultureInfo.InvariantCulture);
+        }
+
         public static int? ReadAsInt32(JsonTextReader reader, string propertyName)
         {
             reader.Read();

--- a/src/SignalR/common/Shared/JsonUtils.cs
+++ b/src/SignalR/common/Shared/JsonUtils.cs
@@ -123,7 +123,6 @@ namespace Microsoft.AspNetCore.Internal
                 throw new InvalidDataException($"Expected '{propertyName}' to be of type {JTokenType.Boolean}.");
             }
 
-            // REVIEW: I'm trying to keep this similar to ReadAsInt32, but why not just call reader.ReadAsBoolean() and verify it's not null?
             return Convert.ToBoolean(reader.Value, CultureInfo.InvariantCulture);
         }
 

--- a/src/SignalR/common/Shared/SystemTextJsonExtensions.cs
+++ b/src/SignalR/common/Shared/SystemTextJsonExtensions.cs
@@ -57,6 +57,18 @@ namespace Microsoft.AspNetCore.Internal
             }
         }
 
+        public static bool ReadAsBoolean(this ref Utf8JsonReader reader, string propertyName)
+        {
+            reader.Read();
+
+            return reader.TokenType switch
+            {
+                JsonTokenType.False => false,
+                JsonTokenType.True => true,
+                _ => throw new InvalidDataException($"Expected '{propertyName}' to be true or false."),
+            };
+        }
+
         public static string ReadAsString(this ref Utf8JsonReader reader, string propertyName)
         {
             reader.Read();

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netcoreapp.cs
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netcoreapp.cs
@@ -31,6 +31,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public static readonly Microsoft.AspNetCore.SignalR.Protocol.CloseMessage Empty;
         public CloseMessage(string error) { }
+        public CloseMessage(string error, bool allowAutomaticReconnect) { }
+        public bool AllowAutomaticReconnect { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public partial class CompletionMessage : Microsoft.AspNetCore.SignalR.Protocol.HubInvocationMessage

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netcoreapp.cs
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netcoreapp.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public static readonly Microsoft.AspNetCore.SignalR.Protocol.CloseMessage Empty;
         public CloseMessage(string error) { }
-        public CloseMessage(string error, bool allowAutomaticReconnect) { }
-        public bool AllowAutomaticReconnect { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public CloseMessage(string error, bool allowReconnect) { }
+        public bool AllowReconnect { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public partial class CompletionMessage : Microsoft.AspNetCore.SignalR.Protocol.HubInvocationMessage

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netstandard2.0.cs
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netstandard2.0.cs
@@ -31,6 +31,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public static readonly Microsoft.AspNetCore.SignalR.Protocol.CloseMessage Empty;
         public CloseMessage(string error) { }
+        public CloseMessage(string error, bool allowAutomaticReconnect) { }
+        public bool AllowAutomaticReconnect { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public partial class CompletionMessage : Microsoft.AspNetCore.SignalR.Protocol.HubInvocationMessage

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netstandard2.0.cs
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.netstandard2.0.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     {
         public static readonly Microsoft.AspNetCore.SignalR.Protocol.CloseMessage Empty;
         public CloseMessage(string error) { }
-        public CloseMessage(string error, bool allowAutomaticReconnect) { }
-        public bool AllowAutomaticReconnect { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public CloseMessage(string error, bool allowReconnect) { }
+        public bool AllowReconnect { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Error { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public partial class CompletionMessage : Microsoft.AspNetCore.SignalR.Protocol.HubInvocationMessage

--- a/src/SignalR/common/SignalR.Common/src/Protocol/CloseMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/CloseMessage.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     public class CloseMessage : HubMessage
     {
         /// <summary>
-        /// An empty close message with no error.
+        /// An empty close message with no error and <see cref="PreventAutomaticReconnect"/> set to <see langword="true"/>.
         /// </summary>
-        public static readonly CloseMessage Empty = new CloseMessage(null);
+        public static readonly CloseMessage Empty = new CloseMessage(error: null, preventAutomaticReconnect: true);
 
         /// <summary>
         /// Gets the optional error message.
@@ -22,12 +22,32 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         public string Error { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message.
+        /// If <see langword="true"/>, clients with automatic reconnects enabled should not attempt to reconnect after receiving the <see cref="CloseMessage"/>.
+        /// </summary>
+        public bool PreventAutomaticReconnect { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message and <see cref="PreventAutomaticReconnect"/> set to <see langword="true"/>.
         /// </summary>
         /// <param name="error">An optional error message.</param>
         public CloseMessage(string error)
+            : this(error, preventAutomaticReconnect: true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message and a <see cref="bool"/> indicating whether or not a client with
+        /// automatic reconnects enabled should attempt to reconnect upon receiving the message.
+        /// </summary>
+        /// <param name="error">An optional error message.</param>
+        /// <param name="preventAutomaticReconnect">
+        /// <see langword="true"/>, if the client should not try to reconnect whether or not automatic reconnects are enabled.
+        /// <see langword="false"/>, if client with automatic reconnects enabled should attempt to reconnect after receiving the <see cref="CloseMessage"/>;
+        /// </param>
+        public CloseMessage(string error, bool preventAutomaticReconnect)
         {
             Error = error;
+            PreventAutomaticReconnect = preventAutomaticReconnect;
         }
     }
 }

--- a/src/SignalR/common/SignalR.Common/src/Protocol/CloseMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/CloseMessage.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     public class CloseMessage : HubMessage
     {
         /// <summary>
-        /// An empty close message with no error and <see cref="PreventAutomaticReconnect"/> set to <see langword="true"/>.
+        /// An empty close message with no error and <see cref="AllowAutomaticReconnect"/> set to <see langword="false"/>.
         /// </summary>
-        public static readonly CloseMessage Empty = new CloseMessage(error: null, preventAutomaticReconnect: true);
+        public static readonly CloseMessage Empty = new CloseMessage(error: null, allowAutomaticReconnect: false);
 
         /// <summary>
         /// Gets the optional error message.
@@ -22,16 +22,16 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         public string Error { get; }
 
         /// <summary>
-        /// If <see langword="true"/>, clients with automatic reconnects enabled should not attempt to reconnect after receiving the <see cref="CloseMessage"/>.
+        /// If <see langword="false"/>, clients with automatic reconnects enabled should not attempt to automatically reconnect after receiving the <see cref="CloseMessage"/>.
         /// </summary>
-        public bool PreventAutomaticReconnect { get; }
+        public bool AllowAutomaticReconnect { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message and <see cref="PreventAutomaticReconnect"/> set to <see langword="true"/>.
+        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message and <see cref="AllowAutomaticReconnect"/> set to <see langword="false"/>.
         /// </summary>
         /// <param name="error">An optional error message.</param>
         public CloseMessage(string error)
-            : this(error, preventAutomaticReconnect: true)
+            : this(error, allowAutomaticReconnect: false)
         {
         }
 
@@ -40,14 +40,14 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// automatic reconnects enabled should attempt to reconnect upon receiving the message.
         /// </summary>
         /// <param name="error">An optional error message.</param>
-        /// <param name="preventAutomaticReconnect">
-        /// <see langword="true"/>, if the client should not try to reconnect whether or not automatic reconnects are enabled.
-        /// <see langword="false"/>, if client with automatic reconnects enabled should attempt to reconnect after receiving the <see cref="CloseMessage"/>;
+        /// <param name="allowAutomaticReconnect">
+        /// <see langword="true"/>, if client with automatic reconnects enabled should attempt to reconnect after receiving the <see cref="CloseMessage"/>;
+        /// <see langword="false"/>, if the client should not try to reconnect whether or not automatic reconnects are enabled.
         /// </param>
-        public CloseMessage(string error, bool preventAutomaticReconnect)
+        public CloseMessage(string error, bool allowAutomaticReconnect)
         {
             Error = error;
-            PreventAutomaticReconnect = preventAutomaticReconnect;
+            AllowAutomaticReconnect = allowAutomaticReconnect;
         }
     }
 }

--- a/src/SignalR/common/SignalR.Common/src/Protocol/CloseMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/CloseMessage.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
     public class CloseMessage : HubMessage
     {
         /// <summary>
-        /// An empty close message with no error and <see cref="AllowAutomaticReconnect"/> set to <see langword="false"/>.
+        /// An empty close message with no error and <see cref="AllowReconnect"/> set to <see langword="false"/>.
         /// </summary>
-        public static readonly CloseMessage Empty = new CloseMessage(error: null, allowAutomaticReconnect: false);
+        public static readonly CloseMessage Empty = new CloseMessage(error: null, allowReconnect: false);
 
         /// <summary>
         /// Gets the optional error message.
@@ -24,14 +24,14 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// <summary>
         /// If <see langword="false"/>, clients with automatic reconnects enabled should not attempt to automatically reconnect after receiving the <see cref="CloseMessage"/>.
         /// </summary>
-        public bool AllowAutomaticReconnect { get; }
+        public bool AllowReconnect { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message and <see cref="AllowAutomaticReconnect"/> set to <see langword="false"/>.
+        /// Initializes a new instance of the <see cref="CloseMessage"/> class with an optional error message and <see cref="AllowReconnect"/> set to <see langword="false"/>.
         /// </summary>
         /// <param name="error">An optional error message.</param>
         public CloseMessage(string error)
-            : this(error, allowAutomaticReconnect: false)
+            : this(error, allowReconnect: false)
         {
         }
 
@@ -40,14 +40,14 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// automatic reconnects enabled should attempt to reconnect upon receiving the message.
         /// </summary>
         /// <param name="error">An optional error message.</param>
-        /// <param name="allowAutomaticReconnect">
+        /// <param name="allowReconnect">
         /// <see langword="true"/>, if client with automatic reconnects enabled should attempt to reconnect after receiving the <see cref="CloseMessage"/>;
         /// <see langword="false"/>, if the client should not try to reconnect whether or not automatic reconnects are enabled.
         /// </param>
-        public CloseMessage(string error, bool allowAutomaticReconnect)
+        public CloseMessage(string error, bool allowReconnect)
         {
             Error = error;
-            AllowAutomaticReconnect = allowAutomaticReconnect;
+            AllowReconnect = allowReconnect;
         }
     }
 }

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTestsBase.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTestsBase.cs
@@ -67,6 +67,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             new JsonProtocolTestData("CloseMessage_HasError", new CloseMessage("Error!"), false, true, "{\"type\":7,\"error\":\"Error!\"}"),
             new JsonProtocolTestData("CloseMessage_HasErrorEmptyString", new CloseMessage(""), false, true, "{\"type\":7,\"error\":\"\"}"),
             new JsonProtocolTestData("CloseMessage_HasErrorWithCamelCase", new CloseMessage("Error!"), true, true, "{\"type\":7,\"error\":\"Error!\"}"),
+            new JsonProtocolTestData("CloseMessage_HasAllowReconnect", new CloseMessage(error: null, allowReconnect: true), true, true, "{\"type\":7,\"allowReconnect\":true}"),
+            new JsonProtocolTestData("CloseMessage_HasErrorAndAllowReconnect", new CloseMessage("Error!", allowReconnect: true), true, true, "{\"type\":7,\"error\":\"Error!\",\"allowReconnect\":true}"),
 
         }.ToDictionary(t => t.Name);
 

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTestBase.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTestBase.cs
@@ -178,6 +178,24 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 name: "Ping",
                 message: PingMessage.Instance,
                 binary: "kQY="),
+
+            // Close Messages
+            new ProtocolTestData(
+                name: "CloseMessage",
+                message: CloseMessage.Empty,
+                binary: "kwfAwg=="),
+            new ProtocolTestData(
+                name: "CloseMessage_HasError",
+                message: new CloseMessage("Error!"),
+                binary: "kwemRXJyb3Ihwg=="),
+            new ProtocolTestData(
+                name: "CloseMessage_HasAllowReconnect",
+                message: new CloseMessage(error: null, allowReconnect: true),
+                binary: "kwfAww=="),
+            new ProtocolTestData(
+                name: "CloseMessage_HasErrorAndAllowReconnect",
+                message: new CloseMessage("Error!", allowReconnect: true),
+                binary: "kwemRXJyb3Ihww=="),
         }.ToDictionary(t => t.Name);
 
         [Theory]

--- a/src/SignalR/docs/specs/HubProtocol.md
+++ b/src/SignalR/docs/specs/HubProtocol.md
@@ -482,6 +482,7 @@ A `Close` message is a JSON object with the following properties
 
 * `type` - A `Number` with the literal value `7`, indicating that this message is a `Close`.
 * `error` - An optional `String` encoding the error message.
+* `allowReconnect` - An optional `Boolean` indicating to clients with automatic reconnects enabled that they should attempt to reconnect after receiving the message.
 
 Example - A `Close` message without an error
 ```json
@@ -495,6 +496,15 @@ Example - A `Close` message with an error
 {
     "type": 7,
     "error": "Connection closed because of an error!"
+}
+```
+
+Example - A `Close` message with an error that allows automatic client reconnects.
+```json
+{
+    "type": 7,
+    "error": "Connection closed because of an error!",
+    "allowReconnect": true
 }
 ```
 
@@ -809,11 +819,12 @@ is decoded as follows:
 `Close` messages have the following structure
 
 ```
-[7, Error]
+[7, Error, AllowReconnect?]
 ```
 
 * `7` - Message Type - `7` indicates this is a `Close` message.
 * `Error` - Error - A `String` encoding the error for the message.
+* `AllowReconnect` - An optional `Boolean` indicating to clients with automatic reconnects enabled that they should attempt to reconnect after receiving the message.
 
 Examples:
 
@@ -832,6 +843,23 @@ is decoded as follows:
 * `0x78` - `x`
 * `0x79` - `y`
 * `0x7a` - `z`
+
+#### Close message that allows automatic client reconnects
+
+The following payload:
+```
+0x93 0x07 0xa3 0x78 0x79 0x7a 0xc3
+```
+
+is decoded as follows:
+
+* `0x93` - 3-element array
+* `0x07` - `7` (Message Type - `Close` message)
+* `0xa3` - string of length 3 (Error)
+* `0x78` - `x`
+* `0x79` - `y`
+* `0x7a` - `z`
+* `0xc3` - `True` (AllowReconnect)
 
 ### MessagePack Headers Encoding
 

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.SignalR
         private ReadOnlyMemory<byte> _cachedPingMessage;
         private bool _clientTimeoutActive;
         private bool _connectionAborted;
-        private volatile bool _preventAutomaticReconnect;
+        private volatile bool _allowAutomaticReconnect = true;
         private int _streamBufferCapacity;
         private long? _maxMessageSize;
 
@@ -107,8 +107,8 @@ namespace Microsoft.AspNetCore.SignalR
         /// </summary>
         public virtual IDictionary<object, object> Items => _connectionContext.Items;
 
-        // Used by HubConnectionHandler to determine whether to set CloseMessage.PreventAutomaticReconnect.
-        internal bool PreventAutomaticReconnect => _preventAutomaticReconnect;
+        // Used by HubConnectionHandler to determine whether to set CloseMessage.AllowAutomaticReconnect.
+        internal bool AllowAutomaticReconnect => _allowAutomaticReconnect;
 
         // Used by HubConnectionHandler
         internal PipeReader Input => _connectionContext.Transport.Input;
@@ -364,7 +364,7 @@ namespace Microsoft.AspNetCore.SignalR
         public virtual void Abort()
         {
             // REVIEW: Should we provide a new API that *doesn't* prevent automatic reconnects?
-            _preventAutomaticReconnect = true;
+            _allowAutomaticReconnect = false;
             AbortAllowAutoReconnect();
         }
 

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.SignalR
                 Log.ErrorDispatchingHubEvent(_logger, "OnConnectedAsync", ex);
 
                 // The client shouldn't try to reconnect given an error in OnConnected.
-                await SendCloseAsync(connection, ex, preventAutomaticReconnect: true);
+                await SendCloseAsync(connection, ex, allowAutomaticReconnect: false);
 
                 // return instead of throw to let close message send successfully
                 return;
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.SignalR
         private async Task HubOnDisconnectedAsync(HubConnectionContext connection, Exception exception)
         {
             // send close message before aborting the connection
-            await SendCloseAsync(connection, exception, connection.PreventAutomaticReconnect);
+            await SendCloseAsync(connection, exception, connection.AllowAutomaticReconnect);
 
             // We wait on abort to complete, this is so that we can guarantee that all callbacks have fired
             // before OnDisconnectedAsync
@@ -177,18 +177,18 @@ namespace Microsoft.AspNetCore.SignalR
             }
         }
 
-        private async Task SendCloseAsync(HubConnectionContext connection, Exception exception, bool preventAutomaticReconnect)
+        private async Task SendCloseAsync(HubConnectionContext connection, Exception exception, bool allowAutomaticReconnect)
         {
             var closeMessage = CloseMessage.Empty;
 
             if (exception != null)
             {
                 var errorMessage = ErrorMessageHelper.BuildErrorMessage("Connection closed with an error.", exception, _enableDetailedErrors);
-                closeMessage = new CloseMessage(errorMessage, preventAutomaticReconnect);
+                closeMessage = new CloseMessage(errorMessage, allowAutomaticReconnect);
             }
-            else if (!preventAutomaticReconnect)
+            else if (allowAutomaticReconnect)
             {
-                closeMessage = new CloseMessage(null, preventAutomaticReconnect: false);
+                closeMessage = new CloseMessage(null, allowAutomaticReconnect);
             }
 
             try

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.SignalR
                 Log.ErrorDispatchingHubEvent(_logger, "OnConnectedAsync", ex);
 
                 // The client shouldn't try to reconnect given an error in OnConnected.
-                await SendCloseAsync(connection, ex, allowAutomaticReconnect: false);
+                await SendCloseAsync(connection, ex, allowReconnect: false);
 
                 // return instead of throw to let close message send successfully
                 return;
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.SignalR
         private async Task HubOnDisconnectedAsync(HubConnectionContext connection, Exception exception)
         {
             // send close message before aborting the connection
-            await SendCloseAsync(connection, exception, connection.AllowAutomaticReconnect);
+            await SendCloseAsync(connection, exception, connection.AllowReconnect);
 
             // We wait on abort to complete, this is so that we can guarantee that all callbacks have fired
             // before OnDisconnectedAsync
@@ -177,18 +177,18 @@ namespace Microsoft.AspNetCore.SignalR
             }
         }
 
-        private async Task SendCloseAsync(HubConnectionContext connection, Exception exception, bool allowAutomaticReconnect)
+        private async Task SendCloseAsync(HubConnectionContext connection, Exception exception, bool allowReconnect)
         {
             var closeMessage = CloseMessage.Empty;
 
             if (exception != null)
             {
                 var errorMessage = ErrorMessageHelper.BuildErrorMessage("Connection closed with an error.", exception, _enableDetailedErrors);
-                closeMessage = new CloseMessage(errorMessage, allowAutomaticReconnect);
+                closeMessage = new CloseMessage(errorMessage, allowReconnect);
             }
-            else if (allowAutomaticReconnect)
+            else if (allowReconnect)
             {
-                closeMessage = new CloseMessage(error: null, allowAutomaticReconnect);
+                closeMessage = new CloseMessage(error: null, allowReconnect);
             }
 
             try

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             else if (allowAutomaticReconnect)
             {
-                closeMessage = new CloseMessage(null, allowAutomaticReconnect);
+                closeMessage = new CloseMessage(error: null, allowAutomaticReconnect);
             }
 
             try


### PR DESCRIPTION
Add "allowReconnect" to SignalR CloseMessages so the Azure SignalR Service can disconnect clients with a reason while still allowing the automatic reconnect features of the C# and TS/JS client to automatically reconnect.

For backwards compatibility, received CloseMessages with "allowReconnect" completely missing is interpreted the same as if it were false.

Compat Testing:
* [x] Tested 3.0 JS Client receiving close message with this new flag from 3.1 Server with JSON protocol
* [x] Tested 3.0 JS Client receiving close message with this new flag from 3.1 Server with MessagePack protocol
* [x] Tested 3.0 .NET Client receiving close message with this new flag from 3.1 Server with JSON protocol
* [x] Tested 3.0 .NET Client receiving close message with this new flag from 3.1 Server with MessagePack protocol
* [x] Tested 3.1 JS Client receiving close message *without* this new flag from 3.0 Server with MessagePack protocol
* [x] Tested 3.1 .NET Client receiving close message *without* this new flag from 3.0 Server with MessagePack protocol