### PR TITLE
Set new HTTPS environment variable when using out of process (#16724)

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -23,6 +23,8 @@ Directory.Build.props checks this property using the following condition:
       Microsoft.AspNetCore.Http.Abstractions;
       Microsoft.AspNetCore.Http.Features;
       Microsoft.AspNetCore.CookiePolicy;
+      Microsoft.AspNetCore.HttpsPolicy;
+      Microsoft.AspNetCore.AspNetCoreModuleV2;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Ports https://github.com/aspnet/AspNetCore/pull/16724 manually (for 3.1-preview3), since it's blocked by https://github.com/aspnet/AspNetCore/pull/16621. CC @jkotalik 