### PR TITLE
Fix Blazor WebAssembly hosted publishing

### DIFF
--- a/src/Components/Blazor/Build/src/targets/Publish.targets
+++ b/src/Components/Blazor/Build/src/targets/Publish.targets
@@ -43,7 +43,7 @@
 
     <ItemGroup>
       <_BlazorPublishConfigContent Include="." />
-      <_BlazorPublishConfigContent Include="$(AssemblyName)" />
+      <_BlazorPublishConfigContent Include="$(AssemblyName)/" />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/Components/Blazor/Build/test/BuildIntegrationTests/PublishIntegrationTest.cs
+++ b/src/Components/Blazor/Build/test/BuildIntegrationTests/PublishIntegrationTest.cs
@@ -147,8 +147,10 @@ namespace Microsoft.AspNetCore.Blazor.Build
             // Verify web.config
             Assert.FileExists(result, publishDirectory, "web.config");
 
-            var blazorConfig = Path.Combine(publishDirectory, "standalone.blazor.config");
-            Assert.FileContains(result, blazorConfig, ".");
+            var blazorConfig = Path.Combine(result.Project.DirectoryPath, publishDirectory, "standalone.blazor.config");
+            var blazorConfigLines = File.ReadAllLines(blazorConfig);
+            Assert.Equal(".", blazorConfigLines[0]);
+            Assert.Equal("standalone/", blazorConfigLines[1]);
         }
 
         [Fact]


### PR DESCRIPTION
This addresses the issue found during verification by @javiercn, restoring the behavior from previous releases.