### PR TITLE
HttpSys logs and samples cleanup

### DIFF
--- a/src/Servers/HttpSys/HttpSysServer.sln
+++ b/src/Servers/HttpSys/HttpSysServer.sln
@@ -74,6 +74,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueueSharing", "samples\Que
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets", "..\Kestrel\Transport.Sockets\src\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj", "{33CF53ED-A4BC-4EAA-9EA7-EF5E748A03BB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore", "..\..\DefaultBuilder\src\Microsoft.AspNetCore.csproj", "{E8880B06-7172-4995-893D-13E87AF00E7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -332,6 +334,18 @@ Global
 		{33CF53ED-A4BC-4EAA-9EA7-EF5E748A03BB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{33CF53ED-A4BC-4EAA-9EA7-EF5E748A03BB}.Release|x86.ActiveCfg = Release|Any CPU
 		{33CF53ED-A4BC-4EAA-9EA7-EF5E748A03BB}.Release|x86.Build.0 = Release|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Release|x86.ActiveCfg = Release|Any CPU
+		{E8880B06-7172-4995-893D-13E87AF00E7B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -359,6 +373,7 @@ Global
 		{00A88B8D-D539-45DD-B071-1E955AF89A4A} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
 		{9B58DF76-DC6D-4728-86B7-40087BDDC897} = {3A1E31E3-2794-4CA3-B8E2-253E96BDE514}
 		{33CF53ED-A4BC-4EAA-9EA7-EF5E748A03BB} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
+		{E8880B06-7172-4995-893D-13E87AF00E7B} = {4DA3C456-5050-4AC0-A554-795F6DEC8660}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34B42B42-FA09-41AB-9216-14073990C504}

--- a/src/Servers/HttpSys/samples/SelfHostServer/Program.cs
+++ b/src/Servers/HttpSys/samples/SelfHostServer/Program.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.HttpSys;
+using Microsoft.Extensions.Hosting;
+
+namespace SelfHostServer
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>()
+                    .UseHttpSys(options =>
+                    {
+                        options.UrlPrefixes.Add("http://localhost:5000");
+                        // This is a pre-configured IIS express port. See the PackageTags in the csproj.
+                        options.UrlPrefixes.Add("https://localhost:44319");
+                        options.Authentication.Schemes = AuthenticationSchemes.None;
+                        options.Authentication.AllowAnonymous = true;
+                    });
+                });
+    }
+}

--- a/src/Servers/HttpSys/samples/SelfHostServer/SelfHostServer.csproj
+++ b/src/Servers/HttpSys/samples/SelfHostServer/SelfHostServer.csproj
@@ -12,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
+    <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 </Project>

--- a/src/Servers/HttpSys/samples/SelfHostServer/Startup.cs
+++ b/src/Servers/HttpSys/samples/SelfHostServer/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -27,24 +30,6 @@ namespace SelfHostServer
                 context.Response.ContentType = "text/plain";
                 await context.Response.WriteAsync("Hello world from " + context.Request.Host + " at " + DateTime.Now);
             });
-        }
-
-        public static void Main(string[] args)
-        {
-            var host = new WebHostBuilder()
-                .ConfigureLogging(factory => factory.AddConsole())
-                .UseStartup<Startup>()
-                .UseHttpSys(options =>
-                {
-                    options.UrlPrefixes.Add("http://localhost:5000");
-                    // This is a pre-configured IIS express port. See the PackageTags in the csproj.
-                    options.UrlPrefixes.Add("https://localhost:44319");
-                    options.Authentication.Schemes = AuthenticationSchemes.None;
-                    options.Authentication.AllowAnonymous = true;
-                })
-                .Build();
-
-            host.Run();
         }
     }
 }

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             CheckDisposed();
 
-            LogHelper.LogInfo(Logger, "Start");
+            LogHelper.LogTrace(Logger, "Starting the listener.");
 
             // Make sure there are no race conditions between Start/Stop/Abort/Close/Dispose.
             // Start needs to setup all resources. Abort/Stop must not interfere while Start is
@@ -195,6 +195,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         return;
                     }
 
+                    LogHelper.LogTrace(Logger, "Stopping the listener.");
+
                     // If this instance created the queue then remove the URL prefixes before shutting down.
                     if (_requestQueue.Created)
                     {
@@ -236,7 +238,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     {
                         return;
                     }
-                    LogHelper.LogInfo(Logger, "Dispose");
+                    LogHelper.LogTrace(Logger, "Disposing the listener.");
 
                     Stop();
                     DisposeInternal();

--- a/src/Servers/HttpSys/src/LogHelper.cs
+++ b/src/Servers/HttpSys/src/LogHelper.cs
@@ -79,6 +79,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        internal static void LogTrace(ILogger logger, string data)
+        {
+            if (logger == null)
+            {
+                Debug.WriteLine(data);
+            }
+            else
+            {
+                logger.LogTrace(data);
+            }
+        }
+
         internal static void LogException(ILogger logger, string location, Exception exception)
         {
             if (logger == null)

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal void RegisterPrefix(string uriPrefix, int contextId)
         {
-            LogHelper.LogInfo(_logger, "Listening on prefix: " + uriPrefix);
+            LogHelper.LogDebug(_logger, "Listening on prefix: " + uriPrefix);
             CheckDisposed();
             var statusCode = HttpApi.HttpAddUrlToUrlGroup(Id, uriPrefix, (ulong)contextId, 0);
 
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         
         internal bool UnregisterPrefix(string uriPrefix)
         {
-            LogHelper.LogInfo(_logger, "Stop listening on prefix: " + uriPrefix);
+            LogHelper.LogDebug(_logger, "Stop listening on prefix: " + uriPrefix);
             CheckDisposed();
 
             var statusCode = HttpApi.HttpRemoveUrlFromUrlGroup(Id, uriPrefix, 0);


### PR DESCRIPTION
This cleans up some logs that @davidfowl showed me in HttpSys which were logging at too high a level. I also cleaned up the sample and converted it to use generic host and CreateDefaultBuilder.

Before:
```
info: Microsoft.AspNetCore.Server.HttpSys.HttpSysListener[0]
      Start
info: Microsoft.AspNetCore.Server.HttpSys.HttpSysListener[0]
      Listening on prefix: http://localhost:5000/
info: Microsoft.AspNetCore.Server.HttpSys.HttpSysListener[0]
      Listening on prefix: https://localhost:44319/
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:5000/
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: https://localhost:44319/
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\github\AspNetCore\artifacts\bin\SelfHostServer\Debug\netcoreapp5.0
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
info: Microsoft.AspNetCore.Server.HttpSys.HttpSysListener[0]
      Dispose
info: Microsoft.AspNetCore.Server.HttpSys.HttpSysListener[0]
      Stop listening on prefix: http://localhost:5000/
info: Microsoft.AspNetCore.Server.HttpSys.HttpSysListener[0]
      Stop listening on prefix: https://localhost:44319/
```

After:
```
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:5000/
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: https://localhost:44319/
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\github\AspNetCore\artifacts\bin\SelfHostServer\Debug\netcoreapp5.0
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
```