### PR TITLE
Fix references in documentation

### DIFF
--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Http
         /// The cookie path.
         /// </summary>
         /// <remarks>
-        /// Determines the value that will set on <seealso cref="CookieOptions.Path"/>.
+        /// Determines the value that will set on <see cref="CookieOptions.Path"/>.
         /// </remarks>
         public virtual string Path { get; set; }
 
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Http
         /// The domain to associate the cookie with.
         /// </summary>
         /// <remarks>
-        /// Determines the value that will set on <seealso cref="CookieOptions.Domain"/>.
+        /// Determines the value that will set on <see cref="CookieOptions.Domain"/>.
         /// </remarks>
         public virtual string Domain { get; set; }
 
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Http
         /// Indicates whether a cookie is accessible by client-side script.
         /// </summary>
         /// <remarks>
-        /// Determines the value that will set on <seealso cref="CookieOptions.HttpOnly"/>.
+        /// Determines the value that will set on <see cref="CookieOptions.HttpOnly"/>.
         /// </remarks>
         public virtual bool HttpOnly { get; set; }
 
@@ -52,12 +52,12 @@ namespace Microsoft.AspNetCore.Http
         /// The SameSite attribute of the cookie. The default value is <see cref="SameSiteMode.Unspecified"/>
         /// </summary>
         /// <remarks>
-        /// Determines the value that will set on <seealso cref="CookieOptions.SameSite"/>.
+        /// Determines the value that will set on <see cref="CookieOptions.SameSite"/>.
         /// </remarks>
         public virtual SameSiteMode SameSite { get; set; } = SameSiteMode.Unspecified;
 
         /// <summary>
-        /// The policy that will be used to determine <seealso cref="CookieOptions.Secure"/>.
+        /// The policy that will be used to determine <see cref="CookieOptions.Secure"/>.
         /// This is determined from the <see cref="HttpContext"/> passed to <see cref="Build(HttpContext, DateTimeOffset)"/>.
         /// </summary>
         public virtual CookieSecurePolicy SecurePolicy { get; set; }
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Http
         /// Creates the cookie options from the given <paramref name="context"/> with an expiration based on <paramref name="expiresFrom"/> and <see cref="Expiration"/>.
         /// </summary>
         /// <param name="context">The <see cref="HttpContext"/>.</param>
-        /// <param name="expiresFrom">The time to use as the base for computing <seealso cref="CookieOptions.Expires" />.</param>
+        /// <param name="expiresFrom">The time to use as the base for computing <see cref="CookieOptions.Expires" />.</param>
         /// <returns>The cookie options.</returns>
         public virtual CookieOptions Build(HttpContext context, DateTimeOffset expiresFrom)
         {

--- a/src/Identity/Core/src/IdentityBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityBuilderExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds a <see cref="SignInManager{TUser}"/> for the <seealso cref="IdentityBuilder.UserType"/>.
+        /// Adds a <see cref="SignInManager{TUser}"/> for the <see cref="IdentityBuilder.UserType"/>.
         /// </summary>
         /// <param name="builder">The current <see cref="IdentityBuilder"/> instance.</param>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds a <see cref="SignInManager{TUser}"/> for the <seealso cref="IdentityBuilder.UserType"/>.
+        /// Adds a <see cref="SignInManager{TUser}"/> for the <see cref="IdentityBuilder.UserType"/>.
         /// </summary>
         /// <typeparam name="TSignInManager">The type of the sign in manager to add.</typeparam>
         /// <param name="builder">The current <see cref="IdentityBuilder"/> instance.</param>

--- a/src/Identity/Extensions.Core/src/IdentityBuilder.cs
+++ b/src/Identity/Extensions.Core/src/IdentityBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds an <see cref="IUserValidator{TUser}"/> for the <seealso cref="UserType"/>.
+        /// Adds an <see cref="IUserValidator{TUser}"/> for the <see cref="UserType"/>.
         /// </summary>
         /// <typeparam name="TValidator">The user validator type.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Identity
             => AddScoped(typeof(IUserValidator<>).MakeGenericType(UserType), typeof(TValidator));
 
         /// <summary>
-        /// Adds an <see cref="IUserClaimsPrincipalFactory{TUser}"/> for the <seealso cref="UserType"/>.
+        /// Adds an <see cref="IUserClaimsPrincipalFactory{TUser}"/> for the <see cref="UserType"/>.
         /// </summary>
         /// <typeparam name="TFactory">The type of the claims principal factory.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds an <see cref="IPasswordValidator{TUser}"/> for the <seealso cref="UserType"/>.
+        /// Adds an <see cref="IPasswordValidator{TUser}"/> for the <see cref="UserType"/>.
         /// </summary>
         /// <typeparam name="TValidator">The validator type used to validate passwords.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Identity
             => AddScoped(typeof(IPasswordValidator<>).MakeGenericType(UserType), typeof(TValidator));
 
         /// <summary>
-        /// Adds an <see cref="IUserStore{TUser}"/> for the <seealso cref="UserType"/>.
+        /// Adds an <see cref="IUserStore{TUser}"/> for the <see cref="UserType"/>.
         /// </summary>
         /// <typeparam name="TStore">The user store type.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Identity
             => AddTokenProvider(providerName, typeof(TProvider));
 
         /// <summary>
-        /// Adds a token provider for the <seealso cref="UserType"/>.
+        /// Adds a token provider for the <see cref="UserType"/>.
         /// </summary>
         /// <param name="providerName">The name of the provider to add.</param>
         /// <param name="provider">The type of the <see cref="IUserTwoFactorTokenProvider{TUser}"/> to add.</param>
@@ -134,11 +134,11 @@ namespace Microsoft.AspNetCore.Identity
                 options.Tokens.ProviderMap[providerName] = new TokenProviderDescriptor(provider);
             });
             Services.AddTransient(provider);
