### PR TITLE
[3.1.x] Allow external startup hooks

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.cpp
@@ -47,6 +47,7 @@ void HostFxr::Load(HMODULE moduleHandle)
         m_corehost_set_error_writer_fn = ModuleHelpers::GetKnownProcAddress<corehost_set_error_writer_fn>(moduleHandle, "hostfxr_set_error_writer", /* optional */ true);
         m_hostfxr_initialize_for_dotnet_commandline_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_initialize_for_dotnet_runtime_fn>(moduleHandle, "hostfxr_initialize_for_dotnet_command_line", /* optional */ true);
         m_hostfxr_set_runtime_property_value_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_set_runtime_property_value_fn>(moduleHandle, "hostfxr_set_runtime_property_value", /* optional */ true);
+        m_hostfxr_get_runtime_property_value_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_get_runtime_property_value_fn>(moduleHandle, "hostfxr_get_runtime_property_value", /* optional */ true);
         m_hostfxr_run_app_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_run_app_fn>(moduleHandle, "hostfxr_run_app", /* optional */ true);
         m_hostfxr_close_fn = ModuleHelpers::GetKnownProcAddress<hostfxr_close_fn>(moduleHandle, "hostfxr_close", /* optional */ true);
     }
@@ -160,6 +161,15 @@ int HostFxr::SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept
     if (m_host_context_handle != nullptr && m_hostfxr_set_runtime_property_value_fn != nullptr)
     {
         return m_hostfxr_set_runtime_property_value_fn(m_host_context_handle, name, value);
+    }
+    return 0;
+}
+
+int HostFxr::GetRuntimePropertyValue(PCWSTR name, PWSTR* value) const noexcept
+{
+    if (m_host_context_handle != nullptr && m_hostfxr_get_runtime_property_value_fn != nullptr)
+    {
+        return m_hostfxr_get_runtime_property_value_fn(m_host_context_handle, name, value);
     }
     return 0;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -25,6 +25,7 @@ typedef void(*corehost_error_writer_fn) (const WCHAR* message);
 typedef corehost_error_writer_fn(*corehost_set_error_writer_fn) (corehost_error_writer_fn error_writer);
 typedef int(*hostfxr_initialize_for_dotnet_runtime_fn)(int argc, const PCWSTR* argv, hostfxr_initialize_parameters* parameters, void* const* host_context_handle);
 typedef int(*hostfxr_set_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PCWSTR value);
+typedef int(*hostfxr_get_runtime_property_value_fn)(void* host_context_handle, PCWSTR name, PWSTR* value);
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
 typedef int(*hostfxr_close_fn)(void* hostfxr_context_handle);
 
@@ -73,6 +74,7 @@ public:
 
     HostFxrErrorRedirector RedirectOutput(RedirectionOutput* writer) const noexcept;
     int SetRuntimePropertyValue(PCWSTR name, PCWSTR value) const noexcept;
+    int GetRuntimePropertyValue(PCWSTR name, PWSTR* value) const noexcept;
     int InitializeForApp(int argc, PCWSTR* argv, const std::wstring& m_dotnetExeKnownLocation) const noexcept;
     void Close() const noexcept;
 
@@ -82,6 +84,7 @@ private:
     hostfxr_get_native_search_directories_fn m_hostfxr_get_native_search_directories_fn;
     hostfxr_initialize_for_dotnet_runtime_fn m_hostfxr_initialize_for_dotnet_commandline_fn;
     hostfxr_set_runtime_property_value_fn m_hostfxr_set_runtime_property_value_fn;
+    hostfxr_get_runtime_property_value_fn m_hostfxr_get_runtime_property_value_fn;
     hostfxr_run_app_fn m_hostfxr_run_app_fn;
     corehost_set_error_writer_fn m_corehost_set_error_writer_fn;
     hostfxr_close_fn m_hostfxr_close_fn;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -252,18 +252,17 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
 
         if (m_pConfig->QueryCallStartupHook())
         {
-            PWSTR startupHookValue;
+            PWSTR startupHookValue = NULL;
             // Will get property not found if the enviroment variable isn't set.
             context->m_hostFxr.GetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, &startupHookValue);
             
-            std::wstring startupHook(startupHookValue);
-
-            if (startupHook.empty())
+            if (startupHookValue == NULL)
             {
                 RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, ASPNETCORE_STARTUP_ASSEMBLY));
             }
             else
             {
+                std::wstring startupHook(startupHookValue);
                 startupHook.append(L";").append(ASPNETCORE_STARTUP_ASSEMBLY);
                 RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, startupHook.c_str()));
             }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -252,7 +252,21 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
 
         if (m_pConfig->QueryCallStartupHook())
         {
-            RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, ASPNETCORE_STARTUP_ASSEMBLY));
+            PWSTR startupHookValue;
+            // Will get property not found if the enviroment variable isn't set.
+            context->m_hostFxr.GetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, &startupHookValue);
+            
+            std::wstring startupHook(startupHookValue);
+
+            if (startupHook.empty())
+            {
+                RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, ASPNETCORE_STARTUP_ASSEMBLY));
+            }
+            else
+            {
+                startupHook.append(L";").append(ASPNETCORE_STARTUP_ASSEMBLY);
+                RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_STARTUP_HOOK, startupHook.c_str()));
+            }
         }
 
         RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(DOTNETCORE_USE_ENTRYPOINT_FILTER, L"1"));

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -817,6 +817,24 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             VerifyDotnetRuntimeEventLog(deploymentResult);
         }
 
