### PR TITLE
Use M.NC.App RefPack version for dotnet targeting pack dependency version

### DIFF
--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -21,7 +21,7 @@
     </ProjectReference>
 
     <InstallerOwnedDirectory Include="$(RpmPackageInstallRoot)packs/$(TargetingPackName)/" />
-    <RpmDependency Include="dotnet-targeting-pack-$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)" Version="$(MicrosoftNETCoreAppRuntimeVersion.Split('-')[0])" />
+    <RpmDependency Include="dotnet-targeting-pack-$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)" Version="$(MicrosoftNETCoreAppRefPackageVersion.Split('-')[0])" />
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />


### PR DESCRIPTION
We should keep the dependency on the dotnet-targeting-pack in line with our (pinned) dependency on `Microsoft.NetCore.App.Ref. This fixes the following error in Core-SDK:

> EXEC : error : Failed dependencies: [/home/vsts/work/1/s/src/redist/redist.csproj] 
##[error]EXEC(0,0): error : Failed dependencies: 
dotnet-targeting-pack-3.0 >= 3.0.1 is needed by aspnetcore-targeting-pack-3.0-3.0.1-1.x86_64 


> /home/vsts/work/1/s/src/redist/targets/GenerateRPMs.targets(295,5): error MSB3073: The command "sudo rpm -iv /home/vsts/work/1/s/artifacts/obj/redist/Release/downloads/aspnetcore-targeting-pack-3.0.1.rpm" exited with code 1. [/home/vsts/work/1/s/src/redist/redist.csproj] 


> ##[error]src/redist/targets/GenerateRPMs.targets(295,5): error MSB3073: The command "sudo rpm -iv /home/vsts/work/1/s/artifacts/obj/redist/Release/downloads/aspnetcore-targeting-pack-3.0.1.rpm" exited with code 1.

CC @dougbu @JunTaoLuo @nguerrera @mmitche 