### PR TITLE
HubConnection failures: Provide Better Opportunity Http Status Code Handling 

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1411,6 +1411,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 {
                     var ex = await Assert.ThrowsAnyAsync<HttpRequestException>(() => hubConnection.StartAsync().OrTimeout());
                     Assert.Equal("Response status code does not indicate success: 401 (Unauthorized).", ex.Message);
+
+                    var expectedInnerException = typeof(HttpException);
+                    var innerException  = (HttpException)ex.InnerException;
+                    Assert.IsType(expectedInnerException, ex.InnerException);
+                    Assert.Equal<HttpStatusCode>(HttpStatusCode.Unauthorized, innerException.StatusCode);
                 }
                 finally
                 {

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -450,7 +450,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                     // avoid leaving the connection open.
                     using (var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
                     {
-                        response.EnsureSuccessStatusCode();
+                        if (!response.IsSuccessStatusCode)
+                            {
+                            throw new HttpRequestException($"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).",
+                                                    new HttpException(response.StatusCode, response.ReasonPhrase));
+                            }
                         var responseBuffer = await response.Content.ReadAsByteArrayAsync();
                         var negotiateResponse = NegotiateProtocol.ParseResponse(responseBuffer);
                         if (!string.IsNullOrEmpty(negotiateResponse.Error))

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpException.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpException.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+
+namespace Microsoft.AspNetCore.Http.Connections.Client
+{
+    /// <summary>
+    /// Base Http Exception
+    /// </summary>
+    public class HttpException : Exception
+    {
+        /// <summary>
+        /// HTTP Status Code for this exception
+        /// </summary>
+        public HttpStatusCode StatusCode { get; private set; }
+
+        /// <summary>
+        /// Create an exception with a HTTP status code
+        /// </summary>
+        /// <param name="httpStatusCode">HTTP Status Code</param>
+        public HttpException(HttpStatusCode httpStatusCode)
+        {
+            StatusCode = httpStatusCode;
+        }
+
+        /// <summary>
+        /// Create an exception with a HTTP status code and message
+        /// </summary>
+        /// <param name="httpStatusCode">HTTP Status Code</param>
+        /// <param name="message">Error description</param>
+        public HttpException(HttpStatusCode httpStatusCode, string message)
+        : base(message)
+        {
+            StatusCode = httpStatusCode;
+        }
+
+        /// <summary>
+        /// Create an exception with a HTTP status code and message. Also set 'inner' as the inner exception.
+        /// </summary>
+        /// <param name="httpStatusCode">HTTP Status Code</param>
+        /// <param name="message">Error description</param>
+        /// <param name="inner"></param>
+        public HttpException(HttpStatusCode httpStatusCode, string message, Exception inner)
+        : base(message, inner)
+        {
+            StatusCode = httpStatusCode;
+        }
+
+        /// <summary>
+        /// ToString override produces 'StatusCode - Message'
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"{(int)StatusCode} - {Message}";
+        }
+    }
+}

--- a/src/SignalR/server/SignalR/test/EndToEndTests.cs
+++ b/src/SignalR/server/SignalR/test/EndToEndTests.cs
@@ -435,6 +435,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 catch (Exception ex)
                 {
                     Assert.Equal("Response status code does not indicate success: 401 (Unauthorized).", ex.Message);
+                    var expectedInnerException = typeof(HttpException);
+                    var innerException  = (HttpException)ex.InnerException;
+                    Assert.IsType(expectedInnerException, ex.InnerException);
+                    Assert.Equal<System.Net.HttpStatusCode>(System.Net.HttpStatusCode.Unauthorized, innerException.StatusCode);
                 }
                 finally
                 {
@@ -609,6 +613,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 catch (Exception ex)
                 {
                     Assert.Equal("Response status code does not indicate success: 401 (Unauthorized).", ex.Message);
+                    var expectedInnerException = typeof(HttpException);
+                    var innerException  = (HttpException)ex.InnerException;
+                    Assert.IsType(expectedInnerException, ex.InnerException);
+                    Assert.Equal<System.Net.HttpStatusCode>(System.Net.HttpStatusCode.Unauthorized, innerException.StatusCode);
                 }
                 finally
                 {
@@ -648,6 +656,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 catch (Exception ex)
                 {
                     Assert.Equal("Response status code does not indicate success: 401 (Unauthorized).", ex.Message);
+                    var expectedInnerException = typeof(HttpException);
+                    var innerException  = (HttpException)ex.InnerException;
+                    Assert.IsType(expectedInnerException, ex.InnerException);
+                    Assert.Equal<System.Net.HttpStatusCode>(System.Net.HttpStatusCode.Unauthorized, innerException.StatusCode);
                 }
                 finally
                 {


### PR DESCRIPTION
HubConnection failures: Provide Better Opportunity Http Status Code Handling 

    Adding an HttpException.  This will be returned as the
    InnerException of a HttpRequestException(that is returned on a
    HubConnection failure). This exception contains a
    StatusCode property which consumers may use to check which type of HTTP error
    is being returned. This will provide the ability to respond differently
    based on the value of the error. For example, if a 401 unauthorized is
    returned, one may deem it appropriate to retrieve a new token before the
    code proceeds. Prior to this, the HttpRequestException provided no
    modern means to detect the status code. That is, other
    than parsing the Message (string) property. This is not
    optimal.
