### PR TITLE
Allow easily using custom OpenId Connect handler (#16998)

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectExtensions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
             => builder.AddOpenIdConnect<THandler>(authenticationScheme, OpenIdConnectDefaults.DisplayName, configureOptions);
 
         public static AuthenticationBuilder AddOpenIdConnect<THandler>(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<OpenIdConnectOptions> configureOptions)
-        : where THandler : OpenIdConnectHandler
+            : where THandler : OpenIdConnectHandler
         {
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>());
             return builder.AddRemoteScheme<OpenIdConnectOptions, THandler>(authenticationScheme, displayName, configureOptions);

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectExtensions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectExtensions.cs
@@ -25,5 +25,20 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>());
             return builder.AddRemoteScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, displayName, configureOptions);
         }
+        
+        public static AuthenticationBuilder AddOpenIdConnect<THandler>(this AuthenticationBuilder builder, Action<OpenIdConnectOptions> configureOptions)
+            : where THandler : OpenIdConnectHandler
+            => builder.AddOpenIdConnect<THandler>(OpenIdConnectDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddOpenIdConnect<THandler>(this AuthenticationBuilder builder, string authenticationScheme, Action<OpenIdConnectOptions> configureOptions)
+            : where THandler : OpenIdConnectHandler
+            => builder.AddOpenIdConnect<THandler>(authenticationScheme, OpenIdConnectDefaults.DisplayName, configureOptions);
+
+        public static AuthenticationBuilder AddOpenIdConnect<THandler>(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<OpenIdConnectOptions> configureOptions)
+        : where THandler : OpenIdConnectHandler
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>());
+            return builder.AddRemoteScheme<OpenIdConnectOptions, THandler>(authenticationScheme, displayName, configureOptions);
+        }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Allow to easliy use a custom OpenId Connect handler similar to OAuth

Addresses #16998 
