### PR TITLE
Enable building `blazor-wasm` branch

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -7,6 +7,7 @@ trigger:
   batch: true
   branches:
     include:
+    - blazor-wasm
     - master
     - release/*
 


### PR DESCRIPTION
Making sure the `blazor-wasm` branches are being built.