### PR TITLE
Update baselines for 3.0.1 release

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -35,7 +35,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.App.Runtime.win-x64-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.App.Runtime.win-x64' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureAD.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' ">
@@ -332,11 +332,11 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.1, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' ">
@@ -407,14 +407,14 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Features-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.0.1, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.0.1, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.EntityFrameworkCore-->
@@ -635,19 +635,19 @@
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.Client.ItemTemplates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Client.ItemTemplates' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.ItemTemplates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ItemTemplates' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.ProjectTemplates.3.0-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ProjectTemplates.3.0' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.ApiDescription.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ApiDescription.Client' ">

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>3.0.0</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>3.0.1</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: AspNetCoreRuntime.3.0.x64-->
   <PropertyGroup Condition=" '$(PackageId)' == 'AspNetCoreRuntime.3.0.x64' ">

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -332,11 +332,11 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.0.1</BaselinePackageVersion>
+    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.1, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' ">

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -4,13 +4,12 @@ This file contains a list of all the packages and their versions which were rele
 Update this list when preparing for a new patch.
 
 -->
-
 <Baseline Version="3.0.0">
   <Package Id="AspNetCoreRuntime.3.0.x64" Version="3.0.0" />
   <Package Id="AspNetCoreRuntime.3.0.x86" Version="3.0.0" />
   <Package Id="dotnet-sql-cache" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.0.0" />
+  <Package Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.0.1" />
   <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Authentication.Certificate" Version="3.0.0" />
@@ -45,7 +44,7 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.0.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.0.1" />
   <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.0.0" />
@@ -53,7 +52,7 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Features" Version="3.0.0" />
+  <Package Id="Microsoft.AspNetCore.Http.Features" Version="3.0.1" />
   <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Identity.UI" Version="3.0.0" />
@@ -78,14 +77,13 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
   <Package Id="Microsoft.dotnet-openapi" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.Client.ItemTemplates" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.ProjectTemplates.3.0" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.0" />
+  <Package Id="Microsoft.DotNet.Web.Client.ItemTemplates" Version="3.0.1" />
+  <Package Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.0.1" />
+  <Package Id="Microsoft.DotNet.Web.ProjectTemplates.3.0" Version="3.0.1" />
+  <Package Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.1" />
   <Package Id="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0" />
   <Package Id="Microsoft.Extensions.ApiDescription.Server" Version="3.0.0" />
   <Package Id="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0" />
   <Package Id="Microsoft.Extensions.Identity.Core" Version="3.0.0" />
   <Package Id="Microsoft.Extensions.Identity.Stores" Version="3.0.0" />
-
-</Baseline>
+</Baseline>ine>

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -86,4 +86,5 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0" />
   <Package Id="Microsoft.Extensions.Identity.Core" Version="3.0.0" />
   <Package Id="Microsoft.Extensions.Identity.Stores" Version="3.0.0" />
-</Baseline>ine>
+
+</Baseline>

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -1,10 +1,10 @@
 ﻿<!--
 
-This file contains a list of all the packages and their versions which were released in ASP.NET Core 3.0.0. 
+This file contains a list of all the packages and their versions which were released in ASP.NET Core 3.0.0.
 Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="3.0.0">
+<Baseline Version="3.0.1">
   <Package Id="AspNetCoreRuntime.3.0.x64" Version="3.0.0" />
   <Package Id="AspNetCoreRuntime.3.0.x86" Version="3.0.0" />
   <Package Id="dotnet-sql-cache" Version="3.0.0" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -44,7 +44,7 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.0.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.0.0" />
   <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.0.0" />


### PR DESCRIPTION
- should have been part of branding change
- not causing issues only because `$(IsServicingBuild)` is temporarily disabled