### PR TITLE
Fix TestServer from blocking on request stream

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -65,8 +66,33 @@ namespace Microsoft.AspNetCore.TestHost
             var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO, PreserveExecutionContext);
 
             var requestContent = request.Content ?? new StreamContent(Stream.Null);
-            var body = await requestContent.ReadAsStreamAsync();
-            contextBuilder.Configure(context =>
+
+            // Read content from the request HttpContent into a pipe in a background task. This will allow the request
+            // delegate to start before the request HttpContent is complete. A background task allows duplex streaming scenarios.
+            contextBuilder.SendRequestStream(async writer =>
+            {
+                if (requestContent is StreamContent)
+                {
+                    // This is odd but required for backwards compat. If StreamContent is passed in then seek to beginning.
+                    // This is safe because StreamContent.ReadAsStreamAsync doesn't block. It will return the inner stream.
+                    var body = await requestContent.ReadAsStreamAsync();
+                    if (body.CanSeek)
+                    {
+                        // This body may have been consumed before, rewind it.
+                        body.Seek(0, SeekOrigin.Begin);
+                    }
+
+                    await body.CopyToAsync(writer);
+                }
+                else
+                {
+                    await requestContent.CopyToAsync(writer.AsStream());
+                }
+
+                await writer.CompleteAsync();
+            });
+
+            contextBuilder.Configure((context, reader) =>
             {
                 var req = context.Request;
 
@@ -115,12 +141,7 @@ namespace Microsoft.AspNetCore.TestHost
                     }
                 }
 
-                if (body.CanSeek)
-                {
-                    // This body may have been consumed before, rewind it.
-                    body.Seek(0, SeekOrigin.Begin);
-                }
-                req.Body = new AsyncStreamWrapper(body, () => contextBuilder.AllowSynchronousIO);
+                req.Body = new AsyncStreamWrapper(reader.AsStream(), () => contextBuilder.AllowSynchronousIO);
             });
 
             var response = new HttpResponseMessage();

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
             else
             {
-                await _requestPipe.Writer.CompleteAsync();
+                // Writer was already completed in send request callback.
                 await _requestPipe.Reader.CompleteAsync();
             }
 

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.TestHost
 
             // Cancel any pending request async activity when the client aborts a duplex
             // streaming scenario by disposing the HttpResponseMessage.
-            AbortRequest();
+            CancelRequestBody();
         }
 
         private async Task CompleteRequestAsync()
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.TestHost
             if (!_requestPipe.Reader.TryRead(out var result) || !result.IsCompleted)
             {
                 // If request is still in progress then abort it.
-                AbortRequest();
+                CancelRequestBody();
             }
             else
             {
@@ -239,10 +239,10 @@ namespace Microsoft.AspNetCore.TestHost
             _responseReaderStream.Abort(exception);
             _requestLifetimeFeature.Cancel();
             _responseTcs.TrySetException(exception);
-            AbortRequest();
+            CancelRequestBody();
         }
 
-        private void AbortRequest()
+        private void CancelRequestBody()
         {
             _requestPipe.Writer.CancelPendingFlush();
             _requestPipe.Reader.CancelPendingRead();

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -26,7 +26,10 @@ namespace Microsoft.AspNetCore.TestHost
         private bool _pipelineFinished;
         private bool _returningResponse;
         private object _testContext;
+        private Pipe _requestPipe;
+
         private Action<HttpContext> _responseReadCompleteCallback;
+        private Task _sendRequestStreamTask;
 
         internal HttpContextBuilder(ApplicationWrapper application, bool allowSynchronousIO, bool preserveExecutionContext)
         {
@@ -41,9 +44,11 @@ namespace Microsoft.AspNetCore.TestHost
             request.Protocol = "HTTP/1.1";
             request.Method = HttpMethods.Get;
 
-            var pipe = new Pipe();
-            _responseReaderStream = new ResponseBodyReaderStream(pipe, ClientInitiatedAbort, () => _responseReadCompleteCallback?.Invoke(_httpContext));
-            _responsePipeWriter = new ResponseBodyPipeWriter(pipe, ReturnResponseMessageAsync);
+            _requestPipe = new Pipe();
+
+            var responsePipe = new Pipe();
+            _responseReaderStream = new ResponseBodyReaderStream(responsePipe, ClientInitiatedAbort, () => _responseReadCompleteCallback?.Invoke(_httpContext));
+            _responsePipeWriter = new ResponseBodyPipeWriter(responsePipe, ReturnResponseMessageAsync);
             _responseFeature.Body = new ResponseBodyWriterStream(_responsePipeWriter, () => AllowSynchronousIO);
             _responseFeature.BodyWriter = _responsePipeWriter;
 
@@ -56,14 +61,24 @@ namespace Microsoft.AspNetCore.TestHost
 
         public bool AllowSynchronousIO { get; set; }
 
-        internal void Configure(Action<HttpContext> configureContext)
+        internal void Configure(Action<HttpContext, PipeReader> configureContext)
         {
             if (configureContext == null)
             {
                 throw new ArgumentNullException(nameof(configureContext));
             }
 
-            configureContext(_httpContext);
+            configureContext(_httpContext, _requestPipe.Reader);
+        }
+
+        internal void SendRequestStream(Func<PipeWriter, Task> sendRequestStream)
+        {
+            if (sendRequestStream == null)
+            {
+                throw new ArgumentNullException(nameof(sendRequestStream));
+            }
+
+            _sendRequestStreamTask = sendRequestStream(_requestPipe.Writer);
         }
 
         internal void RegisterResponseReadCompleteCallback(Action<HttpContext> responseReadCompleteCallback)
@@ -92,10 +107,10 @@ namespace Microsoft.AspNetCore.TestHost
                 // since we are now inside the Server's execution context. If it happens outside this cont
                 // it will be lost when we abandon the execution context.
                 _testContext = _application.CreateContext(_httpContext.Features);
-
                 try
                 {
                     await _application.ProcessRequestAsync(_testContext);
+                    await CompleteRequestAsync();
                     await CompleteResponseAsync();
                     _application.DisposeContext(_testContext, exception: null);
                 }
@@ -134,8 +149,24 @@ namespace Microsoft.AspNetCore.TestHost
                 // We don't want to trigger the token for already completed responses.
                 _requestLifetimeFeature.Cancel();
             }
+
             // Writes will still succeed, the app will only get an error if they check the CT.
             _responseReaderStream.Abort(new IOException("The client aborted the request."));
+
+            // Cancel any pending request async activity when the client aborts a duplex
+            // streaming scenario by disposing the HttpResponseMessage.
+            AbortRequest();
+        }
+
+        private async Task CompleteRequestAsync()
+        {
+            if (_sendRequestStreamTask != null)
+            {
+                await _sendRequestStreamTask;
+            }
+
+            await _requestPipe.Writer.CompleteAsync();
+            await _requestPipe.Reader.CompleteAsync();
         }
 
         internal async Task CompleteResponseAsync()
