### PR TITLE
Adding null-conditional operator on IEnumerable.GetEnumerator()

### DIFF
--- a/src/Http/Http/src/Internal/ItemsDictionary.cs
+++ b/src/Http/Http/src/Internal/ItemsDictionary.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Http
                 EmptyDictionary.Collection.CopyTo(array, arrayIndex);
             }
 
-            _items.CopyTo(array, arrayIndex);
+            _items?.CopyTo(array, arrayIndex);
         }
 
         int ICollection<KeyValuePair<object, object>>.Count => _items?.Count ?? 0;

--- a/src/Http/Http/src/Internal/ItemsDictionary.cs
+++ b/src/Http/Http/src/Internal/ItemsDictionary.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Http
         IEnumerator<KeyValuePair<object, object>> IEnumerable<KeyValuePair<object, object>>.GetEnumerator()
             => _items?.GetEnumerator() ?? EmptyEnumerator.Instance;
 
-        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator() ?? EmptyEnumerator.Instance;
+        IEnumerator IEnumerable.GetEnumerator() => _items?.GetEnumerator() ?? EmptyEnumerator.Instance;
 
         private class EmptyEnumerator : IEnumerator<KeyValuePair<object, object>>
         {

--- a/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
+++ b/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
@@ -26,5 +26,16 @@ namespace Microsoft.AspNetCore.Http
             IEnumerable en = (IEnumerable) dict;
             Assert.NotNull(en.GetEnumerator());
         }
+
+        [Fact]
+        public void CopyTo_ShouldCopyItemsWithoutNullReferenceException() {
+            // Arrange
+            var dict = new ItemsDictionary();
+            var pairs = new KeyValuePair<object, object>[] { new KeyValuePair<object, object>("first", "value") };
+
+            // Act and Assert
+            ICollection<KeyValuePair<object, object>> cl = (ICollection<KeyValuePair<object, object>>) dict;
+            cl.CopyTo(pairs, 0);
+        }
     }
 }

--- a/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
+++ b/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public class ItemsDictionaryTests
+    {
+        [Fact]
+        public void GetEnumerator_ShouldResolveWithoutNullReferenceException()
+        {
+            // Arrange
+            var dict = new Microsoft.AspNetCore.Http.ItemsDictionary();
+
+            // Act and Assert
+            System.Collections.IEnumerable en = (System.Collections.IEnumerable) dict;
+            foreach(var item in en) // <-- in the original code, the implicit call to .GetEnumerator() would throw a NullReferenceException
+            {
+                // if there is a problem this code won't be reached
+            }
+
+            Assert.True(true, "The code should make it here without throwing an exception.");
+        }
+    }
+}

--- a/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
+++ b/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -19,16 +20,11 @@ namespace Microsoft.AspNetCore.Http
         public void GetEnumerator_ShouldResolveWithoutNullReferenceException()
         {
             // Arrange
-            var dict = new Microsoft.AspNetCore.Http.ItemsDictionary();
+            var dict = new ItemsDictionary();
 
             // Act and Assert
-            System.Collections.IEnumerable en = (System.Collections.IEnumerable) dict;
-            foreach(var item in en) // <-- in the original code, the implicit call to .GetEnumerator() would throw a NullReferenceException
-            {
-                // if there is a problem this code won't be reached
-            }
-
-            Assert.True(true, "The code should make it here without throwing an exception.");
+            IEnumerable en = (IEnumerable) dict;
+            Assert.NotNull(en.GetEnumerator());
         }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Added `?.` operator to prevent null reference exception (`_items?.GetEnumerator()`)

Addresses #16938 
