### PR TITLE
HttpSys HTTP/2 Response Trailers

### DIFF
--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -234,7 +234,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     {
                         // We haven't sent a response yet, try to send a 500 Internal Server Error
                         requestContext.Response.Headers.IsReadOnly = false;
+                        requestContext.Response.Trailers.IsReadOnly = false;
                         requestContext.Response.Headers.Clear();
+                        requestContext.Response.Trailers.Clear();
                         SetFatalResponse(requestContext, 500);
                     }
                 }

--- a/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
@@ -11,11 +11,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Minimum support for Windows 7 is assumed.
         internal static readonly bool IsWin8orLater;
 
+        internal static readonly bool SupportsTrailers;
+
         static ComNetOS()
         {
             var win8Version = new Version(6, 2);
 
             IsWin8orLater = (Environment.OSVersion.Version >= win8Version);
+
+            SupportsTrailers = Environment.OSVersion.Version >= new Version(10, 0, 19505);
         }
     }
 }

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -144,11 +144,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         public HeaderCollection Headers { get; }
 
-        public HeaderCollection Trailers { get => _trailers ??= new HeaderCollection(checkTrailers: true); }
+        public HeaderCollection Trailers => _trailers ??= new HeaderCollection(checkTrailers: true);
 
-        internal bool HasTrailers { get => _trailers?.Count > 0; }
+        internal bool HasTrailers => _trailers?.Count > 0;
 
-        // Trailers are supported on this OS, it's HTTP/2, and the app added a Trailer response header to annouce trailers were intended.
+        // Trailers are supported on this OS, it's HTTP/2, and the app added a Trailer response header to announce trailers were intended.
         // Needed to delay the completion of Content-Length responses.
         internal bool TrailersExpected => HasTrailers
             || (ComNetOS.SupportsTrailers && Request.ProtocolVersion >= HttpVersion.Version20

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
@@ -253,6 +253,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 _requestContext.Response.SerializeTrailers(dataChunks, currentChunk, pins);
             }
+            else if (endOfRequest)
+            {
+                _requestContext.Response.MakeTrailersReadOnly();
+            }
 
             return pins;
         }
@@ -466,6 +470,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             if (_leftToWrite == 0 && !_requestContext.Response.TrailersExpected)
             {
                 // in this case we already passed 0 as the flag, so we don't need to call HttpSendResponseEntityBody() when we Close()
+                _requestContext.Response.MakeTrailersReadOnly();
                 _disposed = true;
             }
             // else -1 unlimited

--- a/src/Servers/HttpSys/src/StandardFeatureCollection.cs
+++ b/src/Servers/HttpSys/src/StandardFeatureCollection.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             { typeof(IHttpMaxRequestBodySizeFeature), _identityFunc },
             { typeof(IHttpBodyControlFeature), _identityFunc },
             { typeof(IHttpSysRequestInfoFeature), _identityFunc },
