### PR TITLE
Include the ExitCode in the error message

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -591,7 +591,6 @@ stages:
 
   - template: jobs/default-build.yml
     parameters:
-      condition: ne(variables['Build.Reason'], 'PullRequest')
       jobName: Helix_x64_daily
       jobDisplayName: 'Tests: Helix x64 Daily'
       agentOs: Windows

--- a/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
@@ -252,7 +252,7 @@ namespace Microsoft.DotNet.OpenApi.Commands
                         await Out.WriteAsync(output);
                         await Error.WriteAsync(error);
 
-                        throw new ArgumentException($"Adding package `{packageId}` to `{projectFile.Directory}` returned ExitCode `{process.ExitCode}` and gave the following error: `{error}`");
+                        throw new ArgumentException($"Adding package `{packageId}` to `{projectFile.Directory}` returned ExitCode `{process.ExitCode}` and gave error `{error}` and output `{output}`");
                     }
                 }
             }

--- a/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
@@ -240,12 +240,21 @@ namespace Microsoft.DotNet.OpenApi.Commands
 
             if (process.ExitCode != 0)
             {
-                var output = await process.StandardOutput.ReadToEndAsync();
-                var error = await process.StandardError.ReadToEndAsync();
-                await Out.WriteAsync(output);
-                await Error.WriteAsync(error);
+                using (var csprojStream = projectFile.OpenRead())
+                using (var csprojReader = new StreamReader(csprojStream))
+                {
+                    var csprojContent = await csprojReader.ReadToEndAsync();
+                    // We suspect that sometimes dotnet add package is giving a non-zero exit code when it has actually succeeded.
+                    if (!csprojContent.Contains($"<PackageReference Include=\"{packageId}\" Version=\"{packageVersion}\""))
+                    {
+                        var output = await process.StandardOutput.ReadToEndAsync();
+                        var error = await process.StandardError.ReadToEndAsync();
+                        await Out.WriteAsync(output);
+                        await Error.WriteAsync(error);
 
-                throw new ArgumentException($"Could not add package `{packageId}` to `{projectFile.Directory}` due to: `{error}`");
+                        throw new ArgumentException($"Adding package `{packageId}` to `{projectFile.Directory}` returned ExitCode `{process.ExitCode}` and gave the following error: `{error}`");
+                    }
+                }
             }
         }
 

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
@@ -3,11 +3,9 @@
 
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.OpenApi.Tests;
-using Microsoft.Extensions.Internal;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,8 +21,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new string[] { });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             Assert.Contains("Usage: openapi ", _output.ToString());
         }
@@ -56,10 +53,9 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         public void OpenApi_Add_Empty_ShowsHelp()
         {
             var app = GetApplication();
-            var run = app.Execute(new string[] { "add" });
+            var appExitCode = app.Execute(new string[] { "add" });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(appExitCode);
 
             Assert.Contains("Usage: openapi add", _output.ToString());
         }
@@ -70,8 +66,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new string[] { "add", "file", "--help" });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             Assert.Contains("Usage: openapi ", _output.ToString());
         }
@@ -84,12 +79,10 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "file", project.NSwagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var secondRun = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, secondRun);
+            AssertNoErrors(secondRun);
 
             var csproj = new FileInfo(project.Project.Path);
             string content;
@@ -116,15 +109,13 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "file", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             app = GetApplication();
             var absolute = Path.GetFullPath(nswagJsonFile, project.Project.Dir().Root);
             run = app.Execute(new[] { "add", "file", absolute });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var csproj = new FileInfo(project.Project.Path);
             var projXml = new XmlDocument();
@@ -143,18 +134,15 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "file", nswagJsonFile, "--code-generator", "NSwagTypeScript" });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(project.Project.Path);
-            using (var csprojStream = csproj.OpenRead())
-            using (var reader = new StreamReader(csprojStream))
-            {
-                var content = await reader.ReadToEndAsync();
-                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
-                Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\" CodeGenerator=\"NSwagTypeScript\" />", content);
-            }
+            using var csprojStream = csproj.OpenRead();
+            using var reader = new StreamReader(csprojStream);
+            var content = await reader.ReadToEndAsync();
+            Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+            Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\" CodeGenerator=\"NSwagTypeScript\" />", content);
         }
 
         [Fact]