+
+        [ConditionalFact]
+        [RequiresNewHandler]
+        public async Task CanAddCustomStartupHook()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+
+            // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
+            deploymentParameters.WebConfigBasedEnvironmentVariables["DOTNET_STARTUP_HOOKS"] = "InProcessWebSite";
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+            var result = await deploymentResult.HttpClient.GetAsync("/StartupHook");
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Equal("True", content);
+
+            StopServer();
+        }
+
         [ConditionalFact]
         [RequiresNewHandler]
         public async Task StackOverflowIsAvoidedBySettingLargerStack()

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -837,6 +837,24 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
         [ConditionalFact]
         [RequiresNewHandler]
+        public async Task CanAddCustomStartupHookWhenIISOneIsDisabled()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+
+            // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
+            deploymentParameters.WebConfigBasedEnvironmentVariables["DOTNET_STARTUP_HOOKS"] = "InProcessWebSite";
+            deploymentParameters.HandlerSettings["callStartupHook"] = "false";
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+            var result = await deploymentResult.HttpClient.GetAsync("/StartupHook");
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Equal("True", content);
+
+            StopServer();
+        }
+
+        [ConditionalFact]
+        [RequiresNewHandler]
         public async Task StackOverflowIsAvoidedBySettingLargerStack()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters();

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -32,6 +32,8 @@ namespace TestSite
 {
     public partial class Startup
     {
+        public static bool StartupHookCalled;
+
         public void Configure(IApplicationBuilder app)
         {
             if (Environment.GetEnvironmentVariable("ENABLE_HTTPS_REDIRECTION") != null)
@@ -898,6 +900,11 @@ namespace TestSite
                 return;
             }
             RecursiveFunction(i - 1);
+        }
+
+        private async Task StartupHook(HttpContext ctx)
+        {
+            await ctx.Response.WriteAsync(StartupHookCalled.ToString());
         }
 
         private async Task GetServerVariableStress(HttpContext ctx)

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/StartupHook.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/StartupHook.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using TestSite;
 
 internal class StartupHook

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/StartupHook.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/StartupHook.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TestSite;
+
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        Startup.StartupHookCalled = true;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/17039. 

## Description
We introduced a regression between 2.2 and 3.0/3.1 where ANCM would override any startup hooks set outside of the IIS process. This is because we added a default startup hook for diagnostics, however, we didn't query the runtime property before setting/appending it.

## Risk
Low. This just gets the runtime property (which is an environment variable read by the host) before setting. If there is an existing variable, we append.

## User impact

Startup hooks are a feature we would like to explore with internal partners for hooking into applications. Without this fix, IIS inprocess applications wouldn't get these features.

cc @Pilchie @vitek-karas