### PR TITLE
Set status code for the object result returned by Api Behavior

### DIFF
--- a/src/Mvc/Mvc.Core/src/DependencyInjection/ApiBehaviorOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/ApiBehaviorOptionsSetup.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             else
             {
-                result = new ObjectResult(problemDetails);
+                result = new ObjectResult(problemDetails)
+                {
+                    StatusCode = problemDetails.Status
+                };
             }
             result.ContentTypes.Add("application/problem+json");
             result.ContentTypes.Add("application/problem+xml");

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/ApiBehaviorOptionsSetupTest.cs
@@ -49,6 +49,27 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        public void ProblemDetailsInvalidModelStateResponse_ReturnsObjectResultWithProblemDetails()
+        {
+            // Arrange
+            var actionContext = GetActionContext();
+            var factory = GetProblemDetailsFactory();
+
+            // Act
+            var result = ApiBehaviorOptionsSetup.ProblemDetailsInvalidModelStateResponse(factory, actionContext);
+
+            // Assert
+            var badRequest = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(422, result.StatusCode);
+            Assert.Equal(new[] { "application/problem+json", "application/problem+xml" }, badRequest.ContentTypes.OrderBy(c => c));
+
+            var problemDetails = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+            Assert.Equal(422, problemDetails.Status);
+            Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+            Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
+        }
+
+        [Fact]
         public void ProblemDetailsInvalidModelStateResponse_UsesUserConfiguredLink()
         {
             // Arrange
@@ -117,6 +138,72 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return new DefaultProblemDetailsFactory(Options.Options.Create(options));
+        }
+
+        private static ProblemDetailsFactory GetCustomProblemDetailsFactory()
+        {
+            var options = new ApiBehaviorOptions();
+            var setup = new ApiBehaviorOptionsSetup();
+
+            return new CustomProblemDetailsFactory();
+        }
+
+        private class CustomProblemDetailsFactory : ProblemDetailsFactory
+        {
+            public override ProblemDetails CreateProblemDetails(
+                HttpContext httpContext,
+                int? statusCode = null,
+                string title = null,
+                string type = null,
+                string detail = null,
+                string instance = null)
+            {
+                statusCode ??= 500;
+
+                var problemDetails = new ProblemDetails
+                {
+                    Status = statusCode,
+                    Title = title,
+                    Type = type,
+                    Detail = detail,
+                    Instance = instance,
+                };
+
+                return problemDetails;
+            }
+
+            public override ValidationProblemDetails CreateValidationProblemDetails(
+                HttpContext httpContext,
+                ModelStateDictionary modelStateDictionary,
+                int? statusCode = null,
+                string title = null,
+                string type = null,
+                string detail = null,
+                string instance = null)
+            {
+                if (modelStateDictionary == null)
+                {
+                    throw new ArgumentNullException(nameof(modelStateDictionary));
+                }
+
+                statusCode ??= 422;
+
+                var problemDetails = new ValidationProblemDetails(modelStateDictionary)
+                {
+                    Status = statusCode,
+                    Type = type,
+                    Detail = detail,
+                    Instance = instance,
+                };
+
+                if (title != null)
+                {
+                    // For validation problem details, don't overwrite the default title with null.
+                    problemDetails.Title = title;
+                }
+
+                return problemDetails;
+            }
         }
 
         private static ActionContext GetActionContext()


### PR DESCRIPTION
Set status code for the object result returned by ApiBehaviorOptionsSetup to match the problem details status code.

Summary of the changes (Less than 80 chars)
During some testing I noticed if you had a custom ProblemDetailsFactory returning a status code that was not 400, the status code returned was 200.  This is because the status code is not getting applied to the ObjectResult in `ApiBehaviorOptionsSetup`

Addresses #bugnumber (in this specific format)
https://github.com/aspnet/AspNetCore/issues/14663  fix: https://github.com/aspnet/AspNetCore/pull/14672