@@ -166,18 +154,15 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "file", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(project.Project.Path);
-            using (var csprojStream = csproj.OpenRead())
-            using (var reader = new StreamReader(csprojStream))
-            {
-                var content = await reader.ReadToEndAsync();
-                Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
-                Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\"", content);
-            }
+            using var csprojStream = csproj.OpenRead();
+            using var reader = new StreamReader(csprojStream);
+            var content = await reader.ReadToEndAsync();
+            Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+            Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\"", content);
         }
 
         [Fact]
@@ -189,8 +174,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "file", "--updateProject", project.Project.Path, nswagJsonFIle });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(project.Project.Path);
@@ -210,14 +194,12 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "file", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             app = GetApplication();
             run = app.Execute(new[] { "add", "file", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(project.Project.Path);

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddProjectTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddProjectTests.cs
@@ -20,38 +20,33 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         {
             var project = CreateBasicProject(withOpenApi: true);
 
-            using (var refProj1 = project.Project.Dir().SubDir("refProj1"))
-            using (var refProj2 = project.Project.Dir().SubDir("refProj2"))
-            {
-                var project1 = refProj1.WithCSharpProject("refProj");
-                project1
-                    .WithTargetFrameworks(TestTFM)
-                    .Dir()
-                    .Create();
+            using var refProj1 = project.Project.Dir().SubDir("refProj1");
+            using var refProj2 = project.Project.Dir().SubDir("refProj2");
+            var project1 = refProj1.WithCSharpProject("refProj");
+            project1
+                .WithTargetFrameworks(TestTFM)
+                .Dir()
+                .Create();
 
-                var project2 = refProj2.WithCSharpProject("refProj2");
-                project2
-                    .WithTargetFrameworks(TestTFM)
-                    .Dir()
-                    .Create();
+            var project2 = refProj2.WithCSharpProject("refProj2");
+            project2
+                .WithTargetFrameworks(TestTFM)
+                .Dir()
+                .Create();
 
-                var app = GetApplication();
+            var app = GetApplication();
 
-                var run = app.Execute(new[] { "add", "project", project1.Path, project2.Path});
+            var run = app.Execute(new[] { "add", "project", project1.Path, project2.Path });
 
-                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-                Assert.Equal(0, run);
+            AssertNoErrors(run);
 
-                // csproj contents
-                using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
-                using (var reader = new StreamReader(csprojStream))
-                {
-                    var content = await reader.ReadToEndAsync();
-                    Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
-                    Assert.Contains($"<OpenApiProjectReference Include=\"{project1.Path}\"", content);
-                    Assert.Contains($"<OpenApiProjectReference Include=\"{project2.Path}\"", content);
-                }
-            }
+            // csproj contents
+            using var csprojStream = new FileInfo(project.Project.Path).OpenRead();
+            using var reader = new StreamReader(csprojStream);
+            var content = await reader.ReadToEndAsync();
+            Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+            Assert.Contains($"<OpenApiProjectReference Include=\"{project1.Path}\"", content);
+            Assert.Contains($"<OpenApiProjectReference Include=\"{project2.Path}\"", content);
         }
 
         [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/12738")]
@@ -59,33 +54,29 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         {
             var project = CreateBasicProject(withOpenApi: false);
 
-            using (var refProj = new TemporaryDirectory())
-            {
-                var refProjName = "refProj";
-                var csproj = refProj.WithCSharpProject(refProjName);
-                csproj
-                    .WithTargetFrameworks(TestTFM)
-                    .Dir()
-                    .Create();
+            using var refProj = new TemporaryDirectory();
+            var refProjName = "refProj";
+            var csproj = refProj.WithCSharpProject(refProjName);
+            csproj
+                .WithTargetFrameworks(TestTFM)
+                .Dir()
+                .Create();
 
-                var app = GetApplication();
-                var run = app.Execute(new[] { "add", "project", csproj.Path});
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "project", csproj.Path });
 
-                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-                Assert.Equal(0, run);
+            AssertNoErrors(run);
 
-                app = GetApplication();
-                run = app.Execute(new[] { "add", "project", Path.Combine(csproj.Path, "..", "refProj.csproj")});
+            app = GetApplication();
+            run = app.Execute(new[] { "add", "project", Path.Combine(csproj.Path, "..", "refProj.csproj") });
 
-                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-                Assert.Equal(0, run);
+            AssertNoErrors(run);
 
-                var projXml = new XmlDocument();
-                projXml.Load(project.Project.Path);
+            var projXml = new XmlDocument();
+            projXml.Load(project.Project.Path);
 
-                var openApiRefs = projXml.GetElementsByTagName(Commands.BaseCommand.OpenApiProjectReference);
-                Assert.Single(openApiRefs);
-            }
+            var openApiRefs = projXml.GetElementsByTagName(Commands.BaseCommand.OpenApiProjectReference);
+            Assert.Single(openApiRefs);
         }
 
         [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/12738")]
@@ -93,31 +84,26 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         {
             var project = CreateBasicProject(withOpenApi: false);
 
-            using (var refProj = new TemporaryDirectory())
-            {
-                var refProjName = "refProj";
-                refProj
-                    .WithCSharpProject(refProjName)
-                    .WithTargetFrameworks(TestTFM)
-                    .Dir()
-                    .Create();
+            using var refProj = new TemporaryDirectory();
+            var refProjName = "refProj";
+            refProj
+                .WithCSharpProject(refProjName)
+                .WithTargetFrameworks(TestTFM)
+                .Dir()
+                .Create();
 
-                var app = GetApplication();
-                var refProjFile = Path.Join(refProj.Root, $"{refProjName}.csproj");
-                var run = app.Execute(new[] { "add", "project", refProjFile });
+            var app = GetApplication();
+            var refProjFile = Path.Join(refProj.Root, $"{refProjName}.csproj");
+            var run = app.Execute(new[] { "add", "project", refProjFile });
 
-                Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-                Assert.Equal(0, run);
+            AssertNoErrors(run);
 
-                // csproj contents
-                using(var csprojStream = new FileInfo(project.Project.Path).OpenRead())
-                using(var reader = new StreamReader(csprojStream))
-                {
-                    var content = await reader.ReadToEndAsync();
-                    Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
-                    Assert.Contains($"<OpenApiProjectReference Include=\"{refProjFile}\"", content);
-                }
-            }
+            // csproj contents
+            using var csprojStream = new FileInfo(project.Project.Path).OpenRead();
+            using var reader = new StreamReader(csprojStream);
+            var content = await reader.ReadToEndAsync();
+            Assert.Contains("<PackageReference Include=\"NSwag.ApiDescription.Client\" Version=\"", content);
+            Assert.Contains($"<OpenApiProjectReference Include=\"{refProjFile}\"", content);
         }
     }
 }

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -24,8 +24,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "filename.json";
 
