### PR TITLE
[Fixes #14959] Update navlink to perform case-insensitive matches

### DIFF
--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             var prefixLength = prefix.Length;
             if (value.Length > prefixLength)
             {
-                return value.StartsWith(prefix, StringComparison.Ordinal)
+                return value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
                     && (
                         // Only match when there's a separator character either at the end of the
                         // prefix or right after it.

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
@@ -14,7 +14,7 @@
     <li><NavLink href="/subdir/Default.html">With extension</NavLink></li>
     <li><NavLink href="/subdir/Other">Other</NavLink></li>
     <li><NavLink href="Other" Match=NavLinkMatch.All>Other with base-relative URL (matches all)</NavLink></li>
-    <li><NavLink href="/subdir/Other?abc=123">Other with query</NavLink></li>
+    <li><NavLink href="/subdir/other?abc=123">Other with query</NavLink></li>
     <li><NavLink href="/subdir/Other#blah">Other with hash</NavLink></li>
     <li><NavLink href="/subdir/WithParameters/Name/Abc">With parameters</NavLink></li>
     <li><NavLink href="/subdir/WithParameters/Name/Abc/LastName/McDef">With more parameters</NavLink></li>


### PR DESCRIPTION
Otherwise the link doesn't get highlighted even though the route matches (routing is case insensitive).
