### PR TITLE
Keep Kestrel's connection PipeReader in a consistent state

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -163,7 +163,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
 
                         // Read() will have already have greedily consumed the entire request body if able.
-                        CheckCompletedReadResult(result);
+                        if (result.IsCompleted)
+                        {
+                            ThrowUnexpectedEndOfRequestContent();
+                        }
                     }
                     finally
                     {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1UpgradeMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1UpgradeMessageBody.cs
@@ -25,19 +25,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
-            if (_completed)
-            {
-                throw new InvalidOperationException("Reading is not allowed after the reader was completed.");
-            }
+            ThrowIfCompleted();
             return _context.Input.ReadAsync(cancellationToken);
         }
 
         public override bool TryRead(out ReadResult result)
         {
-            if (_completed)
-            {
-                throw new InvalidOperationException("Reading is not allowed after the reader was completed.");
-            }
+            ThrowIfCompleted();
             return _context.Input.TryRead(out result);
         }
 


### PR DESCRIPTION
- When the request body PipeReader.ReadAsync throws, the connection-level
pipe should be advanced, so subsequent attempts to read from the
connection-level pipe don't fail unnecessarily

Addresses #14727
