### PR TITLE
Re-enable Linux installer builds

### DIFF
--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -23,7 +23,8 @@
   <Target Name="Build" DependsOnTargets="DebBuild" />
   <Target Name="Pack" />
 
-  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)" Condition="'$(IsTargetingPackBuilding)' != 'false'">
+  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)"
+      Condition="!( '$(IsTargetingPackBuilding)' == 'false' AND '$(MSBuildProjectName)' == 'Debian.TargetingPack' )">
     <!-- Generate debian_config.json. We can't simply use WriteLinesToFile because of https://github.com/Microsoft/msbuild/issues/1622. Use our custom GenerateFileFromTemplate task instead -->
     <PropertyGroup>
       <DebianConfigProperties>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -32,7 +32,8 @@
   <Target Name="Build" DependsOnTargets="RpmBuild" />
   <Target Name="Pack" />
 
-  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)" Condition="'$(IsTargetingPackBuilding)' != 'false'">
+  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)"
+      Condition="!( '$(IsTargetingPackBuilding)' == 'false' AND '$(MSBuildProjectName)' == 'Rpm.TargetingPack' )">
     <!-- Create layout: Create changelog -->
     <PropertyGroup>
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -82,7 +82,8 @@
     <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 
-   <Target Name="CreateTargetingPackNugetPackage" AfterTargets="CopyToArtifactsDirectory;Build">
+   <Target Name="CreateTargetingPackNugetPackage" AfterTargets="CopyToArtifactsDirectory;Build"
+      Condition="'$(IsTargetingPackBuilding)' != 'false'">
     <PropertyGroup>
       <MsiFullPath>$(InstallersOutputPath)$(PackageFileName)</MsiFullPath>
 


### PR DESCRIPTION
- `'$(IsTargetingPackBuilding)' == 'false'` should only disable the targeting packs

/see https://github.com/dotnet/core-sdk/pull/5250#issuecomment-543190824