### PR TITLE
[release/3.1] Use Microsoft.NETCore.App.Internal for runtime version

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,10 +6,10 @@
     "dotnet": "3.1.100-preview1-014400",
     "runtimes": {
       "dotnet/x64": [
-        "$(MicrosoftNETCoreAppRuntimeVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ],
       "dotnet/x86": [
-        "$(MicrosoftNETCoreAppRuntimeVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ]
     },
     "Git": "2.22.0",


### PR DESCRIPTION
* Use Microsoft.NETCore.App.Internal for runtime version
For stable builds, core-setup is now publishing its artifacts to a suffixed directory (e.g. 3.0.1-servicing-19510-13) instead of 3.0.1. This ensures we don't have to overwrite outputs when we rebuild stable versions. Within that directory, it publishes the same set of files with the final file names as well as suffixed file names:
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-win-x64.msi
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-servicing-19510-13-win-x64.msi

Downstream repos should install the runtime using the full suffixed version.