### PR TITLE
Fix linker doc URL

### DIFF
--- a/src/Components/Blazor/Build/src/targets/BuiltInBclLinkerDescriptor.xml
+++ b/src/Components/Blazor/Build/src/targets/BuiltInBclLinkerDescriptor.xml
@@ -2,7 +2,7 @@
 
   <!-- This file specifies which parts of the BCL or Blazor packages must not be stripped
   by the IL linker even if they are not referenced by user code. The file format is
-  described at https://github.com/mono/linker/blob/master/linker/README.md#syntax-of-xml-descriptor -->
+  described at https://github.com/mono/linker/blob/master/src/linker/README.md#syntax-of-xml-descriptor -->
 
   <assembly fullname="mscorlib">
     <!-- Preserve all methods on WasmRuntime, because these are called by JS-side code


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Fixed URL in `BuiltInBclLinkerDescriptor.xml` which returns 404.