### PR TITLE
[Blazor][Fixes #16569] Updates _Host.cshtml to avoid rendering the Identity layout

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/_Host.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/_Host.cshtml
@@ -1,6 +1,9 @@
 ﻿@page "/"
 @namespace BlazorServerWeb_CSharp.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{ 
+    Layout = null;
+}
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
When Identity gets scaffolded into the project, it's layout gets applied to the `_Host.cshtml` which results in 2 layouts being applied.
Adding `Layout = null` to `_Host.cshtml` fixes the issue.