### PR TITLE
[TS Client] Catch exception in onreceive and close connection 

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts
+++ b/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts
@@ -96,7 +96,12 @@ export class WebSocketTransport implements ITransport {
             webSocket.onmessage = (message: MessageEvent) => {
                 this.logger.log(LogLevel.Trace, `(WebSockets transport) data received. ${getDataDetail(message.data, this.logMessageContent)}.`);
                 if (this.onreceive) {
-                    this.onreceive(message.data);
+                    try {
+                        this.onreceive(message.data);
+                    } catch (error) {
+                        this.close(error);
+                        return;
+                    }
                 }
             };
 
@@ -131,15 +136,23 @@ export class WebSocketTransport implements ITransport {
         return Promise.resolve();
     }
 
-    private close(event?: CloseEvent): void {
+    private close(event?: CloseEvent | Error): void {
         // webSocket will be null if the transport did not start successfully
         this.logger.log(LogLevel.Trace, "(WebSockets transport) socket closed.");
         if (this.onclose) {
-            if (event && (event.wasClean === false || event.code !== 1000)) {
+            if (this.isCloseEvent(event) && (event.wasClean === false || event.code !== 1000)) {
                 this.onclose(new Error(`WebSocket closed with status code: ${event.code} (${event.reason}).`));
             } else {
-                this.onclose();
+                if (event instanceof Error) {
+                    this.onclose(event);
+                } else {
+                    this.onclose();
+                }
             }
         }
+    }
+
+    private isCloseEvent(event?: any): event is CloseEvent {
+        return event && typeof event.wasClean === "boolean" && typeof event.code === "number";
     }
 }

--- a/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts
+++ b/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts
@@ -142,12 +142,10 @@ export class WebSocketTransport implements ITransport {
         if (this.onclose) {
             if (this.isCloseEvent(event) && (event.wasClean === false || event.code !== 1000)) {
                 this.onclose(new Error(`WebSocket closed with status code: ${event.code} (${event.reason}).`));
+            } else if (event instanceof Error) {
+                this.onclose(event);
             } else {
-                if (event instanceof Error) {
-                    this.onclose(event);
-                } else {
-                    this.onclose();
-                }
+                this.onclose();
             }
         }
     }


### PR DESCRIPTION
Fixes #13276

Before, if the `onreceive` callback threw you could get an unhandled promise exception.