### PR TITLE
[Templating][Fixes #15048] Fixes build hang in template tests caused by an unbound blocking collection

### DIFF
--- a/src/ProjectTemplates/test/Helpers/ProcessEx.cs
+++ b/src/ProjectTemplates/test/Helpers/ProcessEx.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 using Xunit.Abstractions;
@@ -26,6 +27,7 @@ namespace Templates.Test.Helpers
         private readonly object _pipeCaptureLock = new object();
         private BlockingCollection<string> _stdoutLines;
         private TaskCompletionSource<int> _exited;
+        private CancellationTokenSource _stdoutLinesCancellationSource = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         public ProcessEx(ITestOutputHelper output, Process proc)
         {
@@ -71,7 +73,7 @@ namespace Templates.Test.Helpers
             }
         }
 
-        public IEnumerable<string> OutputLinesAsEnumerable => _stdoutLines.GetConsumingEnumerable();
+        public IEnumerable<string> OutputLinesAsEnumerable => _stdoutLines.GetConsumingEnumerable(_stdoutLinesCancellationSource.Token);
 
         public int ExitCode => _process.ExitCode;
 


### PR DESCRIPTION
There is an underlying issue here, which is a race condition between console logging and hosting logging.

In some rare cases the messages on the console for both get interleaved in wrong ways like `dbugNow listening on: http://127.0.0.1:12857` which causes the test to fail finding the `Listening on: ` pattern.

* It prevents waiting indefinitely on the blocked collection, which is what caused the hangs.
* It relaxes the pattern we use to find the message so that it can match simpler values and accounts for the message being preceded by other text in the output as in the example above.

Filed https://github.com/aspnet/AspNetCore/issues/15060 to triage the underlying hosting issue.