### PR TITLE
Have TestServer merge the user-agent header 

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.TestHost
 {
@@ -111,7 +112,15 @@ namespace Microsoft.AspNetCore.TestHost
 
                 foreach (var header in request.Headers)
                 {
-                    req.Headers.Append(header.Key, header.Value.ToArray());
+                    // User-Agent is a space delineated single line header but HttpRequestHeaders parses it as multiple elements.
+                    if (string.Equals(header.Key, HeaderNames.UserAgent, StringComparison.OrdinalIgnoreCase))
+                    {
+                        req.Headers.Append(header.Key, string.Join(" ", header.Value));
+                    }
+                    else
+                    {
+                        req.Headers.Append(header.Key, header.Value.ToArray());
+                    }
                 }
 
                 if (!req.Host.HasValue)

--- a/src/Hosting/TestHost/test/ClientHandlerTests.cs
+++ b/src/Hosting/TestHost/test/ClientHandlerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.TestHost
@@ -83,6 +84,23 @@ namespace Microsoft.AspNetCore.TestHost
             }));
             var httpClient = new HttpClient(handler);
             return httpClient.GetAsync("https://example.com/");
+        }
+
+        [Fact]
+        public Task UserAgentHeaderWorks()
+        {
+            var userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0";
+            var handler = new ClientHandler(new PathString(""), new DummyApplication(context =>
+            {
+                var actualResult = context.Request.Headers[HeaderNames.UserAgent];
+                Assert.Equal(userAgent, actualResult);
+
+                return Task.CompletedTask;
+            }));
+            var httpClient = new HttpClient(handler);
+            httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, userAgent);
+
+            return httpClient.GetAsync("http://example.com");
         }
 
         [Fact]

--- a/src/Hosting/TestHost/test/HttpContextBuilderTests.cs
+++ b/src/Hosting/TestHost/test/HttpContextBuilderTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.TestHost
@@ -45,6 +46,22 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.NotNull(context.Response.Body);
             Assert.Equal(404, context.Response.StatusCode);
             Assert.Null(context.Features.Get<IHttpResponseFeature>().ReasonPhrase);
+        }
+
+        [Fact]
+        public async Task UserAgentHeaderWorks()
+        {
+            var userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0";
+            var builder = new WebHostBuilder().Configure(app => { });
+            var server = new TestServer(builder);
+            server.BaseAddress = new Uri("https://example.com/");
+            var context = await server.SendAsync(c =>
+            {
+                c.Request.Headers[HeaderNames.UserAgent] = userAgent;
+            });
+
+            var actualResult = context.Request.Headers[HeaderNames.UserAgent];
+            Assert.Equal(userAgent, actualResult);
         }
 
         [Fact]


### PR DESCRIPTION
#18198
User-Agent defies the normal HTTP rules as it's explicitly space delimited (not commas). HttpClient normally deals with this by overriding the separator (only user-agent does this).
https://github.com/dotnet/runtime/blob/aa13fb88d7640f1ccee952976ea45345c97cd7a3/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ProductInfoHeaderParser.cs#L13-L14
https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L319-L323
Unfortionately those APIs are internal, we have to add our own special case.