### PR TITLE
Update branding for Blazor packages and update baseline

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>3.0.0</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>3.1.0</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: AspNetCoreRuntime.3.0.x64-->
   <PropertyGroup Condition=" '$(PackageId)' == 'AspNetCoreRuntime.3.0.x64' ">
@@ -16,132 +16,132 @@
   <ItemGroup Condition=" '$(PackageId)' == 'AspNetCoreRuntime.3.0.x86' AND '$(TargetFramework)' == 'net461' " />
   <!-- Package: dotnet-sql-cache-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-sql-cache' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.ApiAuthorization.IdentityServer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.0, )" />
     <BaselinePackageReference Include="IdentityServer4" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.AspNetIdentity" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.EntityFramework" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.EntityFramework.Storage" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.Storage" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.App.Runtime.win-x64-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.App.Runtime.win-x64' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureAD.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureADB2C.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Certificate-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Certificate' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Certificate' AND '$(TargetFramework)' == 'netcoreapp3.0' " />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Certificate' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Facebook-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' AND '$(TargetFramework)' == 'netcoreapp3.0' " />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Google-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' AND '$(TargetFramework)' == 'netcoreapp3.0' " />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.JwtBearer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[5.5.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.MicrosoftAccount-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' AND '$(TargetFramework)' == 'netcoreapp3.0' " />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Negotiate-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Negotiate' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Negotiate' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Negotiate' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.OpenIdConnect-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[5.5.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Twitter-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' AND '$(TargetFramework)' == 'netcoreapp3.0' " />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.WsFederation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="[5.5.0, )" />
     <BaselinePackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[5.5.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authorization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServices.HostingStartup-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServices.SiteExtension-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.SiteExtension' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.SiteExtension' AND '$(TargetFramework)' == 'net461' ">
-    <BaselinePackageReference Include="Microsoft.Web.Xdt.Extensions" Version="[3.0.0-rc2.19465.2, )" />
+    <BaselinePackageReference Include="Microsoft.Web.Xdt.Extensions" Version="[3.1.0-rtm.19566.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServicesIntegration-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' ">
@@ -186,510 +186,510 @@
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Components-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[4.7.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Analyzers-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Analyzers' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Authorization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Forms-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Web-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.ConcurrencyLimiter-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ConcurrencyLimiter' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ConcurrencyLimiter' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ConcurrencyLimiter' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Connections.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.0.0, )" />
-    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.1.0, )" />
+    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Cryptography.Internal-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.Internal' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.Internal' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.Cryptography.KeyDerivation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.6.0, )" />
-    <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[4.6.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.7.0, )" />
+    <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.6.0, )" />
-    <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[4.6.0, )" />
-    <BaselinePackageReference Include="System.Security.Principal.Windows" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.7.0, )" />
+    <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[4.7.0, )" />
+    <BaselinePackageReference Include="System.Security.Principal.Windows" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Abstractions' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.DataProtection.AzureKeyVault-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureKeyVault' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureKeyVault' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Microsoft.Azure.KeyVault" Version="[2.3.2, )" />
     <BaselinePackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.19.8, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.AzureStorage-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureStorage' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureStorage' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Microsoft.Azure.Storage.Blob" Version="[10.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Data.OData" Version="[5.8.4, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.StackExchangeRedis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
     <BaselinePackageReference Include="StackExchange.Redis" Version="[2.0.593, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HeaderPropagation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HeaderPropagation' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HeaderPropagation' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HeaderPropagation' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Hosting.WindowsServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="System.ServiceProcess.ServiceController" Version="[4.6.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="System.ServiceProcess.ServiceController" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections.Common-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.Text.Json" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.Text.Json" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Features-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.Specification.Tests-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Testing" Version="[3.0.0-rc2.19463.5, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Testing" Version="[3.1.0-rtm.19565.4, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
     <BaselinePackageReference Include="xunit.assert" Version="[2.4.1, )" />
     <BaselinePackageReference Include="xunit.extensibility.core" Version="[2.4.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.JsonPatch-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.JsonPatch' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.JsonPatch' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.CSharp" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.CSharp" Version="[4.7.0, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Metadata-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Metadata' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Metadata' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.MiddlewareAnalysis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.NewtonsoftJson-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.NewtonsoftJson' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.NewtonsoftJson' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.NewtonsoftJson' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
     <BaselinePackageReference Include="Newtonsoft.Json.Bson" Version="[1.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Testing-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.TestHost" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Hosting" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.TestHost" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.NodeServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Console" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Console" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Owin-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' AND '$(TargetFramework)' == 'netcoreapp3.0' " />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Libuv" Version="[1.10.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Client.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.Threading.Channels" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.Threading.Channels" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.Threading.Channels" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.Threading.Channels" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Common-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="System.Text.Json" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="System.Text.Json" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.Json-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.MessagePack-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.MessagePack' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.MessagePack' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
     <BaselinePackageReference Include="MessagePack" Version="[1.7.3.7, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Specification.Tests-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Specification.Tests' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Specification.Tests' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Specification.Tests' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
     <BaselinePackageReference Include="xunit.assert" Version="[2.4.1, )" />
     <BaselinePackageReference Include="xunit.extensibility.core" Version="[2.4.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.StackExchangeRedis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.StackExchangeRedis' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.StackExchangeRedis' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.StackExchangeRedis' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="MessagePack" Version="[1.7.3.7, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
     <BaselinePackageReference Include="StackExchange.Redis" Version="[2.0.593, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SpaServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.NodeServices" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.NodeServices" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SpaServices.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.TestHost-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.6.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.dotnet-openapi-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.dotnet-openapi' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.Client.ItemTemplates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Client.ItemTemplates' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.ItemTemplates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ItemTemplates' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <!-- Package: Microsoft.DotNet.Web.ProjectTemplates.3.0-->
-  <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ProjectTemplates.3.0' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+  <!-- Package: Microsoft.DotNet.Web.ProjectTemplates.3.1-->
+  <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ProjectTemplates.3.1' ">
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <!-- Package: Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0-->
-  <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+  <!-- Package: Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1-->
+  <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1' ">
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.ApiDescription.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ApiDescription.Client' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.ApiDescription.Server-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ApiDescription.Server' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Stores-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' ">
-    <BaselinePackageVersion>3.0.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
   </ItemGroup>
 </Project>

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -1,91 +1,89 @@
 ﻿<!--
 
-This file contains a list of all the packages and their versions which were released in ASP.NET Core 3.0.0. 
+This file contains a list of all the packages and their versions which were released in ASP.NET Core 3.1.0.
 Update this list when preparing for a new patch.
 
 -->
-
-<Baseline Version="3.0.0">
+<Baseline Version="3.1.0">
   <Package Id="AspNetCoreRuntime.3.0.x64" Version="3.0.0" />
   <Package Id="AspNetCoreRuntime.3.0.x86" Version="3.0.0" />
-  <Package Id="dotnet-sql-cache" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Certificate" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Twitter" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.WsFederation" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Authorization" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.0.0" />
+  <Package Id="dotnet-sql-cache" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Certificate" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authentication.WsFederation" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Authorization" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.1.0" />
   <Package Id="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Templates" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Components" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Analyzers" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Authorization" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Forms" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Web" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.ConcurrencyLimiter" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Cryptography.Internal" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.HeaderPropagation" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Features" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Identity.UI" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.JsonPatch" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Metadata" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.MiddlewareAnalysis" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.NodeServices" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Owin" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Client.Core" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Common" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Specification.Tests" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SpaServices" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
-  <Package Id="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
-  <Package Id="Microsoft.dotnet-openapi" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.Client.ItemTemplates" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.ProjectTemplates.3.0" Version="3.0.0" />
-  <Package Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.0" />
-  <Package Id="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0" />
-  <Package Id="Microsoft.Extensions.ApiDescription.Server" Version="3.0.0" />
-  <Package Id="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0" />
-  <Package Id="Microsoft.Extensions.Identity.Core" Version="3.0.0" />
-  <Package Id="Microsoft.Extensions.Identity.Stores" Version="3.0.0" />
-
+  <Package Id="Microsoft.AspNetCore.Components" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Components.Authorization" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Components.Forms" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.ConcurrencyLimiter" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Cryptography.Internal" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.HeaderPropagation" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Identity.UI" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.JsonPatch" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Metadata" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.MiddlewareAnalysis" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.NodeServices" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Owin" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Client.Core" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Common" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Specification.Tests" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SpaServices" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
+  <Package Id="Microsoft.dotnet-openapi" Version="3.1.0" />
+  <Package Id="Microsoft.DotNet.Web.Client.ItemTemplates" Version="3.1.0" />
+  <Package Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.1.0" />
+  <Package Id="Microsoft.DotNet.Web.ProjectTemplates.3.1" Version="3.1.0" />
+  <Package Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.0" />
+  <Package Id="Microsoft.Extensions.ApiDescription.Client" Version="3.1.0" />
+  <Package Id="Microsoft.Extensions.ApiDescription.Server" Version="3.1.0" />
+  <Package Id="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
+  <Package Id="Microsoft.Extensions.Identity.Core" Version="3.1.0" />
+  <Package Id="Microsoft.Extensions.Identity.Stores" Version="3.1.0" />
 </Baseline>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
     <IncludePreReleaseLabelInPackageVersion Condition=" '$(DotNetFinalVersionKind)' == 'release' ">false</IncludePreReleaseLabelInPackageVersion>

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -161,10 +161,11 @@ try {
         & $PSScriptRoot\GenerateReferenceAssemblies.ps1 -ci:$ci
     }
 
-    Write-Host "Re-generating package baselines"
-    Invoke-Block {
-        & dotnet run -p "$repoRoot/eng/tools/BaselineGenerator/"
-    }
+    # Temporarily disable package baseline generation while we stage for publishing
+    # Write-Host "Re-generating package baselines"
+    # Invoke-Block {
+    #     & dotnet run -p "$repoRoot/eng/tools/BaselineGenerator/"
+    # }
 
     Write-Host "Run git diff to check for pending changes"
 

--- a/eng/tools/BaselineGenerator/BaselineGenerator.csproj
+++ b/eng/tools/BaselineGenerator/BaselineGenerator.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
-    <StartArguments>-s https://api.nuget.org/v3/index.json</StartArguments>
     <StartWorkingDirectory>$(MSBuildThisFileDirectory)../../</StartWorkingDirectory>
   </PropertyGroup>
 

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <!-- Override version labels -->
-    <VersionPrefix>3.2.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
+    <VersionPrefix>3.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>preview4</PreReleaseVersionLabel>
     <DotNetFinalVersionKind />
   </PropertyGroup>
 </Project>

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <!-- Override version labels -->
+    <VersionPrefix>3.2.0</VersionPrefix>
+    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
+    <DotNetFinalVersionKind />
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Addresses parts of https://github.com/aspnet/AspNetCore-Internal/issues/3417.

From local builds I see that Blazor packages are built with non-finalized versions. As a side-effect and non-Blazor packages are built with final versions but I think this is fine. 
![image](https://user-images.githubusercontent.com/2030323/69469686-040cac80-0d47-11ea-982d-681f062b24ac.png)

I also checked the nuspec of the Microsoft.AspNetCore.Blazor package and it looks correct to me:
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Microsoft.AspNetCore.Blazor</id>
    <version>3.2.0-dev</version>
    <authors>Microsoft</authors>
    <owners>Microsoft</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <license type="expression">Apache-2.0</license>
    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
    <icon>Icon.png</icon>
    <projectUrl>https://asp.net/</projectUrl>
    <description>Build client-side single-page applications (SPAs) with Blazor running under WebAssembly.

This package was built from the source code at https://github.com/aspnet/AspNetCore/tree/d6c88a36ffe89614be26bf846d64791b9958406b</description>
    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
    <tags>aspnetcore components</tags>
    <serviceable>true</serviceable>
    <repository type="git" url="https://github.com/aspnet/AspNetCore" commit="d6c88a36ffe89614be26bf846d64791b9958406b" />
    <dependencies>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Microsoft.AspNetCore.Components.Web" version="3.1.0" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Extensions.Options" version="3.1.0" exclude="Build,Analyzers" />
        <dependency id="Mono.WebAssembly.Interop" version="3.1.0-preview4.19568.3" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```

It'll be good to have some more eyes on the packages produced, especially the ones we plan on shipping from this branch @javiercn 