### PR TITLE
Fix deserialization of nested objects int JsonPatch Replace operation

### DIFF
--- a/src/Features/JsonPatch/src/Adapters/AdapterFactory.cs
+++ b/src/Features/JsonPatch/src/Adapters/AdapterFactory.cs
@@ -3,8 +3,6 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.AspNetCore.JsonPatch.Adapters
 {
@@ -32,24 +30,24 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
 
             if (target is JObject)
             {
-                return new JObjectAdapter();
+                return new JObjectAdapter(contractResolver);
             }
             if (target is IList)
             {
-                return new ListAdapter();
+                return new ListAdapter(contractResolver);
             }
             else if (jsonContract is JsonDictionaryContract jsonDictionaryContract)
             {
                 var type = typeof(DictionaryAdapter<,>).MakeGenericType(jsonDictionaryContract.DictionaryKeyType, jsonDictionaryContract.DictionaryValueType);
-                return (IAdapter)Activator.CreateInstance(type);
+                return (IAdapter)Activator.CreateInstance(type, contractResolver);
             }
             else if (jsonContract is JsonDynamicContract)
             {
-                return new DynamicObjectAdapter();
+                return new DynamicObjectAdapter(contractResolver);
             }
             else
             {
-                return new PocoAdapter();
+                return new PocoAdapter(contractResolver);
             }
         }
     }

--- a/src/Features/JsonPatch/src/Adapters/ObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Adapters/ObjectAdapter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                 return;
             }
 
-            if (!adapter.TryAdd(target, parsedPath.LastSegment, ContractResolver, value, out errorMessage))
+            if (!adapter.TryAdd(target, parsedPath.LastSegment, value, out errorMessage))
             {
                 var error = CreateOperationFailedError(objectToApplyTo, path, operation, errorMessage);
                 ErrorReporter(error);
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                 return;
             }
 
-            if (!adapter.TryRemove(target, parsedPath.LastSegment, ContractResolver, out errorMessage))
+            if (!adapter.TryRemove(target, parsedPath.LastSegment, out errorMessage))
             {
                 var error = CreateOperationFailedError(objectToApplyTo, path, operationToReport, errorMessage);
                 ErrorReporter(error);
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                 return;
             }
 
-            if (!adapter.TryReplace(target, parsedPath.LastSegment, ContractResolver, operation.value, out errorMessage))
+            if (!adapter.TryReplace(target, parsedPath.LastSegment, operation.value, out errorMessage))
             {
                 var error = CreateOperationFailedError(objectToApplyTo, operation.path, operation, errorMessage);
                 ErrorReporter(error);
@@ -269,7 +269,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                 return;
             }
 
-            if (!adapter.TryTest(target, parsedPath.LastSegment, ContractResolver, operation.value, out errorMessage))
+            if (!adapter.TryTest(target, parsedPath.LastSegment, operation.value, out errorMessage))
             {
                 var error = CreateOperationFailedError(objectToApplyTo, operation.path, operation, errorMessage);
                 ErrorReporter(error);
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                 return false;
             }
 
