### PR TITLE
Change the minimum VS version requirement

### DIFF
--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Git": "2.22.0",
     "jdk": "11.0.3",
     "vs": {
-      "version": "16.0",
+      "version": "16.3",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",


### PR DESCRIPTION
Likely resolution for https://github.com/aspnet/AspNetCore/issues/16664#issuecomment-553150427

Arcade falls back to a xcopy deployable MSBuild if it cannot find a compatible VS. If the minimum required VS isn't installed or if any of the required components are missing, the build currently falls back to using the 16.0 version of MSBuild (as indicated by global.json) which fails with 

```
Version 5.0.100-alpha1-015536 of the .NET Core SDK requires at least version 16.3.0 of MSBuild. The current available version of MSBuild is 16.0.461.62831.
```