### PR TITLE
Use MinimumOSVersion in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
+++ b/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
@@ -76,8 +76,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.False(https);
         }
 
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
         [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_RS4)]
         public void ParseAddressUnixPipe()
         {
             var listenOptions = AddressBinder.ParseAddress("http://unix:/tmp/kestrel-test.sock", out var https);

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationBuilderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationBuilderTests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         // [InlineData("http2", HttpProtocols.Http2)] // Not supported due to missing ALPN support. https://github.com/dotnet/corefx/issues/33016
         [InlineData("http1AndHttp2", HttpProtocols.Http1AndHttp2)] // Gracefully falls back to HTTP/1
         [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win10, WindowsVersions.Win8, WindowsVersions.Win81)]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win10, WindowsVersions.Win81)]
         public void DefaultConfigSectionCanSetProtocols_MacAndWin7(string input, HttpProtocols expected)
             => DefaultConfigSectionCanSetProtocols(input, expected);
 
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         [InlineData("http2", HttpProtocols.Http2)]
         [InlineData("http1AndHttp2", HttpProtocols.Http1AndHttp2)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7)]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win81)]
         public void DefaultConfigSectionCanSetProtocols_NonMacAndWin7(string input, HttpProtocols expected)
             => DefaultConfigSectionCanSetProtocols(input, expected);
 
@@ -389,7 +389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         // [InlineData("http2", HttpProtocols.Http2)] // Not supported due to missing ALPN support. https://github.com/dotnet/corefx/issues/33016
         [InlineData("http1AndHttp2", HttpProtocols.Http1AndHttp2)] // Gracefully falls back to HTTP/1
         [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win10, WindowsVersions.Win8, WindowsVersions.Win81)]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win10, WindowsVersions.Win81)]
         public void EndpointConfigSectionCanSetProtocols_MacAndWin7(string input, HttpProtocols expected) =>
             EndpointConfigSectionCanSetProtocols(input, expected);
 
@@ -398,7 +398,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         [InlineData("http2", HttpProtocols.Http2)]
         [InlineData("http1AndHttp2", HttpProtocols.Http1AndHttp2)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7)]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win81)]
         public void EndpointConfigSectionCanSetProtocols_NonMacAndWin7(string input, HttpProtocols expected) =>
             EndpointConfigSectionCanSetProtocols(input, expected);
 

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/HandshakeTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
 
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win10, WindowsVersions.Win8, WindowsVersions.Win81)]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win10, WindowsVersions.Win81)]
         // Win7 SslStream is missing ALPN support.
         public void TlsAndHttp2NotSupportedOnWin7()
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
 
         [CollectDump]
         [ConditionalFact]
-        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/9985", Queues = "Fedora.28.Amd64.Open")] // https://github.com/aspnet/AspNetCore/issues/9985
+        [SkipOnHelix("https://github.com/aspnet/AspNetCore/issues/9985", Queues = "Fedora.28.Amd64.Open")]
         [Flaky("https://github.com/aspnet/AspNetCore/issues/9985", FlakyOn.All)]
         public async Task GracefulShutdownWaitsForRequestsToFinish()
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 #if LIBUV
         [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Libuv does not support unix domain sockets on Windows.")]
 #else
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win8, WindowsVersions.Win81, WindowsVersions.Win2008R2, SkipReason = "UnixDomainSocketEndPoint is not supported on older versions of Windows")]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_RS4)]
 #endif
         [ConditionalFact]
         [CollectDump]


### PR DESCRIPTION
@anurse Test only change.

Some tests require specific versions of Win10 and we recently added support for detecting that via MinimumOSVersion. We'd also like to move away from using OSSkipCondition for version checks, only using it for platform checks instead.

I also adjusted the APLN related skips to clarify that Win8 does not support it.

I'll need to make some additional reactions in master where some of these conditions were changed.
https://github.com/aspnet/AspNetCore/issues/14382