### PR TITLE
Make constraint cache thread safe

### DIFF
--- a/src/Components/Components/src/Routing/RouteConstraint.cs
+++ b/src/Components/Components/src/Routing/RouteConstraint.cs
@@ -35,8 +35,10 @@ namespace Microsoft.AspNetCore.Components.Routing
                 var newInstance = CreateRouteConstraint(constraint);
                 if (newInstance != null)
                 {
-                    _cachedConstraints.TryAdd(constraint, newInstance);
-                    return newInstance;
+                    // We've done to the work to create the constraint now, but it's possible
+                    // we're competing with another thread. GetOrAdd can ensure only a single
+                    // instance is returned so that any extra ones can be GC'ed.
+                    return _cachedConstraints.GetOrAdd(constraint, newInstance);
                 }
                 else
                 {

--- a/src/Components/Components/test/Routing/RouteConstraintTest.cs
+++ b/src/Components/Components/test/Routing/RouteConstraintTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Routing
+{
+    public class RouteConstraintTest
+    {
+        [Fact]
+        public void Parse_CreatesDifferentConstraints_ForDifferentKinds()
+        {
+            // Arrange
+            var original = RouteConstraint.Parse("ignore", "ignore", "int");
+
+            // Act
+            var another = RouteConstraint.Parse("ignore", "ignore", "guid");
+
+            // Assert
+            Assert.NotSame(original, another);
+        }
+
+        [Fact]
+        public void Parse_CachesCreatedConstraint_ForSameKind()
+        {
+            // Arrange
+            var original = RouteConstraint.Parse("ignore", "ignore", "int");
+
+            // Act
+            var another = RouteConstraint.Parse("ignore", "ignore", "int");
+
+            // Assert
+            Assert.Same(original, another);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #17101

This changes the constraint cache to use ConcurrentDictionary. This code
is invoked in a multithreaded way in Blazor server resulting in internal
failures in dictionary.

Since this is a threading issue there's no good way to unit test it, but
I noticed we're missing tests in general for this class, so I added a
few for the caching behavior.