### PR TITLE
Run users options last

### DIFF
--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -37,8 +37,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _dispatcher = new DefaultHubDispatcher<TestHub>(
                 serviceScopeFactory,
                 new HubContext<TestHub>(new DefaultHubLifetimeManager<TestHub>(NullLogger<DefaultHubLifetimeManager<TestHub>>.Instance)),
-                Options.Create(new HubOptions<TestHub>()),
-                Options.Create(new HubOptions()),
+                enableDetailedErrors: false,
                 new Logger<DefaultHubDispatcher<TestHub>>(NullLoggerFactory.Instance));
 
             var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -60,7 +60,14 @@ namespace Microsoft.AspNetCore.SignalR
             _userIdProvider = userIdProvider;
 
             _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _globalHubOptions.EnableDetailedErrors ?? false;
-            _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize ?? _globalHubOptions.MaximumReceiveMessageSize;
+            if (_hubOptions._maximumReceiveMessageSizeSet)
+            {
+                _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize;
+            }
+            else
+            {
+                _maximumMessageSize = _globalHubOptions.MaximumReceiveMessageSize;
+            }
 
             _dispatcher = new DefaultHubDispatcher<THub>(
                 serviceScopeFactory,

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -59,21 +59,22 @@ namespace Microsoft.AspNetCore.SignalR
             _logger = loggerFactory.CreateLogger<HubConnectionHandler<THub>>();
             _userIdProvider = userIdProvider;
 
-            _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _globalHubOptions.EnableDetailedErrors ?? false;
-            if (_hubOptions._maximumReceiveMessageSizeSet)
+            _enableDetailedErrors = false;
+            if (_hubOptions.UserHasSetValues)
             {
                 _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize;
+                _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             }
             else
             {
                 _maximumMessageSize = _globalHubOptions.MaximumReceiveMessageSize;
+                _enableDetailedErrors = _globalHubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             }
 
             _dispatcher = new DefaultHubDispatcher<THub>(
                 serviceScopeFactory,
                 new HubContext<THub>(lifetimeManager),
-                hubOptions,
-                globalHubOptions,
+                _enableDetailedErrors,
                 new Logger<DefaultHubDispatcher<THub>>(loggerFactory));
         }
 

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// </summary>
         public int? StreamBufferCapacity { get; set; } = null;
 
-        internal long? _maximumReceiveMessageSize = null;
-        internal bool _maximumReceiveMessageSizeSet;
+        internal long? _maximumReceiveMessageSize { get; set; } = null;
+        internal bool _maximumReceiveMessageSizeSet { get; set; }
     }
 }

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -39,17 +39,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets or sets the maximum message size of a single incoming hub message. The default is 32KB.
         /// </summary>
-        public long? MaximumReceiveMessageSize
-        {
-            get => _maximumReceiveMessageSize;
-            set
-            {
-                // null means no-limit and uninitialized, in order to allow the no-limit case
-                // we need to track if the user has set the value
-                _maximumReceiveMessageSizeSet = true;
-                _maximumReceiveMessageSize = value;
-            }
-        }
+        public long? MaximumReceiveMessageSize { get; set; } = null;
 
         /// <summary>
         /// Gets or sets a value indicating whether detailed error messages are sent to the client.
@@ -61,8 +51,5 @@ namespace Microsoft.AspNetCore.SignalR
         /// Gets or sets the max buffer size for client upload streams. The default size is 10.
         /// </summary>
         public int? StreamBufferCapacity { get; set; } = null;
-
-        internal long? _maximumReceiveMessageSize { get; set; } = null;
-        internal bool _maximumReceiveMessageSizeSet { get; set; }
     }
 }

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -39,7 +39,17 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets or sets the maximum message size of a single incoming hub message. The default is 32KB.
         /// </summary>
