### PR TITLE
Treat FormatExceptions and OverflowExceptions to be treated as model state errors

### DIFF
--- a/src/Mvc/Mvc.Core/test/Formatters/JsonInputFormatterTestBase.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/JsonInputFormatterTestBase.cs
@@ -334,7 +334,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Assert
             Assert.True(result.HasError, "Model should have produced an error!");
             Assert.Collection(formatterContext.ModelState.OrderBy(k => k.Key),
-                kvp => {
+                kvp =>
+                {
                     Assert.Equal(expectedValue, kvp.Key);
                 });
         }

--- a/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonInputFormatterTest.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -81,6 +83,48 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 });
         }
 
+        [Fact]
+        public async Task ReadAsync_DoesNotThrowFormatException()
+        {
+            // Arrange
+            var formatter = GetInputFormatter();
+
+            var contentBytes = Encoding.UTF8.GetBytes("{\"dateValue\":\"not-a-date\"}");
+            var httpContext = GetHttpContext(contentBytes);
+
+            var formatterContext = CreateInputFormatterContext(typeof(TypeWithBadConverters), httpContext);
+
+            // Act
+            await formatter.ReadAsync(formatterContext);
+
+            Assert.False(formatterContext.ModelState.IsValid);
+            var kvp = Assert.Single(formatterContext.ModelState);
+            Assert.Empty(kvp.Key);
+            var error = Assert.Single(kvp.Value.Errors);
+            Assert.Equal("The supplied value is invalid.", error.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task ReadAsync_DoesNotThrowOverflowException()
+        {
+            // Arrange
+            var formatter = GetInputFormatter();
+
+            var contentBytes = Encoding.UTF8.GetBytes("{\"shortValue\":\"32768\"}");
+            var httpContext = GetHttpContext(contentBytes);
+
+            var formatterContext = CreateInputFormatterContext(typeof(TypeWithBadConverters), httpContext);
+
+            // Act
+            await formatter.ReadAsync(formatterContext);
+
+            Assert.False(formatterContext.ModelState.IsValid);
+            var kvp = Assert.Single(formatterContext.ModelState);
+            Assert.Empty(kvp.Key);
+            var error = Assert.Single(kvp.Value.Errors);
+            Assert.Equal("The supplied value is invalid.", error.ErrorMessage);
+        }
+
         protected override TextInputFormatter GetInputFormatter()
         {
             return new SystemTextJsonInputFormatter(new JsonOptions(), LoggerFactory.CreateLogger<SystemTextJsonInputFormatter>());
@@ -99,5 +143,40 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         internal override string ReadAsync_InvalidComplexArray_AddsOverflowErrorsToModelState_Expected => "$[1].Small";
 
         internal override string ReadAsync_ComplexPoco_Expected => "$.Person.Numbers[2]";
+
+        private class TypeWithBadConverters
+        {
+            [JsonConverter(typeof(DateTimeConverter))]
+            public DateTime DateValue { get; set; }
+
+            [JsonConverter(typeof(ShortConverter))]
+            public short ShortValue { get; set; }
+        }
+
+        private class ShortConverter : JsonConverter<short>
+        {
+            public override short Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                return short.Parse(reader.GetString());
+            }
+
+            public override void Write(Utf8JsonWriter writer, short value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class DateTimeConverter : JsonConverter<DateTime>
+        {
+            public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                return DateTime.Parse(reader.GetString());
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -196,8 +196,15 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 }
             }
 
-            if (!(exception is JsonException || exception is OverflowException))
+            if (!(exception is JsonException || exception is OverflowException || exception is FormatException))
             {
+                // At this point we've already recorded all exceptions as an entry in the ModelStateDictionary.
+                // We only need to rethrow an exception if we believe it needs to be handled by something further up
+                // the stack.
+                // JsonException, OverflowException, and FormatException are assumed to be only encountered when
+                // parsing the JSON and are consequently "safe" to be exposed as part of ModelState. Everything else
+                // needs to be rethrown.
+
                 var exceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
                 exceptionDispatchInfo.Throw();
             }


### PR DESCRIPTION
In SystemTextJsonInputFormatter and NewtonsoftJsonInputFormatter, suppress
FormatExceptions and OverflowExceptions and instead report them as model state errors.

This makes the behavior more consistent between these formatters, model binders, and
the XML formatters

Fixes https://github.com/aspnet/AspNetCore/issues/14504
