### PR TITLE
Azure Key Vault DataProtection ConfigureAwait(false)

### DIFF
--- a/src/DataProtection/AzureKeyVault/src/AzureDataProtectionBuilderExtensions.cs
+++ b/src/DataProtection/AzureKeyVault/src/AzureDataProtectionBuilderExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.DataProtection
         private static async Task<string> GetTokenFromClientCertificate(string authority, string resource, string clientId, X509Certificate2 certificate)
         {
             var authContext = new AuthenticationContext(authority);
-            var result = await authContext.AcquireTokenAsync(resource, new ClientAssertionCertificate(clientId, certificate));
+            var result = await authContext.AcquireTokenAsync(resource, new ClientAssertionCertificate(clientId, certificate)).ConfigureAwait(false);
             return result.AccessToken;
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.DataProtection
         {
             var authContext = new AuthenticationContext(authority);
             var clientCred = new ClientCredential(clientId, clientSecret);
-            var result = await authContext.AcquireTokenAsync(resource, clientCred);
+            var result = await authContext.AcquireTokenAsync(resource, clientCred).ConfigureAwait(false);
             return result.AccessToken;
         }
 

--- a/src/DataProtection/AzureKeyVault/src/AzureKeyVaultXmlDecryptor.cs
+++ b/src/DataProtection/AzureKeyVault/src/AzureKeyVaultXmlDecryptor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.DataProtection.AzureKeyVault
 
             var encryptedValue = Convert.FromBase64String((string)encryptedElement.Element("value"));
 
-            var result = await _client.UnwrapKeyAsync(kid, AzureKeyVaultXmlEncryptor.DefaultKeyEncryption, symmetricKey);
+            var result = await _client.UnwrapKeyAsync(kid, AzureKeyVaultXmlEncryptor.DefaultKeyEncryption, symmetricKey).ConfigureAwait(false);
 
             byte[] decryptedValue;
             using (var symmetricAlgorithm = AzureKeyVaultXmlEncryptor.DefaultSymmetricAlgorithmFactory())

--- a/src/DataProtection/AzureKeyVault/src/AzureKeyVaultXmlEncryptor.cs
+++ b/src/DataProtection/AzureKeyVault/src/AzureKeyVaultXmlEncryptor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.DataProtection.AzureKeyVault
                     encryptedValue = encryptor.TransformFinalBlock(value, 0, value.Length);
                 }
 
-                var wrappedKey = await _client.WrapKeyAsync(_keyId, DefaultKeyEncryption, symmetricKey);
+                var wrappedKey = await _client.WrapKeyAsync(_keyId, DefaultKeyEncryption, symmetricKey).ConfigureAwait(false);
 
                 var element = new XElement("encryptedKey",
                     new XComment(" This key is encrypted with Azure KeyVault. "),


### PR DESCRIPTION
This change adds ConfigureAwait(false) to a few calls in the AzureKeyVault DataProtection library.  As this is library code, It is still a best practice to use ConfigureAwait(false) in conjunction with awaiting a task.