### PR TITLE
Keep Blazor at pre-release for 3.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,9 @@
     <IncludePreReleaseLabelInPackageVersion Condition=" '$(DotNetFinalVersionKind)' == 'release' ">false</IncludePreReleaseLabelInPackageVersion>
     <PreReleaseVersionLabel>preview$(PreReleasePreviewNumber)</PreReleaseVersionLabel>
     <PreReleaseBrandingLabel>Preview $(PreReleasePreviewNumber)</PreReleaseBrandingLabel>
+    <!-- Blazor Client packages will not RTM with 3.1 -->
+    <BlazorClientPreReleasePreviewNumber>4</BlazorClientPreReleasePreviewNumber>
+    <BlazorClientPreReleaseVersionLabel>preview$(BlazorClientPreReleasePreviewNumber)</BlazorClientPreReleaseVersionLabel>
     <AspNetCoreMajorMinorVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</AspNetCoreMajorMinorVersion>
     <!-- Additional assembly attributes are already configured to include the source revision ID. -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <!-- Override prerelease label and use preview 4, even in the final build -->
+    <PreReleaseVersionLabel>$(BlazorClientPreReleaseVersionLabel)</PreReleaseVersionLabel>
+    <DotNetFinalVersionKind></DotNetFinalVersionKind>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This ensures that the following Blazor packages remain branded as 3.1.x-preview4:
•	Microsoft.AspNetCore.Blazor
•	Microsoft.AspNetCore.Blazor.HttpClient
•	Microsoft.AspNetCore.Blazor.DataAnnotations.Validation
•	Microsoft.AspNetCore.Blazor.Templates
•	Microsoft.AspNetCore.Blazor.Build
•	Microsoft.AspNetCore.Blazor.Mono
•	Microsoft.AspNetCore.Blazor.Server
•	Microsoft.AspNetCore.Blazor.DevServer

Note that Microsoft.AspNetCore.Blazor.Mono is built in aspnet/Blazor so that will require a different branding change.