### PR TITLE
[Blazor][Fixes #15399]The Blazor descriptor can contain two consecutive dashes

### DIFF
--- a/src/Components/Server/src/Circuits/ServerComponentDeserializer.cs
+++ b/src/Components/Server/src/Circuits/ServerComponentDeserializer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
@@ -153,7 +154,9 @@ namespace Microsoft.AspNetCore.Components.Server
             string unprotected;
             try
             {
-                unprotected = _dataProtector.Unprotect(record.Descriptor);
+                var payload = Convert.FromBase64String(record.Descriptor);
+                var unprotectedBytes = _dataProtector.Unprotect(payload);
+                unprotected = Encoding.UTF8.GetString(unprotectedBytes);
             }
             catch (Exception e)
             {

--- a/src/Mvc/Mvc.ViewFeatures/src/ServerComponentSerializer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ServerComponentSerializer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.DataProtection;
@@ -43,7 +44,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 invocationId.Value);
 
             var serializedServerComponent = JsonSerializer.Serialize(serverComponent, ServerComponentSerializationSettings.JsonSerializationOptions);
-            return (serverComponent.Sequence, _dataProtector.Protect(serializedServerComponent, ServerComponentSerializationSettings.DataExpiration));
+            var serializedServerComponentBytes = Encoding.UTF8.GetBytes(serializedServerComponent);
+            var protectedBytes = _dataProtector.Protect(serializedServerComponentBytes, ServerComponentSerializationSettings.DataExpiration);
+            return (serverComponent.Sequence, Convert.ToBase64String(protectedBytes));
         }
 
         internal IEnumerable<string> GetPreamble(ServerComponentMarker record)

--- a/src/Mvc/Mvc.ViewFeatures/src/ServerComponentSerializer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ServerComponentSerializer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 invocationId.Value);
 
             var serializedServerComponent = JsonSerializer.Serialize(serverComponent, ServerComponentSerializationSettings.JsonSerializationOptions);
-            var serializedServerComponentBytes = Encoding.UTF8.GetBytes(serializedServerComponent);
+            var serializedServerComponentBytes = JsonSerializer.SerializeToUtf8Bytes(serverComponent, ServerComponentSerializationSettings.JsonSerializationOptions);
             var protectedBytes = _dataProtector.Protect(serializedServerComponentBytes, ServerComponentSerializationSettings.DataExpiration);
             return (serverComponent.Sequence, Convert.ToBase64String(protectedBytes));
         }


### PR DESCRIPTION
* We Base64 encode it instead of Base64Url encode it as data protection does.
* It uses "+/" instead of "-_", both of which are safe inside HTML
  comments.
* The descriptors are not sent in any url, nor are present inside headers
  or similar, so Base64 encoding them is fine.