### PR TITLE
Use RandomNumberGenerator.Fill()

### DIFF
--- a/src/Antiforgery/src/Internal/BinaryBlob.cs
+++ b/src/Antiforgery/src/Internal/BinaryBlob.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.Antiforgery
     [DebuggerDisplay("{DebuggerString}")]
     internal sealed class BinaryBlob : IEquatable<BinaryBlob>
     {
-        private static readonly RandomNumberGenerator _randomNumberGenerator = RandomNumberGenerator.Create();
         private readonly byte[] _data;
 
         // Generates a new token using a specified bit length.
@@ -92,7 +91,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         private static byte[] GenerateNewToken(int bitLength)
         {
             var data = new byte[bitLength / 8];
-            _randomNumberGenerator.GetBytes(data);
+            RandomNumberGenerator.Fill(data);
             return data;
         }
 

--- a/src/Antiforgery/test/DefaultAntiforgeryTokenGeneratorTest.cs
+++ b/src/Antiforgery/test/DefaultAntiforgeryTokenGeneratorTest.cs
@@ -149,10 +149,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             httpContext.User = new ClaimsPrincipal(identity);
 
             byte[] data = new byte[256 / 8];
-            using (var rng = RandomNumberGenerator.Create())
-            {
-                rng.GetBytes(data);
-            }
+            RandomNumberGenerator.Fill(data);
             var base64ClaimUId = Convert.ToBase64String(data);
             var expectedClaimUid = new BinaryBlob(256, data);
 

--- a/src/Components/Server/src/Circuits/CircuitIdFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitIdFactory.cs
@@ -20,7 +20,6 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         private const int SecretLength = 64;
         private const int IdLength = 32;
 
-        private readonly RandomNumberGenerator _generator = RandomNumberGenerator.Create();
         private readonly IDataProtector _protector;
 
         public CircuitIdFactory(IDataProtectionProvider provider)
@@ -35,7 +34,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         public CircuitId CreateCircuitId()
         {
             var buffer = new byte[SecretLength];
-            _generator.GetBytes(buffer);
+            RandomNumberGenerator.Fill(buffer);
 
             var id = new byte[IdLength];
             Array.Copy(

--- a/src/DataProtection/DataProtection/src/Managed/ManagedGenRandomImpl.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedGenRandomImpl.cs
@@ -8,7 +8,6 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
 {
     internal unsafe sealed class ManagedGenRandomImpl : IManagedGenRandom
     {
-        private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
         public static readonly ManagedGenRandomImpl Instance = new ManagedGenRandomImpl();
 
         private ManagedGenRandomImpl()
@@ -18,7 +17,7 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
         public byte[] GenRandom(int numBytes)
         {
             var bytes = new byte[numBytes];
-            _rng.GetBytes(bytes);
+            RandomNumberGenerator.Fill(bytes);
             return bytes;
         }
     }

--- a/src/DataProtection/DataProtection/src/Managed/ManagedGenRandomImpl.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedGenRandomImpl.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
 {
     internal unsafe sealed class ManagedGenRandomImpl : IManagedGenRandom
     {
+        private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
         public static readonly ManagedGenRandomImpl Instance = new ManagedGenRandomImpl();
 
         private ManagedGenRandomImpl()
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
         public byte[] GenRandom(int numBytes)
         {
             var bytes = new byte[numBytes];
-            RandomNumberGenerator.Fill(bytes);
+            _rng.GetBytes(bytes);
             return bytes;
         }
     }

--- a/src/Hosting/TestHost/src/WebSocketClient.cs
+++ b/src/Hosting/TestHost/src/WebSocketClient.cs
@@ -109,8 +109,7 @@ namespace Microsoft.AspNetCore.TestHost
         private string CreateRequestKey()
         {
             byte[] data = new byte[16];
-            var rng = RandomNumberGenerator.Create();
-            rng.GetBytes(data);
+            RandomNumberGenerator.Fill(data);
             return Convert.ToBase64String(data);
         }
 

--- a/src/Middleware/Session/src/DistributedSession.cs
+++ b/src/Middleware/Session/src/DistributedSession.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Session
 {
     public class DistributedSession : ISession
     {
-        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
         private const int IdByteCount = 16;
 
         private const byte SerializationRevision = 2;
@@ -104,7 +103,7 @@ namespace Microsoft.AspNetCore.Session
                 if (IsAvailable && _sessionIdBytes == null)
                 {
                     _sessionIdBytes = new byte[IdByteCount];
-                    CryptoRandom.GetBytes(_sessionIdBytes);
+                    RandomNumberGenerator.Fill(_sessionIdBytes);
                 }
                 return _sessionIdBytes;
             }

--- a/src/Middleware/Session/src/SessionMiddleware.cs
+++ b/src/Middleware/Session/src/SessionMiddleware.cs
@@ -20,7 +20,6 @@ namespace Microsoft.AspNetCore.Session
     /// </summary>
     public class SessionMiddleware
     {
-        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
         private const int SessionKeyLength = 36; // "382c74c3-721d-4f34-80e5-57657b6cbc27"
         private static readonly Func<bool> ReturnTrue = () => true;
         private readonly RequestDelegate _next;
@@ -91,7 +90,7 @@ namespace Microsoft.AspNetCore.Session
             {
                 // No valid cookie, new session.
                 var guidBytes = new byte[16];
-                CryptoRandom.GetBytes(guidBytes);
+                RandomNumberGenerator.Fill(guidBytes);
                 sessionKey = new Guid(guidBytes).ToString();
                 cookieValue = CookieProtection.Protect(_dataProtector, sessionKey);
                 var establisher = new SessionEstablisher(context, cookieValue, _options);

--- a/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
@@ -18,8 +18,6 @@ namespace Microsoft.AspNetCore.Authentication
         private const string CorrelationMarker = "N";
         private const string AuthSchemeKey = ".AuthScheme";
 
-        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
-
         protected string SignInScheme => Options.SignInScheme;
 
         /// <summary>
@@ -194,7 +192,7 @@ namespace Microsoft.AspNetCore.Authentication
             }
 
             var bytes = new byte[32];
-            CryptoRandom.GetBytes(bytes);
+            RandomNumberGenerator.Fill(bytes);
             var correlationId = Base64UrlTextEncoder.Encode(bytes);
 
             var cookieOptions = Options.CorrelationCookie.Build(Context, Clock.UtcNow);

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
@@ -20,8 +20,6 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 {
     public class MicrosoftAccountHandler : OAuthHandler<MicrosoftAccountOptions>
     {
-        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
-
         public MicrosoftAccountHandler(IOptionsMonitor<MicrosoftAccountOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock)
         { }
@@ -64,7 +62,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             if (Options.UsePkce)
             {
                 var bytes = new byte[32];
-                CryptoRandom.GetBytes(bytes);
+                RandomNumberGenerator.Fill(bytes);
                 var codeVerifier = Base64UrlTextEncoder.Encode(bytes);
 
                 // Store this for use during the code redemption.

--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 {
     public class OAuthHandler<TOptions> : RemoteAuthenticationHandler<TOptions> where TOptions : OAuthOptions, new()
     {
-        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
         protected HttpClient Backchannel => Options.Backchannel;
 
         /// <summary>
@@ -274,7 +273,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             if (Options.UsePkce)
             {
                 var bytes = new byte[32];
-                CryptoRandom.GetBytes(bytes);
+                RandomNumberGenerator.Fill(bytes);
                 var codeVerifier = Base64UrlTextEncoder.Encode(bytes);
 
                 // Store this for use during the code redemption.

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -34,8 +34,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         private const string NonceProperty = "N";
         private const string HeaderValueEpocDate = "Thu, 01 Jan 1970 00:00:00 GMT";
 
-        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
-
         private OpenIdConnectConfiguration _configuration;
 
         protected HttpClient Backchannel => Options.Backchannel;
@@ -371,7 +369,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             if (Options.UsePkce && Options.ResponseType == OpenIdConnectResponseType.Code)
             {
                 var bytes = new byte[32];
-                CryptoRandom.GetBytes(bytes);
+                RandomNumberGenerator.Fill(bytes);
                 var codeVerifier = Base64UrlTextEncoder.Encode(bytes);
 
                 // Store this for use during the code redemption. See RunAuthorizationCodeReceivedEventAsync.


### PR DESCRIPTION
Use the new `RandomNumberGenerator.Fill()` method instead of maintaining various instances of `RandomNumberGenerator` to use `GetBytes()`.

Also happens to fix the `RandomNumberGenerator` instance(s) created by `WebSocketClient` for the test host not being disposed of.