### PR TITLE
Fix SignalR Java tests not running

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -236,3 +236,4 @@ jobs:
           testResultsFiles: '**/TEST-com.microsoft.signalr*.xml'
           buildConfiguration: $(BuildConfiguration)
           buildPlatform: $(AgentOsName)
+          mergeTestResults: true

--- a/src/SignalR/clients/java/signalr/signalr.client.java.javaproj
+++ b/src/SignalR/clients/java/signalr/signalr.client.java.javaproj
@@ -11,6 +11,8 @@
 
     <IsShippingPackage>true</IsShippingPackage>
 
+    <IsTestProject>true</IsTestProject>
+
     <!-- Disable gradle daemon on CI since the CI seems to try to wait for the daemon to shut down, which it doesn't do :) -->
     <GradleOptions Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(GradleOptions) -Dorg.gradle.daemon=false</GradleOptions>
   </PropertyGroup>
@@ -33,6 +35,9 @@
     </PackDependsOn>
   </PropertyGroup>
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+
+  <!-- Define Target overrides after importing Directory.Build.targets so these don't get overriden -->
   <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Condition="'$(IsPackable)' == 'true'">
     <Message Text="> gradlew $(GradleOptions) createPackage" Importance="high" />
     <Exec Command="./gradlew $(GradleOptions) createPackage" />
@@ -50,10 +55,8 @@
     <Exec Command="./gradlew $(GradleOptions) test" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
-
   <PropertyGroup>
     <!-- Pass the Java Package Version down to Gradle -->
-    <GradleOptions>-PpackageVersion="$(PackageVersion)"</GradleOptions>
+    <GradleOptions Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(GradleOptions) -PpackageVersion="$(PackageVersion)"</GradleOptions>
   </PropertyGroup>
 </Project>

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
@@ -1,3 +1,4 @@
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 


### PR DESCRIPTION
IDK when it happened, but the Java tests stopped running at some point.