### PR TITLE
Mark classes in typescript as private for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,4 +19,4 @@
 /src/Servers/                   @tratcher @jkotalik @anurse @halter73
 /src/Middleware/Rewrite         @jkotalik @anurse
 /src/Middleware/HttpsPolicy     @jkotalik @anurse
-/src/SignalR/                   @mikaelm12 @BrennanConroy @halter73 @anurse
+/src/SignalR/                   @BrennanConroy @halter73 @anurse

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/src/BinaryMessageFormat.ts
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/src/BinaryMessageFormat.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // Not exported from index.
+/** @private */
 export class BinaryMessageFormat {
 
     // The length prefix of binary messages is encoded as VarInt. Read the comment in

--- a/src/SignalR/clients/ts/signalr/src/EmptyNodeHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/EmptyNodeHttpClient.ts
@@ -6,6 +6,7 @@
 import { HttpClient, HttpResponse } from "./HttpClient";
 import { ILogger } from "./ILogger";
 
+/** @private */
 export class NodeHttpClient extends HttpClient {
     // @ts-ignore: Need ILogger to compile, but unused variables generate errors
     public constructor(logger: ILogger) {

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -547,6 +547,7 @@ function transportMatches(requestedTransport: HttpTransportType | undefined, act
     return !requestedTransport || ((actualTransport & requestedTransport) !== 0);
 }
 
+/** @private */
 export class TransportSendQueue {
     private buffer: any[] = [];
     private sendBufferedData: PromiseSource;

--- a/src/SignalR/clients/ts/signalr/src/NodeHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/NodeHttpClient.ts
@@ -17,6 +17,7 @@ if (typeof XMLHttpRequest === "undefined") {
     requestModule = requireFunc("request");
 }
 
+/** @private */
 export class NodeHttpClient extends HttpClient {
     private readonly logger: ILogger;
     private readonly request: typeof requestModule;

--- a/src/SignalR/clients/ts/signalr/src/Polyfills.ts
+++ b/src/SignalR/clients/ts/signalr/src/Polyfills.ts
@@ -3,8 +3,10 @@
 
 // Not exported from index
 
+/** @private */
 export type EventSourceConstructor = new(url: string, eventSourceInitDict?: EventSourceInit) => EventSource;
 
+/** @private */
 export interface WebSocketConstructor {
     new(url: string, protocols?: string | string[], options?: any): WebSocket;
     readonly CLOSED: number;


### PR DESCRIPTION
Even though the classes aren't exported from index.ts they still show up in docs because it just scans all files. So we need to mark non-exported classes as private explicitly.
