### PR TITLE
Fix: @aspnet/signalr -> @microsoft/signalr

### DIFF
--- a/src/SignalR/README.md
+++ b/src/SignalR/README.md
@@ -25,7 +25,7 @@ npm install @microsoft/signalr
 
 The `@microsoft/signalr` package (and it's dependencies) require NPM 5.6.0 or higher.
 
-**NOTE:** Previous previews of the SignalR client library for JavaScript were named `@aspnet/signalr-client`. This has been deprecated as of Preview 1.
+**NOTE:** Previous versions of the SignalR client were named `@aspnet/signalr` or `@aspnet/signalr-client`.
 
 **IMPORTANT:** When using preview builds, you should always ensure you are using the same version of both the JavaScript client and the Server. The version numbers should align as they are produced in the same build process.
 

--- a/src/SignalR/README.md
+++ b/src/SignalR/README.md
@@ -20,33 +20,33 @@ When in doubt, check the version of TypeScript referenced by our [package.json](
 You can install the latest released JavaScript client from npm with the following command:
 
 ```bash
-npm install @aspnet/signalr
+npm install @microsoft/signalr
 ```
 
-The `@aspnet/signalr` package (and it's dependencies) require NPM 5.6.0 or higher.
+The `@microsoft/signalr` package (and it's dependencies) require NPM 5.6.0 or higher.
 
 **NOTE:** Previous previews of the SignalR client library for JavaScript were named `@aspnet/signalr-client`. This has been deprecated as of Preview 1.
 
 **IMPORTANT:** When using preview builds, you should always ensure you are using the same version of both the JavaScript client and the Server. The version numbers should align as they are produced in the same build process.
 
-The CI build publishes the latest dev version of the JavaScript client to our dev npm registry as @aspnet/signalr. You can install the module as follows:
+The CI build publishes the latest dev version of the JavaScript client to our dev npm registry as @microsoft/signalr. You can install the module as follows:
 
 - Create an .npmrc file with the following line:
-  `@aspnet:registry=https://dotnet.myget.org/f/aspnetcore-dev/npm/`
+  `@microsoft:registry=https://dotnet.myget.org/f/aspnetcore-dev/npm/`
 - Run:
-  `npm install @aspnet/signalr`
+  `npm install @microsoft/signalr`
 
 Alternatively, if you don't want to create the .npmrc file run the following commands:
 ```
-npm install @aspnet/signalr --registry https://dotnet.myget.org/f/aspnetcore-dev/npm/
+npm install @microsoft/signalr --registry https://dotnet.myget.org/f/aspnetcore-dev/npm/
 ```
 
 We also have a MsgPack protocol library which is installed via:
 
 ```bash
-npm install @aspnet/signalr-protocol-msgpack
+npm install @microsoft/signalr-protocol-msgpack
 ```
 
 ## Deploying
 
-Once you've installed the NPM modules, they will be located in the `node_modules/@aspnet/signalr` and `node_modules/@aspnet/signalr-protocol-msgpack` folders. If you are building a NodeJS application or using an ECMAScript module loader/bundler (such as [webpack](https://webpack.js.org)), you can load them directly. If you are building a browser application without using a module bundler, you can find UMD-compatible bundles in the `dist/browser` folder; minified versions are provided as well. Simply copy these to your project as appropriate and use a build task to keep them up-to-date.
+Once you've installed the NPM modules, they will be located in the `node_modules/@microsoft/signalr` and `node_modules/@microsoft/signalr-protocol-msgpack` folders. If you are building a NodeJS application or using an ECMAScript module loader/bundler (such as [webpack](https://webpack.js.org)), you can load them directly. If you are building a browser application without using a module bundler, you can find UMD-compatible bundles in the `dist/browser` folder; minified versions are provided as well. Simply copy these to your project as appropriate and use a build task to keep them up-to-date.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Change @aspnet/signalr to @microsoft/signalr

Since @aspnet/signalr has been deprecated sine 3.0.0-preview6.19307.2, you should update the README and Docs.
