### PR TITLE
Update RemoveCommand.cs

### DIFF
--- a/src/Tools/Microsoft.dotnet-openapi/src/Commands/RemoveCommand.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Commands/RemoveCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.OpenApi.Commands
     {
         private const string CommandName = "remove";
 
-        private const string SourceArgName = "soruce";
+        private const string SourceArgName = "source";
 
         public RemoveCommand(Application parent, IHttpClientWrapper httpClient) : base(parent, CommandName, httpClient)
         {


### PR DESCRIPTION
fixed a typo

Summary of the changes (Less than 80 chars)
 - There is a tiny typo in this file. That will produce wrong English on the console.

![image](https://user-images.githubusercontent.com/88981/70727786-39e7f400-1d3b-11ea-876a-5b84fca13c32.png)

