### PR TITLE
Improve error for RRV substitution case

### DIFF
--- a/src/Mvc/Mvc.Core/test/Routing/ActionEndpointFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/ActionEndpointFactoryTest.cs
@@ -209,6 +209,22 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         }
 
         [Fact]
+        public void AddEndpoints_AttributeRouted_ContainsParameterUsingReservedNameWithConstraint_ExceptionThrown()
+        {
+            // Arrange
+            var values = new { controller = "TestController", action = "TestAction", page = (string)null };
+            var action = CreateActionDescriptor(values, "Products/{action:int}");
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => CreateAttributeRoutedEndpoint(action));
+            Assert.Equal(
+                "Failed to update the route pattern 'Products/{action:int}' with required route values. " +
+                "This can occur when the route pattern contains parameters with reserved names such as: 'controller', 'action', 'page' and also uses route constraints such as '{action:int}'. " +
+                "To fix this error, choose a different parmaeter name.",
+                exception.Message);
+        }
+
+        [Fact]
         public void AddEndpoints_AttributeRouted_ContainsParameterWithNullRequiredRouteValue_EndpointCreated()
         {
             // Arrange


### PR DESCRIPTION
Fixes: #14789

Users can hit this error case when using a route parameter that has a
special meaning in MVC, in attribute routing with a route constraint.
This will cause us to fail while expanding the route pattern, because
the canonical value associated with the parameter won't satisfy the
constraint.

TLDR: don't do that. Using MVC's reserved parameter names for
application-level concerns will always cause bugs.

This was a case where you'd fail with a totally unactionable error
message. Updating it to reflect the proper root cause and our guidance
to fix it.

