### PR TITLE
Change z-index value for reconnect modal. Fixes #12867

### DIFF
--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
@@ -22,7 +22,7 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
       'right: 0',
       'bottom: 0',
       'left: 0',
-      'z-index: 1000',
+      'z-index: 1050',
       'display: none',
       'overflow: hidden',
       'background-color: #fff',


### PR DESCRIPTION
This changes the z-index of the Blazor reconnect modal to be aligned
with the z-index used by Bootstrap for modals overlays. If users rely on
Bootstrap for overlays within application this would prevent obstruction
of the Blazor's reconnect information with other overlays in the
application.

ref:
https://github.com/twbs/bootstrap/blob/master/scss/_variables.scss#L810

Addresses #12867