@@ -192,6 +223,13 @@ namespace Microsoft.AspNetCore.TestHost
             _responseReaderStream.Abort(exception);
             _requestLifetimeFeature.Cancel();
             _responseTcs.TrySetException(exception);
+            AbortRequest();
+        }
+
+        private void AbortRequest()
+        {
+            _requestPipe.Writer.CancelPendingFlush();
+            _requestPipe.Reader.CancelPendingRead();
         }
 
         void IHttpResetFeature.Reset(int errorCode)

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
 
             var builder = new HttpContextBuilder(Application, AllowSynchronousIO, PreserveExecutionContext);
-            builder.Configure(context =>
+            builder.Configure((context, reader) =>
             {
                 var request = context.Request;
                 request.Scheme = BaseAddress.Scheme;
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.TestHost
                 }
                 request.PathBase = pathBase;
             });
-            builder.Configure(configureContext);
+            builder.Configure((context, reader) => configureContext(context));
             // TODO: Wrap the request body if any?
             return await builder.SendAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/Hosting/TestHost/src/WebSocketClient.cs
+++ b/src/Hosting/TestHost/src/WebSocketClient.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.TestHost
         {
             WebSocketFeature webSocketFeature = null;
             var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO, PreserveExecutionContext);
-            contextBuilder.Configure(context =>
+            contextBuilder.Configure((context, reader) =>
             {
                 var request = context.Request;
                 var scheme = uri.Scheme;

--- a/src/Hosting/TestHost/test/Microsoft.AspNetCore.TestHost.Tests.csproj
+++ b/src/Hosting/TestHost/test/Microsoft.AspNetCore.TestHost.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\Shared\SyncPoint\SyncPoint.cs" Link="SyncPoint.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.Extensions.DiagnosticAdapter" />
     <Reference Include="Microsoft.Extensions.Hosting" />

--- a/src/Hosting/TestHost/test/Utilities.cs
+++ b/src/Hosting/TestHost/test/Utilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.TestHost
 {
@@ -10,20 +11,8 @@ namespace Microsoft.AspNetCore.TestHost
     {
         internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
 
-        internal static Task<T> WithTimeout<T>(this Task<T> task) => task.WithTimeout(DefaultTimeout);
+        internal static Task<T> WithTimeout<T>(this Task<T> task) => task.TimeoutAfter(DefaultTimeout);
 
-        internal static async Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout)
-        {
-            var completedTask = await Task.WhenAny(task, Task.Delay(timeout));
-
-            if (completedTask == task)
-            {
-                return await task;
-            }
-            else
-            {
-                throw new TimeoutException("The task has timed out.");
-            }
-        }
+        internal static Task WithTimeout(this Task task) => task.TimeoutAfter(DefaultTimeout);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/15415

`HttpContent.ReadAsStreamAsync()` will block when called in custom `HttpContent` implementations. Calling `HttpContent.CopyToAsync(stream)` mirrors what `HttpClient` does more closely.

Note, this PR is on 3.1. The bug blocks people from using TestServer with gRPC. Would be nice to unblock before 5.0. @anurse is this your call? Need anymore info?