### PR TITLE
Add log event name for Identity

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureApiResources.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureApiResources.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 foreach (var kvp in data)
                 {
-                    _logger.LogInformation($"Configuring API resource '{kvp.Key}'.");
+                    _logger.LogInformation(LoggerEventIds.ConfiguringAPIResource, "Configuring API resource '{ApiResourceName}'.", kvp.Key);
                     yield return GetResource(kvp.Key, kvp.Value);
                 }
             }
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 foreach (var kvp in localResources)
                 {
-                    _logger.LogInformation($"Configuring local API resource '{kvp.Key}'.");
+                    _logger.LogInformation(LoggerEventIds.ConfiguringLocalAPIResource, "Configuring local API resource '{ApiResourceName}'.", kvp.Key);
                     yield return GetResource(kvp.Key, kvp.Value);
                 }
             }

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureClientScopes.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureClientScopes.cs
@@ -31,24 +31,24 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
             {
                 if (!identityResource.Properties.TryGetValue(ApplicationProfilesPropertyNames.Clients, out var clientList))
                 {
-                    _logger.LogInformation($"Identity resource '{identityResource.Name}' doesn't define a list of allowed applications.");
+                    _logger.LogInformation(LoggerEventIds.AllowedApplicationNotDefienedForIdentityResource, "Identity resource '{IdentityResourceName}' doesn't define a list of allowed applications.", identityResource.Name);
                     continue;
                 }
 
                 var resourceClients = clientList.Split(DefaultClientListSeparator, StringSplitOptions.RemoveEmptyEntries);
                 if (resourceClients.Length == 0)
                 {
-                    _logger.LogInformation($"Identity resource '{identityResource.Name}' doesn't define a list of allowed applications.");
+                    _logger.LogInformation(LoggerEventIds.AllowedApplicationNotDefienedForIdentityResource, "Identity resource '{IdentityResourceName}' doesn't define a list of allowed applications.", identityResource.Name);
                     continue;
                 }
 
                 if (resourceClients.Length == 1 && resourceClients[0] == ApplicationProfilesPropertyValues.AllowAllApplications)
                 {
-                    _logger.LogInformation($"Identity resource '{identityResource.Name}' allows all applications.");
+                    _logger.LogInformation(LoggerEventIds.AllApplicationsAllowedForIdentityResource, "Identity resource '{IdentityResourceName}' allows all applications.", identityResource.Name);
                 }
                 else
                 {
-                    _logger.LogInformation($"Identity resource '{identityResource.Name}' allows applications '{string.Join(" ", resourceClients)}'.");
+                    _logger.LogInformation(LoggerEventIds.ApplicationsAllowedForIdentityResource, "Identity resource '{IdentityResourceName}' allows applications '{ResourceClients}'.", identityResource.Name, string.Join(" ", resourceClients));
                 }
 
                 foreach (var client in options.Clients)
@@ -68,24 +68,24 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration
             {
                 if (!resource.Properties.TryGetValue(ApplicationProfilesPropertyNames.Clients, out var clientList))
                 {
-                    _logger.LogInformation($"Resource '{resource.Name}' doesn't define a list of allowed applications.");
+                    _logger.LogInformation(LoggerEventIds.AllowedApplicationNotDefienedForApiResource, "Resource '{ApiResourceName}' doesn't define a list of allowed applications.", resource.Name);
                     continue;
                 }
 
                 var resourceClients = clientList.Split(DefaultClientListSeparator, StringSplitOptions.RemoveEmptyEntries);
                 if (resourceClients.Length == 0)
                 {
-                    _logger.LogInformation($"Resource '{resource.Name}' doesn't define a list of allowed applications.");
+                    _logger.LogInformation(LoggerEventIds.AllowedApplicationNotDefienedForApiResource, "Resource '{ApiResourceName}' doesn't define a list of allowed applications.", resource.Name);
                     continue;
                 }
 
                 if (resourceClients.Length == 1 && resourceClients[0] == ApplicationProfilesPropertyValues.AllowAllApplications)
                 {
-                    _logger.LogInformation($"Resource '{resource.Name}' allows all applications.");
+                    _logger.LogInformation(LoggerEventIds.AllApplicationsAllowedForApiResource, "Resource '{ApiResourceName}' allows all applications.", resource.Name);
                 }
                 else
                 {
-                    _logger.LogInformation($"Resource '{resource.Name}' allows applications '{string.Join(" ", resourceClients)}'.");
+                    _logger.LogInformation(LoggerEventIds.ApplicationsAllowedForApiResource, "Resource '{ApiResourceName}' allows applications '{resourceClients}'.", resource.Name, string.Join(" ", resourceClients));
                 }
 
                 foreach (var client in options.Clients)

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureClients.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureClients.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
             {
                 foreach (var kvp in data)
                 {
-                    _logger.LogInformation($"Configuring client '{kvp.Key}'.");
+                    _logger.LogInformation(LoggerEventIds.ConfiguringClient, "Configuring client '{ClientName}'.", kvp.Key);
                     var name = kvp.Key;
                     var definition = kvp.Value;
 

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
                 case KeySources.Development:
                     var developmentKeyPath = Path.Combine(Directory.GetCurrentDirectory(), key.FilePath ?? DefaultTempKeyRelativePath);
                     var createIfMissing = key.Persisted ?? true;
-                    _logger.LogInformation($"Loading development key at '{developmentKeyPath}'.");
+                    _logger.LogInformation(LoggerEventIds.DevelopmentKeyLoaded, "Loading development key at '{developmentKeyPath}'.", developmentKeyPath);
                     var developmentKey = new RsaSecurityKey(SigningKeysLoader.LoadDevelopment(developmentKeyPath, createIfMissing))
                     {
                         KeyId = "Development"
@@ -80,16 +80,15 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
                     return new SigningCredentials(developmentKey, "RS256");
                 case KeySources.File:
                     var pfxPath = Path.Combine(Directory.GetCurrentDirectory(), key.FilePath);
-                    var pfxPassword = key.Password;
                     var storageFlags = GetStorageFlags(key);
-                    _logger.LogInformation($"Loading certificate file at '{pfxPath}' with storage flags '{key.StorageFlags}'.");
+                    _logger.LogInformation(LoggerEventIds.CertificateLoadedFromFile, "Loading certificate file at '{CertificatePath}' with storage flags '{CertificateStorageFlags}'.", pfxPath, key.StorageFlags);
                     return new SigningCredentials(new X509SecurityKey(SigningKeysLoader.LoadFromFile(pfxPath, key.Password, storageFlags)), "RS256");
                 case KeySources.Store:
                     if (!Enum.TryParse<StoreLocation>(key.StoreLocation, out var storeLocation))
                     {
                         throw new InvalidOperationException($"Invalid certificate store location '{key.StoreLocation}'.");
                     }
-                    _logger.LogInformation($"Loading certificate with subject '{key.Name}' in '{key.StoreLocation}\\{key.StoreName}'.");
+                    _logger.LogInformation(LoggerEventIds.CertificateLoadedFromStore, "Loading certificate with subject '{CertificateSubject}' in '{CertificateStoreLocation}\\{CertificateStoreName}'.", key.Name, key.StoreLocation, key.StoreName);
                     return new SigningCredentials(new X509SecurityKey(SigningKeysLoader.LoadFromStoreCert(key.Name, key.StoreName, storeLocation, GetCurrentTime())), "RS256");
                 default:
                     throw new InvalidOperationException($"Invalid key type '{key.Type ?? "(null)"}'.");

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Extensions/AutoRedirectEndSessionEndpoint.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Extensions/AutoRedirectEndSessionEndpoint.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
             var result = await _requestvalidator.ValidateAsync(parameters, user);
             if (result.IsError)
             {
-                _logger.LogError($"Error ending session {result.Error}");
+                _logger.LogError(LoggerEventIds.EndingSessionFailed, "Error ending session {Error}", result.Error);
                 return new RedirectResult(_identityServerOptions.Value.UserInteraction.ErrorUrl);
             }
 

--- a/src/Identity/ApiAuthorization.IdentityServer/src/LoggerEventIds.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/LoggerEventIds.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
+{
+    internal static class LoggerEventIds
+    {
+        public static readonly EventId ConfiguringAPIResource = new EventId(1, "ConfiguringAPIResource");
+        public static readonly EventId ConfiguringLocalAPIResource = new EventId(2, "ConfiguringLocalAPIResource");
+        public static readonly EventId ConfiguringClient = new EventId(3, "ConfiguringClient");
+        public static readonly EventId AllowedApplicationNotDefienedForIdentityResource = new EventId(4, "AllowedApplicationNotDefienedForIdentityResource");
+        public static readonly EventId AllApplicationsAllowedForIdentityResource = new EventId(5, "AllApplicationsAllowedForIdentityResource");
+        public static readonly EventId ApplicationsAllowedForIdentityResource = new EventId(6, "ApplicationsAllowedForIdentityResource");
+        public static readonly EventId AllowedApplicationNotDefienedForApiResource = new EventId(7, "AllowedApplicationNotDefienedForApiResource");
+        public static readonly EventId AllApplicationsAllowedForApiResource = new EventId(8, "AllApplicationsAllowedForApiResource");
+        public static readonly EventId ApplicationsAllowedForApiResource = new EventId(9, "ApplicationsAllowedForApiResource");
+        public static readonly EventId DevelopmentKeyLoaded = new EventId(10, "DevelopmentKeyLoaded");
+        public static readonly EventId CertificateLoadedFromFile = new EventId(11, "CertificateLoadedFromFile");
+        public static readonly EventId CertificateLoadedFromStore = new EventId(12, "CertificateLoadedFromStore");
+        public static readonly EventId EndingSessionFailed = new EventId(13, "EndingSessionFailed");
+    }
+}

--- a/src/Identity/Core/src/EventIds.cs
+++ b/src/Identity/Core/src/EventIds.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    internal static class EventIds
+    {
+        public static EventId UserCannotSignInWithoutConfirmedEmail = new EventId(0, "UserCannotSignInWithoutConfirmedEmail");
+        public static EventId SecurityStampValidationFailed = new EventId(0, "SecurityStampValidationFailed");
+        public static EventId SecurityStampValidationFailedId4 = new EventId(4, "SecurityStampValidationFailed");
+        public static EventId UserCannotSignInWithoutConfirmedPhoneNumber = new EventId(1, "UserCannotSignInWithoutConfirmedPhoneNumber");
+        public static EventId InvalidPassword = new EventId(2, "InvalidPassword");
+        public static EventId UserLockedOut = new EventId(3, "UserLockedOut");
+        public static EventId UserCannotSignInWithoutConfirmedAccount = new EventId(4, "UserCannotSignInWithoutConfirmedAccount");
+        public static EventId TwoFactorSecurityStampValidationFailed = new EventId(5, "TwoFactorSecurityStampValidationFailed");
+    }
+}

--- a/src/Identity/Core/src/SecurityStampValidator.cs
+++ b/src/Identity/Core/src/SecurityStampValidator.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Identity
                 }
                 else
                 {
-                    Logger.LogDebug(0, "Security stamp validation failed, rejecting cookie.");
+                    Logger.LogDebug(EventIds.SecurityStampValidationFailed, "Security stamp validation failed, rejecting cookie.");
                     context.RejectPrincipal();
                     await SignInManager.SignOutAsync();
                 }

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -145,17 +145,17 @@ namespace Microsoft.AspNetCore.Identity
         {
             if (Options.SignIn.RequireConfirmedEmail && !(await UserManager.IsEmailConfirmedAsync(user)))
             {
-                Logger.LogWarning(0, "User cannot sign in without a confirmed email.");
+                Logger.LogWarning(EventIds.UserCannotSignInWithoutConfirmedEmail, "User cannot sign in without a confirmed email.");
                 return false;
             }
             if (Options.SignIn.RequireConfirmedPhoneNumber && !(await UserManager.IsPhoneNumberConfirmedAsync(user)))
             {
-                Logger.LogWarning(1, "User cannot sign in without a confirmed phone number.");
+                Logger.LogWarning(EventIds.UserCannotSignInWithoutConfirmedPhoneNumber, "User cannot sign in without a confirmed phone number.");
                 return false;
             }
             if (Options.SignIn.RequireConfirmedAccount && !(await _confirmation.IsConfirmedAsync(UserManager, user)))
             {
-                Logger.LogWarning(4, "User cannot sign in without a confirmed account.");
+                Logger.LogWarning(EventIds.UserCannotSignInWithoutConfirmedAccount, "User cannot sign in without a confirmed account.");
                 return false;
             }
             return true;
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.Identity
             {
                 return user;
             }
-            Logger.LogDebug(4, "Failed to validate a security stamp.");
+            Logger.LogDebug(EventIds.SecurityStampValidationFailedId4, "Failed to validate a security stamp.");
             return null;
         }
 
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.Identity
             {
                 return user;
             }
-            Logger.LogDebug(5, "Failed to validate a security stamp.");
+            Logger.LogDebug(EventIds.TwoFactorSecurityStampValidationFailed, "Failed to validate a security stamp.");
             return null;
         }
 
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Identity
 
                 return SignInResult.Success;
             }
-            Logger.LogWarning(2, "User failed to provide the correct password.");
+            Logger.LogWarning(EventIds.InvalidPassword, "User failed to provide the correct password.");
 
             if (UserManager.SupportsUserLockout && lockoutOnFailure)
             {
@@ -837,7 +837,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>A locked out SignInResult</returns>
         protected virtual Task<SignInResult> LockedOut(TUser user)
         {
-            Logger.LogWarning(3, "User is currently locked out.");
+            Logger.LogWarning(EventIds.UserLockedOut, "User is currently locked out.");
             return Task.FromResult(SignInResult.LockedOut);
         }
 

--- a/src/Identity/Extensions.Core/src/LoggerEventIds.cs
+++ b/src/Identity/Extensions.Core/src/LoggerEventIds.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Identity.Core
+{
+    internal static class LoggerEventIds
+    {
+        public static readonly EventId RoleValidationFailed = new EventId(0, "RoleValidationFailed");
+        public static readonly EventId InvalidPassword = new EventId(0, "InvalidPassword");
+        public static readonly EventId UserAlreadyHasPassword = new EventId(1, "UserAlreadyHasPassword");
+        public static readonly EventId ChangePasswordFailed = new EventId(2, "ChangePasswordFailed");
+        public static readonly EventId AddLoginFailed = new EventId(4, "AddLoginFailed");
+        public static readonly EventId UserAlreadyInRole = new EventId(5, "UserAlreadyInRole");
+        public static readonly EventId UserNotInRole = new EventId(6, "UserNotInRole");
+        public static readonly EventId PhoneNumberChanged = new EventId(7, "PhoneNumberChanged");
+        public static readonly EventId VerifyUserTokenFailed = new EventId(9, "VerifyUserTokenFailed");
+        public static readonly EventId VerifyTwoFactorTokenFailed = new EventId(10, "VerifyTwoFactorTokenFailed");
+        public static readonly EventId LockoutFailed = new EventId(11, "LockoutFailed");
+        public static readonly EventId UserLockedOut = new EventId(12, "UserLockedOut");
+        public static readonly EventId UserValidationFailed = new EventId(13, "UserValidationFailed");
+        public static readonly EventId PasswordValidationFailed = new EventId(14, "PasswordValidationFailed");
+        public static readonly EventId GetSecurityStampFailed = new EventId(15, "GetSecurityStampFailed");
+    }
+}

--- a/src/Identity/Extensions.Core/src/RoleManager.cs
+++ b/src/Identity/Extensions.Core/src/RoleManager.cs
@@ -434,7 +434,7 @@ namespace Microsoft.AspNetCore.Identity
             }
             if (errors.Count > 0)
             {
-                Logger.LogWarning(0, "Role {roleId} validation failed: {errors}.", await GetRoleIdAsync(role), string.Join(";", errors.Select(e => e.Code)));
+                Logger.LogWarning(LoggerEventIds.RoleValidationFailed, "Role {roleId} validation failed: {errors}.", await GetRoleIdAsync(role), string.Join(";", errors.Select(e => e.Code)));
                 return IdentityResult.Failed(errors.ToArray());
             }
             return IdentityResult.Success;

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -716,7 +716,7 @@ namespace Microsoft.AspNetCore.Identity
             var success = result != PasswordVerificationResult.Failed;
             if (!success)
             {
-                Logger.LogWarning(0, "Invalid password for user.");
+                Logger.LogWarning(LoggerEventIds.InvalidPassword, "Invalid password for user.");
             }
             return success;
         }
