### PR TITLE
More RNG.Fill() and UnixEpoch usage

### DIFF
--- a/src/DataProtection/DataProtection/src/Managed/ManagedGenRandomImpl.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedGenRandomImpl.cs
@@ -8,7 +8,9 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
 {
     internal unsafe sealed class ManagedGenRandomImpl : IManagedGenRandom
     {
+#if NETSTANDARD2_0
         private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
+#endif
         public static readonly ManagedGenRandomImpl Instance = new ManagedGenRandomImpl();
 
         private ManagedGenRandomImpl()
@@ -18,7 +20,11 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
         public byte[] GenRandom(int numBytes)
         {
             var bytes = new byte[numBytes];
+#if NETSTANDARD2_0
             _rng.GetBytes(bytes);
+#else
+            RandomNumberGenerator.Fill(bytes);
+#endif
             return bytes;
         }
     }

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -43,7 +43,9 @@ namespace Microsoft.AspNetCore.Identity
 
         private TimeSpan _defaultLockout = TimeSpan.Zero;
         private bool _disposed;
+#if NETSTANDARD2_0
         private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
+#endif
         private IServiceProvider _services;
 
         /// <summary>
@@ -2428,7 +2430,11 @@ namespace Microsoft.AspNetCore.Identity
         private static string NewSecurityStamp()
         {
             byte[] bytes = new byte[20];
+#if NETSTANDARD2_0
             _rng.GetBytes(bytes);
+#else
+            RandomNumberGenerator.Fill(bytes);
+#endif
             return Base32.ToBase32(bytes);
         }
 


### PR DESCRIPTION
Apply more changes omitted from #18126 and #18128, and use `RandomNumberGenerator.Fill()` and `DateTimeOffset.UnixEpoch` for supported TFMs (i.e. not `netstandard2.0`).

I followed the conditional define approach/style that seemed to be already in use elsewhere in the code.