### PR TITLE
Optimize namespace comparisons 

### DIFF
--- a/src/Components/Analyzers/src/ComponentInternalUsageDiagnosticAnalzyer.cs
+++ b/src/Components/Analyzers/src/ComponentInternalUsageDiagnosticAnalzyer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.AspNetCore.Components.Analyzers;
 using Microsoft.CodeAnalysis;
@@ -15,6 +16,8 @@ namespace Microsoft.Extensions.Internal
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class ComponentInternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
     {
+        private static readonly string[] NamespaceParts = new[] { "RenderTree", "Components", "AspNetCore", "Microsoft", };
+
         private readonly InternalUsageAnalyzer _inner;
 
         public ComponentInternalUsageDiagnosticAnalyzer()
@@ -27,17 +30,25 @@ namespace Microsoft.Extensions.Internal
 
         public override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             _inner.Register(context);
         }
 
         private static bool IsInInternalNamespace(ISymbol symbol)
         {
-            if (symbol?.ContainingNamespace?.ToDisplayString() is string ns)
+            var @namespace = symbol?.ContainingNamespace;
+            for (var i = 0; i < NamespaceParts.Length; i++)
             {
-                return string.Equals(ns, "Microsoft.AspNetCore.Components.RenderTree");
+                if (@namespace == null || !string.Equals(NamespaceParts[i], @namespace.Name, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                @namespace = @namespace.ContainingNamespace;
             }
 
-            return false;
+            return true;
         }
     }
 }

--- a/src/Components/Analyzers/src/ComponentInternalUsageDiagnosticAnalzyer.cs
+++ b/src/Components/Analyzers/src/ComponentInternalUsageDiagnosticAnalzyer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Internal
                 @namespace = @namespace.ContainingNamespace;
             }
 
-            return true;
+            return @namespace.IsGlobalNamespace;
         }
     }
 }

--- a/src/Components/Analyzers/src/InternalUsageAnalyzer.cs
+++ b/src/Components/Analyzers/src/InternalUsageAnalyzer.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Extensions.Internal
             context.RegisterOperationAction(
                 AnalyzeOperation,
                 OperationKind.ObjectCreation,
+                OperationKind.Invocation,
                 OperationKind.FieldReference,
                 OperationKind.MethodReference,
                 OperationKind.PropertyReference,

--- a/src/Components/Analyzers/test/ComponentInternalUsageDiagnosticsAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/ComponentInternalUsageDiagnosticsAnalyzerTest.cs
@@ -44,6 +44,11 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 diagnostic =>
                 {
                     Assert.Same(DiagnosticDescriptors.DoNotUseRenderTreeTypes, diagnostic.Descriptor);
+                    AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MMInvocation"], diagnostic.Location);
+                },
+                diagnostic =>
+                {
+                    Assert.Same(DiagnosticDescriptors.DoNotUseRenderTreeTypes, diagnostic.Descriptor);
                     AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MMProperty"], diagnostic.Location);
                 },
                 diagnostic =>
@@ -84,6 +89,16 @@ namespace Microsoft.AspNetCore.Components.Analyzers
                 {
                     Assert.Same(DiagnosticDescriptors.DoNotUseRenderTreeTypes, diagnostic.Descriptor);
                     AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MMProperty"], diagnostic.Location);
+                },
+                diagnostic =>
+                {
+                    Assert.Same(DiagnosticDescriptors.DoNotUseRenderTreeTypes, diagnostic.Descriptor);
+                    AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MMNewObject2"], diagnostic.Location);
+                },
+                diagnostic =>
+                {
+                    Assert.Same(DiagnosticDescriptors.DoNotUseRenderTreeTypes, diagnostic.Descriptor);
+                    AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MMInvocation"], diagnostic.Location);
                 });
         }
     }

--- a/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsersRendererTypesInMethodBody.cs
+++ b/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsersRendererTypesInMethodBody.cs
@@ -12,7 +12,9 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Tests.TestFiles.ComponentInt
 
             var frame = /*MMNewObject*/new RenderTreeFrame();
             GC.KeepAlive(/*MMProperty*/frame.Component);
-        }
 
+            var range = /*MMNewObject2*/new ArrayRange<string>(null, 0);
+            /*MMInvocation*/range.Clone();
+        }
     }
 }

--- a/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererTypesInDeclarations.cs
+++ b/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererTypesInDeclarations.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Tests.TestFiles.ComponentInt
         private Renderer /*MMField*/_field = null;
 
         public UsesRendererTypesInDeclarations()
-            : base(null, null)
+            /*MMInvocation*/: base(null, null)
         {
         }
 


### PR DESCRIPTION
Fixes: #16922

Improves the performance significantly by avoiding allocations for the
purpose of comparing the namespace.