@@ -763,7 +763,7 @@ namespace Microsoft.AspNetCore.Identity
             var hash = await passwordStore.GetPasswordHashAsync(user, CancellationToken);
             if (hash != null)
             {
-                Logger.LogWarning(1, "User already has a password.");
+                Logger.LogWarning(LoggerEventIds.UserAlreadyHasPassword, "User already has a password.");
                 return IdentityResult.Failed(ErrorDescriber.UserAlreadyHasPassword());
             }
             var result = await UpdatePasswordHash(passwordStore, user, password);
@@ -804,7 +804,7 @@ namespace Microsoft.AspNetCore.Identity
                 }
                 return await UpdateUserAsync(user);
             }
-            Logger.LogWarning(2, "Change password failed for user.");
+            Logger.LogWarning(LoggerEventIds.ChangePasswordFailed, "Change password failed for user.");
             return IdentityResult.Failed(ErrorDescriber.PasswordMismatch());
         }
 
@@ -865,7 +865,7 @@ namespace Microsoft.AspNetCore.Identity
             var stamp = await securityStore.GetSecurityStampAsync(user, CancellationToken);
             if (stamp == null)
             {
-                Logger.LogWarning(15, "GetSecurityStampAsync for user failed because stamp was null.");
+                Logger.LogWarning(LoggerEventIds.GetSecurityStampFailed, "GetSecurityStampAsync for user failed because stamp was null.");
                 throw new InvalidOperationException(Resources.NullSecurityStamp);
             }
             return stamp;
