### PR TITLE
React to runtime/594 Encoder.Convert change

### DIFF
--- a/src/Http/Http.Abstractions/src/Extensions/HttpResponseWritingExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/HttpResponseWritingExtensions.cs
@@ -133,7 +133,8 @@ namespace Microsoft.AspNetCore.Http
             // Therefore, we check encodedLength - totalBytesUsed too.
             while (!completed || encodedLength - totalBytesUsed != 0)
             {
-                encoder.Convert(source, destination, flush: source.Length == 0, out var charsUsed, out var bytesUsed, out completed);
+                // 'text' is a complete string, the converter should always flush its buffer.
+                encoder.Convert(source, destination, flush: true, out var charsUsed, out var bytesUsed, out completed);
                 totalBytesUsed += bytesUsed;
 
                 writer.Advance(bytesUsed);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/594 is reverting a 3.1 fix to encoders for compat reasons. That might have side-effects for our use of encoders so we're pre-emptively updating AspNetCore as well.

This change works because we know WriteMultiSegmentEncoded is always called with a complete string, there's no tearing, so we can always flush the encoder.