-        public long? MaximumReceiveMessageSize { get; set; } = null;
+        public long? MaximumReceiveMessageSize
+        {
+            get => _maximumReceiveMessageSize;
+            set
+            {
+                // null means no-limit and uninitialized, in order to allow the no-limit case
+                // we need to track if the user has set the value
+                _maximumReceiveMessageSizeSet = true;
+                _maximumReceiveMessageSize = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether detailed error messages are sent to the client.
@@ -51,5 +61,8 @@ namespace Microsoft.AspNetCore.SignalR
         /// Gets or sets the max buffer size for client upload streams. The default size is 10.
         /// </summary>
         public int? StreamBufferCapacity { get; set; } = null;
+
+        internal long? _maximumReceiveMessageSize = null;
+        internal bool _maximumReceiveMessageSizeSet;
     }
 }

--- a/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
+++ b/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
@@ -23,6 +23,12 @@ namespace Microsoft.AspNetCore.SignalR
             }
             options.KeepAliveInterval = _hubOptions.KeepAliveInterval;
             options.HandshakeTimeout = _hubOptions.HandshakeTimeout;
+            options.ClientTimeoutInterval = _hubOptions.ClientTimeoutInterval;
+            options.EnableDetailedErrors = _hubOptions.EnableDetailedErrors;
+            options.MaximumReceiveMessageSize = _hubOptions.MaximumReceiveMessageSize;
+            options.StreamBufferCapacity = _hubOptions.StreamBufferCapacity;
+
+            options.UserHasSetValues = true;
         }
     }
 }

--- a/src/SignalR/server/Core/src/HubOptions`T.cs
+++ b/src/SignalR/server/Core/src/HubOptions`T.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.SignalR
@@ -9,5 +9,6 @@ namespace Microsoft.AspNetCore.SignalR
     /// <typeparam name="THub">The hub type to configure.</typeparam>
     public class HubOptions<THub> : HubOptions where THub : Hub
     {
+        internal bool UserHasSetValues { get; set; }
     }
 }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -28,12 +28,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         private readonly ILogger<HubDispatcher<THub>> _logger;
         private readonly bool _enableDetailedErrors;
 
-        public DefaultHubDispatcher(IServiceScopeFactory serviceScopeFactory, IHubContext<THub> hubContext, IOptions<HubOptions<THub>> hubOptions,
-            IOptions<HubOptions> globalHubOptions, ILogger<DefaultHubDispatcher<THub>> logger)
+        public DefaultHubDispatcher(IServiceScopeFactory serviceScopeFactory, IHubContext<THub> hubContext, bool enableDetailedErrors, ILogger<DefaultHubDispatcher<THub>> logger)
         {
             _serviceScopeFactory = serviceScopeFactory;
             _hubContext = hubContext;
-            _enableDetailedErrors = hubOptions.Value.EnableDetailedErrors ?? globalHubOptions.Value.EnableDetailedErrors ?? false;
+            _enableDetailedErrors = enableDetailedErrors;
             _logger = logger;
             DiscoverHubMethods();
         }

--- a/src/SignalR/server/SignalR/src/SignalRDependencyInjectionExtensions.cs
+++ b/src/SignalR/server/SignalR/src/SignalRDependencyInjectionExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
@@ -67,8 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            return services.Configure(configure)
-                .AddSignalR();
+            var signalrBuilder = services.AddSignalR();
+            // Setup users settings after we've setup ours
+            services.Configure(configure);
+            return signalrBuilder;
         }
     }
 }

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -1,6 +1,7 @@
 // Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,6 +94,36 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
             Assert.Equal(42, serviceProvider.GetRequiredService<IOptions<HubOptions<CustomHub>>>().Value.StreamBufferCapacity);
