### PR TITLE
[WIP] Link more assemblies using type granularity

### DIFF
--- a/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/Blazor/Blazor/src/Hosting/WebAssemblyHost.cs
@@ -19,6 +19,10 @@ namespace Microsoft.AspNetCore.Blazor.Hosting
 
         public WebAssemblyHost(IServiceProvider services, IJSRuntime runtime)
         {
+            // To ensure [JSInterop] methods don't get linked out, have a reference to their enclosing types
+            GC.KeepAlive(typeof(JSInteropMethods));
+            GC.KeepAlive(typeof(WebAssemblyEventDispatcher));
+
             Services = services ?? throw new ArgumentNullException(nameof(services));
             _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         }

--- a/src/Components/Blazor/Build/src/Tasks/BlazorILLink.cs
+++ b/src/Components/Blazor/Build/src/Tasks/BlazorILLink.cs
@@ -112,6 +112,14 @@ namespace Microsoft.AspNetCore.Blazor.Build.Tasks
                     args.Append(action);
                     args.Append(" ").AppendLine(Quote(assemblyName));
                 }
+
+                var actionflag = assembly.GetMetadata("actionflag");
+                if ((actionflag != null) && (actionflag.Length > 0))
+                {
+                    args.Append("-f ");
+                    args.Append(actionflag);
+                    args.Append(" ").AppendLine(Quote(assemblyName));
+                }
             }
 
             if (ReferenceAssemblyPaths != null)

--- a/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
@@ -171,7 +171,10 @@
       Outputs="$(_BlazorLinkerOutputCache)">
 
     <ItemGroup>
-      <_BlazorDependencyAssembly Include="@(_BlazorDependencyInput)" IsLinkable="$([System.String]::Copy('%(FileName)').StartsWith('System.'))" />
+      <_BlazorDependencyAssembly Include="@(_BlazorDependencyInput)" />
+      <_BlazorDependencyAssembly IsLinkable="true" Condition="$([System.String]::Copy(%(Filename)).StartsWith('System.'))" />
+      <_BlazorDependencyAssembly IsLinkable="true" ActionFlag="TypeGranularity" Condition="$([System.String]::Copy(%(Filename)).StartsWith('Microsoft.AspNetCore.'))" />
+      <_BlazorDependencyAssembly IsLinkable="true" Condition="$([System.String]::Copy(%(Filename)).StartsWith('Microsoft.Extensions.'))" />
 
       <_BlazorAssemblyToLink Include="@(_WebAssemblyBCLAssembly)" />
       <_BlazorAssemblyToLink Include="@(_BlazorDependencyAssembly)" Condition="'%(_BlazorDependencyAssembly.IsLinkable)' == 'true'" />


### PR DESCRIPTION
**Can only be merged after https://github.com/mono/linker/pull/854 and when we take an updated build of the Mono linker that includes that**

This is a preferred implementation for https://github.com/aspnet/AspNetCore/issues/17022. It's very nice and simple (doesn't require creating any new MSBuild tasks!), though relies on a new linker feature.

It reduces the out-of-box transferred size for StandaloneApp from 2.17 MB to 1.98 MB.