### PR TITLE
SignalR java client: Allow users to use a custom HttpClient implementation

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpClient.java
@@ -3,78 +3,11 @@
 
 package com.microsoft.signalr;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import io.reactivex.Single;
 
-class HttpRequest {
-    private String method;
-    private String url;
-    private final Map<String, String> headers = new HashMap<>();
-
-    public void setMethod(String method) {
-        this.method = method;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public void addHeader(String key, String value) {
-        this.headers.put(key, value);
-    }
-
-    public void addHeaders(Map<String, String> headers) {
-        this.headers.putAll(headers);
-    }
-
-    public String getMethod() {
-        return method;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
-}
-
-class HttpResponse {
-    private final int statusCode;
-    private final String statusText;
-    private final String content;
-
-    public HttpResponse(int statusCode) {
-        this(statusCode, "");
-    }
-
-    public HttpResponse(int statusCode, String statusText) {
-        this(statusCode, statusText, "");
-    }
-
-    public HttpResponse(int statusCode, String statusText, String content) {
-        this.statusCode = statusCode;
-        this.statusText = statusText;
-        this.content = content;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public String getStatusText() {
-        return statusText;
-    }
-}
-
-abstract class HttpClient {
+public abstract class HttpClient {
     public Single<HttpResponse> get(String url) {
         HttpRequest request = new HttpRequest();
         request.setUrl(url);

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -48,7 +48,7 @@ public class HttpHubConnectionBuilder {
      * @param httpClient The {@link HttpClient} to be used by the {@link HubConnection}.
      * @return This instance of the HttpHubConnectionBuilder.
      */
-    HttpHubConnectionBuilder withHttpClient(HttpClient httpClient) {
+    public HttpHubConnectionBuilder withHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
         return this;
     }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpRequest.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpRequest.java
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequest {
+    private String method;
+    private String url;
+    private final Map<String, String> headers = new HashMap<>();
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public void addHeader(String key, String value) {
+        this.headers.put(key, value);
+    }
+
+    public void addHeaders(Map<String, String> headers) {
+        this.headers.putAll(headers);
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpResponse.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpResponse.java
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+public class HttpResponse {
+    private final int statusCode;
+    private final String statusText;
+    private final String content;
+
+    public HttpResponse(int statusCode) {
+        this(statusCode, "");
+    }
+
+    public HttpResponse(int statusCode, String statusText) {
+        this(statusCode, statusText, "");
+    }
+
+    public HttpResponse(int statusCode, String statusText, String content) {
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getStatusText() {
+        return statusText;
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/OnReceiveCallBack.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/OnReceiveCallBack.java
@@ -3,6 +3,6 @@
 
 package com.microsoft.signalr;
 
-interface OnReceiveCallBack {
+public interface OnReceiveCallBack {
     void invoke(String message);
 }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketOnClosedCallback.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketOnClosedCallback.java
@@ -3,6 +3,6 @@
 
 package com.microsoft.signalr;
 
-interface WebSocketOnClosedCallback {
+public interface WebSocketOnClosedCallback {
     void invoke(Integer code, String reason);
 }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketWrapper.java
@@ -5,7 +5,7 @@ package com.microsoft.signalr;
 
 import io.reactivex.Completable;
 
-abstract class WebSocketWrapper {
+public abstract class WebSocketWrapper {
     public abstract Completable start();
 
     public abstract Completable stop();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
- Makes HttpClient abstract class and related classes/interfaces public
- Makes HttpHubConnectionBuilder withHttpClient method public

Addresses #15404
