### PR TITLE
Fix layout of installer help page for non-ENU locales, #18152

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/thm.xml
+++ b/src/Installers/Windows/SharedFrameworkBundle/thm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
-    <Window Width="585" Height="317" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
+    <Window Width="585" Height="347" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
     <Font Id="0" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
     <Font Id="1" Height="-24" Weight="500" Foreground="000000">Segoe UI</Font>
     <Font Id="2" Height="-22" Weight="500" Foreground="666666">Segoe UI</Font>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.xml
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
-    <Window Width="485" Height="317" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
+    <Window Width="485" Height="347" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
     <Font Id="0" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
     <Font Id="1" Height="-24" Weight="500" Foreground="000000">Segoe UI</Font>
     <Font Id="2" Height="-22" Weight="500" Foreground="666666">Segoe UI</Font>


### PR DESCRIPTION
For some non-ENU locale, the help text is being clipped because the bundle UI is static. This change increases the height of the window to accommodate longer text

Fixes #18152 