@@ -1021,7 +1021,7 @@ namespace Microsoft.AspNetCore.Identity
             var existingUser = await FindByLoginAsync(login.LoginProvider, login.ProviderKey);
             if (existingUser != null)
             {
-                Logger.LogWarning(4, "AddLogin for user failed because it was already associated with another user.");
+                Logger.LogWarning(LoggerEventIds.AddLoginFailed, "AddLogin for user failed because it was already associated with another user.");
                 return IdentityResult.Failed(ErrorDescriber.LoginAlreadyAssociated());
             }
             await loginStore.AddLoginAsync(user, login, CancellationToken);
@@ -1285,13 +1285,13 @@ namespace Microsoft.AspNetCore.Identity
 
         private IdentityResult UserAlreadyInRoleError(string role)
         {
-            Logger.LogWarning(5, "User is already in role {role}.", role);
+            Logger.LogWarning(LoggerEventIds.UserAlreadyInRole, "User is already in role {role}.", role);
             return IdentityResult.Failed(ErrorDescriber.UserAlreadyInRole(role));
         }
 
         private IdentityResult UserNotInRoleError(string role)
         {
-            Logger.LogWarning(6, "User is not in role {role}.", role);
+            Logger.LogWarning(LoggerEventIds.UserNotInRole, "User is not in role {role}.", role);
             return IdentityResult.Failed(ErrorDescriber.UserNotInRole(role));
         }
 
