### PR TITLE
ModelValidation: Fixed MaxDepth exception when there are more items left then MaxValidationDepth after reaching MaxAllowedErrors

### DIFF
--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
@@ -3256,7 +3256,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
         {
             private readonly object _dummy;
             private readonly int _dummyPrimitive;
-            public StateManager(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor visitor, object newModel) { throw null; }
+            public StateManager(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor visitor) { throw null; }
             public void Dispose() { }
             public static Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.StateManager Recurse(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor visitor, string key, Microsoft.AspNetCore.Mvc.ModelBinding.ModelMetadata metadata, object model, Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IValidationStrategy strategy) { throw null; }
         }

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
@@ -3256,7 +3256,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
         {
             private readonly object _dummy;
             private readonly int _dummyPrimitive;
-            public StateManager(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor visitor) { throw null; }
+            public StateManager(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor visitor, object newModel) { throw null; }
             public void Dispose() { }
             public static Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.StateManager Recurse(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor visitor, string key, Microsoft.AspNetCore.Mvc.ModelBinding.ModelMetadata metadata, object model, Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IValidationStrategy strategy) { throw null; }
         }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
@@ -258,6 +258,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             if (ModelState.HasReachedMaxErrors)
             {
                 SuppressValidation(key);
+                _currentPath.Pop(model);
                 return false;
             }
             else if (entry != null && entry.SuppressValidation)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
@@ -226,6 +226,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             bool result;
             try
             {
+                // Throws InvalidOperationException if the object graph is too deep
                 result = VisitImplementation(ref metadata, ref key, model);
             }
             finally

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
@@ -420,7 +420,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                 object model,
                 IValidationStrategy strategy)
             {
-                var recursifier = new StateManager(visitor);
+                var recursifier = new StateManager(visitor, null);
 
                 visitor.Container = visitor.Model;
                 visitor.Key = key;
@@ -431,7 +431,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                 return recursifier;
             }
 
-            public StateManager(ValidationVisitor visitor)
+            public StateManager(ValidationVisitor visitor, object newModel)
             {
                 _visitor = visitor;
 


### PR DESCRIPTION
In the Model Validation, when MaxAllowedErrors is reached, the following models are pushed but not popped from the stack, raising incorrectly a InvalidOperationException if the number of remaining items is more then MaxValidationDepth.

Addresses #13778

Probably is better to look at the commits individually, as given I consolidated a test the diff is not optimal:
1- Consolidated two similar tests to a test theory
2 - Actual [fix](https://github.com/dotnet/aspnetcore/pull/18212/commits/870a5aa26c96ca2d87490e65882211c72c9c5d9c#diff-d930ca39121ff5a6afabf920467f4c7bR261) (later refactored) and related test case to reproduce the issue
3 - Refactored Visitor logic to reduce the risk of a missing Pop

/cc @ryanbrandenburg 
