### PR TITLE
replace 'an' with 'a' in xml comments

### DIFF
--- a/src/Mvc/Mvc.Core/src/Filters/FilterCollection.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/FilterCollection.cs
@@ -10,10 +10,10 @@ namespace Microsoft.AspNetCore.Mvc.Filters
     public class FilterCollection : Collection<IFilterMetadata>
     {
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <typeparam name="TFilterType">Type representing an <see cref="IFilterMetadata"/>.</typeparam>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added type.</returns>
+        /// <typeparam name="TFilterType">Type representing a <see cref="IFilterMetadata"/>.</typeparam>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added type.</returns>
         /// <remarks>
         /// Filter instances will be created using
         /// <see cref="Microsoft.Extensions.DependencyInjection.ActivatorUtilities"/>.
@@ -25,10 +25,10 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
 
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <param name="filterType">Type representing an <see cref="IFilterMetadata"/>.</param>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added type.</returns>
+        /// <param name="filterType">Type representing a <see cref="IFilterMetadata"/>.</param>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added type.</returns>
         /// <remarks>
         /// Filter instances will be created using
         /// <see cref="Microsoft.Extensions.DependencyInjection.ActivatorUtilities"/>.
@@ -45,11 +45,11 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
 
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <typeparam name="TFilterType">Type representing an <see cref="IFilterMetadata"/>.</typeparam>
+        /// <typeparam name="TFilterType">Type representing a <see cref="IFilterMetadata"/>.</typeparam>
         /// <param name="order">The order of the added filter.</param>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added type.</returns>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added type.</returns>
         /// <remarks>
         /// Filter instances will be created using
         /// <see cref="Microsoft.Extensions.DependencyInjection.ActivatorUtilities"/>.
@@ -61,11 +61,11 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
 
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <param name="filterType">Type representing an <see cref="IFilterMetadata"/>.</param>
+        /// <param name="filterType">Type representing a <see cref="IFilterMetadata"/>.</param>
         /// <param name="order">The order of the added filter.</param>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added type.</returns>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added type.</returns>
         /// <remarks>
         /// Filter instances will be created using
         /// <see cref="Microsoft.Extensions.DependencyInjection.ActivatorUtilities"/>.
@@ -92,10 +92,10 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
         
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <typeparam name="TFilterType">Type representing an <see cref="IFilterMetadata"/>.</typeparam>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added service type.</returns>
+        /// <typeparam name="TFilterType">Type representing a <see cref="IFilterMetadata"/>.</typeparam>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added service type.</returns>
         /// <remarks>
         /// Filter instances will be created through dependency injection. Use
         /// <see cref="Add(Type)"/> to register a service that will be created via
@@ -107,10 +107,10 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
 
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <param name="filterType">Type representing an <see cref="IFilterMetadata"/>.</param>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added service type.</returns>
+        /// <param name="filterType">Type representing a <see cref="IFilterMetadata"/>.</param>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added service type.</returns>
         /// <remarks>
         /// Filter instances will be created through dependency injection. Use
         /// <see cref="Add(Type)"/> to register a service that will be created via
@@ -127,11 +127,11 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
 
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <typeparam name="TFilterType">Type representing an <see cref="IFilterMetadata"/>.</typeparam>
+        /// <typeparam name="TFilterType">Type representing a <see cref="IFilterMetadata"/>.</typeparam>
         /// <param name="order">The order of the added filter.</param>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added service type.</returns>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added service type.</returns>
         /// <remarks>
         /// Filter instances will be created through dependency injection. Use
         /// <see cref="Add(Type)"/> to register a service that will be created via
@@ -143,11 +143,11 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         }
 
         /// <summary>
-        /// Adds a type representing an <see cref="IFilterMetadata"/>.
+        /// Adds a type representing a <see cref="IFilterMetadata"/>.
         /// </summary>
-        /// <param name="filterType">Type representing an <see cref="IFilterMetadata"/>.</param>
+        /// <param name="filterType">Type representing a <see cref="IFilterMetadata"/>.</param>
         /// <param name="order">The order of the added filter.</param>
-        /// <returns>An <see cref="IFilterMetadata"/> representing the added service type.</returns>
+        /// <returns>A <see cref="IFilterMetadata"/> representing the added service type.</returns>
         /// <remarks>
         /// Filter instances will be created through dependency injection. Use
         /// <see cref="Add(Type)"/> to register a service that will be created via


### PR DESCRIPTION
Replaces `An` with `A` and `an` with `a` in the xml comments.

Addresses #17446
