### PR TITLE
Exclude test logs from SDL validation

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -714,4 +714,5 @@ stages:
         -TsaIterationPath $(_TsaIterationPath)
         -TsaRepositoryName "AspNetCore"
         -TsaCodebaseName "AspNetCore"
-        -TsaPublish $True'
+        -TsaPublish $True
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < eng/PoliCheckExclusions.xml")'

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -715,4 +715,4 @@ stages:
         -TsaRepositoryName "AspNetCore"
         -TsaCodebaseName "AspNetCore"
         -TsaPublish $True
-        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < eng/PoliCheckExclusions.xml")'
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'

--- a/eng/PoliCheckExclusions.xml
+++ b/eng/PoliCheckExclusions.xml
@@ -1,0 +1,3 @@
+<PoliCheckExclusions>
+	<Exclusion Type="FolderPathFull">LINUX_TEST_RESULTS|MACOS_TEST_RESULTS|WINDOWS_TEST_RESULTS</Exclusion>
+</PoliCheckExclusions>


### PR DESCRIPTION
Resolves (part of) https://github.com/aspnet/AspNetCore/issues/16835

I'm trying to exclude all files under "artifacts/Linux_Test_Results/" and friends.

I have an internal build running with this change: https://dnceng.visualstudio.com/internal/_build/results?buildId=420854

@sunandabalu PTAL