### PR TITLE
Fix multiple attributes usage in conjunction with OpenRegion. Fixes #16570

### DIFF
--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -581,6 +581,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
         public void OpenRegion(int sequence)
         {
+            // We are entering a new scope, since we track the "duplicate attributes" per
+            // element/component we might need to clean them up now.
+            if (_hasSeenAddMultipleAttributes)
+            {
+                var indexOfLastElementOrComponent = _openElementIndices.Peek();
+                ProcessDuplicateAttributes(first: indexOfLastElementOrComponent + 1);
+            }
+
             _openElementIndices.Push(_entries.Count);
             Append(RenderTreeFrame.Region(sequence));
         }

--- a/src/Components/Components/test/Rendering/RenderTreeBuilderTest.cs
+++ b/src/Components/Components/test/Rendering/RenderTreeBuilderTest.cs
@@ -299,6 +299,39 @@ namespace Microsoft.AspNetCore.Components.Rendering
         }
 
         [Fact]
+        public void CanAddMultipleAttributes_WithChildRegion()
+        {
+            // This represents bug https://github.com/aspnet/AspNetCore/issues/16570
+            // If a sequence of attributes is terminated by a call to builder.OpenRegion,
+            // then the attribute deduplication logic wasn't working correctly
+
+            // Arrange
+            var builder = new RenderTreeBuilder();
+
+            // Act
+            builder.OpenElement(0, "myelement");
+            builder.AddAttribute(0, "attribute1", "value1");
+            builder.AddMultipleAttributes(1, new Dictionary<string, object>()
+            {
+                { "attribute1", "value2" },
+            });
+            builder.OpenRegion(2);
+            builder.OpenElement(3, "child");
+            builder.CloseElement();
+            builder.CloseRegion();
+            builder.CloseElement();
+
+            // Assert
+            var frames = builder.GetFrames().AsEnumerable().ToArray();
+            Assert.Collection(
+                frames,
+                frame => AssertFrame.Element(frame, "myelement", 4),
+                frame => AssertFrame.Attribute(frame, "attribute1", "value2"),
+                frame => AssertFrame.Region(frame, 2, 2),
+                frame => AssertFrame.Element(frame, "child", 1, 3));
+        }
+
+        [Fact]
         public void CanAddMultipleAttributes_DictionaryObject()
         {
             var attributes = new Dictionary<string, object>


### PR DESCRIPTION
Each of the scope-opening methods (`OpenElement`, `OpenComponent`, `OpenRegion`) is meant to do a bit of housekeeping related to `AddMultipleAttributes`.

However it seems that `OpenRegion` had been missed out, and the necessary logic had only been applied to `OpenElement` and `OpenComponent`. This resulted in duplicated attributes that confused the diff and produced overall strangeness as seen in #16570.