### PR TITLE
Drop deprecated TSLint rule in Angular SPA template

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/tslint.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/tslint.json
@@ -72,7 +72,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [


### PR DESCRIPTION
This minor updates removes warning from the results of running linter on
the project (ng lint):

x-ref: angular/angular-cli#15689

Summary of the changes:
- if the user decides to run built-in linting tool with out-of-the-box configuration the output yields:

> ng lint
> Linting "WebApplication"...
> no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
> All files pass linting.

The upstream project already removed that rule in linked PR, so this change just make sure  this details is up-to-date.

Thanks!