### PR TITLE
Add issue policies doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Follow the [Getting Started](https://docs.microsoft.com/aspnet/core/getting-star
 
 Also check out the [.NET Homepage](https://www.microsoft.com/net) for released versions of .NET, getting started guides, and learning resources.
 
+See the [Issue Management Policies](https://github.com/aspnet/AspNetCore/blob/anurse/issue-policies/docs/IssueManagementPolicies.md) document for more information on how we handle incoming issues.
+
 ## How to Engage, Contribute, and Give Feedback
 
 Some of the best ways to contribute are to try things out, file issues, join in design conversations,

--- a/docs/IssueManagementPolicies.md
+++ b/docs/IssueManagementPolicies.md
@@ -1,0 +1,27 @@
+# Issue Management Policies
+
+We have a lot of issue traffic to manage, so we have a few policies in place to help us do that. This is a brief summary of some of the policies we have in place and the justification for them.
+
+## Commenting on closed issues
+
+In general, we recommend you open a new issue if you have a bug, feature request, or question to discuss. If you find a closed issue that is related, open a *new issue* and link to the closed issue rather than posting on the closed issue. Closed issues don't appear in our triage process, so only the people who have been active on the original thread will be notified of your comment. A new issue will get more attention from the team.
+
+*In general* we don't mind getting duplicate issues. It's easier for us to close duplicate issues than to discuss multiple root causes on a single issue! We may close your issue as a duplicate if we determine it has the same root cause as another. Don't worry! It's not a waste of our time!
+
+## Needs Author Feedback
+
+If a contributor reviews an issue and determines that more information is needed from the author, they will post a comment requesting that information and apply the `Needs: Author Feedback` label. This label indicates that the author needs to post a response in order for us to continue investigating the issue.
+
+If the author does not post a response within **7 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that not everyone can respond immediately to our requests, so if you post a response on a closed issue we're happy to take a look.
+
+## Duplicate issues
+
+If we determine that the issue is a duplicate of another, we will label it with the `Resolution: Duplicate` label. The issue will be automatically closed in 1 day.
+
+## Answered questions
+
+If we determine that the issue is a question and have posted an answer, we will label it with the `Resolution: Answered` label. The issue will be automatically closed in 1 day.
+
+## Locking closed issues
+
+After an issue has been closed and had no activity for **30 days** it will be automatically locked as *resolved*. This is done in order to reduce confusion as to where to post new comments. If you are still encountering the problem reported in an issue, or have a related question or bug report, feel free to open a *new issue* and link to the original (now locked) issue!

--- a/docs/IssueManagementPolicies.md
+++ b/docs/IssueManagementPolicies.md
@@ -12,15 +12,15 @@ In general, we recommend you open a new issue if you have a bug, feature request
 
 If a contributor reviews an issue and determines that more information is needed from the author, they will post a comment requesting that information and apply the `Needs: Author Feedback` label. This label indicates that the author needs to post a response in order for us to continue investigating the issue.
 
-If the author does not post a response within **7 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that you may not be able to respond immediately to our requests, so if you post a response on a closed issue we're happy to take a look.
+If the author does not post a response within **7 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that you may not be able to respond immediately to our requests, we're happy to hear from you whenever you're able to provide the new information.
 
 ## Duplicate issues
 
-If we determine that the issue is a duplicate of another, we will label it with the `Resolution: Duplicate` label. The issue will be automatically closed in 1 day.
+If we determine that the issue is a duplicate of another, we will label it with the `Resolution: Duplicate` label. The issue will be automatically closed in 1 day of inactivity.
 
 ## Answered questions
 
-If we determine that the issue is a question and have posted an answer, we will label it with the `Resolution: Answered` label. The issue will be automatically closed in 1 day.
+If we determine that the issue is a question and have posted an answer, we will label it with the `Resolution: Answered` label. The issue will be automatically closed in 1 day of inactivity.
 
 ## Locking closed issues
 

--- a/docs/IssueManagementPolicies.md
+++ b/docs/IssueManagementPolicies.md
@@ -12,7 +12,7 @@ In general, we recommend you open a new issue if you have a bug, feature request
 
 If a contributor reviews an issue and determines that more information is needed from the author, they will post a comment requesting that information and apply the `Needs: Author Feedback` label. This label indicates that the author needs to post a response in order for us to continue investigating the issue.
 
-If the author does not post a response within **7 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that not everyone can respond immediately to our requests, so if you post a response on a closed issue we're happy to take a look.
+If the author does not post a response within **7 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that you may not be able to respond immediately to our requests, so if you post a response on a closed issue we're happy to take a look.
 
 ## Duplicate issues
 


### PR DESCRIPTION
I thought that since we're rolling out some automation, it would be good to document our "issue management policies" so that the community knows what the automation is doing and why. All the comments the bot will post will contain a link to this document. It will be available at https://aka.ms/aspnet/issue-policies as well.

@ajcvickers These don't apply to EFCore/EF6 unless you choose to make them ;).

* [x] TODO: After merge, update aka.ms link