### PR TITLE
[release/3.1] Don't use baseline assembly versions for RID-agnostic packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!-- When OnlyPackPlatformSpecificPackages is set, only produce packages for projects which set RuntimeIdentifier. -->
-    <IsPackable Condition=" '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(IsPackable)' != 'false' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
 
     <!--
       By default, assemblies which are only in the Microsoft.AspNetCore.App shared framework are not available as NuGet packages.
@@ -65,6 +63,12 @@
     <IsPackableInNonServicingBuild>true</IsPackableInNonServicingBuild>
     <!-- Suppress creation of .nupkg for servicing builds of non-shipping projects. -->
     <IsPackable Condition=" '$(IsPackageInThisPatch)' != 'true' ">false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- When OnlyPackPlatformSpecificPackages is set, only produce packages for projects which set RuntimeIdentifier. -->
+    <!-- Keep this below where we set "IsPackageInThisPatch" -->
+    <IsPackable Condition=" '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
3.1 port of https://github.com/aspnet/AspNetCore/pull/17969

In all CI builds except Windows x64, we set `OnlyPackPlatformSpecificPackages=true`: https://github.com/aspnet/AspNetCore/blob/e6af4bfe7e022e2c3b32c583b280965041c3d15c/.azure/pipelines/ci.yml#L254-L261

This makes us decide that all libraries without `RuntimeIdentifiers` are not packable: https://github.com/aspnet/AspNetCore/blob/1ff3e7b21ea5270b832a6e05c74b1b5f67d4cfb0/Directory.Build.targets#L5

Then later, we say that everything that is not packable, is not part of "this patch" (if we're doing a patch build): https://github.com/aspnet/AspNetCore/blob/1ff3e7b21ea5270b832a6e05c74b1b5f67d4cfb0/Directory.Build.targets#L62-L68

Which causes us to use basline assembly versions:

https://github.com/aspnet/AspNetCore/blob/1ff3e7b21ea5270b832a6e05c74b1b5f67d4cfb0/Directory.Build.targets#L74-L77

We are incorrect to say that these libraries/packages aren't "in this patch" - we're just not building them right now. Moving the condition for `OnlyPackPlatformSpecificPackages` down in the file should fix the issue. Without this, all of our non-Windows-x64 builds create runtime packs w/ `3.0.0.0` assembly versioned .dll's.

@JunTaoLuo @Pilchie @dagood @dougbu PTAL