### PR TITLE
Implement HttpRequestStreamReader.ReadToEndAsync

### DIFF
--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
@@ -152,6 +152,8 @@ namespace Microsoft.AspNetCore.WebUtilities
         public override string ReadLine() { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public override System.Threading.Tasks.Task<string> ReadToEndAsync() { throw null; }
     }
     public partial class HttpResponseStreamWriter : System.IO.TextWriter
     {

--- a/src/Http/WebUtilities/src/HttpRequestStreamReader.cs
+++ b/src/Http/WebUtilities/src/HttpRequestStreamReader.cs
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(HttpRequestStreamReader));
-            }              
+            }
 
             StringBuilder sb = null;
             var consumeLineFeed = false;
@@ -526,6 +526,20 @@ namespace Microsoft.AspNetCore.WebUtilities
             while (_charsRead == 0);
 
             return _charsRead;
+        }
+
+        public async override Task<string> ReadToEndAsync()
+        {
+            StringBuilder sb = new StringBuilder(_charsRead - _charBufferIndex);
+            do
+            {
+                int tmpCharPos = _charBufferIndex;
+                sb.Append(_charBuffer, tmpCharPos, _charsRead - tmpCharPos);
+                _charBufferIndex = _charsRead;  // We consumed these characters
+                await ReadIntoBufferAsync().ConfigureAwait(false);
+            } while (_charsRead > 0);
+
+            return sb.ToString();
         }
 
         private readonly struct ReadLineStepResult


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Implement `ReadToEndAsync` on `HttpRequestStreamReader`
 - Rename incorrectly named test class

Addresses #13834 

The implementation is based on `StreamReader.ReadToEndAsync`, adapted to work with `HttpRequestStreamReader`.