### PR TITLE
Add missed fields in internal readonly structs

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.Manual.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.Manual.cs
@@ -107,6 +107,7 @@ namespace Microsoft.AspNetCore.Components
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct CascadingParameterState
     {
+        private readonly object _dummy;
         public CascadingParameterState(string localValueName, Microsoft.AspNetCore.Components.ICascadingValueComponent valueSupplier) { throw null; }
         public string LocalValueName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.AspNetCore.Components.ICascadingValueComponent ValueSupplier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Components/Server/ref/Microsoft.AspNetCore.Components.Server.Manual.cs
+++ b/src/Components/Server/ref/Microsoft.AspNetCore.Components.Server.Manual.cs
@@ -6,6 +6,8 @@ namespace Microsoft.AspNetCore.Components
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal partial struct ServerComponent
     {
+        private object _dummy;
+        private int _dummyPrimitive;
         public ServerComponent(int sequence, string assemblyName, string typeName, System.Guid invocationId) { throw null; }
         public string AssemblyName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Guid InvocationId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
@@ -27,6 +29,8 @@ namespace Microsoft.AspNetCore.Components
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal partial struct ServerComponentMarker
     {
+        private object _dummy;
+        private int _dummyPrimitive;
         public string Descriptor { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string PrerenderId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public int? Sequence { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
@@ -151,6 +155,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         internal readonly partial struct UnacknowledgedRenderBatch
         {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
             public UnacknowledgedRenderBatch(long batchId, Microsoft.AspNetCore.Components.Server.Circuits.ArrayBuilder<byte> data, System.Threading.Tasks.TaskCompletionSource<object> completionSource, Microsoft.Extensions.Internal.ValueStopwatch valueStopwatch) { throw null; }
             public long BatchId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
             public System.Threading.Tasks.TaskCompletionSource<object> CompletionSource { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
@@ -217,6 +223,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct CircuitId : System.IEquatable<Microsoft.AspNetCore.Components.Server.Circuits.CircuitId>
     {
+        private readonly object _dummy;
         public CircuitId(string secret, string id) { throw null; }
         public string Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Secret { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
@@ -291,6 +298,7 @@ namespace Microsoft.Extensions.Internal
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal partial struct ValueStopwatch
     {
+        private int _dummyPrimitive;
         public bool IsActive { get { throw null; } }
         public System.TimeSpan GetElapsedTime() { throw null; }
         public static Microsoft.Extensions.Internal.ValueStopwatch StartNew() { throw null; }

--- a/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.Manual.cs
+++ b/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.Manual.cs
@@ -367,6 +367,7 @@ namespace Microsoft.AspNetCore.Routing
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         internal readonly partial struct MatcherState
         {
+            private readonly object _dummy;
             public readonly Microsoft.AspNetCore.Routing.RoutePatternMatcher Matcher;
             public readonly System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<IRouteConstraint>> Constraints;
             public MatcherState(Microsoft.AspNetCore.Routing.RoutePatternMatcher matcher, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Microsoft.AspNetCore.Routing.IRouteConstraint>> constraints) { throw null; }

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.Manual.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.Manual.cs
@@ -640,6 +640,13 @@ namespace Microsoft.AspNetCore.Mvc.Filters
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct FilterCursorItem<TFilter, TFilterAsync>
     {
+        [System.Diagnostics.DebuggerBrowsableAttribute(System.Diagnostics.DebuggerBrowsableState.Never)]
+        [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+        private readonly TFilter _Filter_k__BackingField;
+        [System.Diagnostics.DebuggerBrowsableAttribute(System.Diagnostics.DebuggerBrowsableState.Never)]
+        [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+        private readonly TFilterAsync _FilterAsync_k__BackingField;
+        private readonly int _dummyPrimitive;
         public FilterCursorItem(TFilter filter, TFilterAsync filterAsync) { throw null; }
         public TFilter Filter { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public TFilterAsync FilterAsync { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.Manual.cs
+++ b/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.Manual.cs
@@ -251,6 +251,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Filters
         public void OnTempDataSaving(Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionary tempData) { }
         protected void SetPropertyValues(Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionary tempData) { }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct LifecycleProperty
     {
         private readonly object _dummy;

--- a/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.Manual.cs
+++ b/src/Mvc/Mvc.ViewFeatures/ref/Microsoft.AspNetCore.Mvc.ViewFeatures.Manual.cs
@@ -253,6 +253,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Filters
     }
     internal readonly partial struct LifecycleProperty
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public LifecycleProperty(System.Reflection.PropertyInfo propertyInfo, string key) { throw null; }
         public string Key { get { throw null; } }
         public System.Reflection.PropertyInfo PropertyInfo { get { throw null; } }
@@ -342,6 +344,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct MemberExpressionCacheKey
     {
+        private readonly object _dummy;
         public MemberExpressionCacheKey(System.Type modelType, System.Linq.Expressions.MemberExpression memberExpression) { throw null; }
         public MemberExpressionCacheKey(System.Type modelType, System.Reflection.MemberInfo[] members) { throw null; }
         public System.Linq.Expressions.MemberExpression MemberExpression { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
@@ -572,6 +575,8 @@ namespace Microsoft.AspNetCore.Components.Rendering
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct ComponentRenderedText
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public ComponentRenderedText(int componentId, System.Collections.Generic.IEnumerable<string> tokens) { throw null; }
         public int ComponentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> Tokens { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.Manual.cs
+++ b/src/Servers/HttpSys/ref/Microsoft.AspNetCore.Server.HttpSys.Manual.cs
@@ -78,6 +78,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     internal readonly partial struct CookedUrl
     {
+        private readonly int _dummyPrimitive;
         internal CookedUrl(Microsoft.AspNetCore.HttpSys.Internal.HttpApiTypes.HTTP_COOKED_URL nativeCookedUrl) { throw null; }
         internal string GetAbsPath() { throw null; }
         internal string GetFullUrl() { throw null; }

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.Manual.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.Manual.cs
@@ -1552,6 +1552,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack
     internal readonly partial struct HeaderField
     {
         public const int RfcOverhead = 32;
+        private readonly object _dummy;
         public HeaderField(System.Span<byte> name, System.Span<byte> value) { throw null; }
         public int Length { get { throw null; } }
         public byte[] Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }


### PR DESCRIPTION
Follow up to https://github.com/aspnet/AspNetCore/pull/17311, we missed these fields in that PR. They're already included in https://github.com/aspnet/AspNetCore/pull/16621.

@dougbu PTAL

CC @mmitche 