### PR TITLE
Workaround template fix for incorrect file encoding when the first line is a conditional statement

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
@@ -1,4 +1,5 @@
-﻿@*#if (NoAuth)
+﻿
+@*#if (NoAuth)
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/18058

This is a workaround for the issue https://github.com/dotnet/templating/issues/2217.