### PR TITLE
GenerateReferenceAssemblies requires restore.cmd

### DIFF
--- a/docs/ReferenceAssemblies.md
+++ b/docs/ReferenceAssemblies.md
@@ -22,4 +22,4 @@ Set `<HasReferenceAssembly>false</HasReferenceAssembly>` in the implementation (
 
 ### Regenerate reference assemblies for all projects
 
-Run `.\eng\scripts\GenerateReferenceAssemblies.ps1` from repository root.
+Run `.\eng\scripts\GenerateReferenceAssemblies.ps1` from repository root. Make sure you've run `.\restore.cmd` first.


### PR DESCRIPTION
Running GenerateReferenceAssemblies without first running restore.cmd fails.
https://github.com/aspnet/AspNetCore/pull/14909#issuecomment-542766814