@@ -1627,7 +1627,7 @@ namespace Microsoft.AspNetCore.Identity
 
             if (!await VerifyChangePhoneNumberTokenAsync(user, token, phoneNumber))
             {
-                Logger.LogWarning(7, "Change phone number for user failed with invalid token.");
+                Logger.LogWarning(LoggerEventIds.PhoneNumberChanged, "Change phone number for user failed with invalid token.");
                 return IdentityResult.Failed(ErrorDescriber.InvalidToken());
             }
             await store.SetPhoneNumberAsync(user, phoneNumber, CancellationToken);
@@ -1725,7 +1725,7 @@ namespace Microsoft.AspNetCore.Identity
 
             if (!result)
             {
-                Logger.LogWarning(9, "VerifyUserTokenAsync() failed with purpose: {purpose} for user.", purpose);
+                Logger.LogWarning(LoggerEventIds.VerifyUserTokenFailed, "VerifyUserTokenAsync() failed with purpose: {purpose} for user.", purpose);
             }
             return result;
         }
@@ -1827,7 +1827,7 @@ namespace Microsoft.AspNetCore.Identity
             var result = await _tokenProviders[tokenProvider].ValidateAsync("TwoFactor", token, this, user);
             if (!result)
             {
-                Logger.LogWarning(10, $"{nameof(VerifyTwoFactorTokenAsync)}() failed for user.");
+                Logger.LogWarning(LoggerEventIds.VerifyTwoFactorTokenFailed, $"{nameof(VerifyTwoFactorTokenAsync)}() failed for user.");
             }
             return result;
         }
