### PR TITLE
Suppress unused code warning in the shared test project

### DIFF
--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>CS0649</NoWarn><!-- Not all APIs are called in the shared test project -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Recent builds get a warning:
`Warning CS0649: Field 'HttpA piTypes.HTTP_REQUEST_PROPERTY_STREAM_ERROR.ErrorCode' is never assigned to, and will always have its default value`

This is happening because it's shared src code which confuses the analysis tools. ErrorCode is set in the HttpSys project:
https://github.com/dotnet/aspnetcore/blame/c7937640a4079465d36441724933eae5a9ca0085/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs#L233
But that type is not used in the Shared.Tests project where this warning appears.

I've suppressed the warning in the shared test project.