### PR TITLE
Allow using base path in application

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Authentication
         protected virtual Task InitializeHandlerAsync() => Task.CompletedTask;
 
         protected string BuildRedirectUri(string targetPath)
-            => Request.Scheme + "://" + Request.Host + OriginalPathBase + targetPath;
+            => Request.Scheme + "://" + Request.Host + OriginalPathBase.ToString().TrimEnd('/') + targetPath;
 
         protected virtual string ResolveTarget(string scheme)
         {


### PR DESCRIPTION
We have an application which requires changing base path:

**Template (_Layout.cshtml):**
`<base href="/somestring/" />`

Middleware in **Startup.cs**
`app.Use((context, next) => { context.Request.PathBase = "/somestring/"; return next.Invoke(); });`

Authentication in **Startup.cs**:
` services.AddAuthentication().AddGoogle(googleOptions => { googleOptions.ClientId = "..."; googleOptions.ClientSecret = "..."; })`;

In this case Authentication handler returns wrong uri: _http://localhost:4000/somestring//signin-google_.
