### PR TITLE
A bug fix for InputSelect binding for Guid and int data types

### DIFF
--- a/src/Components/Web/src/Forms/InputSelect.cs
+++ b/src/Components/Web/src/Forms/InputSelect.cs
@@ -32,12 +32,26 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override bool TryParseValueFromString(string value, out TValue result, out string validationErrorMessage)
         {
+            var targetType = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+            
             if (typeof(TValue) == typeof(string))
             {
                 result = (TValue)(object)value;
                 validationErrorMessage = null;
                 return true;
             }
+            else if (targetType == typeof(Guid))
+			{
+				result = (TValue)(object)Guid.Parse(value);
+				validationErrorMessage = null;
+				return true;
+			}
+			else if (targetType == typeof(int))
+			{
+				result = (TValue)(object)int.Parse(value);
+				validationErrorMessage = null;
+				return true;
+			}
             else if (typeof(TValue).IsEnum)
             {
                 var success = BindConverter.TryConvertTo<TValue>(value, CultureInfo.CurrentCulture, out var parsedValue);


### PR DESCRIPTION
With this fix InputSelect binding is working perfect for `Guid?` `Guid` `int?` and `int` data types.

Summary of the changes (Less than 80 chars)
Detail: I compared` targetType` with `Guid` and `int` and provided parsing for the types.

Addresses #9939
