### PR TITLE
Make ApiDescriptionActionData public

### DIFF
--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
@@ -137,6 +137,11 @@ namespace Microsoft.AspNetCore.Mvc
         public ApiConventionTypeAttribute(System.Type conventionType) { }
         public System.Type ConventionType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
+    public partial class ApiDescriptionActionData
+    {
+        public ApiDescriptionActionData() { }
+        public string GroupName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
     public partial class ApiExplorerSettingsAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionGroupNameProvider, Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionVisibilityProvider
     {

--- a/src/Mvc/Mvc.Core/src/ApiExplorer/ApiDescriptionActionData.cs
+++ b/src/Mvc/Mvc.Core/src/ApiExplorer/ApiDescriptionActionData.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Mvc
     /// Represents data used to build an <c>ApiDescription</c>, stored as part of the
     /// <see cref="Abstractions.ActionDescriptor.Properties"/>.
     /// </summary>
-    internal class ApiDescriptionActionData
+    public class ApiDescriptionActionData
     {
         /// <summary>
         /// The <c>ApiDescription.GroupName</c> of <c>ApiDescription</c> objects for the associated


### PR DESCRIPTION
(I have no idea if i took the proper branch, i started on `3.0`, and i wonder if i should have took `3.1.0-preview1`

Summary of the changes
 - Make `ApiDescriptionActionData` public back

Addresses #14954 (suggested by @pranavkm / @mkArtakMSFT )  
see https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1316#discussion_r334642335

I have no idea if the scaffolding should change of if there's anything else to add on top of this