### PR TITLE
Changed the Reason Phrase for 500

### DIFF
--- a/src/Http/WebUtilities/src/ReasonPhrases.cs
+++ b/src/Http/WebUtilities/src/ReasonPhrases.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             { 431, "Request Header Fields Too Large" },
             { 451, "Unavailable For Legal Reasons" },
 
-            { 500, "Internal Server Error" },
+            { 500, "An error occured while processing your request." },
             { 501, "Not Implemented" },
             { 502, "Bad Gateway" },
             { 503, "Service Unavailable" },


### PR DESCRIPTION
Because ApiBehaviorOptionsSetup.cs added a ClientErrorMapping for 500
based on the newly added ApiConventions_Title_500 in Resources.resx,
retrieving ReasonPhrases.GetReasonPhrase(500) was still returning the
old message and so they were out of sync.

Updated the value for the 500 key in ReasonPhrases.cs to match
ApiConventions_Title_500.

Fix #16880