+        }
+
+        [Fact]
+        public void UserSpecifiedOptionsRunAfterDefaultOptions()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSignalR(options =>
+            {
+                options.MaximumReceiveMessageSize = null;
+                options.StreamBufferCapacity = null;
+                options.EnableDetailedErrors = null;
+                options.KeepAliveInterval = null;
+                options.HandshakeTimeout = null;
+                options.SupportedProtocols = null;
+                options.ClientTimeoutInterval = TimeSpan.FromSeconds(1);
+            });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var globalOptions = serviceProvider.GetRequiredService<IOptions<HubOptions>>().Value;
+            Assert.Null(globalOptions.MaximumReceiveMessageSize);
+            Assert.Null(globalOptions.StreamBufferCapacity);
+            Assert.Null(globalOptions.EnableDetailedErrors);
+            Assert.Null(globalOptions.KeepAliveInterval);
+            Assert.Null(globalOptions.HandshakeTimeout);
+            Assert.Null(globalOptions.SupportedProtocols);
+            Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
+
+            var typedOptions = serviceProvider.GetRequiredService<IOptions<HubOptions<CustomHub>>>();
         }
     }
 

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -83,6 +83,29 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        public void HubSpecificOptionsHaveSameValuesAsGlobalHubOptions()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSignalR().AddHubOptions<CustomHub>(options =>
+            {
+            });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var hubOptions = serviceProvider.GetRequiredService<IOptions<HubOptions<CustomHub>>>().Value;
+            var globalHubOptions = serviceProvider.GetRequiredService<IOptions<HubOptions>>().Value;
+
+            Assert.Equal(globalHubOptions.MaximumReceiveMessageSize, hubOptions.MaximumReceiveMessageSize);
+            Assert.Equal(globalHubOptions.StreamBufferCapacity, hubOptions.StreamBufferCapacity);
+            Assert.Equal(globalHubOptions.EnableDetailedErrors, hubOptions.EnableDetailedErrors);
+            Assert.Equal(globalHubOptions.KeepAliveInterval, hubOptions.KeepAliveInterval);
+            Assert.Equal(globalHubOptions.HandshakeTimeout, hubOptions.HandshakeTimeout);
+            Assert.Equal(globalHubOptions.SupportedProtocols, hubOptions.SupportedProtocols);
+            Assert.Equal(globalHubOptions.ClientTimeoutInterval, hubOptions.ClientTimeoutInterval);
+            Assert.True(hubOptions.UserHasSetValues);
+        }
+
+        [Fact]
         public void StreamBufferCapacityGetSet()
         {
             var serviceCollection = new ServiceCollection();

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -101,6 +101,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             var serviceCollection = new ServiceCollection();
 
+            // null is special when the default options setup runs, so we set to null to verify that our options run after the default
+            // setup runs
             serviceCollection.AddSignalR(options =>
             {
                 options.MaximumReceiveMessageSize = null;
@@ -122,8 +124,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Null(globalOptions.HandshakeTimeout);
             Assert.Null(globalOptions.SupportedProtocols);
             Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
-
-            var typedOptions = serviceProvider.GetRequiredService<IOptions<HubOptions<CustomHub>>>();
         }
     }
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -3834,6 +3834,38 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
+        [Fact]
+        public async Task SpecificHubOptionForMaximumReceiveMessageSizeIsUsedOverGlobalHubOption()
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(serviceBuilder =>
+            {
+                serviceBuilder.AddSignalR(o =>
+                {
+                    // ConnectAsync would fail if this value was used
+                    o.MaximumReceiveMessageSize = 1;
+                }).AddHubOptions<MethodHub>(o =>
+                {
+                    // null is treated as both no-limit and not set, this test verifies that we track if the user explicitly sets the value
+                    o.MaximumReceiveMessageSize = null;
+                });
+            });
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (StartVerifiableLog())
+            {
+                using var client = new TestClient();
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
+
+                // Wait for a connection, or for the endpoint to fail.
+                await client.Connected.OrThrowIfOtherFails(connectionHandlerTask).OrTimeout();
+
+                await client.DisposeAsync().OrTimeout();
+
+                await connectionHandlerTask.OrTimeout();
+            }
+        }
+
         private class CustomHubActivator<THub> : IHubActivator<THub> where THub : Hub
         {
             public int ReleaseCount;


### PR DESCRIPTION
Fixes #15085

Before, we were running users options first then running our options setup. This would override null values because we treat those as uninitialized. However, in cases like `MaximumReceiveMessageSize`, null can also mean no-limit.

Now, we run users options second. And for `MaximumReceiveMessageSize` we track if the user sets the value so we don't accidentally use the global value if they set it to null in the hub type specific options.

@Pilchie for 3.1 bug fix approval.