### PR TITLE
[Static Web Assets] Allow assets with empty base paths

### DIFF
--- a/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsFileProvider.cs
+++ b/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsFileProvider.cs
@@ -46,6 +46,11 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
         {
             var modifiedSub = NormalizePath(subpath);
 
+            if (BasePath == "/")
+            {
+                return InnerProvider.GetDirectoryContents(modifiedSub);
+            }
+
             if (StartsWithBasePath(modifiedSub, out var physicalPath))
             {
                 return InnerProvider.GetDirectoryContents(physicalPath.Value);
@@ -66,6 +71,11 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
         public IFileInfo GetFileInfo(string subpath)
         {
             var modifiedSub = NormalizePath(subpath);
+
+            if (BasePath == "/")
+            {
+                return InnerProvider.GetFileInfo(subpath);
+            }
 
             if (!StartsWithBasePath(modifiedSub, out var physicalPath))
             {

--- a/src/Hosting/Hosting/test/StaticWebAssets/StaticWebAssetsFileProviderTests.cs
+++ b/src/Hosting/Hosting/test/StaticWebAssets/StaticWebAssetsFileProviderTests.cs
@@ -118,6 +118,35 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
         }
 
         [Fact]
+        public void GetDirectoryContents_HandlesEmptyBasePath()
+        {
+            // Arrange
+            var provider = new StaticWebAssetsFileProvider("/",
+                Path.Combine(AppContext.BaseDirectory, "testroot", "wwwroot"));
+
+            // Act
+            var directory = provider.GetDirectoryContents("/Static Web/");
+
+            // Assert
+            Assert.Collection(directory,
+                file =>
+                {
+                    Assert.Equal("Static Web.txt", file.Name);
+                });
+        }
+
+        [Fact]
+        public void StaticWebAssetsFileProviderWithEmptyBasePath_FindsFile()
+        {
+            // Arrange & Act
+            var provider = new StaticWebAssetsFileProvider("/",
+                Path.Combine(AppContext.BaseDirectory, "testroot", "wwwroot"));
+
+            // Assert
+            Assert.True(provider.GetFileInfo("/Static Web Assets.txt").Exists);
+        }
+
+        [Fact]
         public void GetFileInfo_DoesNotMatch_IncompletePrefixSegments()
         {
             // Arrange


### PR DESCRIPTION
### Description
Static web assets don't work properly if the library specifies an empty base path "/".
Fixes https://github.com/aspnet/AspNetCore/issues/17375
### Customer Impact
This prevents customers from exposing static web assets at the root of the app. The asset will still get published to the root, but will be inaccessible when running the build output.

### Regression?
No

### Risk
Low. This is not a default use case for static web assets (normally the content for libraries gets exposed from `_content/<<LibraryName>>/...`). But we want to be able to expose the content from "/" for Blazor applications and this is blocking it.

We are not changing a behavior in how the scenario work, simply fixing a bug where something didn't work to something that works.

**Implementation details**
We simply detect this special case and handle it.