### PR TITLE
Reduce the number of members on ModelMetadataIdentity

### DIFF
--- a/src/Mvc/Mvc.Abstractions/ref/Microsoft.AspNetCore.Mvc.Abstractions.netcoreapp.cs
+++ b/src/Mvc/Mvc.Abstractions/ref/Microsoft.AspNetCore.Mvc.Abstractions.netcoreapp.cs
@@ -882,8 +882,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         public Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ModelMetadataKind MetadataKind { get { throw null; } }
         public System.Type ModelType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Reflection.ParameterInfo ParameterInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Reflection.PropertyInfo PropertyInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Reflection.ParameterInfo ParameterInfo { get { throw null; } }
+        public System.Reflection.PropertyInfo PropertyInfo { get { throw null; } }
         public bool Equals(Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ModelMetadataIdentity other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public static Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ModelMetadataIdentity ForParameter(System.Reflection.ParameterInfo parameter) { throw null; }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
@@ -17,14 +17,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             Type modelType,
             string name = null,
             Type containerType = null,
-            ParameterInfo parameterInfo = null,
-            PropertyInfo propertyInfo = null)
+            object fieldInfo = null)
         {
             ModelType = modelType;
             Name = name;
             ContainerType = containerType;
-            ParameterInfo = parameterInfo;
-            PropertyInfo = propertyInfo;
+            FieldInfo = fieldInfo;
         }
 
         /// <summary>
@@ -100,7 +98,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
                 throw new ArgumentNullException(nameof(containerType));
             }
 
-            return new ModelMetadataIdentity(modelType, propertyInfo.Name, containerType, propertyInfo: propertyInfo);
+            return new ModelMetadataIdentity(modelType, propertyInfo.Name, containerType, fieldInfo: propertyInfo);
         }
 
         /// <summary>
@@ -130,7 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
                 throw new ArgumentNullException(nameof(modelType));
             }
 
-            return new ModelMetadataIdentity(modelType, parameter.Name, parameterInfo: parameter);
+            return new ModelMetadataIdentity(modelType, parameter.Name, fieldInfo: parameter);
         }
 
         /// <summary>
@@ -172,17 +170,19 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         /// </summary>
         public string Name { get; }
 
+        private object FieldInfo { get; }
+
         /// <summary>
         /// Gets a descriptor for the parameter, or <c>null</c> if this instance
         /// does not represent a parameter.
         /// </summary>
-        public ParameterInfo ParameterInfo { get; }
+        public ParameterInfo ParameterInfo => FieldInfo as ParameterInfo;
 
         /// <summary>
         /// Gets a descriptor for the property, or <c>null</c> if this instance
         /// does not represent a property.
         /// </summary>
-        public PropertyInfo PropertyInfo { get; }
+        public PropertyInfo PropertyInfo => FieldInfo as PropertyInfo;
 
         /// <inheritdoc />
         public bool Equals(ModelMetadataIdentity other)


### PR DESCRIPTION
ModelMetadataIdentity is a discriminated union. We recently introduced an additional member on this type,
but are concerned about the performance implication of doing this. This change uses a discriminated field
to reset the member count to 3.0.
