### PR TITLE
Fix setter for CandidateState.Values in reference assembly

### DIFF
--- a/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.Manual.cs
+++ b/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.Manual.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
     public partial struct CandidateState
     {
-        public Microsoft.AspNetCore.Routing.RouteValueDictionary Values { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Routing.RouteValueDictionary Values { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]internal set { } }
     }
 
     internal sealed partial class DataSourceDependentMatcher : Microsoft.AspNetCore.Routing.Matching.Matcher


### PR DESCRIPTION
This was caught by ApiCompat in https://github.com/dotnet/aspnetcore/pull/17959. Currently, Values.Set is internal in the implementation:
https://github.com/aspnet/AspNetCore/blob/138e801e342af561c8f12c8bfd2591d47129db82/src/Http/Routing/src/Matching/CandidateState.cs#L53
But public in the ref assembly:
https://github.com/aspnet/AspNetCore/blob/138e801e342af561c8f12c8bfd2591d47129db82/src/Http/Routing/ref/Microsoft.AspNetCore.Routing.Manual.cs#L129

Since we're patching the targeting pack in 3.1.2, we should include this change in that release so we don't have to rebuild the ref pack again down the road.

CC @dougbu @JunTaoLuo @Tratcher @Pilchie 