### PR TITLE
Send confirmation mails for external accounts

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V3/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V3/Account/ExternalLogin.cshtml.cs
@@ -197,13 +197,6 @@ namespace Microsoft.AspNetCore.Identity.UI.V3.Pages.Account.Internal
                     {
                         _logger.LogInformation("User created an account using {Name} provider.", info.LoginProvider);
 
-                        // If account confirmation is required, we need to show the link if we don't have a real email sender
-                        if (_userManager.Options.SignIn.RequireConfirmedAccount)
-                        {
-                            return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
-                        }
-
-                        await _signInManager.SignInAsync(user, isPersistent: false);
                         var userId = await _userManager.GetUserIdAsync(user);
                         var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                         code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
@@ -215,6 +208,14 @@ namespace Microsoft.AspNetCore.Identity.UI.V3.Pages.Account.Internal
 
                         await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
                             $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+                        
+                        // If account confirmation is required, we need to show the link if we don't have a real email sender
+                        if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                        {
+                            return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
+                        }
+
+                        await _signInManager.SignInAsync(user, isPersistent: false);
 
                         return LocalRedirect(returnUrl);
                     }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
@@ -116,10 +116,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
             _emailSender = emailSender;
         }
 
-        public override IActionResult OnGet()
-        {
-            return RedirectToPage("./Login");
-        }
+        public override IActionResult OnGet() => RedirectToPage("./Login");
 
         public override IActionResult OnPost(string provider, string returnUrl = null)
         {
@@ -197,13 +194,6 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
                     {
                         _logger.LogInformation("User created an account using {Name} provider.", info.LoginProvider);
 
-                        // If account confirmation is required, we need to show the link if we don't have a real email sender
-                        if (_userManager.Options.SignIn.RequireConfirmedAccount)
-                        {
-                            return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
-                        }
-
-                        await _signInManager.SignInAsync(user, isPersistent: false);
                         var userId = await _userManager.GetUserIdAsync(user);
                         var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                         code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
@@ -216,6 +206,13 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
                         await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
                             $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
 
+                        // If account confirmation is required, we need to show the link if we don't have a real email sender
+                        if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                        {
+                            return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
+                        }
+
+                        await _signInManager.SignInAsync(user, isPersistent: false);
                         return LocalRedirect(returnUrl);
                     }
                 }

--- a/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Identity.DefaultUI.WebSite;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -155,9 +156,10 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
         public async Task CanRegisterWithASocialLoginProviderFromLoginWithConfirmationAndRealEmailSender()
         {
             // Arrange
+            var emailSender = new ContosoEmailSender();
             void ConfigureTestServices(IServiceCollection services)
             {
-                services.AddSingleton<IEmailSender, FakeEmailSender>();
+                services.SetupTestEmailSender(emailSender);
                 services
                         .Configure<IdentityOptions>(o => o.SignIn.RequireConfirmedAccount = true)
                         .SetupTestThirdPartyLogin();
@@ -173,6 +175,7 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
 
             // Act & Assert
             await UserStories.RegisterNewUserWithSocialLoginWithConfirmationAsync(client, userName, email, hasRealEmailSender: true);
+            Assert.Single(emailSender.SentEmails);            
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/18140

Without this fix, users who create their accounts via social login are unable to login with the templates