### PR TITLE
[release/3.0] Download runtime from suffixed location in dotnetcli blob storage

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -389,6 +389,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>626c14488261f91192e39a4c6c2d9480a7cd1f37</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="3.0.2-servicing-19572-09" CoherentParentDependency="Microsoft.Extensions.Logging">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>626c14488261f91192e39a4c6c2d9480a7cd1f37</Sha>
+    </Dependency>
     <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,6 +71,7 @@
     <MicrosoftNetCompilersToolsetPackageVersion>3.3.1-beta4-19462-11</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- Packages from dotnet/core-setup -->
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.2-servicing-19572-09</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>3.0.2-servicing-19572-09</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>3.0.0</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.2-servicing-19572-09</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -26,10 +26,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <RemoteAsset Include="$(DotNetAssetRootUrl)Runtime/$(MicrosoftNETCoreAppRuntimeVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.exe$(DotNetAssetRootAccessTokenSuffix)">
+      <RemoteAsset Include="$(DotNetAssetRootUrl)Runtime/$(MicrosoftNETCoreAppInternalPackageVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.exe$(DotNetAssetRootAccessTokenSuffix)">
         <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.exe</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="$(DotNetAssetRootUrl)Runtime/$(MicrosoftNETCoreAppRuntimeVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.exe$(DotNetAssetRootAccessTokenSuffix)">
+      <RemoteAsset Include="$(DotNetAssetRootUrl)Runtime/$(MicrosoftNETCoreAppInternalPackageVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.exe$(DotNetAssetRootAccessTokenSuffix)">
         <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.exe</TargetFileName>
       </RemoteAsset>
     </ItemGroup>


### PR DESCRIPTION
Fixes a bug where, when we depend on a stable core-setup, we try to download the runtime from a non-suffixed location in the `dotnetcli` blob storage account. This location will only exist when a build has been placed there manually, which leads to a possible mismatch between the build we bundle, and the build we actually want to ship (e.g. if we spin multiple stable builds, and the first is still in the blob storage location when we spin the 2nd AspNetCore build). Instead we should use the explicit suffixed location so that we know we're consuming the correct build.

CC @dougbu @JunTaoLuo @mmitche @leecow @nguerrera 

Assuming we want this for 3.0.2?