### PR TITLE
Specify Blazor WebAssembly template language

### DIFF
--- a/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/wwwroot/index.html
+++ b/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/wwwroot/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
@@ -18,6 +18,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/wwwroot/index.html
+++ b/src/Components/Blazor/Templates/src/content/BlazorWasm-CSharp/Client/wwwroot/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
@@ -21,5 +20,4 @@
 
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
-
 </html>


### PR DESCRIPTION
This update has already been made in the Blazor Server template ...

https://github.com/aspnet/AspNetCore/blob/master/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/_Host.cshtml

... also matches the line between the `<div>` and `<script>` and removes extra space around `<html>` tags.