### PR TITLE
Use UnixEpoch for cookie deletion

### DIFF
--- a/src/Http/Http/src/Internal/ResponseCookies.cs
+++ b/src/Http/Http/src/Internal/ResponseCookies.cs
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Http
             {
                 Path = options.Path,
                 Domain = options.Domain,
-                Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Expires = DateTimeOffset.UnixEpoch,
                 Secure = options.Secure,
                 HttpOnly = options.HttpOnly,
                 SameSite = options.SameSite

--- a/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
+++ b/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
@@ -288,7 +288,7 @@ namespace Microsoft.AspNetCore.Internal
                     SameSite = options.SameSite,
                     Secure = options.Secure,
                     IsEssential = options.IsEssential,
-                    Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    Expires = DateTimeOffset.UnixEpoch,
                     HttpOnly = options.HttpOnly,
                 });
 
@@ -305,7 +305,7 @@ namespace Microsoft.AspNetCore.Internal
                         SameSite = options.SameSite,
                         Secure = options.Secure,
                         IsEssential = options.IsEssential,
-                        Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                        Expires = DateTimeOffset.UnixEpoch,
                         HttpOnly = options.HttpOnly,
                     });
             }


### PR DESCRIPTION
Use the `DateTimeOffset.UnixEpoch` field instead of a new `DateTime` value when deleting cookies.

I also tried to update [`Rfc6238AuthenticationService`](https://github.com/aspnet/AspNetCore/blob/df33890548214e6f296c54729f2d5a8bc253f1a1/src/Identity/Extensions.Core/src/Rfc6238AuthenticationService.cs#L15) as well, but that project still targets `netstandard2.0` which doesn't have the field available.