+            { typeof(IHttpResponseTrailersFeature), ctx => ctx.GetResponseTrailersFeature() },
         };
 
         private readonly FeatureContext _featureContext;

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -206,16 +206,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private async Task<string> SendRequestAsync(string uri,
             X509Certificate cert = null)
         {
-            var handler = new WinHttpHandler();
-            handler.ServerCertificateValidationCallback = (a, b, c, d) => true;
+            var handler = new HttpClientHandler();
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
             if (cert != null)
             {
                 handler.ClientCertificates.Add(cert);
             }
-            using (HttpClient client = new HttpClient(handler))
-            {
-                return await client.GetStringAsync(uri);
-            }
+            using HttpClient client = new HttpClient(handler);
+            return await client.GetStringAsync(uri);
         }
 
         private async Task<string> SendRequestAsync(string uri, string upload)

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -53,33 +54,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
-        // https://tools.ietf.org/html/rfc7230#section-4.1.2
-        private readonly List<string> _disallowedTrailers = new List<string>()
-        {
-            // Message framing headers.
-            HeaderNames.TransferEncoding, HeaderNames.ContentLength,
-
-            // Routing headers.
-            HeaderNames.Host,
-
-            // Request modifiers: controls and conditionals.
-            // rfc7231#section-5.1: Controls.
-            HeaderNames.CacheControl, HeaderNames.Expect, HeaderNames.MaxForwards, HeaderNames.Pragma, HeaderNames.Range, HeaderNames.TE,
-
-            // rfc7231#section-5.2: Conditionals.
-            HeaderNames.IfMatch, HeaderNames.IfNoneMatch, HeaderNames.IfModifiedSince, HeaderNames.IfUnmodifiedSince, HeaderNames.IfRange,
-
-            // Authentication headers.
-            HeaderNames.WWWAuthenticate, HeaderNames.Authorization, HeaderNames.ProxyAuthenticate, HeaderNames.ProxyAuthorization, HeaderNames.SetCookie, HeaderNames.Cookie,
-
-            // Response control data.
-            // rfc7231#section-7.1: Control Data.
-            HeaderNames.Age, HeaderNames.Expires, HeaderNames.Date, HeaderNames.Location, HeaderNames.RetryAfter, HeaderNames.Vary, HeaderNames.Warning,
-
-            // Content-Encoding, Content-Type, Content-Range, and Trailer itself.
-            HeaderNames.ContentEncoding, HeaderNames.ContentType, HeaderNames.ContentRange, HeaderNames.Trailer
-        };
-
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_ProhibitedTrailers_Blocked()
@@ -87,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
             {
                 Assert.True(httpContext.Response.SupportsTrailers());
-                foreach (var header in _disallowedTrailers)
+                foreach (var header in HeaderCollection.DisallowedTrailers)
                 {
                     Assert.Throws<InvalidOperationException>(() => httpContext.Response.AppendTrailer(header, "value"));
                 }

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
@@ -1,0 +1,384 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    public class ResponseTrailersTests
+    {
+        [ConditionalFact]
+        public async Task ResponseTrailers_HTTP11_TrailersNotAvailable()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                Assert.Equal("HTTP/1.1", httpContext.Request.Protocol);
+                Assert.False(httpContext.Response.SupportsTrailers());
+                return Task.FromResult(0);
+            }))
+            {
+                var response = await SendRequestAsync(address, http2: false);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version11, response.Version);
+                Assert.Empty(response.TrailingHeaders);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_HTTP2_TrailersAvailable()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                Assert.Equal("HTTP/2", httpContext.Request.Protocol);
+                Assert.True(httpContext.Response.SupportsTrailers());
+                return Task.FromResult(0);
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.Empty(response.TrailingHeaders);
+            }
+        }
+
+        // https://tools.ietf.org/html/rfc7230#section-4.1.2
+        private readonly List<string> _disallowedTrailers = new List<string>()
+        {
+            // Message framing headers.
+            HeaderNames.TransferEncoding, HeaderNames.ContentLength,
+
+            // Routing headers.
+            HeaderNames.Host,
+
+            // Request modifiers: controls and conditionals.
+            // rfc7231#section-5.1: Controls.
+            HeaderNames.CacheControl, HeaderNames.Expect, HeaderNames.MaxForwards, HeaderNames.Pragma, HeaderNames.Range, HeaderNames.TE,
+
+            // rfc7231#section-5.2: Conditionals.
+            HeaderNames.IfMatch, HeaderNames.IfNoneMatch, HeaderNames.IfModifiedSince, HeaderNames.IfUnmodifiedSince, HeaderNames.IfRange,
+
+            // Authentication headers.
+            HeaderNames.WWWAuthenticate, HeaderNames.Authorization, HeaderNames.ProxyAuthenticate, HeaderNames.ProxyAuthorization, HeaderNames.SetCookie, HeaderNames.Cookie,
+
+            // Response control data.
+            // rfc7231#section-7.1: Control Data.
+            HeaderNames.Age, HeaderNames.Expires, HeaderNames.Date, HeaderNames.Location, HeaderNames.RetryAfter, HeaderNames.Vary, HeaderNames.Warning,
+
+            // Content-Encoding, Content-Type, Content-Range, and Trailer itself.
+            HeaderNames.ContentEncoding, HeaderNames.ContentType, HeaderNames.ContentRange, HeaderNames.Trailer
+        };
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_ProhibitedTrailers_Blocked()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                Assert.True(httpContext.Response.SupportsTrailers());
+                foreach (var header in _disallowedTrailers)
+                {
+                    Assert.Throws<InvalidOperationException>(() => httpContext.Response.AppendTrailer(header, "value"));
+                }
+                return Task.FromResult(0);
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.Empty(response.TrailingHeaders);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_NoBody_TrailersSent()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                httpContext.Response.DeclareTrailer("trailername");
+                httpContext.Response.AppendTrailer("trailername", "TrailerValue");
+                return Task.FromResult(0);
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.NotEmpty(response.TrailingHeaders);
+                Assert.Equal("TrailerValue", response.TrailingHeaders.GetValues("TrailerName").Single());
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_WithBody_TrailersSent()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                await httpContext.Response.WriteAsync("Hello World");
+                httpContext.Response.AppendTrailer("TrailerName", "Trailer Value");
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+                Assert.NotEmpty(response.TrailingHeaders);
+                Assert.Equal("Trailer Value", response.TrailingHeaders.GetValues("TrailerName").Single());
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_WithContentLengthBody_TrailersNotSent()
+        {
+            var body = "Hello World";
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                httpContext.Response.ContentLength = body.Length;
+                await httpContext.Response.WriteAsync(body);
+                httpContext.Response.AppendTrailer("TrailerName", "Trailer Value");
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.Equal(body.Length.ToString(CultureInfo.InvariantCulture), response.Content.Headers.GetValues(HeaderNames.ContentLength).Single());
+                Assert.Equal(body, await response.Content.ReadAsStringAsync());
+                Assert.Empty(response.TrailingHeaders);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_WithTrailersBeforeContentLengthBody_TrailersSent()
+        {
+            var body = "Hello World";
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                httpContext.Response.ContentLength = body.Length * 2;
+                await httpContext.Response.WriteAsync(body);
+                httpContext.Response.AppendTrailer("TrailerName", "Trailer Value");
+                await httpContext.Response.WriteAsync(body);
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                // Avoid HttpContent's automatic content-length calculation.
+                Assert.True(response.Content.Headers.TryGetValues(HeaderNames.ContentLength, out var contentLength), HeaderNames.ContentLength);
+                Assert.Equal((2 * body.Length).ToString(CultureInfo.InvariantCulture), contentLength.First());
+                Assert.Equal(body + body, await response.Content.ReadAsStringAsync());
+                Assert.NotEmpty(response.TrailingHeaders);
+                Assert.Equal("Trailer Value", response.TrailingHeaders.GetValues("TrailerName").Single());
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_WithContentLengthBodyAndDeclared_TrailersSent()
+        {
+            var body = "Hello World";
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                httpContext.Response.ContentLength = body.Length;
+                httpContext.Response.DeclareTrailer("TrailerName");
+                await httpContext.Response.WriteAsync(body);
+                httpContext.Response.AppendTrailer("TrailerName", "Trailer Value");
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                // Avoid HttpContent's automatic content-length calculation.
+                Assert.True(response.Content.Headers.TryGetValues(HeaderNames.ContentLength, out var contentLength), HeaderNames.ContentLength);
+                Assert.Equal(body.Length.ToString(CultureInfo.InvariantCulture), contentLength.First());
+                Assert.Equal("TrailerName", response.Headers.Trailer.Single());
+                Assert.Equal(body, await response.Content.ReadAsStringAsync());
+                Assert.NotEmpty(response.TrailingHeaders);
+                Assert.Equal("Trailer Value", response.TrailingHeaders.GetValues("TrailerName").Single());
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_WithContentLengthBodyAndDeclaredButMissingTrailers_Completes()
+        {
+            var body = "Hello World";
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                httpContext.Response.ContentLength = body.Length;
+                httpContext.Response.DeclareTrailer("TrailerName");
+                await httpContext.Response.WriteAsync(body);
+                // If we declare trailers but don't send any make sure it completes anyways.
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                // Avoid HttpContent's automatic content-length calculation.
+                Assert.True(response.Content.Headers.TryGetValues(HeaderNames.ContentLength, out var contentLength), HeaderNames.ContentLength);
+                Assert.Equal(body.Length.ToString(CultureInfo.InvariantCulture), contentLength.First());
+                Assert.Equal("TrailerName", response.Headers.Trailer.Single());
+                Assert.Equal(body, await response.Content.ReadAsStringAsync());
+                Assert.Empty(response.TrailingHeaders);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_CompleteAsyncNoBody_TrailersSent()
+        {
+            var trailersReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                httpContext.Response.AppendTrailer("trailername", "TrailerValue");
+                await httpContext.Response.CompleteAsync();
+                await trailersReceived.Task.WithTimeout();
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.NotEmpty(response.TrailingHeaders);
+                Assert.Equal("TrailerValue", response.TrailingHeaders.GetValues("TrailerName").Single());
+                trailersReceived.SetResult(0);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_CompleteAsyncWithBody_TrailersSent()
+        {
+            var trailersReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
+            {
+                await httpContext.Response.WriteAsync("Hello World");
+                httpContext.Response.AppendTrailer("TrailerName", "Trailer Value");
+                await httpContext.Response.CompleteAsync();
+                await trailersReceived.Task.WithTimeout();
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+                Assert.NotEmpty(response.TrailingHeaders);
+                Assert.Equal("Trailer Value", response.TrailingHeaders.GetValues("TrailerName").Single());
+                trailersReceived.SetResult(0);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_MultipleValues_SentAsSeperateHeaders()
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                httpContext.Response.AppendTrailer("trailername", new StringValues(new[] { "TrailerValue0", "TrailerValue1" }));
+                return Task.FromResult(0);
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.NotEmpty(response.TrailingHeaders);
+                // We can't actually assert they are sent as seperate headers using HttpClient, we'd have to write a lower level test
+                // that read the header frames directly.
+                Assert.Equal(new[] { "TrailerValue0", "TrailerValue1" }, response.TrailingHeaders.GetValues("TrailerName"));
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_LargeTrailers_Success()
+        {
+            var values = new[] {
+                        new string('a', 1024),
+                        new string('b', 1024 * 4),
+                        new string('c', 1024 * 8),
+                        new string('d', 1024 * 16),
+                        new string('e', 1024 * 32),
+                        new string('f', 1024 * 64 - 1) }; // Max header size
+
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                httpContext.Response.AppendTrailer("ThisIsALongerHeaderNameThatStillWorksForReals", new StringValues(values));
+                return Task.FromResult(0);
+            }))
+            {
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response.Version);
+                Assert.NotEmpty(response.TrailingHeaders);
+                // We can't actually assert they are sent in multiple frames using HttpClient, we'd have to write a lower level test
+                // that read the header frames directly. We at least verify that really large values work.
+                Assert.Equal(values, response.TrailingHeaders.GetValues("ThisIsALongerHeaderNameThatStillWorksForReals"));
+            }
+        }
+
+        [ConditionalTheory, MemberData(nameof(NullHeaderData))]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        public async Task ResponseTrailers_NullValues_Ignored(string headerName, StringValues headerValue, StringValues expectedValue)
+        {
+            using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
+            {
+                httpContext.Response.AppendTrailer(headerName, headerValue);
+                return Task.FromResult(0);
+            }))
+            {
+                HttpResponseMessage response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                var headers = response.TrailingHeaders;
+
+                if (StringValues.IsNullOrEmpty(expectedValue))
+                {
+                    Assert.False(headers.Contains(headerName));
+                }
+                else
+                {
+                    Assert.True(headers.Contains(headerName));
+                    Assert.Equal(headers.GetValues(headerName), expectedValue);
+                }
+            }
+        }
+
+        public static TheoryData<string, StringValues, StringValues> NullHeaderData
+        {
+            get
+            {
+                var dataset = new TheoryData<string, StringValues, StringValues>();
+
+                dataset.Add("NullString", (string)null, (string)null);
+                dataset.Add("EmptyString", "", "");
+                dataset.Add("NullStringArray", new string[] { null }, "");
+                dataset.Add("EmptyStringArray", new string[] { "" }, "");
+                dataset.Add("MixedStringArray", new string[] { null, "" }, new string[] { "", "" });
+                dataset.Add("WithValidStrings", new string[] { null, "Value", "" }, new string[] { "", "Value", "" });
+
+                return dataset;
+            }
+        }
+
+        private async Task<HttpResponseMessage> SendRequestAsync(string uri, bool http2 = true)
+        {
+            var handler = new HttpClientHandler();
+            handler.MaxResponseHeadersLength = 128;
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            using HttpClient client = new HttpClient(handler);
+            client.DefaultRequestVersion = http2 ? HttpVersion.Version20 : HttpVersion.Version11;
+            return await client.GetAsync(uri);
+        }
+    }
+}