-            if (!adapter.TryGet(target, parsedPath.LastSegment, ContractResolver, out propertyValue, out errorMessage))
+            if (!adapter.TryGet(target, parsedPath.LastSegment, out propertyValue, out errorMessage))
             {
                 var error = CreateOperationFailedError(objectToGetValueFrom, fromLocation, operation, errorMessage);
                 ErrorReporter(error);

--- a/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
+++ b/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Reflection;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.AspNetCore.JsonPatch.Internal
 {
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
     /// </summary>
     public static class ConversionResultProvider
     {
-        public static ConversionResult ConvertTo(object value, Type typeToConvertTo)
+        public static ConversionResult ConvertTo(object value, Type typeToConvertTo, IContractResolver contractResolver)
         {
             if (value == null)
             {
@@ -28,7 +29,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             {
                 try
                 {
-                    var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo);
+                    var serializerSettings = new JsonSerializerSettings
+                    {
+                        ContractResolver = contractResolver
+                    };
+                    var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo, serializerSettings);
                     return new ConversionResult(true, deserialized);
                 }
                 catch

--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -14,14 +14,19 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
     /// </summary>
     public class DictionaryAdapter<TKey, TValue> : IAdapter
     {
-        public virtual bool TryAdd(
-            object target,
+        private readonly IContractResolver _contractResolver;
+
+        public DictionaryAdapter(IContractResolver contractResolver)
+        {
+            _contractResolver = contractResolver;
+        }
+
+        public virtual bool TryAdd(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            var contract = (JsonDictionaryContract)contractResolver.ResolveContract(target.GetType());
+            var contract = (JsonDictionaryContract)_contractResolver.ResolveContract(target.GetType());
             var key = contract.DictionaryKeyResolver(segment);
             var dictionary = (IDictionary<TKey, TValue>)target;
 
@@ -41,14 +46,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryGet(
-            object target,
+        public virtual bool TryGet(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {
-            var contract = (JsonDictionaryContract)contractResolver.ResolveContract(target.GetType());
+            var contract = (JsonDictionaryContract)_contractResolver.ResolveContract(target.GetType());
             var key = contract.DictionaryKeyResolver(segment);
             var dictionary = (IDictionary<TKey, TValue>)target;
 
@@ -70,13 +73,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryRemove(
-            object target,
+        public virtual bool TryRemove(object target,
             string segment,
-            IContractResolver contractResolver,
             out string errorMessage)
         {
-            var contract = (JsonDictionaryContract)contractResolver.ResolveContract(target.GetType());
+            var contract = (JsonDictionaryContract)_contractResolver.ResolveContract(target.GetType());
             var key = contract.DictionaryKeyResolver(segment);
             var dictionary = (IDictionary<TKey, TValue>)target;
 
@@ -98,14 +99,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryReplace(
-            object target,
+        public virtual bool TryReplace(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            var contract = (JsonDictionaryContract)contractResolver.ResolveContract(target.GetType());
+            var contract = (JsonDictionaryContract)_contractResolver.ResolveContract(target.GetType());
             var key = contract.DictionaryKeyResolver(segment);
             var dictionary = (IDictionary<TKey, TValue>)target;
 
@@ -132,14 +131,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTest(
-            object target,
+        public virtual bool TryTest(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            var contract = (JsonDictionaryContract)contractResolver.ResolveContract(target.GetType());
+            var contract = (JsonDictionaryContract)_contractResolver.ResolveContract(target.GetType());
             var key = contract.DictionaryKeyResolver(segment);
             var dictionary = (IDictionary<TKey, TValue>)target;
 
@@ -181,14 +178,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             }
         }
 
-        public virtual bool TryTraverse(
-            object target,
+        public virtual bool TryTraverse(object target,
             string segment,
-            IContractResolver contractResolver,
             out object nextTarget,
             out string errorMessage)
         {
-            var contract = (JsonDictionaryContract)contractResolver.ResolveContract(target.GetType());
+            var contract = (JsonDictionaryContract)_contractResolver.ResolveContract(target.GetType());
             var key = contract.DictionaryKeyResolver(segment);
             var dictionary = (IDictionary<TKey, TValue>)target;
 

--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         protected virtual bool TryConvertKey(string key, out TKey convertedKey, out string errorMessage)
         {
-            var conversionResult = ConversionResultProvider.ConvertTo(key, typeof(TKey));
+            var conversionResult = ConversionResultProvider.ConvertTo(key, typeof(TKey), _contractResolver);
             if (conversionResult.CanBeConverted)
             {
                 errorMessage = null;
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         protected virtual bool TryConvertValue(object value, out TValue convertedValue, out string errorMessage)
         {
-            var conversionResult = ConversionResultProvider.ConvertTo(value, typeof(TValue));
+            var conversionResult = ConversionResultProvider.ConvertTo(value, typeof(TValue), _contractResolver);
             if (conversionResult.CanBeConverted)
             {
                 errorMessage = null;

--- a/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue)
         {
-            var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType);
+            var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType, _contractResolver);
             if (!conversionResult.CanBeConverted)
             {
                 convertedValue = null;

--- a/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,14 +19,19 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
     /// </summary>
     public class DynamicObjectAdapter : IAdapter
     {
-        public virtual bool TryAdd(
-            object target,
+        private readonly IContractResolver _contractResolver;
+
+        public DynamicObjectAdapter(IContractResolver contractResolver)
+        {
+            _contractResolver = contractResolver;
+        }
+
+        public virtual bool TryAdd(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            if (!TrySetDynamicObjectProperty(target, contractResolver, segment, value, out errorMessage))
+            if (!TrySetDynamicObjectProperty(target, _contractResolver, segment, value, out errorMessage))
             {
                 return false;
             }
@@ -35,14 +40,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryGet(
-            object target,
+        public virtual bool TryGet(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {
-            if (!TryGetDynamicObjectProperty(target, contractResolver, segment, out value, out errorMessage))
+            if (!TryGetDynamicObjectProperty(target, _contractResolver, segment, out value, out errorMessage))
             {
                 value = null;
                 return false;
@@ -52,13 +55,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryRemove(
-            object target,
+        public virtual bool TryRemove(object target,
             string segment,
-            IContractResolver contractResolver,
             out string errorMessage)
         {
-            if (!TryGetDynamicObjectProperty(target, contractResolver, segment, out var property, out errorMessage))
+            if (!TryGetDynamicObjectProperty(target, _contractResolver, segment, out var property, out errorMessage))
             {
                 return false;
             }
@@ -72,7 +73,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 value = Activator.CreateInstance(property.GetType());
             }
 
-            if (!TrySetDynamicObjectProperty(target, contractResolver, segment, value, out errorMessage))
+            if (!TrySetDynamicObjectProperty(target, _contractResolver, segment, value, out errorMessage))
             {
                 return false;
             }
@@ -82,14 +83,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         }
 
-        public virtual bool TryReplace(
-            object target,
+        public virtual bool TryReplace(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            if (!TryGetDynamicObjectProperty(target, contractResolver, segment, out var property, out errorMessage))
+            if (!TryGetDynamicObjectProperty(target, _contractResolver, segment, out var property, out errorMessage))
             {
                 return false;
             }
@@ -100,12 +99,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (!TryRemove(target, segment, contractResolver, out errorMessage))
+            if (!TryRemove(target, segment, out errorMessage))
             {
                 return false;
             }
 
-            if (!TrySetDynamicObjectProperty(target, contractResolver, segment, convertedValue, out errorMessage))
+            if (!TrySetDynamicObjectProperty(target, _contractResolver, segment, convertedValue, out errorMessage))
             {
                 return false;
             }
@@ -114,14 +113,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTest(
-            object target,
+        public virtual bool TryTest(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            if (!TryGetDynamicObjectProperty(target, contractResolver, segment, out var property, out errorMessage))
+            if (!TryGetDynamicObjectProperty(target, _contractResolver, segment, out var property, out errorMessage))
             {
                 return false;
             }
@@ -144,14 +141,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             }
         }
 
-        public virtual bool TryTraverse(
-            object target,
+        public virtual bool TryTraverse(object target,
             string segment,
-            IContractResolver contractResolver,
             out object nextTarget,
             out string errorMessage)
         {
-            if (!TryGetDynamicObjectProperty(target, contractResolver, segment, out var property, out errorMessage))
+            if (!TryGetDynamicObjectProperty(target, _contractResolver, segment, out var property, out errorMessage))
             {
                 nextTarget = null;
                 return false;

--- a/src/Features/JsonPatch/src/Internal/IAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/IAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json.Serialization;
@@ -14,41 +14,35 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         bool TryTraverse(
             object target,
             string segment,
-            IContractResolver contractResolver,
             out object nextTarget,
             out string errorMessage);
 
         bool TryAdd(
             object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage);
 
         bool TryRemove(
             object target,
             string segment,
-            IContractResolver contractResolver,
             out string errorMessage);
 
         bool TryGet(
             object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage);
 
         bool TryReplace(
             object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage);
 
         bool TryTest(
             object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage);
     }

--- a/src/Features/JsonPatch/src/Internal/JObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/JObjectAdapter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.JsonPatch.Internal;
+using Microsoft.AspNetCore.JsonPatch.Internal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -7,10 +7,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 {
     public class JObjectAdapter : IAdapter
     {
-        public virtual bool TryAdd(
-            object target,
+        private readonly IContractResolver _contractResolver;
+
+        public JObjectAdapter(IContractResolver contractResolver)
+        {
+            _contractResolver = contractResolver;
+        }
+
+        public virtual bool TryAdd(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
@@ -22,10 +27,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryGet(
-            object target,
+        public virtual bool TryGet(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {
@@ -43,10 +46,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryRemove(
-            object target,
+        public virtual bool TryRemove(object target,
             string segment,
-            IContractResolver contractResolver,
             out string errorMessage)
         {
             var obj = (JObject) target;
@@ -62,10 +63,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryReplace(
-            object target,
+        public virtual bool TryReplace(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
@@ -83,10 +82,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTest(
-            object target,
+        public virtual bool TryTest(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
@@ -116,10 +113,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTraverse(
-            object target,
+        public virtual bool TryTraverse(object target,
             string segment,
-            IContractResolver contractResolver,
             out object nextTarget,
             out string errorMessage)
         {

--- a/src/Features/JsonPatch/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/ListAdapter.cs
@@ -17,10 +17,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
     /// </summary>
     public class ListAdapter : IAdapter
     {
-        public virtual bool TryAdd(
-            object target,
+        private readonly IContractResolver _contractResolver;
+
+        public ListAdapter(IContractResolver contractResolver)
+        {
+            _contractResolver = contractResolver;
+        }
+
+        public virtual bool TryAdd(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
@@ -54,10 +59,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryGet(
-            object target,
+        public virtual bool TryGet(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {
@@ -88,10 +91,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryRemove(
-            object target,
+        public virtual bool TryRemove(object target,
             string segment,
-            IContractResolver contractResolver,
             out string errorMessage)
         {
             var list = (IList)target;
@@ -119,10 +120,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryReplace(
-            object target,
+        public virtual bool TryReplace(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
@@ -156,10 +155,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTest(
-            object target,
+        public virtual bool TryTest(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
@@ -193,10 +190,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             }
         }
 
-        public virtual bool TryTraverse(
-            object target,
+        public virtual bool TryTraverse(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {

--- a/src/Features/JsonPatch/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/ListAdapter.cs
@@ -230,7 +230,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             out object convertedValue,
             out string errorMessage)
         {
-            var conversionResult = ConversionResultProvider.ConvertTo(originalValue, listTypeArgument);
+            var conversionResult = ConversionResultProvider.ConvertTo(originalValue, listTypeArgument, _contractResolver);
             if (!conversionResult.CanBeConverted)
             {
                 convertedValue = null;

--- a/src/Features/JsonPatch/src/Internal/ObjectVisitor.cs
+++ b/src/Features/JsonPatch/src/Internal/ObjectVisitor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Traverse until the penultimate segment to get the target object and adapter
             for (var i = 0; i < _path.Segments.Count - 1; i++)
             {
-                if (!adapter.TryTraverse(target, _path.Segments[i], _contractResolver, out var next, out errorMessage))
+                if (!adapter.TryTraverse(target, _path.Segments[i], out var next, out errorMessage))
                 {
                     adapter = null;
                     return false;

--- a/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,14 +16,19 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
     /// </summary>
     public class PocoAdapter : IAdapter
     {
-        public virtual bool TryAdd(
-            object target,
+        private readonly IContractResolver _contractResolver;
+
+        public PocoAdapter(IContractResolver contractResolver)
+        {
+            _contractResolver = contractResolver;
+        }
+
+        public virtual bool TryAdd(object target,
             string segment,
-            IContractResolver contractResolver,
             object value,
             out string errorMessage)
         {
-            if (!TryGetJsonProperty(target, contractResolver, segment, out var jsonProperty))
+            if (!TryGetJsonProperty(target, _contractResolver, segment, out var jsonProperty))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
@@ -47,14 +52,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryGet(
-            object target,
+        public virtual bool TryGet(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {
-            if (!TryGetJsonProperty(target, contractResolver, segment, out var jsonProperty))
+            if (!TryGetJsonProperty(target, _contractResolver, segment, out var jsonProperty))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 value = null;
@@ -73,13 +76,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryRemove(
-            object target,
+        public virtual bool TryRemove(object target,
             string segment,
-            IContractResolver contractResolver,
             out string errorMessage)
         {
-            if (!TryGetJsonProperty(target, contractResolver, segment, out var jsonProperty))
+            if (!TryGetJsonProperty(target, _contractResolver, segment, out var jsonProperty))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
@@ -106,15 +107,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryReplace(
-            object target,
+        public virtual bool TryReplace(object target,
             string segment,
-            IContractResolver
-            contractResolver,
             object value,
             out string errorMessage)
         {
-            if (!TryGetJsonProperty(target, contractResolver, segment, out var jsonProperty))
+            if (!TryGetJsonProperty(target, _contractResolver, segment, out var jsonProperty))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
@@ -138,15 +136,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTest(
-            object target,
+        public virtual bool TryTest(object target,
             string segment,
-            IContractResolver
-            contractResolver,
             object value,
             out string errorMessage)
         {
-            if (!TryGetJsonProperty(target, contractResolver, segment, out var jsonProperty))
+            if (!TryGetJsonProperty(target, _contractResolver, segment, out var jsonProperty))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
@@ -175,10 +170,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return true;
         }
 
-        public virtual bool TryTraverse(
-            object target,
+        public virtual bool TryTraverse(object target,
             string segment,
-            IContractResolver contractResolver,
             out object value,
             out string errorMessage)
         {
@@ -189,7 +182,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (TryGetJsonProperty(target, contractResolver, segment, out var jsonProperty))
+            if (TryGetJsonProperty(target, _contractResolver, segment, out var jsonProperty))
             {
                 value = jsonProperty.ValueProvider.GetValue(target);
                 errorMessage = null;

--- a/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue)
         {
-            var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType);
+            var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType, _contractResolver);
             if (!conversionResult.CanBeConverted)
             {
                 convertedValue = null;

--- a/src/Features/JsonPatch/test/Internal/DictionaryAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/DictionaryAdapterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,11 +17,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var key = "Status";
             var dictionary = new Dictionary<string, int>(StringComparer.Ordinal);
             dictionary[key] = 404;
-            var dictionaryAdapter = new DictionaryAdapter<string, int>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, int>(resolver);
 
             // Act
-            var addStatus = dictionaryAdapter.TryAdd(dictionary, key, resolver, 200, out var message);
+            var addStatus = dictionaryAdapter.TryAdd(dictionary, key, 200, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -37,11 +37,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var intKey = 1;
             var dictionary = new Dictionary<int, object>();
             dictionary[intKey] = "Mike";
-            var dictionaryAdapter = new DictionaryAdapter<int, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<int, object>(resolver);
 
             // Act
-            var addStatus = dictionaryAdapter.TryAdd(dictionary, intKey.ToString(), resolver, "James", out var message);
+            var addStatus = dictionaryAdapter.TryAdd(dictionary, intKey.ToString(), "James", out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -54,13 +54,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void GetInvalidKey_ThrowsInvalidPathSegmentException()
         {
             // Arrange
-            var dictionaryAdapter = new DictionaryAdapter<int, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<int, object>(resolver);
             var key = 1;
             var dictionary = new Dictionary<int, object>();
 
             // Act
-            var addStatus = dictionaryAdapter.TryAdd(dictionary, key.ToString(), resolver, "James", out var message);
+            var addStatus = dictionaryAdapter.TryAdd(dictionary, key.ToString(), "James", out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
             // Act
             var guidKey = new Guid();
-            var getStatus = dictionaryAdapter.TryGet(dictionary, guidKey.ToString(), resolver, out var outValue, out message);
+            var getStatus = dictionaryAdapter.TryGet(dictionary, guidKey.ToString(), out var outValue, out message);
 
             // Assert
             Assert.False(getStatus);
@@ -82,13 +82,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Get_UsingCaseSensitiveKey_FailureScenario()
         {
             // Arrange
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
             var nameKey = "Name";
             var dictionary = new Dictionary<string, object>(StringComparer.Ordinal);
 
             // Act
-            var addStatus = dictionaryAdapter.TryAdd(dictionary, nameKey, resolver, "James", out var message);
+            var addStatus = dictionaryAdapter.TryAdd(dictionary, nameKey, "James", out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             Assert.Equal("James", dictionary[nameKey]);
 
             // Act
-            var getStatus = dictionaryAdapter.TryGet(dictionary, nameKey.ToUpper(), resolver, out var outValue, out message);
+            var getStatus = dictionaryAdapter.TryGet(dictionary, nameKey.ToUpper(), out var outValue, out message);
 
             // Assert
             Assert.False(getStatus);
@@ -109,13 +109,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Get_UsingCaseSensitiveKey_SuccessScenario()
         {
             // Arrange
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
             var nameKey = "Name";
             var dictionary = new Dictionary<string, object>(StringComparer.Ordinal);
 
             // Act
-            var addStatus = dictionaryAdapter.TryAdd(dictionary, nameKey, resolver, "James", out var message);
+            var addStatus = dictionaryAdapter.TryAdd(dictionary, nameKey, "James", out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             Assert.Equal("James", dictionary[nameKey]);
 
             // Act
-            addStatus = dictionaryAdapter.TryGet(dictionary, nameKey, resolver, out var outValue, out message);
+            addStatus = dictionaryAdapter.TryGet(dictionary, nameKey, out var outValue, out message);
 
             // Assert
             Assert.True(addStatus);
@@ -139,11 +139,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var nameKey = "Name";
             var dictionary = new Dictionary<string, object>(StringComparer.Ordinal);
             dictionary.Add(nameKey, "Mike");
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
 
             // Act
-            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, nameKey, resolver, "James", out var message);
+            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, nameKey, "James", out var message);
 
             // Assert
             Assert.True(replaceStatus);
@@ -159,11 +159,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var guidKey = new Guid();
             var dictionary = new Dictionary<Guid, object>();
             dictionary.Add(guidKey, "Mike");
-            var dictionaryAdapter = new DictionaryAdapter<Guid, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<Guid, object>(resolver);
 
             // Act
-            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, guidKey.ToString(), resolver, "James", out var message);
+            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, guidKey.ToString(), "James", out var message);
 
             // Assert
             Assert.True(replaceStatus);
@@ -179,11 +179,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var guidKey = new Guid();
             var dictionary = new Dictionary<Guid, int>();
             dictionary.Add(guidKey, 5);
-            var dictionaryAdapter = new DictionaryAdapter<Guid, int>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<Guid, int>(resolver);
 
             // Act
-            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, guidKey.ToString(), resolver, "test", out var message);
+            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, guidKey.ToString(), "test", out var message);
 
             // Assert
             Assert.False(replaceStatus);
@@ -197,11 +197,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var nameKey = "Name";
             var dictionary = new Dictionary<string, object>(StringComparer.Ordinal);
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
 
             // Act
-            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, nameKey, resolver, "Mike", out var message);
+            var replaceStatus = dictionaryAdapter.TryReplace(dictionary, nameKey, "Mike", out var message);
 
             // Assert
             Assert.False(replaceStatus);
@@ -215,11 +215,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var nameKey = "Name";
             var dictionary = new Dictionary<string, object>(StringComparer.Ordinal);
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
 
             // Act
-            var removeStatus = dictionaryAdapter.TryRemove(dictionary, nameKey, resolver, out var message);
+            var removeStatus = dictionaryAdapter.TryRemove(dictionary, nameKey, out var message);
 
             // Assert
             Assert.False(removeStatus);
@@ -234,11 +234,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var nameKey = "Name";
             var dictionary = new Dictionary<string, object>(StringComparer.Ordinal);
             dictionary[nameKey] = "James";
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
 
             // Act
-            var removeStatus = dictionaryAdapter.TryRemove(dictionary, nameKey, resolver, out var message);
+            var removeStatus = dictionaryAdapter.TryRemove(dictionary, nameKey, out var message);
 
             //Assert
             Assert.True(removeStatus);
@@ -253,11 +253,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var uriKey = new Uri("http://www.test.com/name");
             var dictionary = new Dictionary<Uri, object>();
             dictionary[uriKey] = "James";
-            var dictionaryAdapter = new DictionaryAdapter<Uri, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<Uri, object>(resolver);
 
             // Act
-            var removeStatus = dictionaryAdapter.TryRemove(dictionary, uriKey.ToString(), resolver, out var message);
+            var removeStatus = dictionaryAdapter.TryRemove(dictionary, uriKey.ToString(), out var message);
 
             //Assert
             Assert.True(removeStatus);
@@ -278,11 +278,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 new Customer("James", 25)
             };
             dictionary[key] = value;
-            var dictionaryAdapter = new DictionaryAdapter<string, List<object>>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, List<object>>(resolver);
 
             // Act
-            var testStatus = dictionaryAdapter.TryTest(dictionary, key, resolver, value, out var message);
+            var testStatus = dictionaryAdapter.TryTest(dictionary, key, value, out var message);
 
             //Assert
             Assert.True(testStatus);
@@ -296,12 +296,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var key = "Name";
             var dictionary = new Dictionary<string, object>();
             dictionary[key] = "James";
-            var dictionaryAdapter = new DictionaryAdapter<string, object>();
             var resolver = new DefaultContractResolver();
+            var dictionaryAdapter = new DictionaryAdapter<string, object>(resolver);
             var expectedErrorMessage = "The current value 'James' at path 'Name' is not equal to the test value 'John'.";
 
             // Act
-            var testStatus = dictionaryAdapter.TryTest(dictionary, key, resolver, "John", out var errorMessage);
+            var testStatus = dictionaryAdapter.TryTest(dictionary, key, "John", out var errorMessage);
 
             //Assert
             Assert.False(testStatus);

--- a/src/Features/JsonPatch/test/Internal/DynamicObjectAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/DynamicObjectAdapterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -13,13 +13,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryAdd_AddsNewProperty()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryAdd(target, segment, resolver, "new", out string errorMessage);
+            var status = adapter.TryAdd(target, segment, "new", out string errorMessage);
 
             // Assert
             Assert.True(status);
@@ -31,15 +31,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryAdd_ReplacesExistingPropertyValue()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             target.List = new List<int>() { 1, 2, 3 };
             var value = new List<string>() { "stringValue1", "stringValue2" };
             var segment = "List";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryAdd(target, segment, resolver, value, out string errorMessage);
+            var status = adapter.TryAdd(target, segment, value, out string errorMessage);
 
             // Assert
             Assert.True(status);
@@ -51,13 +51,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryGet_GetsPropertyValue_ForExistingProperty()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act 1
-            var addStatus = adapter.TryAdd(target, segment, resolver, "new", out string errorMessage);
+            var addStatus = adapter.TryAdd(target, segment, "new", out string errorMessage);
 
             // Assert 1
             Assert.True(addStatus);
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             Assert.Equal("new", target.NewProperty);
 
             // Act 2
-            var getStatus = adapter.TryGet(target, segment, resolver, out object getValue, out string getErrorMessage);
+            var getStatus = adapter.TryGet(target, segment, out object getValue, out string getErrorMessage);
 
             // Assert 2
             Assert.True(getStatus);
@@ -77,13 +77,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryGet_ThrowsPathNotFoundException_ForNonExistingProperty()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var getStatus = adapter.TryGet(target, segment, resolver, out object getValue, out string getErrorMessage);
+            var getStatus = adapter.TryGet(target, segment, out object getValue, out string getErrorMessage);
 
             // Assert
             Assert.False(getStatus);
@@ -95,15 +95,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryTraverse_FindsNextTarget()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             target.NestedObject = new DynamicTestObject();
             target.NestedObject.NewProperty = "A";
             var segment = "NestedObject";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryTraverse(target, segment, resolver, out object nextTarget, out string errorMessage);
+            var status = adapter.TryTraverse(target, segment, out object nextTarget, out string errorMessage);
 
             // Assert
             Assert.True(status);
@@ -115,14 +115,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryTraverse_ThrowsPathNotFoundException_ForNonExistingProperty()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             target.NestedObject = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryTraverse(target.NestedObject, segment, resolver, out object nextTarget, out string errorMessage);
+            var status = adapter.TryTraverse(target.NestedObject, segment, out object nextTarget, out string errorMessage);
 
             // Assert
             Assert.False(status);
@@ -133,14 +133,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryReplace_RemovesExistingValue_BeforeAddingNewValue()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new WriteOnceDynamicTestObject();
             target.NewProperty = new object();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryReplace(target, segment, resolver, "new", out string errorMessage);
+            var status = adapter.TryReplace(target, segment, "new", out string errorMessage);
 
             // Assert
             Assert.True(status);
@@ -152,13 +152,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryReplace_ThrowsPathNotFoundException_ForNonExistingProperty()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryReplace(target, segment, resolver, "test", out string errorMessage);
+            var status = adapter.TryReplace(target, segment, "test", out string errorMessage);
 
             // Assert
             Assert.False(status);
@@ -169,14 +169,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryReplace_ThrowsPropertyInvalidException_IfNewValueIsNotTheSameTypeAsInitialValue()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             target.NewProperty = 1;
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var status = adapter.TryReplace(target, segment, resolver, "test", out string errorMessage);
+            var status = adapter.TryReplace(target, segment, "test", out string errorMessage);
 
             // Assert
             Assert.False(status);
@@ -189,13 +189,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryRemove_SetsPropertyToDefaultOrNull(object value, object expectedValue)
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act 1
-            var addStatus = adapter.TryAdd(target, segment, resolver, value, out string errorMessage);
+            var addStatus = adapter.TryAdd(target, segment, value, out string errorMessage);
 
             // Assert 1
             Assert.True(addStatus);
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             Assert.Equal(value, target.NewProperty);
 
             // Act 2
-            var removeStatus = adapter.TryRemove(target, segment, resolver, out string removeErrorMessage);
+            var removeStatus = adapter.TryRemove(target, segment, out string removeErrorMessage);
 
             // Assert 2
             Assert.True(removeStatus);
@@ -215,13 +215,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryRemove_ThrowsPathNotFoundException_ForNonExistingProperty()
         {
             // Arrange
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var removeStatus = adapter.TryRemove(target, segment, resolver, out string removeErrorMessage);
+            var removeStatus = adapter.TryRemove(target, segment, out string removeErrorMessage);
 
             // Assert
             Assert.False(removeStatus);
@@ -231,7 +231,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         [Fact]
         public void TryTest_DoesNotThrowException_IfTestSuccessful()
         {
-            var adapter = new DynamicObjectAdapter();
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             var value = new List<object>()
             {
@@ -241,10 +242,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             };
             target.NewProperty = value;
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
 
             // Act
-            var testStatus = adapter.TryTest(target, segment, resolver, value, out string errorMessage);
+            var testStatus = adapter.TryTest(target, segment, value, out string errorMessage);
 
             // Assert
             Assert.Equal(value, target.NewProperty);
@@ -255,16 +255,16 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         [Fact]
         public void TryTest_ThrowsJsonPatchException_IfTestFails()
         {
-            // Arrange            
-            var adapter = new DynamicObjectAdapter();
+            // Arrange
+            var resolver = new DefaultContractResolver();
+            var adapter = new DynamicObjectAdapter(resolver);
             dynamic target = new DynamicTestObject();
             target.NewProperty = "Joana";
             var segment = "NewProperty";
-            var resolver = new DefaultContractResolver();
             var expectedErrorMessage = $"The current value 'Joana' at path '{segment}' is not equal to the test value 'John'.";
 
             // Act
-            var testStatus = adapter.TryTest(target, segment, resolver, "John", out string errorMessage);
+            var testStatus = adapter.TryTest(target, segment, "John", out string errorMessage);
 
             // Assert
             Assert.False(testStatus);

--- a/src/Features/JsonPatch/test/Internal/ListAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/ListAdapterTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using Moq;
 using Newtonsoft.Json.Serialization;
 using Xunit;
 
@@ -15,9 +14,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Patch_OnArrayObject_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new[] { 20, 30 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, "0", "40", out var message);
@@ -31,11 +30,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Patch_OnNonGenericListObject_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new ArrayList();
             targetObject.Add(20);
             targetObject.Add(30);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, "-", "40", out var message);
@@ -49,9 +48,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_WithIndexSameAsNumberOfElements_Works()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<string>() { "James", "Mike" };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
             var position = targetObject.Count.ToString();
 
             // Act
@@ -71,9 +70,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_WithOutOfBoundsIndex_Fails(string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<string>() { "James", "Mike" };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, position, "40", out var message);
@@ -89,9 +88,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Patch_WithInvalidPositionFormat_Fails(string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<string>() { "James", "Mike" };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, position, "40", out var message);
@@ -124,8 +123,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_Appends_AtTheEnd(List<int> targetObject, List<int> expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, "-", "20", out var message);
@@ -141,8 +140,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_NullObject_ToReferenceTypeListWorks()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
             var targetObject = new List<string>() { "James", "Mike" };
 
             // Act
@@ -161,9 +160,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var sDto = new SimpleObject();
             var iDto = new InheritedObject();
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<SimpleObject>() { sDto };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, "-", iDto, out var message);
@@ -179,9 +178,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_NonCompatibleType_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, "-", "James", out var message);
@@ -230,8 +229,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_DifferentComplexTypeWorks(IList targetObject, object value, string position, IList expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, position, value, out var message);
@@ -285,8 +284,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_KeepsObjectReference(IList targetObject, object value, string position, IList expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var addStatus = listAdapter.TryAdd(targetObject, position, value, out var message);
@@ -305,9 +304,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Get_IndexOutOfBounds(int[] input, string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var getStatus = listAdapter.TryGet(targetObject, position, out var value, out var message);
@@ -324,9 +323,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Get(int[] input, string position, object expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var getStatus = listAdapter.TryGet(targetObject, position, out var value, out var message);
@@ -344,9 +343,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Remove_IndexOutOfBounds(int[] input, string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var removeStatus = listAdapter.TryRemove(targetObject, position, out var message);
@@ -363,9 +362,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Remove(int[] input, string position, int[] expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var removeStatus = listAdapter.TryRemove(targetObject, position, out var message);
@@ -379,9 +378,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Replace_NonCompatibleType_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var replaceStatus = listAdapter.TryReplace(targetObject, "-", "James", out var message);
@@ -395,9 +394,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Replace_ReplacesValue_AtTheEnd()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var replaceStatus = listAdapter.TryReplace(targetObject, "-", "30", out var message);
@@ -431,9 +430,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Replace_ReplacesValue_AtGivenPosition(string position, List<int> expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var replaceStatus = listAdapter.TryReplace(targetObject, position, "30", out var message);
@@ -448,9 +447,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Test_DoesNotThrowException_IfTestIsSuccessful()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
 
             // Act
             var testStatus = listAdapter.TryTest(targetObject, "0", "10", out var message);
@@ -464,9 +463,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Test_ThrowsJsonPatchException_IfTestFails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
             var expectedErrorMessage = "The current value '20' at position '1' is not equal to the test value '10'.";
 
             // Act
@@ -481,9 +480,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Test_ThrowsJsonPatchException_IfListPositionOutOfBounds()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter(resolver.Object);
+            var contractResolver = new DefaultContractResolver();
+            var listAdapter = new ListAdapter(contractResolver);
             var expectedErrorMessage = "The index value provided by path segment '2' is out of bounds of the array size.";
 
             // Act

--- a/src/Features/JsonPatch/test/Internal/ListAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/ListAdapterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections;
@@ -17,10 +17,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new[] { 20, 30 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "0", resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "0", "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -35,10 +35,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var targetObject = new ArrayList();
             targetObject.Add(20);
             targetObject.Add(30);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -51,11 +51,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<string>() { "James", "Mike" };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
             var position = targetObject.Count.ToString();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, "Rob", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, "Rob", out var message);
 
             // Assert
             Assert.Null(message);
@@ -73,10 +73,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<string>() { "James", "Mike" };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -91,10 +91,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<string>() { "James", "Mike" };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -125,10 +125,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, "20", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", "20", out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -142,11 +142,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
             var targetObject = new List<string>() { "James", "Mike" };
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, value: null, errorMessage: out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", value: null, errorMessage: out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -163,10 +163,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var iDto = new InheritedObject();
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<SimpleObject>() { sDto };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, iDto, out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", iDto, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -181,10 +181,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, "James", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", "James", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -231,10 +231,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, value, out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, value, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -286,10 +286,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, value, out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, value, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -307,10 +307,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var getStatus = listAdapter.TryGet(targetObject, position, resolver.Object, out var value, out var message);
+            var getStatus = listAdapter.TryGet(targetObject, position, out var value, out var message);
 
             // Assert
             Assert.False(getStatus);
@@ -326,10 +326,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var getStatus = listAdapter.TryGet(targetObject, position, resolver.Object, out var value, out var message);
+            var getStatus = listAdapter.TryGet(targetObject, position, out var value, out var message);
 
             // Assert
             Assert.True(getStatus);
@@ -346,10 +346,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var removeStatus = listAdapter.TryRemove(targetObject, position, resolver.Object, out var message);
+            var removeStatus = listAdapter.TryRemove(targetObject, position, out var message);
 
             // Assert
             Assert.False(removeStatus);
@@ -365,10 +365,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>(input);
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var removeStatus = listAdapter.TryRemove(targetObject, position, resolver.Object, out var message);
+            var removeStatus = listAdapter.TryRemove(targetObject, position, out var message);
 
             // Assert
             Assert.True(removeStatus);
@@ -381,10 +381,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var replaceStatus = listAdapter.TryReplace(targetObject, "-", resolver.Object, "James", out var message);
+            var replaceStatus = listAdapter.TryReplace(targetObject, "-", "James", out var message);
 
             // Assert
             Assert.False(replaceStatus);
@@ -397,10 +397,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var replaceStatus = listAdapter.TryReplace(targetObject, "-", resolver.Object, "30", out var message);
+            var replaceStatus = listAdapter.TryReplace(targetObject, "-", "30", out var message);
 
             // Assert
             Assert.True(replaceStatus);
@@ -433,10 +433,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var replaceStatus = listAdapter.TryReplace(targetObject, position, resolver.Object, "30", out var message);
+            var replaceStatus = listAdapter.TryReplace(targetObject, position, "30", out var message);
 
             // Assert
             Assert.True(replaceStatus);
@@ -450,10 +450,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
 
             // Act
-            var testStatus = listAdapter.TryTest(targetObject, "0", resolver.Object, "10", out var message);
+            var testStatus = listAdapter.TryTest(targetObject, "0", "10", out var message);
 
             //Assert
             Assert.True(testStatus);
@@ -466,11 +466,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
             var expectedErrorMessage = "The current value '20' at position '1' is not equal to the test value '10'.";
 
             // Act
-            var testStatus = listAdapter.TryTest(targetObject, "1", resolver.Object, "10", out var errorMessage);
+            var testStatus = listAdapter.TryTest(targetObject, "1", "10", out var errorMessage);
 
             //Assert
             Assert.False(testStatus);
@@ -483,11 +483,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
             var targetObject = new List<int>() { 10, 20 };
-            var listAdapter = new ListAdapter();
+            var listAdapter = new ListAdapter(resolver.Object);
             var expectedErrorMessage = "The index value provided by path segment '2' is out of bounds of the array size.";
 
             // Act
-            var testStatus = listAdapter.TryTest(targetObject, "2", resolver.Object, "10", out var errorMessage);
+            var testStatus = listAdapter.TryTest(targetObject, "2", "10", out var errorMessage);
 
             //Assert
             Assert.False(testStatus);

--- a/src/Features/JsonPatch/test/Internal/PocoAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/PocoAdapterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json.Serialization;
@@ -12,15 +12,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryAdd_ReplacesExistingProperty()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
             };
 
             // Act
-            var addStatus = adapter.TryAdd(model, "Name", contractResolver, "John", out var errorMessage);
+            var addStatus = adapter.TryAdd(model, "Name", "John", out var errorMessage);
 
             // Assert
             Assert.Equal("John", model.Name);
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryAdd_ThrowsJsonPatchException_IfPropertyDoesNotExist()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var expectedErrorMessage = "The target location specified by path segment 'LastName' was not found.";
 
             // Act
-            var addStatus = adapter.TryAdd(model, "LastName", contractResolver, "Smith", out var errorMessage);
+            var addStatus = adapter.TryAdd(model, "LastName", "Smith", out var errorMessage);
 
             // Assert
             Assert.False(addStatus);
@@ -52,15 +52,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryGet_ExistingProperty()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
             };
 
             // Act
-            var getStatus = adapter.TryGet(model, "Name", contractResolver, out var value, out var errorMessage);
+            var getStatus = adapter.TryGet(model, "Name", out var value, out var errorMessage);
 
             // Assert
             Assert.Equal("Joana", value);
@@ -72,8 +72,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryGet_ThrowsJsonPatchException_IfPropertyDoesNotExist()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var expectedErrorMessage = "The target location specified by path segment 'LastName' was not found.";
 
             // Act
-            var getStatus = adapter.TryGet(model, "LastName", contractResolver, out var value, out var errorMessage);
+            var getStatus = adapter.TryGet(model, "LastName", out var value, out var errorMessage);
 
             // Assert
             Assert.Null(value);
@@ -93,15 +93,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryRemove_SetsPropertyToNull()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
             };
 
             // Act
-            var removeStatus = adapter.TryRemove(model, "Name", contractResolver, out var errorMessage);
+            var removeStatus = adapter.TryRemove(model, "Name", out var errorMessage);
 
             // Assert
             Assert.Null(model.Name);
@@ -113,8 +113,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryRemove_ThrowsJsonPatchException_IfPropertyDoesNotExist()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var expectedErrorMessage = "The target location specified by path segment 'LastName' was not found.";
 
             // Act
-            var removeStatus = adapter.TryRemove(model, "LastName", contractResolver, out var errorMessage);
+            var removeStatus = adapter.TryRemove(model, "LastName", out var errorMessage);
 
             // Assert
             Assert.False(removeStatus);
@@ -133,15 +133,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryReplace_OverwritesExistingValue()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
             };
 
             // Act
-            var replaceStatus = adapter.TryReplace(model, "Name", contractResolver, "John", out var errorMessage);
+            var replaceStatus = adapter.TryReplace(model, "Name", "John", out var errorMessage);
 
             // Assert
             Assert.Equal("John", model.Name);
@@ -153,8 +153,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryReplace_ThrowsJsonPatchException_IfNewValueIsInvalidType()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Age = 25
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var expectedErrorMessage = "The value 'TwentySix' is invalid for target location.";
 
             // Act
-            var replaceStatus = adapter.TryReplace(model, "Age", contractResolver, "TwentySix", out var errorMessage);
+            var replaceStatus = adapter.TryReplace(model, "Age", "TwentySix", out var errorMessage);
 
             // Assert
             Assert.Equal(25, model.Age);
@@ -175,8 +175,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void TryReplace_ThrowsJsonPatchException_IfPropertyDoesNotExist()
         {
             // Arrange
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var expectedErrorMessage = "The target location specified by path segment 'LastName' was not found.";
 
             // Act
-            var replaceStatus = adapter.TryReplace(model, "LastName", contractResolver, "Smith", out var errorMessage);
+            var replaceStatus = adapter.TryReplace(model, "LastName", "Smith", out var errorMessage);
 
             // Assert
             Assert.Equal("Joana", model.Name);
@@ -195,15 +195,15 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         [Fact]
         public void TryTest_DoesNotThrowException_IfTestSuccessful()
         {
-            var adapter = new PocoAdapter();
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
             };
 
             // Act
-            var testStatus = adapter.TryTest(model, "Name", contractResolver, "Joana", out var errorMessage);
+            var testStatus = adapter.TryTest(model, "Name", "Joana", out var errorMessage);
 
             // Assert
             Assert.Equal("Joana", model.Name);
@@ -214,9 +214,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         [Fact]
         public void TryTest_ThrowsJsonPatchException_IfTestFails()
         {
-            // Arrange            
-            var adapter = new PocoAdapter();
+            // Arrange
             var contractResolver = new DefaultContractResolver();
+            var adapter = new PocoAdapter(contractResolver);
             var model = new Customer
             {
                 Name = "Joana"
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var expectedErrorMessage = "The current value 'Joana' at path 'Name' is not equal to the test value 'John'.";
 
             // Act
-            var testStatus = adapter.TryTest(model, "Name", contractResolver, "John", out var errorMessage);
+            var testStatus = adapter.TryTest(model, "Name", "John", out var errorMessage);
 
             // Assert
             Assert.False(testStatus);


### PR DESCRIPTION
Passing the `IContractResolver` from the operation object all the way down to `ConversionResultProvider`, so that nested objects can be properly deserialized when non-standard serialization settings are used.

One test is added to verify the case.

Also, pulled the `IContractSerializer` parameter from properties to `IAdapter`s' constructors. Because of that the mock of `IContractResolver` in ListAdapterTests was replaced with an actual `DefaultContractResolver`.

Addresses #16690
