### PR TITLE
Mark IIS test as flaky

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/SynchronousReadAndWriteTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/SynchronousReadAndWriteTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         }
 
         [ConditionalFact]
+        [Flaky("https://github.com/aspnet/AspNetCore/issues/7341", FlakyOn.Helix.All)]
         public async Task ReadAndWriteSynchronously()
         {
             for (int i = 0; i < 100; i++)


### PR DESCRIPTION
@shirhatti this is the test that verifies reading and writing can be synchronous. It is flaky right now. I know you care about this scenario for gRPC, so we may need to allocate time for an engineer to work on it.