### PR TITLE
[SPA] Fixes the error message on timeouts

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
+++ b/src/Middleware/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 var timeout = spaBuilder.Options.StartupTimeout;
                 return targetUriTask.WithTimeout(timeout,
                     $"The Angular CLI process did not start listening for requests " +
-                    $"within the timeout period of {timeout.Seconds} seconds. " +
+                    $"within the timeout period of {timeout.TotalSeconds} seconds. " +
                     $"Check the log output for error information.");
             });
         }


### PR DESCRIPTION
When the angular CLI middleware takes too long to start, it produces an error message with an incorrect value, as it uses `timeSpan.Seconds` instead of `timeSpan.TotalSeconds`

Just found this while looking at test issues.