### PR TITLE
Add HTTP/2 interop tests for HttpClient and Kestrel

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -792,7 +792,7 @@ namespace Interop.FunctionalTests
             var streamingContent = new StreamingContent();
             var request = CreateRequestMessage(HttpMethod.Post, url, streamingContent);
             var requestTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
-            await streamingContent.SendAsync("Hello World");
+            await streamingContent.SendAsync("Hello World").DefaultTimeout();
             using var response = await requestTask;
             responseHeadersReceived.SetResult(0);
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -51,7 +51,7 @@ namespace Interop.FunctionalTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task HelloWorld(string scheme)
         {
@@ -72,7 +72,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Echo(string scheme)
         {
@@ -102,7 +102,7 @@ namespace Interop.FunctionalTests
         }
 
         // Concurrency testing
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task MultiplexGet(string scheme)
         {
@@ -150,7 +150,7 @@ namespace Interop.FunctionalTests
         }
 
         // Concurrency testing
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task MultiplexEcho(string scheme)
         {
@@ -260,7 +260,7 @@ namespace Interop.FunctionalTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task BidirectionalStreaming(string scheme)
         {
@@ -318,7 +318,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task BidirectionalStreamingMoreClientData(string scheme)
         {
@@ -400,7 +400,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ReverseEcho(string scheme)
         {
@@ -515,7 +515,7 @@ namespace Interop.FunctionalTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ResponseTrailersWithoutData(string scheme)
         {
@@ -544,7 +544,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ResponseTrailersWithData(string scheme)
         {
@@ -580,7 +580,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ServerReset_BeforeResponse_ClientThrows(string scheme)
         {
@@ -604,7 +604,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ServerReset_AfterHeaders_ClientBodyThrows(string scheme)
         {
@@ -633,7 +633,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ServerReset_AfterEndStream_NoError(string scheme)
         {
@@ -660,7 +660,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ServerReset_AfterTrailers_NoError(string scheme)
         {
@@ -692,7 +692,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ServerReset_BeforeRequestBody_ClientBodyThrows(string scheme)
         {
@@ -748,7 +748,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ServerReset_BeforeRequestBodyEnd_ClientBodyThrows(string scheme)
         {
@@ -807,7 +807,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ClientReset_BeforeRequestData_ReadThrows(string scheme)
         {
@@ -852,7 +852,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ClientReset_BeforeRequestDataEnd_ReadThrows(string scheme)
         {
@@ -897,7 +897,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ClientReset_BeforeResponse_ResponseSuppressed(string scheme)
         {
@@ -939,7 +939,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ClientReset_BeforeEndStream_WritesSuppressed(string scheme)
         {
@@ -979,7 +979,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ClientReset_BeforeTrailers_TrailersSuppressed(string scheme)
         {
@@ -1020,7 +1020,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [Flaky("https://github.com/dotnet/runtime/issues/860", FlakyOn.All)]
         [MemberData(nameof(SupportedSchemes))]
         public async Task RequestHeaders_MultipleFrames_Accepted(string scheme)
@@ -1073,7 +1073,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ResponseHeaders_MultipleFrames_Accepted(string scheme)
         {
@@ -1122,7 +1122,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         // Expect this to change when the client implements dynamic request header compression.
         // Will the client send the first headers before receiving our settings frame?
         // We'll probobly need to ensure the settings changes are ack'd before enforcing them.
@@ -1185,7 +1185,7 @@ namespace Interop.FunctionalTests
         // Settings_HeaderTableSize_CanBeReduced_Client - The client uses the default 4k HPACK dynamic table size and it cannot be changed.
         // Nor does Kestrel yet support sending dynaimc table updates, so there's nothing to test here. https://github.com/aspnet/AspNetCore/issues/4715 
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxConcurrentStreamsGet_Server(string scheme)
         {
@@ -1246,7 +1246,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/AspNetCore/issues/17484")]
+        [Theory(Skip = "https://github.com/aspnet/AspNetCore/issues/17484")]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxConcurrentStreamsPost_Server(string scheme)
         {
@@ -1309,7 +1309,7 @@ namespace Interop.FunctionalTests
 
         // Settings_MaxConcurrentStreams_Client - Neither client or server support Push, nothing to test in this direction.
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxFrameSize_Larger_Server(string scheme)
         {
@@ -1342,7 +1342,7 @@ namespace Interop.FunctionalTests
 
         // Settings_MaxFrameSize_Larger_Client - Not configurable
 
-        [ConditionalTheory]
+        [Theory]
         [Flaky("https://github.com/dotnet/runtime/issues/860", FlakyOn.All)]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxHeaderListSize_Server(string scheme)
@@ -1375,7 +1375,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxHeaderListSize_Client(string scheme)
         {
@@ -1409,7 +1409,7 @@ namespace Interop.FunctionalTests
         // Settings_InitialWindowSize_Lower_Server - Kestrel does not support lowering the InitialStreamWindowSize below the spec default 64kb.
         // Settings_InitialWindowSize_Lower_Client - Not configurable.
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_InitialWindowSize_Server(string scheme)
         {
@@ -1451,7 +1451,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_InitialWindowSize_Client(string scheme)
         {
@@ -1487,7 +1487,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task ConnectionWindowSize_Server(string scheme)
         {
@@ -1546,7 +1546,7 @@ namespace Interop.FunctionalTests
         // The spec default connection window is 64kb - 1 but the client default is 64Mb (not configurable).
         // The client restricts streams to 64kb - 1 so we would need to issue 64 * 1024 requests to stress the connection window limit.
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task UnicodeRequestHost(string scheme)
         {
@@ -1573,7 +1573,7 @@ namespace Interop.FunctionalTests
             await host.StopAsync().DefaultTimeout();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SupportedSchemes))]
         public async Task UrlEncoding(string scheme)
         {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -725,11 +725,9 @@ namespace Interop.FunctionalTests
 
             await serverReset.Task.DefaultTimeout();
             var responseEx = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsStringAsync().DefaultTimeout());
-            var requestEx = await Assert.ThrowsAsync<HttpRequestException>(() => streamingContent.SendAsync("Hello World").DefaultTimeout());
             Assert.Contains("The HTTP/2 server reset the stream. HTTP/2 error code 'CANCEL' (0x8)", responseEx.ToString());
-            Assert.Contains("The HTTP/2 server reset the stream. HTTP/2 error code 'CANCEL' (0x8)", requestEx.ToString());
-
-            await Assert.ThrowsAsync<IOException>(() => clientEcho.Task.DefaultTimeout());
+            await Assert.ThrowsAsync<TaskCanceledException>(() => streamingContent.SendAsync("Hello World").DefaultTimeout());
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientEcho.Task.DefaultTimeout());
 
             await host.StopAsync().DefaultTimeout();
         }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1631,8 +1631,16 @@ namespace Interop.FunctionalTests
         private static async Task ReadStreamHelloWorld(Stream stream)
         {
             var responseBuffer = new byte["Hello World".Length];
-            var read = await stream.ReadAsync(responseBuffer, 0, responseBuffer.Length).DefaultTimeout();
-            Assert.Equal(responseBuffer.Length, read);
+            var totalRead = 0;
+            do
+            {
+                var read = await stream.ReadAsync(responseBuffer, totalRead, responseBuffer.Length - totalRead).DefaultTimeout();
+                totalRead += read;
+                if (read == 0)
+                {
+                    throw new InvalidOperationException("Unexpected end of stream");
+                }
+            } while (totalRead < responseBuffer.Length);
             Assert.Equal("Hello World", Encoding.UTF8.GetString(responseBuffer));
         }
     }


### PR DESCRIPTION
This completes the test scenarios outlined in https://github.com/aspnet/AspNetCore/issues/4763#issuecomment-507865641. It also updates existing tests to reflect fixes made for previously discovered issues.

Additional issues found:
https://github.com/dotnet/runtime/issues/860
https://github.com/aspnet/AspNetCore/issues/17861
https://github.com/aspnet/AspNetCore/issues/17484