### PR TITLE
Update SignalR NPM package readme to show how to install previews

### DIFF
--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
@@ -4,10 +4,16 @@ MsgPack support for SignalR for ASP.NET Core
 
 ```bash
 npm install @microsoft/signalr-protocol-msgpack
-```
-or
-```bash
+# or
 yarn add @microsoft/signalr-protocol-msgpack
+```
+
+To try previews of the next version, use the `next` tag on NPM:
+
+```bash
+npm install @microsoft/signalr-protocol-msgpack@next
+# or
+yarn add @microsoft/signalr-protocol-msgpack@next
 ```
 
 ## Usage

--- a/src/SignalR/clients/ts/signalr/README.md
+++ b/src/SignalR/clients/ts/signalr/README.md
@@ -4,10 +4,16 @@ JavaScript and TypeScript clients for SignalR for ASP.NET Core and Azure SignalR
 
 ```bash
 npm install @microsoft/signalr
-```
-or
-```bash
+# or
 yarn add @microsoft/signalr
+```
+
+To try previews of the next version, use the `next` tag on NPM:
+
+```bash
+npm install @microsoft/signalr@next
+# or
+yarn add @microsoft/signalr@next
 ```
 
 ## Usage


### PR DESCRIPTION
Was on https://www.npmjs.com/package/@microsoft/signalr validating the 3.1.0-preview2 staging and thought "hey, it would be nice if these READMEs showed how to install previews". Also, I made it a little more compact by using just one code fence for each of latest and next and using a Bash comment to separate them.