@@ -2000,7 +2000,7 @@ namespace Microsoft.AspNetCore.Identity
 
             if (!await store.GetLockoutEnabledAsync(user, CancellationToken))
             {
-                Logger.LogWarning(11, "Lockout for user failed because lockout is not enabled for this user.");
+                Logger.LogWarning(LoggerEventIds.LockoutFailed, "Lockout for user failed because lockout is not enabled for this user.");
                 return IdentityResult.Failed(ErrorDescriber.UserLockoutNotEnabled());
             }
             await store.SetLockoutEndDateAsync(user, lockoutEnd, CancellationToken);
@@ -2029,7 +2029,7 @@ namespace Microsoft.AspNetCore.Identity
             {
                 return await UpdateUserAsync(user);
             }
-            Logger.LogWarning(12, "User is locked out.");
+            Logger.LogWarning(LoggerEventIds.UserLockedOut, "User is locked out.");
             await store.SetLockoutEndDateAsync(user, DateTimeOffset.UtcNow.Add(Options.Lockout.DefaultLockoutTimeSpan),
                 CancellationToken);
             await store.ResetAccessFailedCountAsync(user, CancellationToken);
@@ -2503,7 +2503,7 @@ namespace Microsoft.AspNetCore.Identity
             }
             if (errors.Count > 0)
             {
-                Logger.LogWarning(13, "User validation failed: {errors}.", string.Join(";", errors.Select(e => e.Code)));
+                Logger.LogWarning(LoggerEventIds.UserValidationFailed, "User validation failed: {errors}.", string.Join(";", errors.Select(e => e.Code)));
                 return IdentityResult.Failed(errors.ToArray());
             }
             return IdentityResult.Success;
