### PR TITLE
Prevent modifying ContentLength after starting response

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -27,6 +27,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get { return _contentLength; }
             set
             {
+                if (_isReadOnly)
+                {
+                    ThrowHeadersReadOnlyException();
+                }
                 if (value.HasValue && value.Value < 0)
                 {
                     ThrowInvalidContentLengthException(value.Value);

--- a/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
@@ -139,6 +139,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public void ThrowsWhenSettingContentLengthPropertyAfterReadOnlyIsSet()
+        {
+            var headers = new HttpResponseHeaders();
+            headers.SetReadOnly();
+
+            Assert.Throws<InvalidOperationException>(() => headers.ContentLength = null);
+        }
+
+        [Fact]
         public void ThrowsWhenChangingHeaderAfterReadOnlyIsSet()
         {
             var headers = new HttpResponseHeaders();


### PR DESCRIPTION
 #14056 Setting headers should throw if the response has already started. However the IHeaderDictionary.ContentLength property is special and Kestrel forgot to check that one.

I confirmed HttpSys and IIS both throw as expected when modifying ContentLength after the response started.
