### PR TITLE
Issue 17519: SignalR Java client: allow customisation of the Gson deserialisation process

### DIFF
--- a/src/SignalR/clients/java/signalr/signalr.iml
+++ b/src/SignalR/clients/java/signalr/signalr.iml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":signalr" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../../../../.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":signalr" />
+        <option name="LAST_SUCCESSFUL_SYNC_AGP_VERSION" />
+        <option name="LAST_KNOWN_AGP_VERSION" />
+      </configuration>
+    </facet>
+    <facet type="java-gradle" name="Java-Gradle">
+      <configuration>
+        <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/../../../../../../signalr/build" />
+        <option name="BUILDABLE" value="true" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/../../../../../../signalr/build/classes/java/main" />
+    <output-test url="file://$MODULE_DIR$/../../../../../../signalr/build/classes/java/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/src/main/java">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+    </content>
+    <content url="file://$MODULE_DIR$/src/main/resources">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+    </content>
+    <content url="file://$MODULE_DIR$/src/test/java">
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/src/test/resources">
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../../../../../signalr">
+      <sourceFolder url="file://$MODULE_DIR$/../../../../../../signalr/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../../../../signalr/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../../../../signalr/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../../../../signalr/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" name="Gradle: rxjava-2.2.3" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: gson-2.8.5" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: okhttp-3.11.0" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: slf4j-api-1.7.25" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: reactive-streams-1.0.2" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: okio-1.14.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: slf4j-jdk14-1.7.25" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: junit-jupiter-params-5.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: junit-jupiter-api-5.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: junit-platform-commons-1.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: apiguardian-api-1.0.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: opentest4j-1.1.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: junit-jupiter-engine-5.3.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="Gradle: junit-platform-engine-1.3.1" level="project" />
+  </component>
+</module>

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -20,6 +20,7 @@ public class HttpHubConnectionBuilder {
     private long handshakeResponseTimeout = 0;
     private Map<String, String> headers;
     private TransportEnum transportEnum;
+    private JsonHubProtocolOptions jsonHubProtocolOptions;
 
     HttpHubConnectionBuilder(String url) {
         this.url = url;
@@ -113,12 +114,41 @@ public class HttpHubConnectionBuilder {
         return this;
     }
 
+
+    /**
+     * Assigns the instance of {@link JsonHubProtocolOptions} which should be used by this
+     * {@link HubConnectionBuilder} when the {@link HubConnection} instance is created.
+     * @return An instance of {@link HubConnectionBuilder} configured to create {@link HubConnection}
+     * instances with the supplied {@link JsonHubProtocolOptions}.
+     */
+    public HttpHubConnectionBuilder withJsonProtocolOptions(JsonHubProtocolOptions jsonHubProtocolOptions) {
+        this.jsonHubProtocolOptions = jsonHubProtocolOptions;
+        return this;
+    }
+
+    /**
+     * Gets the {@link JsonHubProtocolOptions} to be used when creating {@link HubConnection}
+     * instances with this builder.
+     */
+    public JsonHubProtocolOptions getJsonHubProtocolOptions() {
+        return jsonHubProtocolOptions;
+    }
+
+    /**
+     * Sets the {@link JsonHubProtocolOptions} to be used when creating {@link HubConnection}
+     * instances with this builder.
+     */
+    public void setJsonHubProtocolOptions(JsonHubProtocolOptions jsonHubProtocolOptions) {
+        this.jsonHubProtocolOptions = jsonHubProtocolOptions;
+    }
+
+
     /**
      * Builds a new instance of {@link HubConnection}.
      *
      * @return A new instance of {@link HubConnection}.
      */
     public HubConnection build() {
-        return new HubConnection(url, transport, skipNegotiate, httpClient, accessTokenProvider, handshakeResponseTimeout, headers, transportEnum);
+        return new HubConnection(url, transport, skipNegotiate, httpClient, accessTokenProvider, handshakeResponseTimeout, headers, transportEnum, jsonHubProtocolOptions);
     }
 }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -59,6 +59,7 @@ public class HubConnection {
     private String connectionId;
     private final int negotiateVersion = 1;
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
+    private final JsonHubProtocolOptions jsonHubProtocolOptions;
 
     /**
      * Sets the server timeout interval for the connection.
@@ -124,13 +125,16 @@ public class HubConnection {
     }
 
     HubConnection(String url, Transport transport, boolean skipNegotiate, HttpClient httpClient,
-                  Single<String> accessTokenProvider, long handshakeResponseTimeout, Map<String, String> headers, TransportEnum transportEnum) {
+                  Single<String> accessTokenProvider, long handshakeResponseTimeout, Map<String, String> headers, TransportEnum transportEnum, JsonHubProtocolOptions jsonHubProtocolOptions) {
         if (url == null || url.isEmpty()) {
             throw new IllegalArgumentException("A valid url is required.");
         }
 
         this.baseUrl = url;
-        this.protocol = new JsonHubProtocol();
+        this.protocol = new JsonHubProtocol(
+            null != jsonHubProtocolOptions
+                ? jsonHubProtocolOptions.getGsonBuilder()
+                : null);
 
         if (accessTokenProvider != null) {
             this.accessTokenProvider = accessTokenProvider;
@@ -156,6 +160,8 @@ public class HubConnection {
 
         this.headers = headers;
         this.skipNegotiate = skipNegotiate;
+
+        this.jsonHubProtocolOptions = jsonHubProtocolOptions;
 
         this.callback = (payload) -> {
             resetServerTimeout();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/InvocationMessage.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/InvocationMessage.java
@@ -3,12 +3,17 @@
 
 package com.microsoft.signalr;
 
+import com.google.gson.annotations.JsonAdapter;
+
 import java.util.Collection;
 
 class InvocationMessage extends HubMessage {
+
     int type = HubMessageType.INVOCATION.value;
     private final String invocationId;
     private final String target;
+
+    @JsonAdapter(UserProvidedGsonType.class)
     private final Object[] arguments;
     private Collection<String> streamIds;
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/InvocationMessage.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/InvocationMessage.java
@@ -13,7 +13,7 @@ class InvocationMessage extends HubMessage {
     private final String invocationId;
     private final String target;
 
-    @JsonAdapter(UserProvidedGsonType.class)
+    @JsonAdapter(UserProvidedGsonTypeFactory.class)
     private final Object[] arguments;
     private Collection<String> streamIds;
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/JsonHubProtocol.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/JsonHubProtocol.java
@@ -8,6 +8,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 
@@ -39,10 +40,8 @@ class JsonHubProtocol implements HubProtocol {
         }
         userGson = gsonBuilder.create();
 
-        UserProvidedGsonType.gson = userGson;
-
         internalGgson = new GsonBuilder()
-            .registerTypeAdapter(UserProvidedGsonType.class, new UserProvidedGsonTypeAdapter(userGson))
+            .registerTypeAdapterFactory(new UserProvidedGsonTypeFactory(userGson))
             .create();
     }
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/JsonHubProtocolOptions.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/JsonHubProtocolOptions.java
@@ -1,0 +1,40 @@
+package com.microsoft.signalr;
+
+import com.google.gson.GsonBuilder;
+
+/**
+ * Used to configure options for the creation of the JSON hub protocol
+ */
+public class JsonHubProtocolOptions {
+
+    private GsonBuilder gsonBuilder;
+
+    /**
+     * Creates a default instance with no changes to the default configuration
+     */
+    public JsonHubProtocolOptions() {
+    }
+
+    /**
+     * Creates an instance with the specified {@link GsonBuilder} which be used to deserialise
+     * user payloads.
+     */
+    public JsonHubProtocolOptions(GsonBuilder gsonBuilder) {
+        this.setGsonBuilder(gsonBuilder);
+    }
+
+    /**
+     * Gets the {@link GsonBuilder} which be used to deserialise user payloads, if provided.
+     */
+    public GsonBuilder getGsonBuilder() {
+        return gsonBuilder;
+    }
+
+    /**
+     * Sets the {@link GsonBuilder} which be used to deserialise user payloads, or null if you
+     * want to use the default {@link GsonBuilder}.
+     */
+    public void setGsonBuilder(GsonBuilder gsonBuilder) {
+        this.gsonBuilder = gsonBuilder;
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserProvidedGsonType.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserProvidedGsonType.java
@@ -1,0 +1,20 @@
+package com.microsoft.signalr;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * This interface is just used to register the type of the user provided Gson instance,
+ * so that we can retrieve it from another Gson instance when required
+ */
+class UserProvidedGsonType implements TypeAdapterFactory {
+
+    public static Gson gson;
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        return (TypeAdapter<T>) new UserProvidedGsonTypeAdapter(gson);
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserProvidedGsonTypeAdapter.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserProvidedGsonTypeAdapter.java
@@ -1,0 +1,32 @@
+package com.microsoft.signalr;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * This internal class is a way to delegate serialisation of a specific sub property of a complex
+ * model to another gson instance.
+ * This is used to allow user customisation of the serialisation of their own types.
+ */
+class UserProvidedGsonTypeAdapter extends com.google.gson.TypeAdapter<Object[]> {
+
+    private Gson gson;
+
+    public UserProvidedGsonTypeAdapter(Gson gson) {
+        if (null == gson) throw new IllegalArgumentException("gson may not be null");
+        this.gson = gson;
+    }
+
+    @Override
+    public void write(JsonWriter out, Object[] value) throws IOException {
+        gson.getAdapter(Object[].class).write(out, value);
+    }
+
+    @Override
+    public Object[] read(JsonReader in) throws IOException {
+        return gson.getAdapter(Object[].class).read(in);
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserProvidedGsonTypeFactory.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/UserProvidedGsonTypeFactory.java
@@ -9,12 +9,18 @@ import com.google.gson.reflect.TypeToken;
  * This interface is just used to register the type of the user provided Gson instance,
  * so that we can retrieve it from another Gson instance when required
  */
-class UserProvidedGsonType implements TypeAdapterFactory {
+class UserProvidedGsonTypeFactory implements TypeAdapterFactory {
 
-    public static Gson gson;
+    private UserProvidedGsonTypeAdapter typeAdapter;
+
+    public UserProvidedGsonTypeFactory(Gson userProvidedGson) {
+        this.typeAdapter = new UserProvidedGsonTypeAdapter(userProvidedGson);
+    }
 
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        return (TypeAdapter<T>) new UserProvidedGsonTypeAdapter(gson);
+        if (type.getRawType() != Object[].class) return null;
+        return (TypeAdapter<T>) typeAdapter;
     }
+
 }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
@@ -1,3 +1,4 @@
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 


### PR DESCRIPTION
This PR is for https://github.com/aspnet/AspNetCore/issues/17519 implementation.

Most of this implementation is straight forward. The only bit that is a bit unusual is the method by which I serialise the contents of InvocationMessage.arguments, so I would appreciate some particular attention there from reviewers.

The alternative to the approach I used was to serialise InvocationMessage twice, once with each Gson instance, then parsing them again and combining them. That doesn't seem particular performant though since the depth of the contents of the arguments is unknown.

The downside of the approach I've used is that if someone else adds another property of type Object[] then it will automatically use the user's serialiser, not the default one.