### PR TITLE
Set connection close with a switch for ANCM out of process

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -14,7 +14,7 @@ class ConfigUtility
     #define CS_ASPNETCORE_HANDLER_SETTINGS                   L"handlerSettings"
     #define CS_ASPNETCORE_HANDLER_VERSION                    L"handlerVersion"
     #define CS_ASPNETCORE_DEBUG_FILE                         L"debugFile"
-    #define CS_ASPNETCORE_ENABLE_CONNECTION_CLOSE            L"enableConnectionClose"
+    #define CS_ASPNETCORE_FORWARD_RESPONSE_CONNECTION_HEADER L"forwardResponseConnectionHeader"
     #define CS_ASPNETCORE_DEBUG_LEVEL                        L"debugLevel"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_NAME              L"name"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_VALUE             L"value"
@@ -43,9 +43,9 @@ public:
 
     static
     HRESULT
-    FindEnableConnectionClose(IAppHostElement* pElement, STRU& strConnectionClose)
+    FindForwardResponseConnectionHeader(IAppHostElement* pElement, STRU& strConnectionClose)
     {
-        return FindKeyValuePair(pElement, CS_ASPNETCORE_ENABLE_CONNECTION_CLOSE, strConnectionClose);
+        return FindKeyValuePair(pElement, CS_ASPNETCORE_FORWARD_RESPONSE_CONNECTION_HEADER, strConnectionClose);
     }
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -43,9 +43,9 @@ public:
 
     static
     HRESULT
-    FindForwardResponseConnectionHeader(IAppHostElement* pElement, STRU& strConnectionClose)
+    FindForwardResponseConnectionHeader(IAppHostElement* pElement, STRU& strForwardResponseConnectionHeader)
     {
-        return FindKeyValuePair(pElement, CS_ASPNETCORE_FORWARD_RESPONSE_CONNECTION_HEADER, strConnectionClose);
+        return FindKeyValuePair(pElement, CS_ASPNETCORE_FORWARD_RESPONSE_CONNECTION_HEADER, strForwardResponseConnectionHeader);
     }
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -14,6 +14,7 @@ class ConfigUtility
     #define CS_ASPNETCORE_HANDLER_SETTINGS                   L"handlerSettings"
     #define CS_ASPNETCORE_HANDLER_VERSION                    L"handlerVersion"
     #define CS_ASPNETCORE_DEBUG_FILE                         L"debugFile"
+    #define CS_ASPNETCORE_ENABLE_CONNECTION_CLOSE            L"enableConnectionClose"
     #define CS_ASPNETCORE_DEBUG_LEVEL                        L"debugLevel"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_NAME              L"name"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_VALUE             L"value"
@@ -38,6 +39,13 @@ public:
     FindDebugLevel(IAppHostElement* pElement, STRU& strDebugFile)
     {
         return FindKeyValuePair(pElement, CS_ASPNETCORE_DEBUG_LEVEL, strDebugFile);
+    }
+
+    static
+    HRESULT
+    FindEnableConnectionClose(IAppHostElement* pElement, STRU& strConnectionClose)
+    {
+        return FindKeyValuePair(pElement, CS_ASPNETCORE_ENABLE_CONNECTION_CLOSE, strConnectionClose);
     }
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -55,7 +55,7 @@ FORWARDING_HANDLER::FORWARDING_HANDLER(
     LOG_TRACE(L"FORWARDING_HANDLER::FORWARDING_HANDLER");
 
     m_fWebSocketSupported = m_pApplication->QueryWebsocketStatus();
-    m_fSendConnectionCloseHeader = m_pApplication->QueryConfig()->QueryEnableConnectionClose()->Equals(L"true", 1);
+    m_fForwardResponseConnectionHeader = m_pApplication->QueryConfig()->QueryForwardResponseConnectionHeader()->Equals(L"true", 1);
     InitializeSRWLock(&m_RequestLock);
 }
 