@@ -58,8 +57,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", url});
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "nodisposition.yaml";
 
@@ -92,8 +90,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", url });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "filename.json";
 
@@ -126,8 +123,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", url });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "contoso.json";
 
@@ -159,8 +155,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "filename.json";
 
@@ -192,8 +187,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var firstExpectedJsonName = "filename.json";
 
@@ -219,8 +213,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             app = GetApplication();
             run = app.Execute(new[] { "add", "url", NoExtensionUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var secondExpectedJsonName = "filename1.json";
 
@@ -254,8 +247,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--code-generator", "NSwagCSharp" });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "filename.json";
 
@@ -287,8 +279,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--code-generator", "NSwagTypeScript" });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = "filename.json";
 
@@ -320,8 +311,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--output-file", Path.Combine("outputdir", "file.yaml") });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonName = Path.Combine("outputdir", "file.yaml");
 
@@ -352,10 +342,9 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
 
             var app = GetApplication();
             var outputFile = Path.Combine("outputdir", "file.yaml");
-            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--output-file", outputFile });
+            var appExitCode = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--output-file", outputFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(appExitCode);
 
             var expectedJsonName = Path.Combine("outputdir", "file.yaml");
 
@@ -380,8 +369,8 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
 
             // Second reference, same output
             app = GetApplication();
-            run = app.Execute(new[] { "add", "url", DifferentUrl, "--output-file", outputFile});
-            Assert.Equal(1, run);
+            appExitCode = app.Execute(new[] { "add", "url", DifferentUrl, "--output-file", outputFile});
+            Assert.Equal(1, appExitCode);
             Assert.True(_error.ToString().Contains("Aborting to avoid conflicts."), $"Should have aborted to avoid conflicts");
 
             // csproj contents
@@ -412,14 +401,12 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             app = GetApplication();
             run = app.Execute(new[] { "add", "url", "--output-file", "openapi.yaml", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(project.Project.Path);
@@ -470,14 +457,12 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
             var url = ActualUrl;
             var run = app.Execute(new[] { "add", "url", url });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             app = GetApplication(realHttp: true);
             run = app.Execute(new[] { "add", "url", url });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(project.Project.Path);

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRefreshTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRefreshTests.cs
@@ -23,8 +23,7 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var expectedJsonPath = Path.Combine(_tempDir.Root, "filename.json");
             var json = await File.ReadAllTextAsync(expectedJsonPath);
@@ -38,8 +37,7 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             app = GetApplication();
             run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
             Assert.True(firstWriteTime < secondWriteTime, $"File wasn't updated! {firstWriteTime} {secondWriteTime}");

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRemoveTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRemoveTests.cs
@@ -29,8 +29,7 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var add = GetApplication();
             var run = add.Execute(new[] { "add", "file", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
@@ -45,8 +44,7 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var remove = GetApplication();
             var removeRun = remove.Execute(new[] { "remove", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, removeRun);
+            AssertNoErrors(removeRun);
 
             // csproj contents
             csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
@@ -74,8 +72,7 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var add = GetApplication();
             var run = add.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             var csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
@@ -90,8 +87,7 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var remove = GetApplication();
             var removeRun = remove.Execute(new[] { "remove", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, removeRun);
+            AssertNoErrors(removeRun);
 
             // csproj contents
             csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));
@@ -125,8 +121,7 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var refProjFile = Path.Join(refProj.Root, $"{refProjName}.csproj");
             var run = app.Execute(new[] { "add", "project", refProjFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             using (var csprojStream = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj")).OpenRead())
@@ -140,8 +135,7 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var remove = GetApplication();
             run = app.Execute(new[] { "remove", refProjFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             // csproj contents
             using (var csprojStream = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj")).OpenRead())
@@ -170,20 +164,17 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
             var add = GetApplication();
             var run = add.Execute(new[] { "add", "file", nswagJsonFile });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             add = GetApplication();
             run = add.Execute(new[] { "add", "file", swagFile2 });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, run);
+            AssertNoErrors(run);
 
             var remove = GetApplication();
             var removeRun = remove.Execute(new[] { "remove", nswagJsonFile, swagFile2 });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
-            Assert.Equal(0, removeRun);
+            AssertNoErrors(removeRun);
 
             // csproj contents
             var csproj = new FileInfo(Path.Join(_tempDir.Root, "testproj.csproj"));

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Openapi.Tools;
 using Microsoft.Extensions.Tools.Internal;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.OpenApi.Tests
@@ -109,6 +110,12 @@ namespace Microsoft.DotNet.OpenApi.Tests
             };
         }
 
+        protected void AssertNoErrors(int appExitCode)
+        {
+            Assert.Equal(0, appExitCode);
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+        }
+
         public void Dispose()
         {
             _outputHelper.WriteLine(_output.ToString());
@@ -150,7 +157,7 @@ namespace Microsoft.DotNet.OpenApi.Tests
             return true;
         }
 
-        private ContentDispositionHeaderValue _contentDisposition;
+        private readonly ContentDispositionHeaderValue _contentDisposition;
 
         public TestHttpResponseMessageWrapper(
             MemoryStream stream,

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
@@ -112,8 +112,8 @@ namespace Microsoft.DotNet.OpenApi.Tests
 
         protected void AssertNoErrors(int appExitCode)
         {
-            Assert.Equal(0, appExitCode);
             Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.Equal(0, appExitCode);
         }
 
         public void Dispose()


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore-Internal/issues/3261. The previous logging wasn't giving us enough useful info so we've expanded it a bit and added some code to check a hypothesis of mine. The failure seems to be isolated to Helix, and the particular Helix config which fails doesn't work on PR builds, so I can't go through with my original idea to just keep retrying this on the PR until we hit one of the failures.