### PR TITLE
Add an option to AuthorizationMiddleware that allows passing the requ…

### DIFF
--- a/src/Security/AuthSamples.sln
+++ b/src/Security/AuthSamples.sln
@@ -68,6 +68,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomPolicyProvider", "sam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StaticFilesAuth", "samples\StaticFilesAuth\StaticFilesAuth.csproj", "{E1E8A599-AB42-4551-8C24-BE4404B65283}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Authorization.Policy", "Authorization\Policy\src\Microsoft.AspNetCore.Authorization.Policy.csproj", "{90DC89E3-0673-474B-8303-797A320D991D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -402,6 +404,18 @@ Global
 		{E1E8A599-AB42-4551-8C24-BE4404B65283}.Release|x64.Build.0 = Release|Any CPU
 		{E1E8A599-AB42-4551-8C24-BE4404B65283}.Release|x86.ActiveCfg = Release|Any CPU
 		{E1E8A599-AB42-4551-8C24-BE4404B65283}.Release|x86.Build.0 = Release|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Debug|x64.Build.0 = Debug|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Debug|x86.Build.0 = Debug|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Release|x64.ActiveCfg = Release|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Release|x64.Build.0 = Release|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Release|x86.ActiveCfg = Release|Any CPU
+		{90DC89E3-0673-474B-8303-797A320D991D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -434,6 +448,7 @@ Global
 		{82C0816D-7051-4DDB-9B9E-6777973AD7AE} = {142C8260-90B5-4D72-9564-17BFDD72F496}
 		{38C0E122-64D0-497F-ABB0-C6A9C3349F02} = {CA4538F5-9DA8-4139-B891-A13279889F79}
 		{E1E8A599-AB42-4551-8C24-BE4404B65283} = {CA4538F5-9DA8-4139-B891-A13279889F79}
+		{90DC89E3-0673-474B-8303-797A320D991D} = {142C8260-90B5-4D72-9564-17BFDD72F496}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {39E3AF62-B1FD-4156-92AA-F4FA99B5AD89}

--- a/src/Security/Authorization/Policy/ref/Microsoft.AspNetCore.Authorization.Policy.netcoreapp.cs
+++ b/src/Security/Authorization/Policy/ref/Microsoft.AspNetCore.Authorization.Policy.netcoreapp.cs
@@ -9,6 +9,17 @@ namespace Microsoft.AspNetCore.Authorization
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }
     }