-            return this; 
+            return this;
         }
 
         /// <summary>
-        /// Adds a <see cref="UserManager{TUser}"/> for the <seealso cref="UserType"/>.
+        /// Adds a <see cref="UserManager{TUser}"/> for the <see cref="UserType"/>.
         /// </summary>
         /// <typeparam name="TUserManager">The type of the user manager to add.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds an <see cref="IRoleValidator{TRole}"/> for the <seealso cref="RoleType"/>.
+        /// Adds an <see cref="IRoleValidator{TRole}"/> for the <see cref="RoleType"/>.
         /// </summary>
         /// <typeparam name="TRole">The role validator type.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <typeparam name="TProtector">The personal data protector type.</typeparam>
         /// <typeparam name="TKeyRing">The personal data protector key ring type.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
-        public virtual IdentityBuilder AddPersonalDataProtection<TProtector, TKeyRing>() 
+        public virtual IdentityBuilder AddPersonalDataProtection<TProtector, TKeyRing>()
             where TProtector : class,ILookupProtector
             where TKeyRing : class, ILookupProtectorKeyRing
         {
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds a <see cref="IRoleStore{TRole}"/> for the <seealso cref="RoleType"/>.
+        /// Adds a <see cref="IRoleStore{TRole}"/> for the <see cref="RoleType"/>.
         /// </summary>
         /// <typeparam name="TStore">The role store.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
-        /// Adds a <see cref="RoleManager{TRole}"/> for the <seealso cref="RoleType"/>.
+        /// Adds a <see cref="RoleManager{TRole}"/> for the <see cref="RoleType"/>.
         /// </summary>
         /// <typeparam name="TRoleManager">The type of the role manager to add.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>

--- a/src/Mvc/Mvc.Core/src/ApiConventionMethodAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApiConventionMethodAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc
     /// <para>
     /// API conventions are used to influence the output of ApiExplorer.
     /// <see cref="ApiConventionMethodAttribute"/> can be used to specify an exact convention method that applies
-    /// to an action. <seealso cref="ApiConventionTypeAttribute"/> for details about applying conventions at
+    /// to an action. <see cref="ApiConventionTypeAttribute"/> for details about applying conventions at
     /// the assembly or controller level.
     /// </para>
     /// </summary>

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -288,7 +288,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// cookie gets added to the response.
         /// </summary>
         /// <remarks>
-        /// The value of <see cref="CookieBuilder.Name"/> is treated as the prefix to the cookie name, and defaults to <seealso cref="OpenIdConnectDefaults.CookieNoncePrefix"/>.
+        /// The value of <see cref="CookieBuilder.Name"/> is treated as the prefix to the cookie name, and defaults to <see cref="OpenIdConnectDefaults.CookieNoncePrefix"/>.
         /// </remarks>
         public CookieBuilder NonceCookie
         {


### PR DESCRIPTION
Follow-up from #15434 to replace `<seealso>` by `<see>` to fix the sentences. 