### PR TITLE
[Blazor] Reliability improvements for the E2E tests

### DIFF
--- a/src/Components/Ignitor/src/BlazorClient.cs
+++ b/src/Components/Ignitor/src/BlazorClient.cs
@@ -347,8 +347,7 @@ namespace Ignitor
                 }
             });
 
-            _hubConnection = builder.Build();
-            await HubConnection.StartAsync(CancellationToken);
+            HubConnection = builder.Build();
 
             HubConnection.On<int, string>("JS.AttachComponent", OnAttachComponent);
             HubConnection.On<int, string, string>("JS.BeginInvokeJS", OnBeginInvokeJS);
@@ -356,6 +355,13 @@ namespace Ignitor
             HubConnection.On<int, byte[]>("JS.RenderBatch", OnRenderBatch);
             HubConnection.On<string>("JS.Error", OnError);
             HubConnection.Closed += OnClosedAsync;
+
+            await HubConnection.StartAsync(CancellationToken);
+
+            if (CaptureOperations)
+            {
+                Operations = new Operations();
+            }
 
             if (!connectAutomatically)
             {

--- a/src/Components/Ignitor/src/BlazorClient.cs
+++ b/src/Components/Ignitor/src/BlazorClient.cs
@@ -347,7 +347,7 @@ namespace Ignitor
                 }
             });
 
-            HubConnection = builder.Build();
+            _hubConnection = builder.Build();
 
             HubConnection.On<int, string>("JS.AttachComponent", OnAttachComponent);
             HubConnection.On<int, string, string>("JS.BeginInvokeJS", OnBeginInvokeJS);
@@ -357,11 +357,6 @@ namespace Ignitor
             HubConnection.Closed += OnClosedAsync;
 
             await HubConnection.StartAsync(CancellationToken);
-
-            if (CaptureOperations)
-            {
-                Operations = new Operations();
-            }
 
             if (!connectAutomatically)
             {

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -57,4 +57,10 @@
     <Compile Include="$(RepoRoot)src\Shared\Components\ServerComponentMarker.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubReliabilityTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubReliabilityTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using TestServer;
 using Xunit;
@@ -119,6 +120,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [Repeat(1000)]
         public async Task CannotInvokeJSInteropCallbackCompletionsBeforeInitialization()
         {
             // Arrange

--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubReliabilityTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubReliabilityTest.cs
@@ -120,7 +120,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
-        [Repeat(1000)]
         public async Task CannotInvokeJSInteropCallbackCompletionsBeforeInitialization()
         {
             // Arrange

--- a/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
@@ -83,14 +83,14 @@ namespace Microsoft.AspNetCore.Components
             return Task.CompletedTask;
         }
 
-        protected virtual Task DisposeAsync()
+        protected async virtual Task DisposeAsync()
         {
             if (TestSink != null)
             {
                 TestSink.MessageLogged -= TestSink_MessageLogged;
             }
 
-            return Task.CompletedTask;
+            await Client.DisposeAsync();
         }
 
         private void TestSink_MessageLogged(WriteContext context)

--- a/src/Components/test/E2ETest/xunit.runner.json
+++ b/src/Components/test/E2ETest/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  // This is set to -1 to allow the usage of an
+  // unlimited ammount of threads.
+  "maxParallelThreads": -1,
+  "diagnosticMessages": true,
+  "longRunningTestSeconds": 30
+}


### PR DESCRIPTION
Suggestions from Brennan to improve the reliability of E2E tests.
* Removes the thread limit on xUnit.
  * This likely fixes timeouts that were caused by test deadlocks between test code waiting and product code not being able to run due to unavailable threads.
* Dispose Ignitor client.
* Add xunit.runner.configuration to produce diagnostics about long running tests (one message after each 30 seconds).
* Add a Repeat attribute to validate the improved reliability.