### PR TITLE
Display login UI on mobile too. Fixes #13003

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/wwwroot/css/site.css
+++ b/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-@import url('open-iconic/font/css/open-iconic-bootstrap.min.css');
+﻿@import url('open-iconic/font/css/open-iconic-bootstrap.min.css');
 
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -36,9 +36,15 @@ app {
         justify-content: flex-end;
     }
 
-        .main .top-row > a {
+        .main .top-row > a, .main .top-row .btn-link {
+            white-space: nowrap;
             margin-left: 1.5rem;
         }
+
+.main .top-row a:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
@@ -131,8 +137,16 @@ app {
 }
 
 @media (max-width: 767.98px) {
-    .main .top-row {
+    .main .top-row:not(.auth) {
         display: none;
+    }
+
+    .main .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .main .top-row a, .main .top-row .btn-link {
+        margin-left: 0;
     }
 }
 

--- a/src/Components/Blazor/testassets/StandaloneApp/wwwroot/css/site.css
+++ b/src/Components/Blazor/testassets/StandaloneApp/wwwroot/css/site.css
@@ -36,9 +36,15 @@ app {
         justify-content: flex-end;
     }
 
-        .main .top-row > a {
+        .main .top-row > a, .main .top-row .btn-link {
+            white-space: nowrap;
             margin-left: 1.5rem;
         }
+
+.main .top-row a:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
@@ -111,9 +117,36 @@ app {
     color: red;
 }
 
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+#blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+}
+
 @media (max-width: 767.98px) {
-    .main .top-row {
+    .main .top-row:not(.auth) {
         display: none;
+    }
+
+    .main .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .main .top-row a, .main .top-row .btn-link {
+        margin-left: 0;
     }
 }
 

--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/site.css
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/site.css
@@ -36,9 +36,15 @@ app {
         justify-content: flex-end;
     }
 
-        .main .top-row > a {
+        .main .top-row > a, .main .top-row .btn-link {
+            white-space: nowrap;
             margin-left: 1.5rem;
         }
+
+.main .top-row a:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
@@ -131,8 +137,16 @@ app {
 }
 
 @media (max-width: 767.98px) {
-    .main .top-row {
+    .main .top-row:not(.auth) {
         display: none;
+    }
+
+    .main .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .main .top-row a, .main .top-row .btn-link {
+        margin-left: 0;
     }
 }
 

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/site.css
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/site.css
@@ -36,9 +36,15 @@ app {
         justify-content: flex-end;
     }
 
-        .main .top-row > a {
+        .main .top-row > a, .main .top-row .btn-link {
+            white-space: nowrap;
             margin-left: 1.5rem;
         }
+
+.main .top-row a:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
@@ -111,9 +117,36 @@ app {
     color: red;
 }
 
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+#blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+}
+
 @media (max-width: 767.98px) {
-    .main .top-row {
+    .main .top-row:not(.auth) {
         display: none;
+    }
+
+    .main .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .main .top-row a, .main .top-row .btn-link {
+        margin-left: 0;
     }
 }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
@@ -5,7 +5,7 @@
 </div>
 
 <div class="main">
-    <div class="top-row px-4">
+    <div class="top-row px-4 auth">
         <LoginDisplay />
         <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
     </div>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -36,9 +36,15 @@ app {
         justify-content: flex-end;
     }
 
-        .main .top-row > a {
+        .main .top-row > a, .main .top-row .btn-link {
+            white-space: nowrap;
             margin-left: 1.5rem;
         }
+
+.main .top-row a:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
@@ -131,8 +137,16 @@ app {
 }
 
 @media (max-width: 767.98px) {
-    .main .top-row {
+    .main .top-row:not(.auth) {
         display: none;
+    }
+
+    .main .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .main .top-row a, .main .top-row .btn-link {
+        margin-left: 0;
     }
 }
 


### PR DESCRIPTION
I will apply these CSS changes to the other Blazor site css files as well, but don't want to do so until after merging #14463, because otherwise there would be a lot of conflicts and confusion about what I'm actually changing.

The changes in this PR make it look like the following on small screens:

![image](https://user-images.githubusercontent.com/1101362/66696004-9fa40980-ed13-11e9-84dd-715b017fdf0c.png)

Notice how now it also deals with email addresses too long to display, which it didn't before.