### PR TITLE
[3.1.x] Backport HttpContext.Items fix

### DIFF
--- a/src/Http/Http/src/Internal/ItemsDictionary.cs
+++ b/src/Http/Http/src/Internal/ItemsDictionary.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Http
                 EmptyDictionary.Collection.CopyTo(array, arrayIndex);
             }
 
-            _items.CopyTo(array, arrayIndex);
+            _items?.CopyTo(array, arrayIndex);
         }
 
         int ICollection<KeyValuePair<object, object>>.Count => _items?.Count ?? 0;
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Http
         IEnumerator<KeyValuePair<object, object>> IEnumerable<KeyValuePair<object, object>>.GetEnumerator()
             => _items?.GetEnumerator() ?? EmptyEnumerator.Instance;
 
-        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator() ?? EmptyEnumerator.Instance;
+        IEnumerator IEnumerable.GetEnumerator() => _items?.GetEnumerator() ?? EmptyEnumerator.Instance;
 
         private class EmptyEnumerator : IEnumerator<KeyValuePair<object, object>>
         {

--- a/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
+++ b/src/Http/Http/test/Internal/ItemsDictionaryTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public class ItemsDictionaryTests
+    {
+        [Fact]
+        public void GetEnumerator_ShouldResolveWithoutNullReferenceException()
+        {
+            // Arrange
+            var dict = new ItemsDictionary();
+
+            // Act and Assert
+            IEnumerable en = (IEnumerable) dict;
+            Assert.NotNull(en.GetEnumerator());
+        }
+
+        [Fact]
+        public void CopyTo_ShouldCopyItemsWithoutNullReferenceException() {
+            // Arrange
+            var dict = new ItemsDictionary();
+            var pairs = new KeyValuePair<object, object>[] { new KeyValuePair<object, object>("first", "value") };
+
+            // Act and Assert
+            ICollection<KeyValuePair<object, object>> cl = (ICollection<KeyValuePair<object, object>>) dict;
+            cl.CopyTo(pairs, 0);
+        }
+    }
+}


### PR DESCRIPTION
#16947 #17068 This backports a 5.0 fix for a 3.0 regression in HttpContext.Items.

What patch.config is required here?

-----
## Description

Prior to 3.0, you could enumerate the `HttpContext.Items` dictionary, even when it was empty. In 3.0, as part of some performance optimizations, we regressed this behavior when the dictionary was empty, and instead it throws a `NullReferenceException`. Enumeration is uncommon here except for diagnostic frameworks such as [Elmah](https://github.com/ElmahCore/ElmahCore/blob/master/ElmahCore/Error.cs#L171).

In 5.0 we fixed this behavior. This request is to backport to the next 3.1 patch.

## Risk

Very minimal. We just added some null checks to return empty enumerables when inner data structures are null.