@@ -2535,7 +2535,7 @@ namespace Microsoft.AspNetCore.Identity
             }
             if (!isValid)
             {
-                Logger.LogWarning(14, "User password validation failed: {errors}.", string.Join(";", errors.Select(e => e.Code)));
+                Logger.LogWarning(LoggerEventIds.PasswordValidationFailed, "User password validation failed: {errors}.", string.Join(";", errors.Select(e => e.Code)));
                 return IdentityResult.Failed(errors.ToArray());
             }
             return IdentityResult.Success;

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
             var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false, bypassTwoFactor: true);
             if (result.Succeeded)
             {
-                _logger.LogInformation("User logged in with {LoginProvider} provider.", info.LoginProvider);
+                _logger.LogInformation(LoggerEventIds.UserLoggedInByExternalProvider, "User logged in with {LoginProvider} provider.", info.LoginProvider);
                 return LocalRedirect(returnUrl);
             }
             if (result.IsLockedOut)
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
                     result = await _userManager.AddLoginAsync(user, info);
                     if (result.Succeeded)
                     {
-                        _logger.LogInformation("User created an account using {Name} provider.", info.LoginProvider);
+                        _logger.LogInformation(LoggerEventIds.UserCreatedByExternalProvider ,"User created an account using {Name} provider.", info.LoginProvider);
 
                         var userId = await _userManager.GetUserIdAsync(user);
                         var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
                 var result = await _signInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
                 if (result.Succeeded)
                 {
-                    _logger.LogInformation("User logged in.");
+                    _logger.LogInformation(LoggerEventIds.UserLogin, "User logged in.");
                     return LocalRedirect(returnUrl);
                 }
                 if (result.RequiresTwoFactor)
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
                 }
                 if (result.IsLockedOut)
                 {
-                    _logger.LogWarning("User account locked out.");
+                    _logger.LogWarning(LoggerEventIds.UserLockout, "User account locked out.");
                     return RedirectToPage("./Lockout");
                 }
                 else

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/LoginWith2fa.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/LoginWith2fa.cshtml.cs
@@ -130,17 +130,17 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
 
             if (result.Succeeded)
             {
-                _logger.LogInformation("User logged in with 2fa.");
+                _logger.LogInformation(LoggerEventIds.UserLoginWith2FA, "User logged in with 2fa.");
                 return LocalRedirect(returnUrl);
             }
             else if (result.IsLockedOut)
             {
-                _logger.LogWarning("User account locked out.");
+                _logger.LogWarning(LoggerEventIds.UserLockout, "User account locked out.");
                 return RedirectToPage("./Lockout");
             }
             else
             {
-                _logger.LogWarning("Invalid authenticator code entered.");
+                _logger.LogWarning(LoggerEventIds.InvalidAuthenticatorCode, "Invalid authenticator code entered.");
                 ModelState.AddModelError(string.Empty, "Invalid authenticator code.");
                 return Page();
             }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/LoginWithRecoveryCode.cshtml.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
 
             if (result.Succeeded)
             {
-                _logger.LogInformation("User logged in with a recovery code.");
+                _logger.LogInformation(LoggerEventIds.UserLoginWithRecoveryCode, "User logged in with a recovery code.");
                 return LocalRedirect(returnUrl ?? Url.Content("~/"));
             }
             if (result.IsLockedOut)
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
             }
             else
             {
-                _logger.LogWarning("Invalid recovery code entered.");
+                _logger.LogWarning(LoggerEventIds.InvalidRecoveryCode, "Invalid recovery code entered.");
                 ModelState.AddModelError(string.Empty, "Invalid recovery code entered.");
                 return Page();
             }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Logout.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Logout.cshtml.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
         public override async Task<IActionResult> OnPost(string returnUrl = null)
         {
             await _signInManager.SignOutAsync();
-            _logger.LogInformation("User logged out.");
+            _logger.LogInformation(LoggerEventIds.UserLoggedOut, "User logged out.");
             if (returnUrl != null)
             {
                 return LocalRedirect(returnUrl);

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ChangePassword.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ChangePassword.cshtml.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
             }
 
             await _signInManager.RefreshSignInAsync(user);
-            _logger.LogInformation("User changed their password successfully.");
+            _logger.LogInformation(LoggerEventIds.PasswordChanged, "User changed their password successfully.");
             StatusMessage = "Your password has been changed.";
 
             return RedirectToPage();

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/DeletePersonalData.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/DeletePersonalData.cshtml.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
 
             await _signInManager.SignOutAsync();
 
-            _logger.LogInformation("User deleted themselves.");
+            _logger.LogInformation(LoggerEventIds.UserDeleted, "User deleted themselves.");
 
             return Redirect("~/");
         }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/Disable2fa.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/Disable2fa.cshtml.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
                 throw new InvalidOperationException($"Unexpected error occurred disabling 2FA.");
             }
 
-            _logger.LogInformation("User has disabled 2fa.");
+            _logger.LogInformation(LoggerEventIds.TwoFADisabled, "User has disabled 2fa.");
             StatusMessage = "2fa has been disabled. You can reenable 2fa when you setup an authenticator app";
             return RedirectToPage("./TwoFactorAuthentication");
         }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/DownloadPersonalData.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/DownloadPersonalData.cshtml.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
                 return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
             }
 
-            _logger.LogInformation("User asked for their personal data.");
+            _logger.LogInformation(LoggerEventIds.PersonalDataRequested, "User asked for their personal data.");
 
             // Only include personal data for download
             var personalData = new Dictionary<string, string>();

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
 
             await _userManager.SetTwoFactorEnabledAsync(user, true);
             var userId = await _userManager.GetUserIdAsync(user);
