### PR TITLE
[Blazor] Fix sample and turn debug logs and detailed errors client and server-side on the sample

### DIFF
--- a/src/Components/Samples/BlazorServerApp/Pages/_Host.cshtml
+++ b/src/Components/Samples/BlazorServerApp/Pages/_Host.cshtml
@@ -13,8 +13,16 @@
     <link href="css/site.css" rel="stylesheet" />
 </head>
 <body>
-    <component type="typeof(App)" render-mode="ServerPrerendered" />
+    <app><component type="typeof(App)" render-mode="ServerPrerendered" /></app>
 
-    <script src="_framework/blazor.server.js"></script>
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+        (function start() {
+            Blazor.start({
+                logLevel: 1, // LogLevel.Debug
+                configureSignalR: builder => builder.configureLogging("debug") // LogLevel.Debug
+            });
+        })()
+    </script>
 </body>
 </html>

--- a/src/Components/Samples/BlazorServerApp/Shared/NavMenu.razor
+++ b/src/Components/Samples/BlazorServerApp/Shared/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿<div class="top-row pl-4 navbar navbar-dark">
+<div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">BlazorServerApp</a>
     <button class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>

--- a/src/Components/Samples/BlazorServerApp/appsettings.Development.json
+++ b/src/Components/Samples/BlazorServerApp/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "detailedErrors": true,
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/site.css
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/site.css
@@ -9,9 +9,9 @@ a, .btn-link {
 }
 
 .btn-primary {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
+    color: #fff;
+    background-color: #1b6ec2;
+    border-color: #1861ac;
 }
 
 app {
@@ -113,19 +113,21 @@ app {
 
 #blazor-error-ui {
     background: lightyellow;
-    position: fixed;
-    border: "1px solid";
-    border-color: black;
-    width: 100%;
     bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
     left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
     z-index: 1000;
 }
 
 #blazor-error-ui .dismiss {
+    cursor: pointer;
     position: absolute;
-    right: 5px;
-    top: 5px;
+    right: 0.75rem;
+    top: 0.5rem;
 }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
* Updates the CSS in the blazor sample and fixes the missing `<app>` tag wrapping the rendered component.
* Turns on detailed errors on the sample.