### PR TITLE
Extend timeout and report failure to WarmUp for template tests

### DIFF
--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -146,17 +146,17 @@ namespace Templates.Test
             Browser.Equal("Hello, world!", () => Browser.FindElement(By.TagName("h1")).Text);
 
             // Can navigate to the counter page
-            Browser.FindElement(By.PartialLinkText("Counter")).Click();
+            Browser.Click(By.PartialLinkText("Counter"));
             Browser.Contains("counter", () => Browser.Url);
             Browser.Equal("Counter", () => Browser.FindElement(By.TagName("h1")).Text);
 
             // Clicking the counter button works
             Browser.Equal("Current count: 0", () => Browser.FindElement(By.CssSelector("h1 + p")).Text);
-            Browser.FindElement(By.CssSelector("p+button")).Click();
+            Browser.Click(By.CssSelector("p+button"));
             Browser.Equal("Current count: 1", () => Browser.FindElement(By.CssSelector("h1 + p")).Text);
 
             // Can navigate to the 'fetch data' page
-            Browser.FindElement(By.PartialLinkText("Fetch data")).Click();
+            Browser.Click(By.PartialLinkText("Fetch data"));
             Browser.Contains("fetchdata", () => Browser.Url);
             Browser.Equal("Weather forecast", () => Browser.FindElement(By.TagName("h1")).Text);
 

--- a/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -253,25 +253,25 @@ namespace Templates.Test.SpaTemplateTest
             browser.Equal("Hello, world!", () => browser.FindElement(By.TagName("h1")).Text);
 
             // Can navigate to the counter page
-            browser.FindElement(By.PartialLinkText("Counter")).Click();
+            browser.Click(By.PartialLinkText("Counter"));
             browser.Contains("counter", () => browser.Url);
 
             browser.Equal("Counter", () => browser.FindElement(By.TagName("h1")).Text);
 
             // Clicking the counter button works
             browser.Equal("0", () => browser.FindElement(By.CssSelector("p>strong")).Text);
-            browser.FindElement(By.CssSelector("p+button")).Click();
+            browser.Click(By.CssSelector("p+button")) ;
             browser.Equal("1", () => browser.FindElement(By.CssSelector("p>strong")).Text);
 
             if (visitFetchData)
             {
-                browser.FindElement(By.PartialLinkText("Fetch data")).Click();
+                browser.Click(By.PartialLinkText("Fetch data"));
 
                 if (usesAuth)
                 {
                     // We will be redirected to the identity UI
                     browser.Contains("/Identity/Account/Login", () => browser.Url);
-                    browser.FindElement(By.PartialLinkText("Register as a new user")).Click();
+                    browser.Click(By.PartialLinkText("Register as a new user"));
 
                     var userName = $"{Guid.NewGuid()}@example.com";
                     var password = $"!Test.Password1$";
@@ -279,24 +279,24 @@ namespace Templates.Test.SpaTemplateTest
                     browser.FindElement(By.Name("Input.Email")).SendKeys(userName);
                     browser.FindElement(By.Name("Input.Password")).SendKeys(password);
                     browser.FindElement(By.Name("Input.ConfirmPassword")).SendKeys(password);
-                    browser.FindElement(By.Id("registerSubmit")).Click();
+                    browser.Click(By.Id("registerSubmit"));
 
                     // We will be redirected to the RegisterConfirmation
                     browser.Contains("/Identity/Account/RegisterConfirmation", () => browser.Url);
-                    browser.FindElement(By.PartialLinkText("Click here to confirm your account")).Click();
+                    browser.Click(By.PartialLinkText("Click here to confirm your account"));
 
                     // We will be redirected to the ConfirmEmail
                     browser.Contains("/Identity/Account/ConfirmEmail", () => browser.Url);
 
                     // Now we can login
-                    browser.FindElement(By.PartialLinkText("Login")).Click();
+                    browser.Click(By.PartialLinkText("Login"));
                     browser.Exists(By.Name("Input.Email"));
                     browser.FindElement(By.Name("Input.Email")).SendKeys(userName);
                     browser.FindElement(By.Name("Input.Password")).SendKeys(password);
-                    browser.FindElement(By.Id("login-submit")).Click();
+                    browser.Click(By.Id("login-submit"));
 
                     // Need to navigate to fetch page
-                    browser.FindElement(By.PartialLinkText("Fetch data")).Click();
+                    browser.Click(By.PartialLinkText("Fetch data"));
                 }
 
                 // Can navigate to the 'fetch data' page

--- a/src/Shared/E2ETesting/WaitAssert.cs
+++ b/src/Shared/E2ETesting/WaitAssert.cs
@@ -63,6 +63,12 @@ namespace Microsoft.AspNetCore.E2ETesting
                 return result;
             }, timeout);
 
+        public static void Click(this IWebDriver driver, By selector)
+            => WaitAssertCore(driver, () =>
+            {
+                driver.FindElement(selector).Click();
+            });
+
         private static void WaitAssertCore(IWebDriver driver, Action assertion, TimeSpan timeout = default)
         {
             WaitAssertCore<object>(driver, () => { assertion(); return null; }, timeout);


### PR DESCRIPTION
## Description

- Retry Click events and get a screenshot on failure.
- Extend warmup timeout and warn when it doesn't complete in time.

## Risk
Very low. The only changes are to tests and test infrastructure. The only risk is that the tests become more flaky, though they're already among the top failures, and this gives us more information when they DO fail.

## User impact
None. Changes are to tests only.

Part of https://github.com/aspnet/AspNetCore-Internal/issues/2996.