### PR TITLE
[2.1] CookieChunkingManager needs to flow the Secure attribute for Delete operations

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -48,4 +48,10 @@ Later on, this will be checked using this condition:
     <PackagesInPatch>
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.16' ">
+    <PackagesInPatch>
+      Microsoft.AspNetCore.Authentication.Cookies;
+      Microsoft.AspNetCore.Mvc.Core;
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -45,7 +45,7 @@ namespace OpenIdConnectSample
 
         private void CheckSameSite(HttpContext httpContext, CookieOptions options)
         {
-            if (options.SameSite > (SameSiteMode)(-1))
+            if (options.SameSite == SameSiteMode.None)
             {
                 var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
                 // TODO: Use your User Agent library of choice here.

--- a/src/Security/Authentication/test/WsFederation/WsFederationTest.cs
+++ b/src/Security/Authentication/test/WsFederation/WsFederationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
             response.EnsureSuccessStatusCode();
 
             var cookie = response.Headers.GetValues(HeaderNames.SetCookie).Single();
-            Assert.Equal(".AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax", cookie);
+            Assert.Equal(".AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly", cookie);
             Assert.Equal("OnRemoteSignOut", response.Headers.GetValues("EventHeader").Single());
             Assert.Equal("", await response.Content.ReadAsStringAsync());
         }

--- a/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
+++ b/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
@@ -169,6 +169,7 @@ namespace Microsoft.AspNetCore.Internal
                 HttpOnly = options.HttpOnly,
                 Path = options.Path,
                 Secure = options.Secure,
+                MaxAge = options.MaxAge,
             };
 
             var templateLength = template.ToString().Length;
@@ -285,8 +286,10 @@ namespace Microsoft.AspNetCore.Internal
                     Path = options.Path,
                     Domain = options.Domain,
                     SameSite = options.SameSite,
+                    Secure = options.Secure,
                     IsEssential = options.IsEssential,
                     Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    HttpOnly = options.HttpOnly,
                 });
 
             for (int i = 1; i <= chunks; i++)
@@ -300,8 +303,10 @@ namespace Microsoft.AspNetCore.Internal
                         Path = options.Path,
                         Domain = options.Domain,
                         SameSite = options.SameSite,
+                        Secure = options.Secure,
                         IsEssential = options.IsEssential,
                         Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                        HttpOnly = options.HttpOnly,
                     });
             }
         }


### PR DESCRIPTION
#17833

This comes from an external report of customers using IdentityServer4. When testing SameSite behavior in Chrome with Core 2.1 they were able to login successfully but had trouble logging out. The new SameSite browser policy requires all cookies that set `SameSite=None` to also set the `secure` attribute. `Secure` was included for sign-in, but it was not included for the sign-out delete cookie because previously there was no need.

This is possible to work around by copying the ChunkingCookieManager class (300 lines) into your application and applying the changes (5 lines).

This was previously [fixed in 3.0](https://github.com/aspnet/AspNetCore/commit/6fa9398781531fe2702f2cab34a5ab4883568150#diff-2f4e8f46b2b0ca7fa8ec27a1608968d5) independently from the SameSite changes and was not included in the SameSite downlevel patches.

Impact: Moderate. Hitting this issue requires setting a non-default but commonly used option (SameSite=None on the authentication cookie). Applications did this in the past to avoid problems with iOS 12.

Risk: Low. These changes are small and were already included in 3.0.

Set as Draft until the next 2.1.x servicing window opens.

Should this be ported to 2.2.x? 2.2 has reached end-of-life.