### PR TITLE
Fix TestServer hang with duplex streaming requests

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -86,7 +86,15 @@ namespace Microsoft.AspNetCore.TestHost
                 }
                 else
                 {
-                    await requestContent.CopyToAsync(writer.AsStream());
+                    try
+                    {
+                        await requestContent.CopyToAsync(writer.AsStream());
+                    }
+                    catch (Exception ex)
+                    {
+
+                        throw ex;
+                    }
                 }
 
                 await writer.CompleteAsync();

--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -86,15 +86,7 @@ namespace Microsoft.AspNetCore.TestHost
                 }
                 else
                 {
-                    try
-                    {
-                        await requestContent.CopyToAsync(writer.AsStream());
-                    }
-                    catch (Exception ex)
-                    {
-
-                        throw ex;
-                    }
+                    await requestContent.CopyToAsync(writer.AsStream());
                 }
 
                 await writer.CompleteAsync();

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -110,8 +110,10 @@ namespace Microsoft.AspNetCore.TestHost
                 try
                 {
                     await _application.ProcessRequestAsync(_testContext);
-                    await CompleteRequestAsync();
+
+                    // Matches Kestrel server: response is completed before request is drained
                     await CompleteResponseAsync();
+                    await CompleteRequestAsync();
                     _application.DisposeContext(_testContext, exception: null);
                 }
                 catch (Exception ex)
@@ -171,18 +173,9 @@ namespace Microsoft.AspNetCore.TestHost
                 await _requestPipe.Reader.CompleteAsync();
             }
 
-            if (_sendRequestStreamTask != null)
-            {
-                try
-                {
-                    // Ensure duplex request is either completely read or has been aborted.
-                    await _sendRequestStreamTask;
-                }
-                catch (OperationCanceledException)
-                {
-                    // Request was canceled, likely because it wasn't read before the request ended.
-                }
-            }
+            // Don't wait for request to drain. It could block indefinitely. In a real server
+            // we would wait for a timeout and then kill the socket.
+            // Potential future improvement: add logging that the request timed out
         }
 
         internal async Task CompleteResponseAsync()

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -418,6 +418,7 @@ namespace Microsoft.AspNetCore.TestHost
 
             // Assert
             response.EnsureSuccessStatusCode();
+            Assert.Equal("true", response.Headers.GetValues("test-header").Single());
 
             // Read response
             byte[] buffer = new byte[1024];

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -389,7 +389,6 @@ namespace Microsoft.AspNetCore.TestHost
         {
             // Arrange
             var requestStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var responseEndingSyncPoint = new SyncPoint();
 
             RequestDelegate appDelegate = ctx =>
             {
@@ -424,6 +423,9 @@ namespace Microsoft.AspNetCore.TestHost
             byte[] buffer = new byte[1024];
             var length = await responseContent.ReadAsync(buffer).AsTask().WithTimeout();
             Assert.Equal(0, length);
+
+            // Writing to request stream will fail because server is complete
+            await Assert.ThrowsAnyAsync<Exception>(() => requestStream.WriteAsync(buffer).AsTask());
 
             // Unblock request
             requestStreamTcs.TrySetResult(null);


### PR DESCRIPTION
#### Description

TestServer does not correctly execute bidirectional requests. The HttpClient from a TestServer request will hang reading the response in two situations:

1. The server writes no response content
2. The client stream is not completed.

This PR resolves both of these issues.

#### Customer Impact

Because of these issues, TestServer can't be used to host gRPC functional tests of bidirectional gRPC calls.

For gRPC functional testing customers will be forced to host an in-process Kestrel instance and call via TCP sockets. This could cause port exhaustion on some OS with a large number of tests.

#### Regression?

No, TestServer has never correctly supported bidirectional requests.
		
#### Risk

Low. TestServer is designed for unit tests, not production use. Note: TestServer ships in Microsoft.AspNetCore.TestHost, an out-of-sdk NuGet package: https://www.nuget.org/packages/Microsoft.AspNetCore.TestHost/
