### PR TITLE
[Blazor] Fixes reliability issues in the blazor reliability tests

### DIFF
--- a/src/Components/Ignitor/src/BlazorClient.cs
+++ b/src/Components/Ignitor/src/BlazorClient.cs
@@ -31,7 +31,7 @@ namespace Ignitor
             });
         }
 
-        public TimeSpan? DefaultConnectionTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan? DefaultConnectionTimeout { get; set; } = TimeSpan.FromSeconds(20);
         public TimeSpan? DefaultOperationTimeout { get; set; } = TimeSpan.FromMilliseconds(500);
 
         /// <summary>


### PR DESCRIPTION
```console
System.Exception : Timed out while waiting for batch.
...
Debug: CompletingBatchWithoutError Completing batch 2 without error in 10059.9243ms.
```

The error is self-explanatory, it times out waiting for the batch after 10 seconds, and the batch takes a bit more than 10 seconds to render. Likely due to a spike in the machine load.

Addresses https://github.com/aspnet/AspNetCore-Internal/issues/3173 among others.