### PR TITLE
[3.1.x] Fix dotnet.exe process recovery after abnormal exit in ANCM

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -14,7 +14,7 @@ class ConfigUtility
     #define CS_ASPNETCORE_HANDLER_SETTINGS                   L"handlerSettings"
     #define CS_ASPNETCORE_HANDLER_VERSION                    L"handlerVersion"
     #define CS_ASPNETCORE_DEBUG_FILE                         L"debugFile"
-    #define CS_ASPNETCORE_ENABLE_OUT_OF_PROCESS_CONSOLE_REDIRECTION L"EnableOutOfProcessConsoleRedirection"
+    #define CS_ASPNETCORE_ENABLE_OUT_OF_PROCESS_CONSOLE_REDIRECTION L"enableOutOfProcessConsoleRedirection"
     #define CS_ASPNETCORE_DEBUG_LEVEL                        L"debugLevel"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_NAME              L"name"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_VALUE             L"value"

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -14,7 +14,7 @@ class ConfigUtility
     #define CS_ASPNETCORE_HANDLER_SETTINGS                   L"handlerSettings"
     #define CS_ASPNETCORE_HANDLER_VERSION                    L"handlerVersion"
     #define CS_ASPNETCORE_DEBUG_FILE                         L"debugFile"
-    #define CS_ASPNETCORE_DISABLE_REDIRECTION_OUT_OF_PROCESS L"disableRedirectionOutOfProcess"
+    #define CS_ASPNETCORE_ENABLE_OUT_OF_PROCESS_CONSOLE_REDIRECTION L"EnableOutOfProcessConsoleRedirection"
     #define CS_ASPNETCORE_DEBUG_LEVEL                        L"debugLevel"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_NAME              L"name"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_VALUE             L"value"
@@ -43,9 +43,9 @@ public:
 
     static
     HRESULT
-    FindDisableRedirectionOutOfProcess(IAppHostElement* pElement, STRU& strForwardResponseConnectionHeader)
+    FindEnableOutOfProcessConsoleRedirection(IAppHostElement* pElement, STRU& strEnableOutOfProcessConsoleRedirection)
     {
-        return FindKeyValuePair(pElement, CS_ASPNETCORE_DISABLE_REDIRECTION_OUT_OF_PROCESS, strForwardResponseConnectionHeader);
+        return FindKeyValuePair(pElement, CS_ASPNETCORE_ENABLE_OUT_OF_PROCESS_CONSOLE_REDIRECTION, strEnableOutOfProcessConsoleRedirection);
     }
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -14,6 +14,7 @@ class ConfigUtility
     #define CS_ASPNETCORE_HANDLER_SETTINGS                   L"handlerSettings"
     #define CS_ASPNETCORE_HANDLER_VERSION                    L"handlerVersion"
     #define CS_ASPNETCORE_DEBUG_FILE                         L"debugFile"
+    #define CS_ASPNETCORE_DISABLE_REDIRECTION_OUT_OF_PROCESS L"disableRedirectionOutOfProcess"
     #define CS_ASPNETCORE_DEBUG_LEVEL                        L"debugLevel"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_NAME              L"name"
     #define CS_ASPNETCORE_HANDLER_SETTINGS_VALUE             L"value"
