### PR TITLE
Fix linker incrementalism

### DIFF
--- a/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
@@ -22,8 +22,6 @@
   <Target
     Name="_BlazorCopyFilesToOutputDirectory"
     DependsOnTargets="PrepareBlazorOutputs"
-    Inputs="@(BlazorOutputWithTargetPath)"
-    Outputs="@(BlazorOutputWithTargetPath->'$(TargetDir)%(TargetOutputPath)')"
     AfterTargets="CopyFilesToOutputDirectory"
     Condition="'$(OutputType.ToLowerInvariant())'=='exe'">
 

--- a/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
@@ -255,6 +255,8 @@
       <Output TaskParameter="Dependencies" ItemName="_BlazorResolvedRuntimeDependencies" />
     </ResolveBlazorRuntimeDependencies>
 
+    <WriteLinesToFile File="$(_BlazorApplicationAssembliesCacheFile)" Lines="@(_BlazorResolvedRuntimeDependencies)" Overwrite="true" />
+
     <ItemGroup>
       <FileWrites Include="$(_BlazorApplicationAssembliesCacheFile)" />
     </ItemGroup>


### PR DESCRIPTION
The `Input`/`Output` values previously specified on `_BlazorCopyFilesToOutputDirectory` could lead to corrupted builds, because this kind of incrementalism skips processing files where the output is newer than the input. The incrementalism we really want here is skipping items where the output is the **same** as the input (so we do copy if it's either older or newer).

As an example of how it was broken before:

 * Build with linker enabled
 * Now set `<BlazorLinkOnBuild>false</BlazorLinkOnBuild>`
 * Now, during the next build, there will be an item with input=`<somenupkgdir>/mscorlib.dll`, output=`bin/.../mscorlib.dll`.
    * Since there's already a file at `bin/.../mscorlib.dll`, and you just generated it using the linker in step 1, the output file will be newer than the input, hence it will skip copying this
 * You now have a corrupted build, in which some of the dlls have been linked and some have not. It will fail at runtime if you start using any APIs that were linked out when you did the build in step 1.

It could even break when you upgrade to new packages, even if you're always using the linker. Example:

 * Make a build with some version of packages and linker enabled
 * Now change to different dependency versions
 * Now, during the next build, there will be an item with input=`<somenupkgdir>/SomeDependency.dll`, output=`bin/.../SomeDependency.dll`.
   * Since you just generated `bin/.../SomeDependency.dll` on your previous build a few minutes ago, its timestamp could be newer than the file from your NuGet package cache
 * Now you have a corrupted build because it's randomly using some older versions of package assemblies than you have declared

I think the fix is to copy whenever the file is different, regardless of whether it's newer or older. This is already handled by the `<CopyTask>`, since we specify `SkipUnchangedFiles` by default. So we just have to remove the input/output declarations from `_BlazorCopyFilesToOutputDirectory` and let `<CopyTask>` take care of the incrementalism.