### PR TITLE
[HttpSys] Set HasStarted for StartAsync 

### DIFF
--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -400,7 +400,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             set { _responseHeaders = value; }
         }
 
-        bool IHttpResponseFeature.HasStarted => Response.HasStarted;
+        bool IHttpResponseFeature.HasStarted => _responseStarted;
 
         void IHttpResponseFeature.OnStarting(Func<object, Task> callback, object state)
         {

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseBodyTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     return Task.CompletedTask;
                 });
                 await httpContext.Response.StartAsync();
+                Assert.True(httpContext.Response.HasStarted);
                 Assert.True(httpContext.Response.Headers.IsReadOnly);
                 await startingTcs.Task.WithTimeout();
                 await httpContext.Response.WriteAsync("Hello World");
@@ -58,6 +59,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     return Task.CompletedTask;
                 });
                 await httpContext.Response.CompleteAsync();
+                Assert.True(httpContext.Response.HasStarted);
                 Assert.True(httpContext.Response.Headers.IsReadOnly);
                 await startingTcs.Task.WithTimeout();
                 await responseReceived.Task.WithTimeout();


### PR DESCRIPTION
#16987 This impacts gRPC. StartAsync support was added late in 3.0 and added its own variable to track state. However, HasStarted was still returning a lower level field that tracks if the headers have actually been sent on the wire. Henice calling StartAsync would not be enough to set HasStarted, you'd have to actually call Flush. 

Fixed by using StartAsync's state variable for HasStarted.

@bkatms 