### PR TITLE
Expose Http.Sys's Http/2 Reset error code API #17276

### DIFF
--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -36,7 +36,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         IHttpMaxRequestBodySizeFeature,
         IHttpBodyControlFeature,
         IHttpSysRequestInfoFeature,
-        IHttpResponseTrailersFeature
+        IHttpResponseTrailersFeature,
+        IHttpResetFeature
     {
         private RequestContext _requestContext;
         private IFeatureCollection _features;
@@ -350,7 +351,16 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal IHttpResponseTrailersFeature GetResponseTrailersFeature()
         {
-            if (Request.ProtocolVersion >= HttpVersion.Version20 && ComNetOS.SupportsTrailers)
+            if (Request.ProtocolVersion >= HttpVersion.Version20 && HttpApi.SupportsTrailers)
+            {
+                return this;
+            }
+            return null;
+        }
+
+        internal IHttpResetFeature GetResetFeature()
+        {
+            if (Request.ProtocolVersion >= HttpVersion.Version20 && HttpApi.SupportsReset)
             {
                 return this;
             }
@@ -454,6 +464,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         Task IHttpResponseBodyFeature.CompleteAsync() => CompleteAsync();
+
+        void IHttpResetFeature.Reset(int errorCode)
+        {
+            _requestContext.SetResetCode(errorCode);
+            _requestContext.Abort();
+        }
 
         internal async Task CompleteAsync()
         {

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -228,6 +228,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     _application.DisposeContext(context, ex);
                     if (requestContext.Response.HasStarted)
                     {
+                        // HTTP/2 INTERNAL_ERROR = 0x2 https://tools.ietf.org/html/rfc7540#section-7
+                        // Otherwise the default is Cancel = 0x8.
+                        requestContext.SetResetCode(2);
                         requestContext.Abort();
                     }
                     else

--- a/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/ComNetOS.cs
@@ -11,15 +11,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Minimum support for Windows 7 is assumed.
         internal static readonly bool IsWin8orLater;
 
-        internal static readonly bool SupportsTrailers;
-
         static ComNetOS()
         {
             var win8Version = new Version(6, 2);
 
             IsWin8orLater = (Environment.OSVersion.Version >= win8Version);
-
-            SupportsTrailers = Environment.OSVersion.Version >= new Version(10, 0, 19505);
         }
     }
 }

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -132,6 +132,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 HttpSetRequestProperty = HttpApiModule.GetProcAddress<HttpSetRequestPropertyInvoker>("HttpSetRequestProperty", throwIfNotFound: false);
 
                 SupportsReset = HttpSetRequestProperty != null;
+                // Trailers support was added in the same release as Reset, but there's no method we can export to check it directly.
                 SupportsTrailers = SupportsReset;
             }
         }

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -70,6 +70,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         [DllImport(HTTPAPI, ExactSpelling = true, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern unsafe uint HttpCloseRequestQueue(IntPtr pReqQueueHandle);
 
+        internal delegate uint HttpSetRequestPropertyInvoker(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId, void* input, uint inputSize, IntPtr overlapped);
 
         private static HTTPAPI_VERSION version;
 
@@ -106,6 +107,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        internal static SafeLibraryHandle HttpApiModule { get; private set; }
+        internal static HttpSetRequestPropertyInvoker HttpSetRequestProperty { get; private set; }
+        internal static bool SupportsTrailers { get; private set; }
+        internal static bool SupportsReset { get; private set; }
+
         static HttpApi()
         {
             InitHttpApi(2, 0);
@@ -119,6 +125,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             var statusCode = HttpInitialize(version, (uint)HTTP_FLAGS.HTTP_INITIALIZE_SERVER, null);
 
             supported = statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS;
+
+            if (supported)
+            {
+                HttpApiModule = SafeLibraryHandle.Open(HTTPAPI);
+                HttpSetRequestProperty = HttpApiModule.GetProcAddress<HttpSetRequestPropertyInvoker>("HttpSetRequestProperty", throwIfNotFound: false);
+
+                SupportsReset = HttpSetRequestProperty != null;
+                SupportsTrailers = SupportsReset;
+            }
         }
 
         private static volatile bool supported;

--- a/src/Servers/HttpSys/src/NativeInterop/SafeLibraryHandle.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/SafeLibraryHandle.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    /// <summary>
+    /// Represents a handle to a Windows module (DLL).
+    /// </summary>
+    internal unsafe sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        // Called by P/Invoke when returning SafeHandles
+        private SafeLibraryHandle()
+            : base(ownsHandle: true)
+        { }
+
+        /// <summary>
+        /// Returns a value stating whether the library exports a given proc.
+        /// </summary>
+        public bool DoesProcExist(string lpProcName)
+        {
+            IntPtr pfnProc = UnsafeNativeMethods.GetProcAddress(this, lpProcName);
+            return (pfnProc != IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Gets a delegate pointing to a given export from this library.
+        /// </summary>
+        public TDelegate GetProcAddress<TDelegate>(string lpProcName, bool throwIfNotFound = true) where TDelegate : class
+        {
+            IntPtr pfnProc = UnsafeNativeMethods.GetProcAddress(this, lpProcName);
+            if (pfnProc == IntPtr.Zero)
+            {
+                if (throwIfNotFound)
+                {
+                    UnsafeNativeMethods.ThrowExceptionForLastWin32Error();
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            return Marshal.GetDelegateForFunctionPointer<TDelegate>(pfnProc);
+        }
+
+        /// <summary>
+        /// Opens a library. If 'filename' is not a fully-qualified path, the default search path is used.
+        /// </summary>
+        public static SafeLibraryHandle Open(string filename)
+        {
+            const uint LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800U; // from libloaderapi.h
+
+            SafeLibraryHandle handle = UnsafeNativeMethods.LoadLibraryEx(filename, IntPtr.Zero, LOAD_LIBRARY_SEARCH_SYSTEM32);
+            if (handle == null || handle.IsInvalid)
+            {
+                UnsafeNativeMethods.ThrowExceptionForLastWin32Error();
+            }
+            return handle;
+        }
+
+        // Do not provide a finalizer - SafeHandle's critical finalizer will call ReleaseHandle for you.
+        protected override bool ReleaseHandle()
+        {
+            return UnsafeNativeMethods.FreeLibrary(handle);
+        }
+
+        [SuppressUnmanagedCodeSecurity]
+        private static class UnsafeNativeMethods
+        {
+            // http://msdn.microsoft.com/en-us/library/ms683152(v=vs.85).aspx
+            [return: MarshalAs(UnmanagedType.Bool)]
+            [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+            [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+            internal static extern bool FreeLibrary(IntPtr hModule);
+
+            // http://msdn.microsoft.com/en-us/library/ms683212(v=vs.85).aspx
+            [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+            internal static extern IntPtr GetProcAddress(
+                [In] SafeLibraryHandle hModule,
+                [In, MarshalAs(UnmanagedType.LPStr)] string lpProcName);
+
+            // http://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx
+            [DllImport("kernel32.dll", EntryPoint = "LoadLibraryExW", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+            internal static extern SafeLibraryHandle LoadLibraryEx(
+                [In, MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+                [In] IntPtr hFile,
+                [In] uint dwFlags);
+
+            internal static void ThrowExceptionForLastWin32Error()
+            {
+                int hr = Marshal.GetHRForLastWin32Error();
+                Marshal.ThrowExceptionForHR(hr);
+            }
+        }
+    }
+}

--- a/src/Servers/HttpSys/src/NativeInterop/SafeLibraryHandle.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/SafeLibraryHandle.cs
@@ -17,7 +17,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Called by P/Invoke when returning SafeHandles
         private SafeLibraryHandle()
             : base(ownsHandle: true)
-        { }
+        {
+        }
 
         /// <summary>
         /// Returns a value stating whether the library exports a given proc.

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Trailers are supported on this OS, it's HTTP/2, and the app added a Trailer response header to announce trailers were intended.
         // Needed to delay the completion of Content-Length responses.
         internal bool TrailersExpected => HasTrailers
-            || (ComNetOS.SupportsTrailers && Request.ProtocolVersion >= HttpVersion.Version20
+            || (HttpApi.SupportsTrailers && Request.ProtocolVersion >= HttpVersion.Version20
                     && Headers.ContainsKey(HttpKnownHeaderNames.Trailer));
 
         internal long ExpectedBodyLength

--- a/src/Servers/HttpSys/src/StandardFeatureCollection.cs
+++ b/src/Servers/HttpSys/src/StandardFeatureCollection.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             { typeof(IHttpBodyControlFeature), _identityFunc },
             { typeof(IHttpSysRequestInfoFeature), _identityFunc },
             { typeof(IHttpResponseTrailersFeature), ctx => ctx.GetResponseTrailersFeature() },
+            { typeof(IHttpResetFeature), ctx => ctx.GetResetFeature() },
         };
 
         private readonly FeatureContext _featureContext;

--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Custom Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Custom Reset support was added in Win10_20H2.")]
         public async Task AppException_AfterHeaders_ResetInternalError()
         {
             using var server = Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
@@ -370,7 +370,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_BeforeResponse_Resets()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -412,7 +412,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_AfterResponseHeaders_Resets()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_DurringResponseBody_Resets()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -517,7 +517,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_AfterCompleteAsync_NoReset()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -573,7 +573,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_BeforeRequestBody_Resets()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_DurringRequestBody_Resets()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -668,7 +668,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19521", SkipReason = "Reset support was added in Win10_20H2.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
         public async Task Reset_CompleteAsyncDurringRequestBody_Resets()
         {
             var appResult = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -685,7 +685,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
 
                     var readTask = httpContext.Request.Body.ReadAsync(new byte[10], 0, 10);
                     await httpContext.Response.CompleteAsync();
-                    feature.Reset(1111);
+                    feature.Reset((int)Http2ErrorCode.NO_ERROR); // GRPC does this
                     await Assert.ThrowsAsync<IOException>(() => readTask);
 
                     appResult.SetResult(0);
@@ -722,7 +722,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
 
                     var resetFrame = await h2Connection.ReceiveFrameAsync();
-                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: Http2ErrorCode.NO_ERROR);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
                 })

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_HTTP2_TrailersAvailable()
         {
             using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_ProhibitedTrailers_Blocked()
         {
             using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_NoBody_TrailersSent()
         {
             using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_WithBody_TrailersSent()
         {
             using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_WithContentLengthBody_TrailersNotSent()
         {
             var body = "Hello World";
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_WithTrailersBeforeContentLengthBody_TrailersSent()
         {
             var body = "Hello World";
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_WithContentLengthBodyAndDeclared_TrailersSent()
         {
             var body = "Hello World";
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_WithContentLengthBodyAndDeclaredButMissingTrailers_Completes()
         {
             var body = "Hello World";
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_CompleteAsyncNoBody_TrailersSent()
         {
             var trailersReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -242,7 +242,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_CompleteAsyncWithBody_TrailersSent()
         {
             var trailersReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_MultipleValues_SentAsSeperateHeaders()
         {
             using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_LargeTrailers_Success()
         {
             var values = new[] {
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalTheory, MemberData(nameof(NullHeaderData))]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19505", SkipReason = "Requires HTTP/2 Trailers support.")]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
         public async Task ResponseTrailers_NullValues_Ignored(string headerName, StringValues headerValue, StringValues expectedValue)
         {
             using (Utilities.CreateDynamicHttpsServer(out var address, httpContext =>

--- a/src/Shared/Http2cat/Http2Utilities.cs
+++ b/src/Shared/Http2cat/Http2Utilities.cs
@@ -938,6 +938,14 @@ namespace Microsoft.AspNetCore.Http2Cat
             return WaitForConnectionErrorAsync<Exception>(ignoreNonGoAwayFrames, expectedLastStreamId, Http2ErrorCode.NO_ERROR);
         }
 
+        internal static void VerifyDataFrame(Http2Frame frame, int expectedStreamId, bool endOfStream, int length)
+        {
+            Assert.Equal(Http2FrameType.DATA, frame.Type);
+            Assert.Equal(expectedStreamId, frame.StreamId);
+            Assert.Equal(endOfStream ? Http2DataFrameFlags.END_STREAM : Http2DataFrameFlags.NONE, frame.DataFlags);
+            Assert.Equal(length, frame.PayloadLength);
+        }
+
         internal void VerifyGoAway(Http2Frame frame, int expectedLastStreamId, Http2ErrorCode expectedErrorCode)
         {
             Assert.Equal(Http2FrameType.GOAWAY, frame.Type);
@@ -946,6 +954,15 @@ namespace Microsoft.AspNetCore.Http2Cat
             Assert.Equal(0, frame.StreamId);
             Assert.Equal(expectedLastStreamId, frame.GoAwayLastStreamId);
             Assert.Equal(expectedErrorCode, frame.GoAwayErrorCode);
+        }
+
+        internal static void VerifyResetFrame(Http2Frame frame, int expectedStreamId, Http2ErrorCode expectedErrorCode)
+        {
+            Assert.Equal(Http2FrameType.RST_STREAM, frame.Type);
+            Assert.Equal(expectedStreamId, frame.StreamId);
+            Assert.Equal(expectedErrorCode, frame.RstStreamErrorCode);
+            Assert.Equal(4, frame.PayloadLength);
+            Assert.Equal(0, frame.Flags);
         }
 
         internal async Task WaitForConnectionErrorAsync<TException>(bool ignoreNonGoAwayFrames, int expectedLastStreamId, Http2ErrorCode expectedErrorCode)

--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -51,6 +51,16 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             HttpResponseInfoTypeQosProperty,
         }
 
+        internal enum HTTP_REQUEST_PROPERTY
+        {
+            HttpRequestPropertyIsb,
+            HttpRequestPropertyTcpInfoV0,
+            HttpRequestPropertyQuicStats,
+            HttpRequestPropertyTcpInfoV1,
+            HttpRequestPropertySni,
+            HttpRequestPropertyStreamError,
+        }
+
         internal enum HTTP_TIMEOUT_TYPE
         {
             EntityBody,
@@ -59,6 +69,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             IdleConnection,
             HeaderWait,
             MinSendRate,
+        }
+
+        internal struct HTTP_REQUEST_PROPERTY_STREAM_ERROR
+        {
+            internal uint ErrorCode;
         }
 
         internal const int MaxTimeout = 6;


### PR DESCRIPTION
#17276 This allows setting the Http/2 reset error code. gRPC wants to set it to NO_ERROR.
This also addressed #16988 (HttpSys trailers OS version detection ), we can check the windows version by checking for the new reset API. 

There's one scenario that differs from Kestrel, trying to send a Reset after CompleteAsync has been called.
- If the request body is incomplete then the request is still half-open and the reset will be sent.
- If the request body is complete then the request is fully closed and a reset will not be sent. Kestrel still sends a reset in this scenario so long as Abort or Reset have not already been called. Kestrel's extra reset here is harmless but unnecessary. If we see it causing issues then we could consider suppressing it.

This should be adequate for the gRPC scenario, and it makes sense within the HTTP/2 protocol.

~~DRAFT until I can verify the NO_ERROR scenario is fixed in the next Windows build.~~ Verified.