--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -88,6 +88,9 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
             [FieldOffset(8)]
             internal FromFileHandle fromFile;
+
+            [FieldOffset(8)]
+            internal Trailers trailers;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -104,6 +107,13 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             internal ulong offset;
             internal ulong count;
             internal IntPtr fileHandle;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct Trailers
+        {
+            internal ushort trailerCount;
+            internal IntPtr pTrailers;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -362,10 +372,12 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         internal enum HTTP_DATA_CHUNK_TYPE : int
         {
-            HttpDataChunkFromMemory = 0,
-            HttpDataChunkFromFileHandle = 1,
-            HttpDataChunkFromFragmentCache = 2,
-            HttpDataChunkMaximum = 3,
+            HttpDataChunkFromMemory,
+            HttpDataChunkFromFileHandle,
+            HttpDataChunkFromFragmentCache,
+            HttpDataChunkFromFragmentCacheEx,
+            HttpDataChunkTrailers,
+            HttpDataChunkMaximum,
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -12,12 +12,42 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 {
     internal class HeaderCollection : IHeaderDictionary
     {
+        // https://tools.ietf.org/html/rfc7230#section-4.1.2
+        private static readonly HashSet<string> _disallowedTrailers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Message framing headers.
+            HeaderNames.TransferEncoding, HeaderNames.ContentLength,
+
+            // Routing headers.
+            HeaderNames.Host,
+
+            // Request modifiers: controls and conditionals.
+            // rfc7231#section-5.1: Controls.
+            HeaderNames.CacheControl, HeaderNames.Expect, HeaderNames.MaxForwards, HeaderNames.Pragma, HeaderNames.Range, HeaderNames.TE,
+
+            // rfc7231#section-5.2: Conditionals.
+            HeaderNames.IfMatch, HeaderNames.IfNoneMatch, HeaderNames.IfModifiedSince, HeaderNames.IfUnmodifiedSince, HeaderNames.IfRange,
+
+            // Authentication headers.
+            HeaderNames.WWWAuthenticate, HeaderNames.Authorization, HeaderNames.ProxyAuthenticate, HeaderNames.ProxyAuthorization, HeaderNames.SetCookie, HeaderNames.Cookie,
+
+            // Response control data.
+            // rfc7231#section-7.1: Control Data.
+            HeaderNames.Age, HeaderNames.Expires, HeaderNames.Date, HeaderNames.Location, HeaderNames.RetryAfter, HeaderNames.Vary, HeaderNames.Warning,
+
+            // Content-Encoding, Content-Type, Content-Range, and Trailer itself.
+            HeaderNames.ContentEncoding, HeaderNames.ContentType, HeaderNames.ContentRange, HeaderNames.Trailer
+        };
+
+        // Should this instance check for prohibited trailers?
+        private readonly bool _checkTrailers;
         private long? _contentLength;
         private StringValues _contentLengthText;
 
-        public HeaderCollection()
+        public HeaderCollection(bool checkTrailers = false)
             : this(new Dictionary<string, StringValues>(4, StringComparer.OrdinalIgnoreCase))
         {
+            _checkTrailers = checkTrailers;
         }
 
         public HeaderCollection(IDictionary<string, StringValues> store)
@@ -39,6 +69,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             }
             set
             {
+                ValidateRestrictedTrailers(key);
                 ThrowIfReadOnly();
                 if (StringValues.IsNullOrEmpty(value))
                 {
@@ -58,6 +89,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             get { return Store[key]; }
             set
             {
+                ValidateRestrictedTrailers(key);
                 ThrowIfReadOnly();
                 ValidateHeaderCharacters(key);
                 ValidateHeaderCharacters(value);
@@ -105,6 +137,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             }
             set
             {
+                ValidateRestrictedTrailers(HeaderNames.ContentLength);
                 ThrowIfReadOnly();
 
                 if (value.HasValue)
@@ -128,6 +161,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         public void Add(KeyValuePair<string, StringValues> item)
         {
+            ValidateRestrictedTrailers(item.Key);
             ThrowIfReadOnly();
             ValidateHeaderCharacters(item.Key);
             ValidateHeaderCharacters(item.Value);
@@ -136,6 +170,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         public void Add(string key, StringValues value)
         {
+            ValidateRestrictedTrailers(key);
             ThrowIfReadOnly();
             ValidateHeaderCharacters(key);
             ValidateHeaderCharacters(value);
@@ -144,6 +179,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         public void Append(string key, string value)
         {
+            ValidateRestrictedTrailers(key);
             ThrowIfReadOnly();
             ValidateHeaderCharacters(key);
             ValidateHeaderCharacters(value);
@@ -237,6 +273,14 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                         throw new InvalidOperationException(string.Format("Invalid control character in header: 0x{0:X2}", (byte)ch));
                     }
                 }
+            }
+        }
+
+        private void ValidateRestrictedTrailers(string key)
+        {
+            if (_checkTrailers && _disallowedTrailers.Contains(key))
+            {
+                throw new InvalidOperationException($"The '{key}' header is not allowed in HTTP trailers.");
             }
         }
     }

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -250,6 +250,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             if (IsReadOnly)
             {
+                if (_checkTrailers)
+                {
+                    throw new InvalidOperationException("The response trailers cannot be modified because the response has already completed. "
+                        + "If this is a Content-Length response then you need to call HttpResponse.DeclareTrailer before starting the body.");
+                }
                 throw new InvalidOperationException("The response headers cannot be modified because the response has already started.");
             }
         }

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
     internal class HeaderCollection : IHeaderDictionary
     {
         // https://tools.ietf.org/html/rfc7230#section-4.1.2
-        private static readonly HashSet<string> _disallowedTrailers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        internal static readonly HashSet<string> DisallowedTrailers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             // Message framing headers.
             HeaderNames.TransferEncoding, HeaderNames.ContentLength,
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         private void ValidateRestrictedTrailers(string key)
         {
-            if (_checkTrailers && _disallowedTrailers.Contains(key))
+            if (_checkTrailers && DisallowedTrailers.Contains(key))
             {
                 throw new InvalidOperationException($"The '{key}' header is not allowed in HTTP trailers.");
             }


### PR DESCRIPTION
 #13893 @bkatms @shirhatti The implementation was pretty straight forward because it re-used the HTTP_UNKNOWN_HEADER and HTTP_DATA_CHUNK APIs.

Things to look out for:
- Feature detection via Windows Version checking. 
- We still need to get a helix queue set up to handle windows previews https://github.com/aspnet/AspNetCore-Internal/issues/3170. These tests will automatically light up when that happens.
- Http/1.1 chunked trailers are not supported.
- The trailers collection will throw if you try to add a prohibited value. We should look at adding that check to Kestrel too.
- Content-Length makes things interesting...

About Content-Length responses: Http.Sys doesn't count content-length for ending responses, we have to track that. The existing behavior is to end the response as soon as the last expected byte is written. However that prevents us from adding trailers afterwards. Note Content-Length is allowed in HTTP/2 regardless of the framing model.

Content-Length responses are handled by the following flow:
- The original behavior is still the default, the response ends immediately if you don't do anything with trailers.
- The response lifetime will be extended to allow for trailers if:
  - "Trailers" were declared in the response header collection before the response started.
  - Any trailers were added to the collection before the last write.
- CompleteAsync still ends the response and flushes trailers.