### PR TITLE
[3.1] Update Grpc.AspNetCore to 2.24.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -236,7 +236,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>2.23.2</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>2.24.0</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0</IdentityServer4PackageVersion>


### PR DESCRIPTION
**Description**

Update Grpc.AspNetCore reference in gRPC template to 2.24.0.

**Customer impact**

2.24.0 fixes a number of issues found in the initial gRPC release that have been reported by customers. Release notes: https://github.com/grpc/grpc-dotnet/releases/tag/v2.24.0-pre1

This PR updates the template so new gRPC projects get a version of gRPC with fixes by default.

**Regression**

No

**Risk**

Low