### PR TITLE
Don't re-use requests

### DIFF
--- a/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
+++ b/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
@@ -104,11 +104,13 @@ namespace Templates.Test.Helpers
 
         public async Task ContainsLinks(Page page)
         {
-            var request = new HttpRequestMessage(
-                HttpMethod.Get,
-                new Uri(ListeningUri, page.Url));
-
-            var response = await RequestWithRetries(client => client.SendAsync(request), _httpClient);
+            var response = await RequestWithRetries(client =>
+            {
+                var request = new HttpRequestMessage(
+                    HttpMethod.Get,
+                    new Uri(ListeningUri, page.Url));
+                return client.SendAsync(request);
+            }, _httpClient);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var parser = new HtmlParser();
@@ -235,16 +237,18 @@ namespace Templates.Test.Helpers
 
         public async Task AssertStatusCode(string requestUrl, HttpStatusCode statusCode, string acceptContentType = null)
         {
-            var request = new HttpRequestMessage(
-                HttpMethod.Get,
-                new Uri(ListeningUri, requestUrl));
+            var response = await RequestWithRetries(client => {
+                var request = new HttpRequestMessage(
+                    HttpMethod.Get,
+                    new Uri(ListeningUri, requestUrl));
 
-            if (!string.IsNullOrEmpty(acceptContentType))
-            {
-                request.Headers.Add("Accept", acceptContentType);
-            }
+                if (!string.IsNullOrEmpty(acceptContentType))
+                {
+                    request.Headers.Add("Accept", acceptContentType);
+                }
 
-            var response = await RequestWithRetries(client => client.SendAsync(request), _httpClient);
+                return client.SendAsync(request);
+            }, _httpClient);
             Assert.True(statusCode == response.StatusCode, $"Expected {requestUrl} to have status '{statusCode}' but it was '{response.StatusCode}'.");
         }
 


### PR DESCRIPTION
Part of the fix for https://github.com/aspnet/AspNetCore-Internal/issues/2996.

This should prevent failures like
```
System.InvalidOperationException : The request message was already sent. Cannot send the same request message multiple times.
```

From happening within the retry loop depending on when they request fails by recreating a new request message for each attempt.