### PR TITLE
[release/3.1] Port ci source build changes

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -584,6 +584,17 @@ stages:
         chmod +x $HOME/bin/jq
         echo "##vso[task.prependpath]$HOME/bin"
       displayName: Install jq
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        packageType: sdk
+        # The SDK version selected here is intentionally supposed to use the latest release
+        # For the purpose of building Linux distros, we can't depend on features of the SDK
+        # which may not exist in pre-built versions of the SDK
+        # Pinning to preview 8 since preview 9 has breaking changes
+        version: 3.1.100
+        installationPath: $(DotNetCoreSdkDir)
+        includePreviewVersions: true
     - script: ./eng/scripts/ci-source-build.sh --ci --configuration Release /p:BuildManaged=true /p:BuildNodeJs=false
       displayName: Run ci-source-build.sh
     - task: PublishBuildArtifacts@1

--- a/eng/scripts/ci-source-build.sh
+++ b/eng/scripts/ci-source-build.sh
@@ -9,6 +9,27 @@ set -euo pipefail
 scriptroot="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 reporoot="$(dirname "$(dirname "$scriptroot")")"
 
+ # For local development, make a backup copy of this file first
+if [ ! -f "$reporoot/global.bak.json" ]; then
+    mv "$reporoot/global.json" "$reporoot/global.bak.json"
+fi
+
+ # Detect the current version of .NET Core installed
+export SDK_VERSION=$(dotnet --version)
+echo "The ambient version of .NET Core SDK version = $SDK_VERSION"
+
+ # Update the global.json file to match the current .NET environment
+cat "$reporoot/global.bak.json" | \
+    jq '.sdk.version=env.SDK_VERSION' | \
+    jq '.tools.dotnet=env.SDK_VERSION' | \
+    jq 'del(.tools.runtimes)' \
+    > "$reporoot/global.json"
+
+ # Restore the original global.json file
+trap "{
+    mv "$reporoot/global.bak.json" "$reporoot/global.json"
+}" EXIT
+
  # Build repo tasks
 "$reporoot/eng/common/build.sh" --restore --build --ci --configuration Release /p:ProjectToBuild=$reporoot/eng/tools/RepoTasks/RepoTasks.csproj
 


### PR DESCRIPTION
This is the way that 3.0 does its source build. Porting to 3.1 to avoid unecessary download of the internal runtimes in the source-build scripts. I think these changes were meant for 3.1, but required a released 3.1 SDK first.