### PR TITLE
Don't access CookieContainer unless needed

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.cs
@@ -90,6 +90,14 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Fact]
+        public void HttpOptionsCannotSetNullCookieContainer()
+        {
+            var httpOptions = new HttpConnectionOptions();
+            Assert.NotNull(httpOptions.Cookies);
+            Assert.Throws<ArgumentNullException>(() => httpOptions.Cookies = null);
+        }
+
+        [Fact]
         public async Task HttpRequestAndErrorResponseLogged()
         {
             var testHttpHandler = new TestHttpMessageHandler(false);

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -517,13 +517,14 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 {
                     httpClientHandler.Proxy = _httpConnectionOptions.Proxy;
                 }
-                if (_httpConnectionOptions.Cookies != null)
+
+                // Only access HttpClientHandler.ClientCertificates and HttpClientHandler.CookieContainer
+                // if the user has configured client certs
+                // Some skews of Mono do not support client certs or cookies and will throw NotImplementedException
+                if (_httpConnectionOptions?.Cookies.Count > 0)
                 {
                     httpClientHandler.CookieContainer = _httpConnectionOptions.Cookies;
                 }
-
-                // Only access HttpClientHandler.ClientCertificates if the user has configured client certs
-                // Mono does not support client certs and will throw NotImplementedException
                 // https://github.com/aspnet/SignalR/issues/2232
                 var clientCertificates = _httpConnectionOptions.ClientCertificates;
                 if (clientCertificates?.Count > 0)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -521,7 +521,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 // Only access HttpClientHandler.ClientCertificates and HttpClientHandler.CookieContainer
                 // if the user has configured those options
                 // Some variants of Mono do not support client certs or cookies and will throw NotImplementedException
-                if (_httpConnectionOptions.Cookies?.Count > 0)
+                if (_httpConnectionOptions.Cookies.Count > 0)
                 {
                     httpClientHandler.CookieContainer = _httpConnectionOptions.Cookies;
                 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -519,8 +519,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
 
                 // Only access HttpClientHandler.ClientCertificates and HttpClientHandler.CookieContainer
-                // if the user has configured client certs
-                // Some skews of Mono do not support client certs or cookies and will throw NotImplementedException
+                // if the user has configured those options
+                // Some variants of Mono do not support client certs or cookies and will throw NotImplementedException
                 if (_httpConnectionOptions?.Cookies.Count > 0)
                 {
                     httpClientHandler.CookieContainer = _httpConnectionOptions.Cookies;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -521,7 +521,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 // Only access HttpClientHandler.ClientCertificates and HttpClientHandler.CookieContainer
                 // if the user has configured those options
                 // Some variants of Mono do not support client certs or cookies and will throw NotImplementedException
-                if (_httpConnectionOptions?.Cookies.Count > 0)
+                if (_httpConnectionOptions.Cookies?.Count > 0)
                 {
                     httpClientHandler.CookieContainer = _httpConnectionOptions.Cookies;
                 }


### PR DESCRIPTION
While experimenting with blazor-webassembly and the SignalR C# Client I found that this is the only blocking (not-user fixable) issue for consuming the client with the LongPolling transport.

We set the `_httpConnectionOptions.Cookies` property to a new object in the `HttpConnectionOptions` constructor, so by default it isn't null and will access the `httpClientHandler.CookieContainer` property which will throw in mono wasm.

We want this for 3.1 because blazor-wasm is scheduled for May 2020 and we would like the SignalR Client to work at that time.

No tests because this isn't unit-testable without making a full end-to-end blazor-wasm + signalr test suite.

@Pilchie for 3.1 approval
