### PR TITLE
Include .pdb files in blazor.boot.json to re-enable debugging

### DIFF
--- a/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
@@ -186,6 +186,7 @@
 
     <ItemGroup>
       <_OldLinkedFile Include="$(BlazorIntermediateLinkerOutputPath)*.dll" />
+      <_OldLinkedFile Include="$(BlazorIntermediateLinkerOutputPath)*.pdb" />
     </ItemGroup>
 
     <Delete Files="@(_OldLinkedFile)" />
@@ -212,6 +213,7 @@
 
     <ItemGroup>
       <_LinkerResult Include="$(BlazorIntermediateLinkerOutputPath)*.dll" />
+      <_LinkerResult Include="$(BlazorIntermediateLinkerOutputPath)*.pdb" Condition="'$(BlazorEnableDebugging)' == 'true'" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(_BlazorLinkerOutputCache)" Lines="@(_LinkerResult)" Overwrite="true" />


### PR DESCRIPTION
Something changed in the build targets/tasks recently and we were no longer including `.pdb` files in the list of linker outputs. This meant that debugging was always treated as disabled, regardless of the build config.

The change here means we now consider `.pdb` outputs from the linker again, and so they end up getting listed in `blazor.boot.json`, which is a prerequisite for debugging.