### PR TITLE
Remove FormatScope from FacebookHandler

### DIFF
--- a/src/Security/Authentication/Facebook/ref/Microsoft.AspNetCore.Authentication.Facebook.netcoreapp.cs
+++ b/src/Security/Authentication/Facebook/ref/Microsoft.AspNetCore.Authentication.Facebook.netcoreapp.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         public FacebookHandler(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.Facebook.FacebookOptions> options, Microsoft.Extensions.Logging.ILoggerFactory logger, System.Text.Encodings.Web.UrlEncoder encoder, Microsoft.AspNetCore.Authentication.ISystemClock clock) : base (default(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.Facebook.FacebookOptions>), default(Microsoft.Extensions.Logging.ILoggerFactory), default(System.Text.Encodings.Web.UrlEncoder), default(Microsoft.AspNetCore.Authentication.ISystemClock)) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         protected override System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.AuthenticationTicket> CreateTicketAsync(System.Security.Claims.ClaimsIdentity identity, Microsoft.AspNetCore.Authentication.AuthenticationProperties properties, Microsoft.AspNetCore.Authentication.OAuth.OAuthTokenResponse tokens) { throw null; }
-        protected override string FormatScope() { throw null; }
         protected override string FormatScope(System.Collections.Generic.IEnumerable<string> scopes) { throw null; }
     }
     public partial class FacebookOptions : Microsoft.AspNetCore.Authentication.OAuth.OAuthOptions

--- a/src/Security/Authentication/Facebook/src/FacebookHandler.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookHandler.cs
@@ -71,8 +71,5 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             // http://tools.ietf.org/html/rfc6749#section-3.3
             return string.Join(",", scopes);
         }
-
-        protected override string FormatScope()
-            => base.FormatScope();
     }
 }


### PR DESCRIPTION
Remove overridden `FormatScope` method since all it's doing is calling its base.