-            _logger.LogInformation("User has enabled 2FA with an authenticator app.");
+            _logger.LogInformation(LoggerEventIds.TwoFAEnabled, "User has enabled 2FA with an authenticator app.");
 
             StatusMessage = "Your authenticator app has been verified.";
 

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/GenerateRecoveryCodes.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/GenerateRecoveryCodes.cshtml.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
             var recoveryCodes = await _userManager.GenerateNewTwoFactorRecoveryCodesAsync(user, 10);
             RecoveryCodes = recoveryCodes.ToArray();
 
-            _logger.LogInformation("User has generated new 2FA recovery codes.");
+            _logger.LogInformation(LoggerEventIds.TwoFARecoveryGenerated, "User has generated new 2FA recovery codes.");
             StatusMessage = "You have generated new recovery codes.";
             return RedirectToPage("./ShowRecoveryCodes");
         }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ResetAuthenticator.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ResetAuthenticator.cshtml.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
             await _userManager.SetTwoFactorEnabledAsync(user, false);
             await _userManager.ResetAuthenticatorKeyAsync(user);
             var userId = await _userManager.GetUserIdAsync(user);
-            _logger.LogInformation("User has reset their authentication app key.");
+            _logger.LogInformation(LoggerEventIds.AuthenticationAppKeyReset, "User has reset their authentication app key.");
 
             await _signInManager.RefreshSignInAsync(user);
             StatusMessage = "Your authenticator app key has been reset, you will need to configure your authenticator app using the new key.";

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Register.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Register.cshtml.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
 
                 if (result.Succeeded)
                 {
-                    _logger.LogInformation("User created a new account with password.");
+                    _logger.LogInformation(LoggerEventIds.UserCreated, "User created a new account with password.");
 
                     var userId = await _userManager.GetUserIdAsync(user);
                     var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);

--- a/src/Identity/UI/src/LoggerEventIds.cs
+++ b/src/Identity/UI/src/LoggerEventIds.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Identity.UI
 {
-    internal static class LoggerEventIds
+    public static class LoggerEventIds
     {
         public static readonly EventId UserCreatedByExternalProvider  = new EventId(1, "UserCreatedByExternalProvider");
         public static readonly EventId UserLoggedInByExternalProvider = new EventId(2, "UserLoggedInByExternalProvider");
@@ -24,7 +24,5 @@ namespace Microsoft.AspNetCore.Identity.UI
         public static readonly EventId AuthenticationAppKeyReset = new EventId(15, "AuthenticationAppKeyReset");
         public static readonly EventId UserCreated = new EventId(16, "UserCreated");
         public static readonly EventId UserLoggedOut = new EventId(17, "UserLoggedOut");
- 
-
     }
 }

--- a/src/Identity/UI/src/LoggerEventIds.cs
+++ b/src/Identity/UI/src/LoggerEventIds.cs
@@ -5,24 +5,94 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Identity.UI
 {
+    /// <summary>
+    /// Static class that exposes logging event ids.
+    /// </summary>
     public static class LoggerEventIds
     {
+        /// <summary>
+        /// Event id when a user is created by an external provider.
+        /// </summary>
         public static readonly EventId UserCreatedByExternalProvider  = new EventId(1, "UserCreatedByExternalProvider");
+
+        /// <summary>
+        /// Event id when a user is logged in by an external provider.
+        /// </summary>
         public static readonly EventId UserLoggedInByExternalProvider = new EventId(2, "UserLoggedInByExternalProvider");
+
+        /// <summary>
+        /// Event id when a user is logged in.
+        /// </summary>
         public static readonly EventId UserLogin = new EventId(3, "UserLogin");
+
+        /// <summary>
+        /// Event id when a user is locked out.
+        /// </summary>
         public static readonly EventId UserLockout = new EventId(4, "UserLockout");
+
+        /// <summary>
+        /// Event id when a user is logged in two factor authentication.
+        /// </summary>
         public static readonly EventId UserLoginWith2FA = new EventId(5, "UserLoginWith2FA");
+
+        /// <summary>
+        /// Event id when a user has entered an invalid authenticator code.
+        /// </summary>
         public static readonly EventId InvalidAuthenticatorCode = new EventId(6, "InvalidAuthenticatorCode");
+
+        /// <summary>
+        /// Event id when a user is logged in with recovey code.
+        /// </summary>
         public static readonly EventId UserLoginWithRecoveryCode = new EventId(7, "UserLoginWithRecoveryCode");
+
+        /// <summary>
+        /// Event id when a user has entered an invalid recovey code.
+        /// </summary>
         public static readonly EventId InvalidRecoveryCode = new EventId(8, "InvalidRecoveryCode");
+
+        /// <summary>
+        /// Event id when a user has changed the password.
+        /// </summary>
         public static readonly EventId PasswordChanged = new EventId(9, "PasswordChanged");
+
+        /// <summary>
+        /// Event id when a user has been deleted.
+        /// </summary>
         public static readonly EventId UserDeleted = new EventId(10, "UserDeleted");
+
+        /// <summary>
+        /// Event id when a user has disabled two factor authentication.
+        /// </summary>
         public static readonly EventId TwoFADisabled = new EventId(11, "TwoFADisabled");
+
+        /// <summary>
+        /// Event id when a user has requested the personal data.
+        /// </summary>
         public static readonly EventId PersonalDataRequested = new EventId(12, "PersonalDataRequested");
+
+        /// <summary>
+        /// Event id when a user has enabled two factor authentication.
+        /// </summary>
         public static readonly EventId TwoFAEnabled = new EventId(13, "TwoFAEnabled");
+
+        /// <summary>
+        /// Event id when two factor authentication recovery code is generated.
+        /// </summary>
         public static readonly EventId TwoFARecoveryGenerated = new EventId(14, "TwoFARecoveryGenerated");
+
+        /// <summary>
+        /// Event id when user has reset the authentication app key.
+        /// </summary>
         public static readonly EventId AuthenticationAppKeyReset = new EventId(15, "AuthenticationAppKeyReset");
+
+        /// <summary>
+        /// Event id when a user is created.
+        /// </summary>
         public static readonly EventId UserCreated = new EventId(16, "UserCreated");
+
+        /// <summary>
+        /// Event id when a user is logged out.
+        /// </summary>
         public static readonly EventId UserLoggedOut = new EventId(17, "UserLoggedOut");
     }
 }

