### PR TITLE
Add dummy target for GetTargetPath to Components.Web.JS.npmproj

### DIFF
--- a/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
+++ b/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
@@ -24,6 +24,7 @@
   <!-- Workaround strange issues with something calling these targets. -->
   <Target Name="GetTargetFramework" />
   <Target Name="GetCopyToPublishDirectoryItems" />
+  <Target Name="GetTargetPath" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 


### PR DESCRIPTION
This target can't be found while packing packages for template tests on OSX (see https://dev.azure.com/dnceng/internal/_build/results?buildId=454267&view=logs&j=f43b187f-6c15-531c-a59b-e4fba4e9ed20&t=0320c262-df6f-5d53-a73e-eb9e8f5ce7e4). This is a workaround to unblock 3.0.2 while we investigate the root cause