### PR TITLE
Disable webpack build progress reporting for Angular projects

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/angular.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/angular.json
@@ -13,7 +13,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "progress": true,
+            "progress": false,
             "extractCss": true,
             "outputPath": "dist",
             "index": "src/index.html",


### PR DESCRIPTION
## Description
Webpack has started writing extra progress information to stderr, which we pass through into calls to LogError. This results in messages like 
![image](https://user-images.githubusercontent.com/34246760/68426078-3a99d300-015c-11ea-982b-e639b5740ec3.png) to be shown in the console output when running a new Angular app. Note, that these are not error messages, but show up as errors. The app is still running.

## Risk
Very low. We're not making any functional changes. Just preventing the messages to show up as errors.

## User impact
The app stills runs successfully, and users will now not see any false 'fail' messages.

Addresses https://github.com/aspnet/AspNetCore-ManualTests/issues/43