--- a/src/Identity/UI/src/LoggerEventIds.cs
+++ b/src/Identity/UI/src/LoggerEventIds.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Identity.UI
+{
+    internal static class LoggerEventIds
+    {
+        public static readonly EventId UserCreatedByExternalProvider  = new EventId(1, "UserCreatedByExternalProvider");
+        public static readonly EventId UserLoggedInByExternalProvider = new EventId(2, "UserLoggedInByExternalProvider");
+        public static readonly EventId UserLogin = new EventId(3, "UserLogin");
+        public static readonly EventId UserLockout = new EventId(4, "UserLockout");
+        public static readonly EventId UserLoginWith2FA = new EventId(5, "UserLoginWith2FA");
+        public static readonly EventId InvalidAuthenticatorCode = new EventId(6, "InvalidAuthenticatorCode");
+        public static readonly EventId UserLoginWithRecoveryCode = new EventId(7, "UserLoginWithRecoveryCode");
+        public static readonly EventId InvalidRecoveryCode = new EventId(8, "InvalidRecoveryCode");
+        public static readonly EventId PasswordChanged = new EventId(9, "PasswordChanged");
+        public static readonly EventId UserDeleted = new EventId(10, "UserDeleted");
+        public static readonly EventId TwoFADisabled = new EventId(11, "TwoFADisabled");
+        public static readonly EventId PersonalDataRequested = new EventId(12, "PersonalDataRequested");
+        public static readonly EventId TwoFAEnabled = new EventId(13, "TwoFAEnabled");
+        public static readonly EventId TwoFARecoveryGenerated = new EventId(14, "TwoFARecoveryGenerated");
+        public static readonly EventId AuthenticationAppKeyReset = new EventId(15, "AuthenticationAppKeyReset");
+        public static readonly EventId UserCreated = new EventId(16, "UserCreated");
+        public static readonly EventId UserLoggedOut = new EventId(17, "UserLoggedOut");
+ 
+
+    }
+}

--- a/src/Identity/UI/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/UI/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Microsoft.AspNetCore.Identity.UI.LoggerEventIds
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.AuthenticationAppKeyReset -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.InvalidAuthenticatorCode -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.InvalidRecoveryCode -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.PasswordChanged -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.PersonalDataRequested -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.TwoFADisabled -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.TwoFAEnabled -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.TwoFARecoveryGenerated -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserCreated -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserCreatedByExternalProvider -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserDeleted -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserLockout -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserLoggedInByExternalProvider -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserLoggedOut -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserLogin -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserLoginWith2FA -> Microsoft.Extensions.Logging.EventId
+static readonly Microsoft.AspNetCore.Identity.UI.LoggerEventIds.UserLoginWithRecoveryCode -> Microsoft.Extensions.Logging.EventId


### PR DESCRIPTION
- Added event id and name for logs.
- change Some of event ids that were 0.
- make logs structured in `Identity/ApiAuthorization.IdentityServer`

Addresses #6381
