### PR TITLE
Remove Microsoft.AspNetCore.SuppressSameSiteNone compat switch

### DIFF
--- a/src/Http/Headers/test/SetCookieHeaderValueTest.cs
+++ b/src/Http/Headers/test/SetCookieHeaderValueTest.cs
@@ -313,28 +313,6 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedValue, input.ToString());
         }
 
-        [Fact]
-        public void SetCookieHeaderValue_ToString_SameSiteNoneCompat()
-        {
-            SetCookieHeaderValue.SuppressSameSiteNone = true;
-
-            var input = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.None,
-            };
-
-            Assert.Equal("name=value", input.ToString());
-
-            SetCookieHeaderValue.SuppressSameSiteNone = false;
-
-            var input2 = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.None,
-            };
-
-            Assert.Equal("name=value; samesite=none", input2.ToString());
-        }
-
         [Theory]
         [MemberData(nameof(SetCookieHeaderDataSet))]
         public void SetCookieHeaderValue_AppendToStringBuilder(SetCookieHeaderValue input, string expectedValue)
@@ -344,32 +322,6 @@ namespace Microsoft.Net.Http.Headers
             input.AppendToStringBuilder(builder);
 
             Assert.Equal(expectedValue, builder.ToString());
-        }
-
-        [Fact]
-        public void SetCookieHeaderValue_AppendToStringBuilder_SameSiteNoneCompat()
-        {
-            SetCookieHeaderValue.SuppressSameSiteNone = true;
-
-            var builder = new StringBuilder();
-            var input = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.None,
-            };
-
-            input.AppendToStringBuilder(builder);
-            Assert.Equal("name=value", builder.ToString());
-
-            SetCookieHeaderValue.SuppressSameSiteNone = false;
-
-            var builder2 = new StringBuilder();
-            var input2 = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.None,
-            };
-
-            input2.AppendToStringBuilder(builder2);
-            Assert.Equal("name=value; samesite=none", builder2.ToString());
         }
 
         [Theory]
@@ -382,31 +334,6 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedValue, header.ToString());
         }
 
-        [Fact]
-        public void SetCookieHeaderValue_Parse_AcceptsValidValues_SameSiteNoneCompat()
-        {
-            SetCookieHeaderValue.SuppressSameSiteNone = true;
-            var header = SetCookieHeaderValue.Parse("name=value; samesite=none");
-
-            var cookie = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.Strict,
-            };
-
-            Assert.Equal(cookie, header);
-            Assert.Equal("name=value; samesite=strict", header.ToString());
-            SetCookieHeaderValue.SuppressSameSiteNone = false;
-
-            var header2 = SetCookieHeaderValue.Parse("name=value; samesite=none");
-
-            var cookie2 = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.None,
-            };
-            Assert.Equal(cookie2, header2);
-            Assert.Equal("name=value; samesite=none", header2.ToString());
-        }
-
         [Theory]
         [MemberData(nameof(SetCookieHeaderDataSet))]
         public void SetCookieHeaderValue_TryParse_AcceptsValidValues(SetCookieHeaderValue cookie, string expectedValue)
@@ -415,31 +342,6 @@ namespace Microsoft.Net.Http.Headers
 
             Assert.Equal(cookie, header);
             Assert.Equal(expectedValue, header.ToString());
-        }
-
-        [Fact]
-        public void SetCookieHeaderValue_TryParse_AcceptsValidValues_SameSiteNoneCompat()
-        {
-            SetCookieHeaderValue.SuppressSameSiteNone = true;
-            Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header));
-            var cookie = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.Strict,
-            };
-
-            Assert.Equal(cookie, header);
-            Assert.Equal("name=value; samesite=strict", header.ToString());
-
-            SetCookieHeaderValue.SuppressSameSiteNone = false;
-
-            Assert.True(SetCookieHeaderValue.TryParse("name=value; samesite=none", out var header2));
-            var cookie2 = new SetCookieHeaderValue("name", "value")
-            {
-                SameSite = SameSiteMode.None,
-            };
-
-            Assert.Equal(cookie2, header2);
-            Assert.Equal("name=value; samesite=none", header2.ToString());
         }
 
         [Theory]

--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -11,19 +11,7 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public class CookieBuilder
     {
-        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
-        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
-        internal static bool SuppressSameSiteNone;
-
         private string _name;
-
-        static CookieBuilder()
-        {
-            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
-            {
-                SuppressSameSiteNone = enabled;
-            }
-        }
 
         /// <summary>
         /// The name of the cookie.
@@ -66,7 +54,7 @@ namespace Microsoft.AspNetCore.Http
         /// <remarks>
         /// Determines the value that will set on <seealso cref="CookieOptions.SameSite"/>.
         /// </remarks>
-        public virtual SameSiteMode SameSite { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : SameSiteMode.Unspecified;
+        public virtual SameSiteMode SameSite { get; set; } = SameSiteMode.Unspecified;
 
         /// <summary>
         /// The policy that will be used to determine <seealso cref="CookieOptions.Secure"/>.

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -10,18 +10,6 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public class CookieOptions
     {
-        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
-        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
-        internal static bool SuppressSameSiteNone;
-
-        static CookieOptions()
-        {
-            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
-            {
-                SuppressSameSiteNone = enabled;
-            }
-        }
-
         /// <summary>
         /// Creates a default cookie with a path of '/'.
         /// </summary>
@@ -58,7 +46,7 @@ namespace Microsoft.AspNetCore.Http
         /// Gets or sets the value for the SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.Unspecified"/>
         /// </summary>
         /// <returns>The <see cref="SameSiteMode"/> representing the enforcement mode of the cookie.</returns>
-        public SameSiteMode SameSite { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : SameSiteMode.Unspecified;
+        public SameSiteMode SameSite { get; set; } = SameSiteMode.Unspecified;
 
         /// <summary>
         /// Gets or sets a value that indicates whether a cookie is accessible by client-side script.

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -12,22 +12,10 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class CookiePolicyOptions
     {
-        // True (old): https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-3.1
-        // False (new): https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
-        internal static bool SuppressSameSiteNone;
-
-        static CookiePolicyOptions()
-        {
-            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.SuppressSameSiteNone", out var enabled))
-            {
-                SuppressSameSiteNone = enabled;
-            }
-        }
-
         /// <summary>
         /// Affects the cookie's same site attribute.
         /// </summary>
-        public SameSiteMode MinimumSameSitePolicy { get; set; } = SuppressSameSiteNone ? SameSiteMode.None : SameSiteMode.Unspecified;
+        public SameSiteMode MinimumSameSitePolicy { get; set; } = SameSiteMode.Unspecified;
 
         /// <summary>
         /// Affects whether cookies must be HttpOnly.

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -115,8 +115,7 @@ namespace Microsoft.AspNetCore.CookiePolicy
         private bool CheckPolicyRequired()
         {
             return !CanTrack
-                || (CookiePolicyOptions.SuppressSameSiteNone && Options.MinimumSameSitePolicy != SameSiteMode.None)
-                || (!CookiePolicyOptions.SuppressSameSiteNone && Options.MinimumSameSitePolicy != SameSiteMode.Unspecified)
+                || Options.MinimumSameSitePolicy != SameSiteMode.Unspecified
                 || Options.HttpOnly != HttpOnlyPolicy.None
                 || Options.Secure != CookieSecurePolicy.None;
         }


### PR DESCRIPTION
 #14739 These were for the patches and are no longer needed in 5.x