### PR TITLE
[Blazor] Improve the reliability of 'JSInteropThrowsInUserCode'

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
@@ -75,11 +75,6 @@ namespace Microsoft.AspNetCore.Components
 
         async Task IAsyncLifetime.DisposeAsync()
         {
-            if (TestSink != null)
-            {
-                TestSink.MessageLogged -= TestSink_MessageLogged;
-            }
-
             await DisposeAsync();
         }
 
@@ -90,6 +85,11 @@ namespace Microsoft.AspNetCore.Components
 
         protected virtual Task DisposeAsync()
         {
+            if (TestSink != null)
+            {
+                TestSink.MessageLogged -= TestSink_MessageLogged;
+            }
+
             return Task.CompletedTask;
         }
 
@@ -97,7 +97,18 @@ namespace Microsoft.AspNetCore.Components
         {
             var log = new LogMessage(context.LogLevel, context.EventId, context.Message, context.Exception);
             Logs.Enqueue(log);
-            Output.WriteLine(log.ToString());
+            try
+            {
+                // This might produce an InvalidOperationException when the logger tries to log a message after
+                // the test has completed but before the handler has been removed.
+                //  ---> System.InvalidOperationException: There is no currently active test.
+                // For that reason, we capture the exception here and silence it, as the message is captured inside the Logs
+                // variable anyway.
+                Output.WriteLine(log.ToString());
+            }
+            catch (Exception)
+            {
+            }
         }
 
         [DebuggerDisplay("{LogLevel.ToString(),nq} - {Message ?? \"null\",nq} - {Exception?.Message,nq}")]


### PR DESCRIPTION
* Moves the Dispose logic into `DisposeAsync` instead
  of `IAsyncLifetime.DisposeAsync`.
* Adds a `try{...}catch{...}` around output.WriteLine to prevent
  situations where writing a log into the ITestOutput outside of the
  context of the test causes an exception that makes the test fail.

Addresses https://github.com/aspnet/AspNetCore-Internal/issues/3162