### PR TITLE
[Blazor][Fixes #14959] NavLink match should be case-insensitive

### DIFF
--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Components.Routing
 
         private bool EqualsHrefExactlyOrIfTrailingSlashAdded(string currentUriAbsolute)
         {
-            if (string.Equals(currentUriAbsolute, _hrefAbsolute, StringComparison.Ordinal))
+            if (string.Equals(currentUriAbsolute, _hrefAbsolute, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Components.Routing
                 // for http://host/vdir as they do for host://host/vdir/ as it's no
                 // good to display a blank page in that case.
                 if (_hrefAbsolute[_hrefAbsolute.Length - 1] == '/'
-                    && _hrefAbsolute.StartsWith(currentUriAbsolute, StringComparison.Ordinal))
+                    && _hrefAbsolute.StartsWith(currentUriAbsolute, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
@@ -16,7 +16,7 @@
     <li><NavLink href="Other" Match=NavLinkMatch.All>Other with base-relative URL (matches all)</NavLink></li>
     <li><NavLink href="/subdir/other?abc=123">Other with query</NavLink></li>
     <li><NavLink href="/subdir/Other#blah">Other with hash</NavLink></li>
-    <li><NavLink href="/subdir/WithParameters/Name/Abc">With parameters</NavLink></li>
+    <li><NavLink href="/subdir/WithParameters/name/Abc">With parameters</NavLink></li>
     <li><NavLink href="/subdir/WithParameters/Name/Abc/LastName/McDef">With more parameters</NavLink></li>
     <li><NavLink href="/subdir/LongPage1">Long page 1</NavLink></li>
     <li><NavLink href="/subdir/LongPage2">Long page 2</NavLink></li>


### PR DESCRIPTION
There were a couple of missing cases it didn't fix.
* It would work for `/Counter/` but not for `/Counter` when `/counter` and `/counter/` both work.