### PR TITLE
[Low Risk Cleanup] Removes double semicolons

### DIFF
--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public async Task EditFormWorksWithDataAnnotationsValidator()
         {
-            var appElement = MountSimpleValidationComponent();;
+            var appElement = MountSimpleValidationComponent();
             var form = appElement.FindElement(By.TagName("form"));
             var userNameInput = appElement.FindElement(By.ClassName("user-name")).FindElement(By.TagName("input"));
             var acceptsTermsInput = appElement.FindElement(By.ClassName("accepts-terms")).FindElement(By.TagName("input"));

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
 
             if (DeploymentParameters.RuntimeArchitecture == RuntimeArchitecture.x86)
             {
-                pool.SetAttributeValue("enable32BitAppOnWin64", "true");;
+                pool.SetAttributeValue("enable32BitAppOnWin64", "true");
             }
 
             RunServerConfigActions(config, contentRoot);

--- a/src/Servers/Kestrel/Core/test/TimeoutControlTests.cs
+++ b/src/Servers/Kestrel/Core/test/TimeoutControlTests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             
             // Read 0 bytes in 1 second
             now += TimeSpan.FromSeconds(1);
-            _timeoutControl.Tick(now);;
+            _timeoutControl.Tick(now);
 
             // Timed out
             _mockTimeoutHandler.Verify(h => h.OnTimeout(TimeoutReason.ReadDataRate), Times.Once);

--- a/src/Servers/Kestrel/Transport.Libuv/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
@@ -2,13 +2,12 @@
 
   <PropertyGroup>
     <Description>Libuv transport for the ASP.NET Core Kestrel cross-platform web server.</Description>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591;$(NoWarn)</NoWarn>
     <IsShippingPackage>true</IsShippingPackage>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.Libuv/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <Description>Libuv transport for the ASP.NET Core Kestrel cross-platform web server.</Description>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591;$(NoWarn)</NoWarn>
     <IsShippingPackage>true</IsShippingPackage>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.Libuv/test/LibuvOutputConsumerTests.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/test/LibuvOutputConsumerTests.cs
@@ -606,7 +606,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
 
                     Assert.True(task3Success.IsCompleted);
                     Assert.False(task3Success.IsCanceled);
-                    Assert.False(task3Success.IsFaulted);;
+                    Assert.False(task3Success.IsFaulted);
                 }
             });
         }

--- a/src/Servers/Kestrel/stress/Program.cs
+++ b/src/Servers/Kestrel/stress/Program.cs
@@ -237,7 +237,7 @@ public class Program
                 using (HttpResponseMessage m = await ctx.HttpClient.SendAsync(req))
                 {
                     ValidateResponse(m, httpVersion);
-                    ValidateContent(content, await m.Content.ReadAsStringAsync());;
+                    ValidateContent(content, await m.Content.ReadAsStringAsync());
                 }
             }),
 

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolSlab.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolSlab.cs
@@ -58,7 +58,7 @@ namespace System.Buffers
             _isDisposed = true;
 
             Array = null;
-            NativePointer = IntPtr.Zero;;
+            NativePointer = IntPtr.Zero;
 
             if (_gcHandle.IsAllocated)
             {

--- a/src/SignalR/common/SignalR.Common/test/Internal/Formatters/BinaryMessageParserTests.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Formatters/BinaryMessageParserTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Formatters
         {
             var ex = Assert.Throws<FormatException>(() =>
             {
-                var buffer = new ReadOnlySequence<byte>(payload);;
+                var buffer = new ReadOnlySequence<byte>(payload);
                 BinaryMessageParser.TryParseMessage(ref buffer, out var message);
             });
             Assert.Equal("Messages over 2GB in size are not supported.", ex.Message);


### PR DESCRIPTION
Removes double semicolons since they are not needed.

No specific testing since there are no functional changes. This is low risk.