@@ -38,6 +39,13 @@ public:
     FindDebugLevel(IAppHostElement* pElement, STRU& strDebugFile)
     {
         return FindKeyValuePair(pElement, CS_ASPNETCORE_DEBUG_LEVEL, strDebugFile);
+    }
+
+    static
+    HRESULT
+    FindDisableRedirectionOutOfProcess(IAppHostElement* pElement, STRU& strForwardResponseConnectionHeader)
+    {
+        return FindKeyValuePair(pElement, CS_ASPNETCORE_DISABLE_REDIRECTION_OUT_OF_PROCESS, strForwardResponseConnectionHeader);
     }
 
 private:

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp
@@ -158,6 +158,7 @@ PROCESS_MANAGER::GetProcess(
                     pConfig->QueryAnonymousAuthEnabled(),
                     pConfig->QueryEnvironmentVariables(),
                     pConfig->QueryStdoutLogEnabled(),
+                    pConfig->QueryDisableRedirectionOutOfProcess(),
                     fWebsocketSupported,
                     pConfig->QueryStdoutLogFile(),
                     pConfig->QueryApplicationPhysicalPath(),   // physical path

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp
@@ -158,7 +158,7 @@ PROCESS_MANAGER::GetProcess(
                     pConfig->QueryAnonymousAuthEnabled(),
                     pConfig->QueryEnvironmentVariables(),
                     pConfig->QueryStdoutLogEnabled(),
-                    pConfig->QueryDisableRedirectionOutOfProcess(),
+                    pConfig->QueryEnableOutOfProcessConsoleRedirection(),
                     fWebsocketSupported,
                     pConfig->QueryStdoutLogFile(),
                     pConfig->QueryApplicationPhysicalPath(),   // physical path

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
@@ -1782,7 +1782,7 @@ SERVER_PROCESS::SERVER_PROCESS() :
     m_hListeningProcessHandle(NULL),
     m_hShutdownHandle(NULL),
     m_hStdErrWritePipe(NULL),
-    m_hReadThread(NULL),
+    m_hReadThread(nullptr),
     m_randomGenerator(std::random_device()())
 {
     //InterlockedIncrement(&g_dwActiveServerProcesses);

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
@@ -25,7 +25,7 @@ SERVER_PROCESS::Initialize(
     BOOL                  fAnonymousAuthEnabled,
     std::map<std::wstring, std::wstring, ignore_case_comparer>& pEnvironmentVariables,
     BOOL                  fStdoutLogEnabled,
-    BOOL                  fDisableRedirection,
+    BOOL                  fEnableOutOfProcessConsoleRedirection,
     BOOL                  fWebSocketSupported,
     STRU                  *pstruStdoutLogFile,
     STRU                  *pszAppPhysicalPath,
@@ -44,7 +44,7 @@ SERVER_PROCESS::Initialize(
     m_fWindowsAuthEnabled = fWindowsAuthEnabled;
     m_fBasicAuthEnabled = fBasicAuthEnabled;
     m_fAnonymousAuthEnabled = fAnonymousAuthEnabled;
-    m_fDisableRedirection = fDisableRedirection;
+    m_fEnableOutOfProcessConsoleRedirection = fEnableOutOfProcessConsoleRedirection;
     m_pProcessManager->ReferenceProcessManager();
     m_fDebuggerAttached = FALSE;
 
@@ -1032,7 +1032,7 @@ SERVER_PROCESS::SetupStdHandles(
     saAttr.bInheritHandle = TRUE;
     saAttr.lpSecurityDescriptor = NULL;
 
-    if (m_fDisableRedirection)
+    if (!m_fEnableOutOfProcessConsoleRedirection)
     {
         pStartupInfo->dwFlags = STARTF_USESTDHANDLES;
         pStartupInfo->hStdInput = INVALID_HANDLE_VALUE;
@@ -1883,9 +1883,8 @@ SERVER_PROCESS::~SERVER_PROCESS()
     {
         if (m_hStdErrWritePipe != INVALID_HANDLE_VALUE)
         {
-            THROW_LAST_ERROR_IF(!FlushFileBuffers(m_hStdErrWritePipe));
+            FlushFileBuffers(m_hStdErrWritePipe);
             CloseHandle(m_hStdErrWritePipe);
-            m_hStdErrWritePipe = INVALID_HANDLE_VALUE;
         }
 
         m_hStdErrWritePipe = NULL;

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -37,6 +37,7 @@ public:
         _In_ BOOL                  fAnonymousAuthEnabled,
         _In_ std::map<std::wstring, std::wstring, ignore_case_comparer>& pEnvironmentVariables,
         _In_ BOOL                  fStdoutLogEnabled,
+        _In_ BOOL                  fDisableRedirection,
         _In_ BOOL                  fWebSocketSupported,
         _In_ STRU                 *pstruStdoutLogFile,
         _In_ STRU                 *pszAppPhysicalPath,
@@ -253,6 +254,7 @@ private:
     BOOL                    m_fBasicAuthEnabled;
     BOOL                    m_fAnonymousAuthEnabled;
     BOOL                    m_fDebuggerAttached;
+    BOOL                    m_fDisableRedirection;
 
     STTIMER                 m_Timer;
     SOCKET                  m_socket;

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -254,7 +254,7 @@ private:
     BOOL                    m_fBasicAuthEnabled;
     BOOL                    m_fAnonymousAuthEnabled;
     BOOL                    m_fDebuggerAttached;
-    BOOL                    m_fDisableRedirection;
+    BOOL                    m_fEnableOutOfProcessConsoleRedirection;
 
     STTIMER                 m_Timer;
     SOCKET                  m_socket;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
@@ -379,7 +379,7 @@ REQUESTHANDLER_CONFIG::Populate(
         goto Finished;
     }
 
-    hr = ConfigUtility::FindDisableRedirectionOutOfProcess(pAspNetCoreElement, m_fDisableRedirectionOutOfProcess);
+    hr = ConfigUtility::FindEnableOutOfProcessConsoleRedirection(pAspNetCoreElement, m_fEnableOutOfProcessConsoleRedirection);
     if (FAILED(hr))
     {
         goto Finished;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
@@ -379,6 +379,12 @@ REQUESTHANDLER_CONFIG::Populate(
         goto Finished;
     }
 
+    hr = ConfigUtility::FindDisableRedirectionOutOfProcess(pAspNetCoreElement, m_fDisableRedirectionOutOfProcess);
+    if (FAILED(hr))
+    {
+        goto Finished;
+    }
+
 Finished:
 
     if (pAspNetCoreElement != NULL)

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -218,6 +218,12 @@ public:
         return &m_struConfigPath;
     }
 
+    BOOL
+    QueryDisableRedirectionOutOfProcess()
+    {
+        return m_fDisableRedirectionOutOfProcess.Equals(L"true", 1);
+    }
+
 protected:
 
     //
@@ -255,6 +261,7 @@ protected:
     BOOL                   m_fWindowsAuthEnabled;
     BOOL                   m_fBasicAuthEnabled;
     BOOL                   m_fAnonymousAuthEnabled;
+    STRU                   m_fDisableRedirectionOutOfProcess;
     APP_HOSTING_MODEL      m_hostingModel;
     std::map<std::wstring, std::wstring, ignore_case_comparer> m_pEnvironmentVariables;
     STRU                   m_struHostFxrLocation;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -219,9 +219,9 @@ public:
     }
 
     BOOL
-    QueryDisableRedirectionOutOfProcess()
+    QueryEnableOutOfProcessConsoleRedirection()
     {
-        return m_fDisableRedirectionOutOfProcess.Equals(L"true", 1);
+        return !m_fEnableOutOfProcessConsoleRedirection.Equals(L"false", 1);
     }
 
 protected:
@@ -261,7 +261,7 @@ protected:
     BOOL                   m_fWindowsAuthEnabled;
     BOOL                   m_fBasicAuthEnabled;
     BOOL                   m_fAnonymousAuthEnabled;
-    STRU                   m_fDisableRedirectionOutOfProcess;
+    STRU                   m_fEnableOutOfProcessConsoleRedirection;
     APP_HOSTING_MODEL      m_hostingModel;
     std::map<std::wstring, std::wstring, ignore_case_comparer> m_pEnvironmentVariables;
     STRU                   m_struHostFxrLocation;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
@@ -235,10 +235,10 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [RequiresNewShim]
-        public async Task SetDisableRedirectionNoLogs()
+        public async Task DisableRedirectionNoLogs()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
-            deploymentParameters.HandlerSettings["disableRedirectionOutOfProcess"] = "true";
+            deploymentParameters.HandlerSettings["enableOutOfProcessConsoleRedirection"] = "false";
             deploymentParameters.TransformArguments((a, _) => $"{a} ConsoleWriteSingle");
             var deploymentResult = await DeployAsync(deploymentParameters);
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
@@ -234,6 +234,22 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         }
 
         [ConditionalFact]
+        [RequiresNewShim]
+        public async Task SetDisableRedirectionNoLogs()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
+            deploymentParameters.HandlerSettings["disableRedirectionOutOfProcess"] = "true";
+            deploymentParameters.TransformArguments((a, _) => $"{a} ConsoleWriteSingle");
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var response = await deploymentResult.HttpClient.GetAsync("Test");
+
+            StopServer();
+
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
+        }
+
+        [ConditionalFact]
         public async Task CaptureLogsForOutOfProcessWhenProcessFailsToStart30KbMax()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
@@ -97,17 +97,8 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
             var response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
             response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
 
-            for (var i = 0; i < 5; i++)
-            {
-                // ANCM should eventually recover from being shutdown multiple times.
-                response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
-                if (response.IsSuccessStatusCode)
-                {
-                    return;
-                }
-            }
-
-            Assert.False(true);
+            response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            Assert.True(response.IsSuccessStatusCode);
         }
 
         private static int GetUnusedRandomPort()

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
@@ -98,7 +98,8 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
             var response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
             
             // Wait for server to start again.
-            for (var i = 0; i < 10; i++)
+            int i;
+            for (i = 0; i < 10; i++)
             {
                 // ANCM should eventually recover from being shutdown multiple times.
                 response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
@@ -108,11 +109,17 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
                 }
             }
             
+            if (i == 10)
+            {
+                // Didn't restart after 10 retries
+                Assert.False(true);
+            }
+            
             // Shutdown again
             response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
             
             // return if server starts again.
-            for (var i = 0; i < 10; i++)
+            for (i = 0; i < 10; i++)
             {
                 // ANCM should eventually recover from being shutdown multiple times.
                 response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
@@ -86,6 +86,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
+        [RequiresNewShim]
         public async Task ShutdownMultipleTimesWorks(TestVariant variant)
         {
             // Must publish to set env vars in web.config
@@ -106,7 +107,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
                 }
             }
 
-            Assert.False();
+            Assert.False(true);
         }
 
         private static int GetUnusedRandomPort()

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
@@ -97,8 +97,17 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
             var response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
             response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
 
-            response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
-            Assert.True(response.IsSuccessStatusCode);
+            for (var i = 0; i < 5; i++)
+            {
+                // ANCM should eventually recover from being shutdown multiple times.
+                response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+                if (response.IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+
+            Assert.False(true);
         }
 
         private static int GetUnusedRandomPort()


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/17063. 

## Description
We introduced a regression between 2.2 and 3.0/3.1 where ANCM out of process wouldn't restart dotnet.exe on crash after restarting once. This was due to a background thread hanging when trying to close a handle for stdout. Also adds an opt-out switch to remove all redirection s.t. if there are still issues with this code-path, we can disable it.

## Risk
Medium, but with reduced risk. Any change to ANCM out-of-process is always risky, but giving an opt-out switch should reduce the risk.

## User impact

On application crash, ANCM normally would start a new dotnet.exe to restart dotnet. However, because a call to CloseHandle would hang, the static callback we registered wouldn't be overwritten. Therefore, on the next process exit, the callback wouldn't be fired, meaning all subsequent crashes wouldn't be detected.

## Workarounds

If people expect their applications to crash or exit abnormally, they can work around this by either using ANCMv1 or enabling stdout logging. Both of these are non-ideal work arounds. 

cc @Pilchie 