@@ -2216,7 +2216,7 @@ FORWARDING_HANDLER::SetStatusAndHeaders(
             case HttpHeaderDate:
                 continue;
             case HttpHeaderConnection:
-                if (!m_fSendConnectionCloseHeader)
+                if (!m_fForwardResponseConnectionHeader)
                 {
                     continue;
                 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -55,6 +55,7 @@ FORWARDING_HANDLER::FORWARDING_HANDLER(
     LOG_TRACE(L"FORWARDING_HANDLER::FORWARDING_HANDLER");
 
     m_fWebSocketSupported = m_pApplication->QueryWebsocketStatus();
+    m_fSendConnectionCloseHeader = m_pApplication->QueryConfig()->QueryEnableConnectionClose()->Equals(L"true", 1);
     InitializeSRWLock(&m_RequestLock);
 }
 
@@ -2212,10 +2213,14 @@ FORWARDING_HANDLER::SetStatusAndHeaders(
                     break;
                 }
                 __fallthrough;
-            case HttpHeaderConnection:
             case HttpHeaderDate:
                 continue;
-
+            case HttpHeaderConnection:
+                if (!m_fSendConnectionCloseHeader)
+                {
+                    continue;
+                }
+                continue;
             case HttpHeaderServer:
                 fServerHeaderPresent = TRUE;
                 break;

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -55,7 +55,7 @@ FORWARDING_HANDLER::FORWARDING_HANDLER(
     LOG_TRACE(L"FORWARDING_HANDLER::FORWARDING_HANDLER");
 
     m_fWebSocketSupported = m_pApplication->QueryWebsocketStatus();
-    m_fForwardResponseConnectionHeader = m_pApplication->QueryConfig()->QueryForwardResponseConnectionHeader()->Equals(L"true", 1);
+    m_fForwardResponseConnectionHeader = m_pApplication->QueryConfig()->QueryForwardResponseConnectionHeader()->Equals(L"true", /* ignoreCase */ 1);
     InitializeSRWLock(&m_RequestLock);
 }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -2220,7 +2220,7 @@ FORWARDING_HANDLER::SetStatusAndHeaders(
                 {
                     continue;
                 }
-                continue;
+                break;
             case HttpHeaderServer:
                 fServerHeaderPresent = TRUE;
                 break;

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.h
@@ -179,6 +179,7 @@ private:
     HINTERNET                           m_hRequest;
     FORWARDING_REQUEST_STATUS           m_RequestStatus;
 
+    BOOL                                m_fSendConnectionCloseHeader;
     BOOL                                m_fWebSocketEnabled;
     BOOL                                m_fWebSocketSupported;
     BOOL                                m_fResponseHeadersReceivedAndSet;

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.h
@@ -179,7 +179,7 @@ private:
     HINTERNET                           m_hRequest;
     FORWARDING_REQUEST_STATUS           m_RequestStatus;
 
-    BOOL                                m_fSendConnectionCloseHeader;
+    BOOL                                m_fForwardResponseConnectionHeader;
     BOOL                                m_fWebSocketEnabled;
     BOOL                                m_fWebSocketSupported;
     BOOL                                m_fResponseHeadersReceivedAndSet;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
@@ -379,7 +379,7 @@ REQUESTHANDLER_CONFIG::Populate(
         goto Finished;
     }
 
-    hr = ConfigUtility::FindForwardResponseConnectionHeader(pAspNetCoreElement, m_struEnableConnectionClose);
+    hr = ConfigUtility::FindForwardResponseConnectionHeader(pAspNetCoreElement, m_struForwardResponseConnectionHeader);
     if (FAILED(hr))
     {
         goto Finished;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
@@ -379,6 +379,12 @@ REQUESTHANDLER_CONFIG::Populate(
         goto Finished;
     }
 
+    hr = ConfigUtility::FindEnableConnectionClose(pAspNetCoreElement, m_struEnableConnectionClose);
+    if (FAILED(hr))
+    {
+        goto Finished;
+    }
+
 Finished:
 
     if (pAspNetCoreElement != NULL)

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
@@ -379,7 +379,7 @@ REQUESTHANDLER_CONFIG::Populate(
         goto Finished;
     }
 
-    hr = ConfigUtility::FindEnableConnectionClose(pAspNetCoreElement, m_struEnableConnectionClose);
+    hr = ConfigUtility::FindForwardResponseConnectionHeader(pAspNetCoreElement, m_struEnableConnectionClose);
     if (FAILED(hr))
     {
         goto Finished;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -218,6 +218,12 @@ public:
         return &m_struConfigPath;
     }
 
+    STRU*
+    QueryEnableConnectionClose()
+    {
+        return &m_struEnableConnectionClose;
+    }
+
 protected:
 
     //
@@ -249,6 +255,7 @@ protected:
     STRU                   m_struApplicationPhysicalPath;
     STRU                   m_struApplicationVirtualPath;
     STRU                   m_struConfigPath;
+    STRU                   m_struEnableConnectionClose;
     BOOL                   m_fStdoutLogEnabled;
     BOOL                   m_fForwardWindowsAuthToken;
     BOOL                   m_fDisableStartUpErrorPage;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -221,7 +221,7 @@ public:
     STRU*
     QueryEnableConnectionClose()
     {
-        return &m_struEnableConnectionClose;
+        return &m_struForwardResponseConnectionHeader;
     }
 
 protected:
@@ -255,7 +255,7 @@ protected:
     STRU                   m_struApplicationPhysicalPath;
     STRU                   m_struApplicationVirtualPath;
     STRU                   m_struConfigPath;
-    STRU                   m_struEnableConnectionClose;
+    STRU                   m_struForwardResponseConnectionHeader;
     BOOL                   m_fStdoutLogEnabled;
     BOOL                   m_fForwardWindowsAuthToken;
     BOOL                   m_fDisableStartUpErrorPage;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -219,7 +219,7 @@ public:
     }
 
     STRU*
-    QueryEnableConnectionClose()
+    QueryForwardResponseConnectionHeader()
     {
         return &m_struForwardResponseConnectionHeader;
     }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -148,6 +148,8 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         [RequiresNewShim]
         public async Task SetsConnectionCloseHeader()
         {
+            // Only tests OutOfProcess as the Connection header is removed for out of process and not inprocess. 
+            // This test checks a quirk to allow setting the Connection header.
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
 
             deploymentParameters.HandlerSettings["forwardResponseConnectionHeader"] = "true";

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -150,11 +150,24 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
 
-            deploymentParameters.HandlerSettings["enableConnectionClose"] = "true";
+            deploymentParameters.HandlerSettings["forwardResponseConnectionHeader"] = "true";
             var deploymentResult = await DeployAsync(deploymentParameters);
 
             var response = await deploymentResult.HttpClient.GetAsync("ConnectionClose");
             Assert.Equal(true, response.Headers.ConnectionClose);
+        }
+
+        [ConditionalFact]
+        [RequiresNewHandler]
+        [RequiresNewShim]
+        public async Task ConnectionCloseIsNotPropagated()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var response = await deploymentResult.HttpClient.GetAsync("ConnectionClose");
+            Assert.Null(response.Headers.ConnectionClose);
         }
 
         private static HttpClient CreateNonValidatingClient(IISDeploymentResult deploymentResult)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -143,6 +143,20 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             Assert.Equal("NOVALUE", await client.GetStringAsync("/HTTPS_PORT"));
         }
 
+        [ConditionalFact]
+        [RequiresNewHandler]
+        [RequiresNewShim]
+        public async Task SetsConnectionCloseHeader()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
+
+            deploymentParameters.HandlerSettings["enableConnectionClose"] = "true";
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var response = await deploymentResult.HttpClient.GetAsync("ConnectionClose");
+            Assert.Equal(true, response.Headers.ConnectionClose);
+        }
+
         private static HttpClient CreateNonValidatingClient(IISDeploymentResult deploymentResult)
         {
             var handler = new HttpClientHandler

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -139,6 +139,12 @@ namespace TestSite
             return Task.CompletedTask;
         }
 
+        public Task ConnectionClose(HttpContext context)
+        {
+            context.Response.Headers["connection"] = "close";
+            return Task.CompletedTask;
+        }
+
         public Task OverrideServer(HttpContext context)
         {
             context.Response.Headers["Server"] = "MyServer/7.8";


### PR DESCRIPTION
Internal customer ask to add the ability to allow the connection close header through.

This may target 3.1 eventually if needed.