### PR TITLE
Move parts of AuthenticationHandler to Endpoint

### DIFF
--- a/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
+++ b/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ASP.NET Core common types used by the various authentication middleware components.</Description>
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.AspNetCore.DataProtection" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Extensions.WebEncoders" />

--- a/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
@@ -299,13 +299,14 @@ namespace Microsoft.AspNetCore.Authentication
         }
 
         protected virtual Endpoint CreateEndpoint<THandler>(PathString path, string name, string httpMethod, Func<THandler, Task> func)
-            where THandler : RemoteAuthenticationHandler<TOptions>
+            where THandler : IAuthenticationHandler
         {
             var builder = new RouteEndpointBuilder(
-               context =>
+               async context =>
                {
-                   var handler = context.RequestServices.GetService<THandler>();
-                   return func(handler);
+                   var handlerProvider = context.RequestServices.GetService<IAuthenticationHandlerProvider>();
+                   var handler = (THandler)await handlerProvider.GetHandlerAsync(context, Scheme.Name);
+                   await func(handler);
                },
                RoutePatternFactory.Parse(path),
                0)

--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -308,5 +309,19 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         /// <remarks>Subclasses should rather override <see cref="FormatScope(IEnumerable{string})"/>.</remarks>
         protected virtual string FormatScope()
             => FormatScope(Options.Scope);
+
+        protected override IEnumerable<Endpoint> GetEndpoints()
+        {
+            var endpoint = CreateEndpoint<OAuthHandler<TOptions>>(Options.CallbackPath,
+                "AuthenticationHandler" + Scheme.Name,
+                "GET",
+                async handler =>
+                {
+                    var result = await handler.HandleRemoteAuthenticateAsync();
+                    await handler.HandleAsync(result);
+                });
+
+            return new[] { endpoint };
+        }
     }
 }

--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -314,11 +314,10 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         {
             var endpoint = CreateEndpoint<OAuthHandler<TOptions>>(Options.CallbackPath,
                 "AuthenticationHandler" + Scheme.Name,
-                "GET",
-                async handler =>
+                HttpMethods.Get,
+                handler =>
                 {
-                    var result = await handler.HandleRemoteAuthenticateAsync();
-                    await handler.HandleAsync(result);
+                    return handler.HandleAsync(handler.HandleRemoteAuthenticateAsync);
                 });
 
             return new[] { endpoint };

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -325,11 +325,10 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         {
             var endpoint = CreateEndpoint<TwitterHandler>(Options.CallbackPath,
                 "AuthenticationHandler" + Scheme.Name,
-                "GET",
+                HttpMethods.Get,
                 async handler =>
                 {
-                    var result = await handler.HandleRemoteAuthenticateAsync();
-                    await handler.HandleAsync(result);
+                    await handler.HandleAsync(handler.HandleRemoteAuthenticateAsync);
                 });
 
             return new[] { endpoint };

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -320,5 +320,19 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 return Convert.ToBase64String(hash);
             }
         }
+
+        protected override IEnumerable<Endpoint> GetEndpoints()
+        {
+            var endpoint = CreateEndpoint<TwitterHandler>(Options.CallbackPath,
+                "AuthenticationHandler" + Scheme.Name,
+                "GET",
+                async handler =>
+                {
+                    var result = await handler.HandleRemoteAuthenticateAsync();
+                    await handler.HandleAsync(result);
+                });
+
+            return new[] { endpoint };
+        }
     }
 }

--- a/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -420,6 +420,27 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
             }
 
             return BuildRedirectUri(uri);
+        }
+
+        protected override IEnumerable<Endpoint> GetEndpoints()
+        {
+            var endpoint = CreateEndpoint<WsFederationHandler>(Options.RemoteSignOutPath,
+                "RemoteSignOutGet" + Scheme.Name,
+                "GET",
+                handler =>
+                {
+                    if (string.Equals(Request.Query[WsFederationConstants.WsFederationParameterNames.Wa],
+                    WsFederationConstants.WsFederationActions.SignOutCleanup, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return HandleRemoteSignOutAsync();
+                    }
+                    else
+                    {
+                        return Task.CompletedTask;
+                    }
+                });
+
+            return new[] { endpoint };
         }
     }
 }


### PR DESCRIPTION
Addresses #17615

The idea of this PR is to move part of the authentication handlers like callbacks and remote sign out to Endpoint.

The first draft is just adding a way which `RemoteAuthenticationHandler`s could provide their `Endpoint`s.

cc @Tratcher 