### PR TITLE
Mark flaky test as flaky

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -2541,7 +2541,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/2408", FlakyOn.AzP.All)]
+        [Flaky("https://github.com/aspnet/AspNetCore/issues/12401", FlakyOn.All)]
         public async Task AppAbortViaIConnectionLifetimeFeatureIsLogged()
         {
             var testContext = new TestServiceContext(LoggerFactory);


### PR DESCRIPTION
Test is flaky on Helix too. Also updating issue link. Will add a comment on the issue pointing to the flaky test.

@Pilchie for 3.1 approval
