### PR TITLE
Fix CODEOWNERS syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,11 +14,11 @@
 /src/Hosting/                   @tratcher @anurse
 /src/Http/                      @tratcher @jkotalik @anurse
 /src/Middleware/                @tratcher @anurse
-/src/Middleware/HttpsPolicy     @jkotalik @anurse
-/src/Middleware/Rewrite         @jkotalik @anurse
+/src/Middleware/HttpsPolicy/    @jkotalik @anurse
+/src/Middleware/Rewrite/        @jkotalik @anurse
 # /src/ProjectTemplates/          @ryanbrandenburg
 /src/Security/                  @tratcher @anurse
 /src/Servers/                   @tratcher @jkotalik @anurse @halter73
-/src/Shared/Http2               @aspnet/http2
-/src/Shared/test/Shared.Tests/Http2 @aspnet/http2
+/src/Shared/Http2/              @aspnet/http2
+/src/Shared/test/Shared.Tests/Http2/ @aspnet/http2
 /src/SignalR/                   @BrennanConroy @halter73 @anurse


### PR DESCRIPTION
Directories require a trailing slash. Also fixed in corefx. https://github.com/dotnet/corefx/pull/42433
