### PR TITLE
Support building for arm64 on arm64 (*nix)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -108,6 +108,7 @@
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
+    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <TargetRuntimeIdentifier>$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
 

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -90,15 +90,17 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <PathSeparator Condition="'$(PathSeparator)' == ''">:</PathSeparator>
     <PathSeparator Condition=" '$(TargetOsName)' == 'win' ">%3B</PathSeparator>
 
+    <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm' ">x64_arm</CrossCompileDirectory>
+    <CrossCompileDirectory Condition=" '$(TargetArchitecture)' == 'arm64' AND '$(BuildArchitecture)' != 'arm64' ">x64_arm64</CrossCompileDirectory>
+    <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'win-arm' ">x86_arm</CrossCompileDirectory>
+
     <!-- Crossgen executable name -->
     <CrossgenToolFileName>crossgen</CrossgenToolFileName>
     <CrossgenToolFileName Condition=" '$(TargetOsName)' == 'win' ">$(CrossgenToolFileName).exe</CrossgenToolFileName>
     <!-- Default crossgen executable relative path -->
     <CrossgenToolPackagePath>$(CrossgenToolFileName)</CrossgenToolPackagePath>
     <!-- Disambiguated RID-specific crossgen executable relative path -->
-    <CrossgenToolPackagePath Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm' ">x64_arm\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
-    <CrossgenToolPackagePath Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm64' OR '$(TargetRuntimeIdentifier)' == 'linux-musl-arm64' ">x64_arm64\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
-    <CrossgenToolPackagePath Condition=" '$(TargetRuntimeIdentifier)' == 'win-arm' ">x86_arm\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
+    <CrossgenToolPackagePath Condition=" '$(CrossCompileDirectory)' != '' ">$(CrossCompileDirectory)\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
 
     <RuntimePackageRoot>$([System.IO.Path]::Combine('$(NuGetPackageRoot)', 'microsoft.netcore.app.runtime.$(RuntimeIdentifier)', '$(MicrosoftNETCoreAppRuntimeVersion)'))</RuntimePackageRoot>
     <RuntimePackageRoot>$([MSBuild]::EnsureTrailingSlash('$(RuntimePackageRoot)'))</RuntimePackageRoot>
@@ -293,7 +295,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   -->
   <PropertyGroup>
     <CrossgenToolDir>$(IntermediateOutputPath)crossgen\</CrossgenToolDir>
-    <CoreCLRJitPath>$(CrossgenToolDir)$(LibPrefix)clrjit$(LibExtension)</CoreCLRJitPath>
+    <!-- Pick the right coreclr jit based on whether we are cross-compiling or not -->
+    <CoreCLRJitPath Condition="'$(CrossCompileDirectory)' == ''">$(RuntimePackageRoot)runtimes\$(RuntimeIdentifier)\native\$(LibPrefix)clrjit$(LibExtension)</CoreCLRJitPath>
+    <CoreCLRJitPath Condition="'$(CrossCompileDirectory)' != ''">$(RuntimepackageRoot)runtimes\$(CrossCompileDirectory)\native\$(LibPrefix)clrjit$(LibExtension)</CoreCLRJitPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit allows ASP.NET Core to be built on arm64 machines directly, without relying on cross-compilation.

There's a few changes in here:

1. ~~Extend `build.sh` to handle non-x64 architectures.~~

   ~~By default, the build assumes the machine is x64. Instead query the machine (using `uname`) to find out what the actual build machine is.~~

   ~~A similar change was made in arcade: https://github.com/dotnet/arcade/pull/4132~~

2. Ask msbuild to handle the BuildArchitecture

     By default, our build systems assums the machine is x64. This modifies the build configuration to check the architecture of the currently running build machine, and set BuildArchitecture to that.


   ~~Ideally, we could just use `ProcessorArchitecture` on all cases and avoid any hardcoding of `x64`, but that would break Visual Studio. Visual Studio runs msbuild as a x86 process and we need to explicitly tell msbuild to target x64 in those cases.~~

   ~~We ran into a similar issue in corefx: https://github.com/dotnet/corefx/pull/40427~~

   ~~The final fix was: https://github.com/dotnet/corefx/pull/40453~~

3. Fix crossgen in Microsoft.AspNetCore.App.Runtime

   We run crossgen for supported architectures (including x64 and arm64). For that, we need a jit that we can point crossgen to. Generally, we can rely on the build scripts to find the right `libclrjit.so`. However, arm64 has multiple `libclirjit.so`, for different use-cases. There's one for arm64 (for running on arm64) and there's another one for cross-compiling for arm64 on x64. We need to figure out and use the right one explicitly rather than assuming the right one gets picked up.

   See https://github.com/dotnet/core-setup/pull/8468 for similar changes made in core-setup.

This also needs https://github.com/aspnet/AspNetCore/pull/14790 to fully work on arm64.