+    public sealed partial class AuthorizationMiddlewareContext
+    {
+        public AuthorizationMiddlewareContext(Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.AspNetCore.Http.Endpoint endpoint) { }
+        public Microsoft.AspNetCore.Http.Endpoint Endpoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.AspNetCore.Http.HttpContext HttpContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public partial class AuthorizationMiddlewareOptions
+    {
+        public AuthorizationMiddlewareOptions() { }
+        public bool AllowRequestContextInHandlerContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
 }
 namespace Microsoft.AspNetCore.Authorization.Policy
 {

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddlewareContext.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddlewareContext.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Context object used by <see cref="AuthorizationMiddleware"/> when invoking an <see cref="IPolicyEvaluator"/>.
+    /// </summary>
+    public sealed class AuthorizationMiddlewareContext
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="AuthorizationHandlerContext"/>.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="Http.HttpContext"/>.</param>
+        /// <param name="endpoint">The <see cref="Http.Endpoint"/>.</param>
+        public AuthorizationMiddlewareContext(HttpContext httpContext, Endpoint endpoint)
+        {
+            HttpContext = httpContext;
+            Endpoint = endpoint;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Http.HttpContext"/>.
+        /// </summary>
+        public HttpContext HttpContext { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Http.Endpoint"/>.
+        /// </summary>
+        public Endpoint Endpoint { get; }
+    }
+}

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddlewareOptions.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddlewareOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Options for an <see cref="AuthorizationMiddleware"/>.
+    /// </summary>
+    public class AuthorizationMiddlewareOptions
+    {
+        /// <summary>
+        /// When an <see cref="AuthorizationHandler{TRequirement}"/> is invoked as part of authorization in the <see cref="AuthorizationMiddleware"/>,
+        /// the <see cref="AuthorizationHandlerContext.Resource"/> instance defaults to being the <see cref="Endpoint"/> that will be processed.
+        /// <para>
+        /// When <see langword="true"/>, the <see cref="AuthorizationMiddleware"/> instead configures the <see cref="AuthorizationHandlerContext.Resource"/> to be
+        /// an instance of <see cref="AuthorizationMiddlewareContext"/>. This allows handlers to access the current request context without the need to use
+        /// <see cref="IHttpContextAccessor"/>.
+        /// </para>
+        /// </summary>
+        public bool AllowRequestContextInHandlerContext { get; set; }
+    }
+}

--- a/src/Security/Security.sln
+++ b/src/Security/Security.sln
@@ -164,8 +164,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server.HttpSys", "..\Servers\HttpSys\src\Microsoft.AspNetCore.Server.HttpSys.csproj", "{D6C3C4A9-197B-47B5-8B72-35047CBC4F22}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Http.Headers", "..\Http\Headers\src\Microsoft.Net.Http.Headers.csproj", "{4BB8D7D7-E111-4A86-B6E5-C1201E0DA8CE}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Security/build.cmd
+++ b/src/Security/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET RepoRoot=%~dp0..\..
+%RepoRoot%\build.cmd -projects %~dp0**\*.*proj %*

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumPolicyProvider.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumPolicyProvider.cs
@@ -5,12 +5,13 @@ using Microsoft.Extensions.Options;
 
 namespace CustomPolicyProvider
 {
-    internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
+    internal class MinimumPolicyProvider : IAuthorizationPolicyProvider
     {
-        const string POLICY_PREFIX = "MinimumAge";
+        internal const string MINIMUMAGE_POLICY_PREFIX = "MinimumAge";
+        internal const string MINIMUMVALUE_POLICY_PREFIX = "MinimumValue";
         public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
 
-        public MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
+        public MinimumPolicyProvider(IOptions<AuthorizationOptions> options)
         {
             // ASP.NET Core only uses one authorization policy provider, so if the custom implementation
             // doesn't handle all policies (including default policies, etc.) it should fall back to an
@@ -35,11 +36,19 @@ namespace CustomPolicyProvider
         // (like [MinimumAgeAuthorize] in this sample)
         public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
         {
-            if (policyName.StartsWith(POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
-                int.TryParse(policyName.Substring(POLICY_PREFIX.Length), out var age))
+            if (policyName.StartsWith(MINIMUMAGE_POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(policyName.Substring(MINIMUMAGE_POLICY_PREFIX.Length), out var age))
             {
                 var policy = new AuthorizationPolicyBuilder();
                 policy.AddRequirements(new MinimumAgeRequirement(age));
+                return Task.FromResult(policy.Build());
+            }
+
+            if (policyName.StartsWith(MINIMUMVALUE_POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(policyName.Substring(MINIMUMVALUE_POLICY_PREFIX.Length), out var value))
+            {
+                var policy = new AuthorizationPolicyBuilder();
+                policy.AddRequirements(new MinimumValueAuthorizationRequirement(value));
                 return Task.FromResult(policy.Build());
             }
 

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumValueAuthorizationHandler.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumValueAuthorizationHandler.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Routing;
+
+namespace CustomPolicyProvider
+{
+    internal class MinimumValueAuthorizationHandler : AuthorizationHandler<MinimumValueAuthorizationRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, MinimumValueAuthorizationRequirement requirement)
+        {
+            var middlewareContext = (AuthorizationMiddlewareContext)context.Resource;
+            var routeContext = middlewareContext.HttpContext.GetRouteData();
+
+            if (!int.TryParse(routeContext.Values["value"].ToString(), out var total) || total < requirement.MinimumValue)
+            {
+                context.Fail();
+            }
+            else
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumValueAuthorizationRequirement.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumValueAuthorizationRequirement.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace CustomPolicyProvider
+{
+    internal class MinimumValueAuthorizationRequirement : IAuthorizationRequirement
+    {
+        public int MinimumValue { get; }
+
+        public MinimumValueAuthorizationRequirement(int minimumValue) { MinimumValue = minimumValue; }
+    }
+}

--- a/src/Security/samples/CustomPolicyProvider/Views/Home/Index.cshtml
+++ b/src/Security/samples/CustomPolicyProvider/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿<h1>Custom Authorization Policy Provider Sample</h1>
+<h1>Custom Authorization Policy Provider Sample</h1>
 
 <p>
     This sample demonstrates a custom IAuthorizationPolicyProvider which
@@ -16,4 +16,6 @@
     <li>@Html.ActionLink("Sign Out", "Signout", "Account")</li>
     <li>@Html.ActionLink("Minimum Age 10", "MinimumAge10", "Home")</li>
     <li>@Html.ActionLink("Minimum Age 50", "MinimumAge50", "Home")</li>
+    <li><a href="/authorized-value/10">Value: 10</a></li>
+    <li><a href="/authorized-value/27">Value: 27</a></li>
 </ul>


### PR DESCRIPTION
…est context to auth handlers

Prior to 3.0, the "resource" instance on AuthorizationHandler was an ActionContext when authorization
executed as an MVC filter. Starting in 3.0, when authorization is invoked as part of the middleware,
the "resource" is an Endpoint instance. Accessing HttpContext requires using the IHttpContextAccessor.

We'll introduce an option that allows, that when set, uses a different context object as the resource.
This AuthorizationMiddlewareContext allows accessing the HttpContext along with the Endpoint that is being
processed.

Fixes https://github.com/aspnet/AspNetCore/issues/16695

