### PR TITLE
[Blazor][Fixes #15413] Notify client of errors during initialization

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -122,6 +122,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                     // Report errors asynchronously. InitializeAsync is designed not to throw.
                     Log.InitializationFailed(_logger, ex);
                     UnhandledException?.Invoke(this, new UnhandledExceptionEventArgs(ex, isTerminating: false));
+                    await TryNotifyClientErrorAsync(Client, GetClientErrorMessage(ex), ex);
                 }
             });
         }


### PR DESCRIPTION
* The exception was being caught and never reached the client.
* The fix consist simply of notifying the client from where the exception is being caught.