### PR TITLE
Minor clean-up in Static Files

### DIFF
--- a/src/Middleware/StaticFiles/src/Constants.cs
+++ b/src/Middleware/StaticFiles/src/Constants.cs
@@ -10,11 +10,5 @@ namespace Microsoft.AspNetCore.StaticFiles
         internal const string ServerCapabilitiesKey = "server.Capabilities";
         internal const string SendFileVersionKey = "sendfile.Version";
         internal const string SendFileVersion = "1.0";
-
-        internal const int Status200Ok = 200;
-        internal const int Status206PartialContent = 206;
-        internal const int Status304NotModified = 304;
-        internal const int Status412PreconditionFailed = 412;
-        internal const int Status416RangeNotSatisfiable = 416;
     }
 }

--- a/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
@@ -63,8 +63,8 @@ namespace Microsoft.AspNetCore.StaticFiles
         /// <returns></returns>
         public Task Invoke(HttpContext context)
         {
-            if (context.GetEndpoint() == null &&
-                Helpers.IsGetOrHeadMethod(context.Request.Method)
+            if (context.GetEndpoint() == null
+                && Helpers.IsGetOrHeadMethod(context.Request.Method)
                 && Helpers.TryMatchPath(context, _matchUrl, forDirectory: true, subpath: out var subpath))
             {
                 var dirContents = _fileProvider.GetDirectoryContents(subpath.Value);
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                         {
                             // If the path matches a directory but does not end in a slash, redirect to add the slash.
                             // This prevents relative links from breaking.
-                            if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.RedirectToAppendTrailingSlash)
+                            if (_options.RedirectToAppendTrailingSlash && !Helpers.PathEndsInSlash(context.Request.Path))
                             {
                                 Helpers.RedirectToPathWithSlash(context);
                                 return Task.CompletedTask;

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             _next = next;
             _options = options.Value;
             _fileProvider = _options.FileProvider ?? Helpers.ResolveFileProvider(hostingEnv);
-            _formatter = options.Value.Formatter ?? new HtmlDirectoryFormatter(encoder);
+            _formatter = _options.Formatter ?? new HtmlDirectoryFormatter(encoder);
             _matchUrl = _options.RequestPath;
         }
 

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
@@ -80,14 +80,14 @@ namespace Microsoft.AspNetCore.StaticFiles
         public Task Invoke(HttpContext context)
         {
             // Check if the URL matches any expected paths, skip if an endpoint was selected
-            if (context.GetEndpoint() == null &&
-                Helpers.IsGetOrHeadMethod(context.Request.Method)
+            if (context.GetEndpoint() == null
+                && Helpers.IsGetOrHeadMethod(context.Request.Method)
                 && Helpers.TryMatchPath(context, _matchUrl, forDirectory: true, subpath: out var subpath)
                 && TryGetDirectoryInfo(subpath, out var contents))
             {
                 // If the path matches a directory but does not end in a slash, redirect to add the slash.
                 // This prevents relative links from breaking.
-                if (!Helpers.PathEndsInSlash(context.Request.Path) && _options.RedirectToAppendTrailingSlash)
+                if (_options.RedirectToAppendTrailingSlash && !Helpers.PathEndsInSlash(context.Request.Path))
                 {
                     Helpers.RedirectToPathWithSlash(context);
                     return Task.CompletedTask;

--- a/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
+++ b/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.StaticFiles
     {
         private const string TextHtmlUtf8 = "text/html; charset=utf-8";
 
-        private HtmlEncoder _htmlEncoder;
+        private readonly HtmlEncoder _htmlEncoder;
 
         /// <summary>
         /// Constructs the <see cref="HtmlDirectoryFormatter"/>.

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
             _next = next;
             _options = options.Value;
-            _contentTypeProvider = options.Value.ContentTypeProvider ?? new FileExtensionContentTypeProvider();
+            _contentTypeProvider = _options.ContentTypeProvider ?? new FileExtensionContentTypeProvider();
             _fileProvider = _options.FileProvider ?? Helpers.ResolveFileProvider(hostingEnv);
             _matchUrl = _options.RequestPath;
             _logger = loggerFactory.CreateLogger<StaticFileMiddleware>();

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -98,18 +98,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         private static bool ValidateMethod(HttpContext context)
         {
-            var method = context.Request.Method;
-            var isValid = false;
-            if (HttpMethods.IsGet(method))
-            {
-                isValid = true;
-            }
-            else if (HttpMethods.IsHead(method))
-            {
-                isValid = true;
-            }
-
-            return isValid;
+            return Helpers.IsGetOrHeadMethod(context.Request.Method);
         }
 
         internal static bool ValidatePath(HttpContext context, PathString matchUrl, out PathString subPath) => Helpers.TryMatchPath(context, matchUrl, forDirectory: false, out subPath);


### PR DESCRIPTION
- Use stored options in middlewares
- Replace const with  `StatusCodes` class
- Replace `Any()` with `Count > 0`
- Check `RedirectToAppendTrailingSlash` first before before `PathEndsInSlash`
