### PR TITLE
Enable servicing features without stabilizing the build in blazor-wasm

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -74,7 +74,7 @@
     <PackageVersionForPackageVersionInfo>$(PackageVersion)</PackageVersionForPackageVersionInfo>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsPackageInThisPatch)' != 'true' AND '$(BaselinePackageVersion)' != '' AND '$(IsServicingBuild)' == 'true' ">
+  <PropertyGroup Condition=" '$(IsPackageInThisPatch)' != 'true' AND '$(BaselinePackageVersion)' != ''">
     <!-- This keeps assembly and package versions consistent across patches. If a package is not included in a patch, its version should stay at the baseline. -->
     <AssemblyVersion Condition="$(BaselinePackageVersion.Contains('-'))">$(BaselinePackageVersion.Substring(0, $(BaselinePackageVersion.IndexOf('-')))).0</AssemblyVersion>
     <AssemblyVersion Condition="! $(BaselinePackageVersion.Contains('-'))">$(BaselinePackageVersion).0</AssemblyVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -70,6 +70,10 @@
     <IsPackable Condition=" '$(IsPackageInThisPatch)' != 'true' ">false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageVersionForPackageVersionInfo>$(PackageVersion)</PackageVersionForPackageVersionInfo>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(IsPackageInThisPatch)' != 'true' AND '$(BaselinePackageVersion)' != '' AND '$(IsServicingBuild)' == 'true' ">
     <!-- This keeps assembly and package versions consistent across patches. If a package is not included in a patch, its version should stay at the baseline. -->
     <AssemblyVersion Condition="$(BaselinePackageVersion.Contains('-'))">$(BaselinePackageVersion.Substring(0, $(BaselinePackageVersion.IndexOf('-')))).0</AssemblyVersion>
@@ -162,5 +166,9 @@
   <Import Project="eng\targets\Wix.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.wixproj'" />
   <Import Project="eng\targets\Npm.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
   <Import Project="eng\targets\ReferenceAssembly.targets" Condition=" '$(HasReferenceAssembly)' == 'true' " />
+
+  <PropertyGroup>
+    <PackageVersionForPackageVersionInfo Condition="'$(UseLatestPackageReferences)' != 'true'">$(BaselinePackageVersion)</PackageVersionForPackageVersionInfo>
+  </PropertyGroup>
 
 </Project>

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -145,44 +145,44 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' ">
-    <BaselinePackageVersion>3.0.0-preview9.19465.2</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Mono.WebAssembly.Interop" Version="[3.0.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[3.1.0-preview3.19555.2, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0-preview3.19553.2, )" />
+    <BaselinePackageReference Include="Mono.WebAssembly.Interop" Version="[3.1.0-preview3.19553.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor.Build-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Build' ">
-    <BaselinePackageVersion>3.0.0-preview9.19465.2</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Build' AND '$(TargetFramework)' == 'any' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Blazor.Mono" Version="[3.0.0-preview9.19462.2, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Blazor.Mono" Version="[3.1.0-preview3.19531.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor.DevServer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.DevServer' ">
-    <BaselinePackageVersion>3.0.0-preview9.19465.2</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor.HttpClient-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.HttpClient' ">
-    <BaselinePackageVersion>3.0.0-preview9.19465.2</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.HttpClient' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="System.Text.Json" Version="[4.6.0, )" />
+    <BaselinePackageReference Include="System.Text.Json" Version="[4.7.0-preview3.19551.4, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor.Server-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Server' ">
-    <BaselinePackageVersion>3.0.0-preview9.19465.2</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Server' AND '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[3.0.0, )" />
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Server' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="[3.1.0-preview3.19555.2, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[3.1.0-preview3.19553.2, )" />
     <BaselinePackageReference Include="Mono.Cecil" Version="[0.10.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor.Templates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Templates' ">
-    <BaselinePackageVersion>3.0.0-preview9.19465.2</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Components-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' ">

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -184,6 +184,13 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor.Templates' ">
     <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
+  <!-- Package: Mono.WebAssembly.Interop-->
+  <PropertyGroup Condition=" '$(PackageId)' == 'Mono.WebAssembly.Interop' ">
+    <BaselinePackageVersion>3.1.0-preview3.19553.2</BaselinePackageVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(PackageId)' == 'Mono.WebAssembly.Interop' AND '$(TargetFramework)' == 'netstandard2.0' ">
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0-preview3.19553.2, )" />
+  </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' ">
     <BaselinePackageVersion>3.1.1</BaselinePackageVersion>

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>3.1.0</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>3.1.1</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: AspNetCoreRuntime.3.0.x64-->
   <PropertyGroup Condition=" '$(PackageId)' == 'AspNetCoreRuntime.3.0.x64' ">
@@ -16,92 +16,92 @@
   <ItemGroup Condition=" '$(PackageId)' == 'AspNetCoreRuntime.3.0.x86' AND '$(TargetFramework)' == 'net461' " />
   <!-- Package: dotnet-sql-cache-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-sql-cache' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.ApiAuthorization.IdentityServer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.1, )" />
     <BaselinePackageReference Include="IdentityServer4" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.AspNetIdentity" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.EntityFramework" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.EntityFramework.Storage" Version="[3.0.0, )" />
     <BaselinePackageReference Include="IdentityServer4.Storage" Version="[3.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.App.Runtime.win-x64-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.App.Runtime.win-x64' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureAD.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureADB2C.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Certificate-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Certificate' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Certificate' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Facebook-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Google-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.JwtBearer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[5.5.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.MicrosoftAccount-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.Negotiate-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Negotiate' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Negotiate' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.OpenIdConnect-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[5.5.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Twitter-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Authentication.WsFederation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="[5.5.0, )" />
@@ -109,39 +109,39 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authorization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServices.HostingStartup-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServices.SiteExtension-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.SiteExtension' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.SiteExtension' AND '$(TargetFramework)' == 'net461' ">
-    <BaselinePackageReference Include="Microsoft.Web.Xdt.Extensions" Version="[3.1.0-rtm.19566.1, )" />
+    <BaselinePackageReference Include="Microsoft.Web.Xdt.Extensions" Version="[3.1.1-servicing.19615.10, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServicesIntegration-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Blazor-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' ">
@@ -186,273 +186,273 @@
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Components-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Analyzers-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Analyzers' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Authorization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Forms-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Web-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.ConcurrencyLimiter-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ConcurrencyLimiter' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ConcurrencyLimiter' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Connections.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.1.0, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Cryptography.Internal-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.Internal' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.Internal' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.Cryptography.KeyDerivation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.7.0, )" />
     <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.7.0, )" />
     <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[4.7.0, )" />
     <BaselinePackageReference Include="System.Security.Principal.Windows" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Abstractions' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.DataProtection.AzureKeyVault-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureKeyVault' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureKeyVault' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Microsoft.Azure.KeyVault" Version="[2.3.2, )" />
     <BaselinePackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.19.8, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.AzureStorage-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureStorage' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.AzureStorage' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Microsoft.Azure.Storage.Blob" Version="[10.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Data.OData" Version="[5.8.4, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.StackExchangeRedis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[3.1.1, )" />
     <BaselinePackageReference Include="StackExchange.Redis" Version="[2.0.593, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HeaderPropagation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HeaderPropagation' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HeaderPropagation' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Http" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Hosting.WindowsServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="System.ServiceProcess.ServiceController" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections.Common-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.Text.Json" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Features-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.Specification.Tests-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Testing" Version="[3.1.0-rtm.19565.4, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Testing" Version="[3.1.1-servicing.19614.4, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
     <BaselinePackageReference Include="xunit.assert" Version="[2.4.1, )" />
     <BaselinePackageReference Include="xunit.extensibility.core" Version="[2.4.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.JsonPatch-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.JsonPatch' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.JsonPatch' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.CSharp" Version="[4.7.0, )" />
@@ -460,236 +460,238 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Metadata-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Metadata' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Metadata' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.MiddlewareAnalysis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.NewtonsoftJson-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.NewtonsoftJson' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.NewtonsoftJson' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
     <BaselinePackageReference Include="Newtonsoft.Json.Bson" Version="[1.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Testing-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.TestHost" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.TestHost" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.NodeServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Console" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Console" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Owin-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' AND '$(TargetFramework)' == 'netcoreapp3.1' " />
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Libuv" Version="[1.10.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Client.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.Threading.Channels" Version="[4.7.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.Threading.Channels" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Common-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
     <BaselinePackageReference Include="System.Text.Json" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.Json-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.MessagePack-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.MessagePack' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.MessagePack' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
     <BaselinePackageReference Include="MessagePack" Version="[1.7.3.7, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[12.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Specification.Tests-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Specification.Tests' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Specification.Tests' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[3.1.1, )" />
     <BaselinePackageReference Include="xunit.assert" Version="[2.4.1, )" />
     <BaselinePackageReference Include="xunit.extensibility.core" Version="[2.4.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.StackExchangeRedis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.StackExchangeRedis' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.StackExchangeRedis' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="MessagePack" Version="[1.7.3.7, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
     <BaselinePackageReference Include="StackExchange.Redis" Version="[2.0.593, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SpaServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.NodeServices" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.NodeServices" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SpaServices.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.TestHost-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[4.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.dotnet-openapi-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.dotnet-openapi' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.Client.ItemTemplates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Client.ItemTemplates' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.ItemTemplates-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ItemTemplates' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.ProjectTemplates.3.1-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.ProjectTemplates.3.1' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.ApiDescription.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ApiDescription.Client' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.ApiDescription.Server-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ApiDescription.Server' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.1' ">
-    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Stores-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' ">
-    <BaselinePackageVersion>3.1.0</BaselinePackageVersion>
+    <BaselinePackageVersion>3.1.1</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.0, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.0, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[3.1.1, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.1, )" />
   </ItemGroup>
 </Project>

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -147,7 +147,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' ">
     <BaselinePackageVersion>3.1.0-preview3.19555.2</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' AND '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Blazor' AND '$(TargetFramework)' == 'netstandard2.1' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[3.1.0-preview3.19555.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[3.1.0-preview3.19553.2, )" />
     <BaselinePackageReference Include="Mono.WebAssembly.Interop" Version="[3.1.0-preview3.19553.2, )" />
@@ -188,7 +188,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Mono.WebAssembly.Interop' ">
     <BaselinePackageVersion>3.1.0-preview3.19553.2</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Mono.WebAssembly.Interop' AND '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Mono.WebAssembly.Interop' AND '$(TargetFramework)' == 'netstandard2.1' ">
     <BaselinePackageReference Include="Microsoft.JSInterop" Version="[3.1.0-preview3.19553.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components-->

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -25,12 +25,12 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.1.1" />
-  <Package Id="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Blazor.Templates" Version="3.0.0-preview9.19465.2" />
+  <Package Id="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
+  <Package Id="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview3.19555.2" />
+  <Package Id="Microsoft.AspNetCore.Blazor.DevServer" Version="3.1.0-preview3.19555.2" />
+  <Package Id="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.1.0-preview3.19555.2" />
+  <Package Id="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview3.19555.2" />
+  <Package Id="Microsoft.AspNetCore.Blazor.Templates" Version="3.1.0-preview3.19555.2" />
   <Package Id="Microsoft.AspNetCore.Components" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.Components.Authorization" Version="3.1.1" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -31,6 +31,7 @@ Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.1.0-preview3.19555.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview3.19555.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Templates" Version="3.1.0-preview3.19555.2" />
+  <Package Id="Mono.WebAssembly.Interop" Version="3.1.0-preview3.19553.2" />
   <Package Id="Microsoft.AspNetCore.Components" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.Components.Authorization" Version="3.1.1" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -1,89 +1,89 @@
 ﻿<!--
 
-This file contains a list of all the packages and their versions which were released in ASP.NET Core 3.1.0.
+This file contains a list of all the packages and their versions which were released in ASP.NET Core 3.1.1.
 Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="3.1.0">
+<Baseline Version="3.1.1">
   <Package Id="AspNetCoreRuntime.3.0.x64" Version="3.0.0" />
   <Package Id="AspNetCoreRuntime.3.0.x86" Version="3.0.0" />
-  <Package Id="dotnet-sql-cache" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Certificate" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authentication.WsFederation" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Authorization" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.1.0" />
+  <Package Id="dotnet-sql-cache" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Certificate" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authentication.WsFederation" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Authorization" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.1.1" />
   <Package Id="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview9.19465.2" />
   <Package Id="Microsoft.AspNetCore.Blazor.Templates" Version="3.0.0-preview9.19465.2" />
-  <Package Id="Microsoft.AspNetCore.Components" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Authorization" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Forms" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.ConcurrencyLimiter" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Cryptography.Internal" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.HeaderPropagation" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Identity.UI" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.JsonPatch" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Metadata" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.MiddlewareAnalysis" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.NodeServices" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Owin" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Client.Core" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Common" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Specification.Tests" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SpaServices" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.0" />
-  <Package Id="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
-  <Package Id="Microsoft.dotnet-openapi" Version="3.1.0" />
-  <Package Id="Microsoft.DotNet.Web.Client.ItemTemplates" Version="3.1.0" />
-  <Package Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.1.0" />
-  <Package Id="Microsoft.DotNet.Web.ProjectTemplates.3.1" Version="3.1.0" />
-  <Package Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.0" />
-  <Package Id="Microsoft.Extensions.ApiDescription.Client" Version="3.1.0" />
-  <Package Id="Microsoft.Extensions.ApiDescription.Server" Version="3.1.0" />
-  <Package Id="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
-  <Package Id="Microsoft.Extensions.Identity.Core" Version="3.1.0" />
-  <Package Id="Microsoft.Extensions.Identity.Stores" Version="3.1.0" />
+  <Package Id="Microsoft.AspNetCore.Components" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Components.Authorization" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Components.Forms" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Components.Web" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.ConcurrencyLimiter" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Cryptography.Internal" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.HeaderPropagation" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Http.Features" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Identity.UI" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.JsonPatch" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Metadata" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.MiddlewareAnalysis" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.NodeServices" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Owin" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Client" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Client.Core" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Common" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Specification.Tests" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SpaServices" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
+  <Package Id="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
+  <Package Id="Microsoft.dotnet-openapi" Version="3.1.1" />
+  <Package Id="Microsoft.DotNet.Web.Client.ItemTemplates" Version="3.1.1" />
+  <Package Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.1.1" />
+  <Package Id="Microsoft.DotNet.Web.ProjectTemplates.3.1" Version="3.1.1" />
+  <Package Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.1" />
+  <Package Id="Microsoft.Extensions.ApiDescription.Client" Version="3.1.1" />
+  <Package Id="Microsoft.Extensions.ApiDescription.Server" Version="3.1.1" />
+  <Package Id="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.1" />
+  <Package Id="Microsoft.Extensions.Identity.Core" Version="3.1.1" />
+  <Package Id="Microsoft.Extensions.Identity.Stores" Version="3.1.1" />
 </Baseline>

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -13,7 +13,7 @@ Directory.Build.props checks this property using the following condition:
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(VersionPrefix)' == '3.0.1' ">
+  <PropertyGroup>
     <PackagesInPatch>
       Microsoft.AspNetCore.Blazor;
       Microsoft.AspNetCore.Blazor.Build;

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -15,14 +15,13 @@ Directory.Build.props checks this property using the following condition:
 
   <PropertyGroup Condition=" '$(VersionPrefix)' == '3.0.1' ">
     <PackagesInPatch>
-      Microsoft.Net.Http.Headers;
-      Microsoft.AspNetCore.CookiePolicy;
-      Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
-      @microsoft/signalr;
-      Microsoft.Net.Http.Headers;
-      Microsoft.AspNetCore.Http.Abstractions;
-      Microsoft.AspNetCore.Http.Features;
-      Microsoft.AspNetCore.CookiePolicy;
+      Microsoft.AspNetCore.Blazor;
+      Microsoft.AspNetCore.Blazor.Build;
+      Microsoft.AspNetCore.Blazor.DataAnnotations.Validation;
+      Microsoft.AspNetCore.Blazor.DevServer;
+      Microsoft.AspNetCore.Blazor.HttpClient;
+      Microsoft.AspNetCore.Blazor.Server;
+      Microsoft.AspNetCore.Blazor.Templates;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
     <IncludePreReleaseLabelInPackageVersion Condition=" '$(DotNetFinalVersionKind)' == 'release' ">false</IncludePreReleaseLabelInPackageVersion>
@@ -26,6 +26,8 @@
       Until package baselines are updated (see aspnet/AspNetCore#12702), ignore them and PatchConfig.props. This also
       gives us time to build the entire repo and settle the infrastructure. Do _not_ do this when stabilizing versions.
     -->
+    <!-- We always enable servicing features in this branch, since its releases are staggered between releases of the rest of the product -->
+    <DisableServicingFeatures>false</DisableServicingFeatures>
     <DisableServicingFeatures Condition=" '$(DisableServicingFeatures)' == '' AND '$(StabilizePackageVersion)' != 'true' ">true</DisableServicingFeatures>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->
     <IsServicingBuild Condition=" '$(DisableServicingFeatures)' != 'true' AND '$(PreReleaseVersionLabel)' == 'servicing' ">true</IsServicingBuild>

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -13,7 +13,7 @@
     <ItemGroup>
       <_ProjectPathWithVersion Include="$(MSBuildProjectFullPath)">
         <PackageId>$(PackageId)</PackageId>
-        <PackageVersion>$(PackageVersion)</PackageVersion>
+        <PackageVersion>$(PackageVersionForPackageVersionInfo)</PackageVersion>
         <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <VersionVariableName>$(PackageId.Replace('.',''))PackageVersion</VersionVariableName>
       </_ProjectPathWithVersion>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -30,14 +30,12 @@
   <PropertyGroup>
     <!--
       Projects should only use the latest package references when:
-        * preparing a new major or minor release (i.e. a non-servicing builds)
         * when a project is a test or sample project
         * when a package is releasing a new patch (we like to update external dependencies in patches when possible)
     -->
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsServicingBuild)' != 'true'  ">true</UseLatestPackageReferences>
     <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseLatestPackageReferences>
     <UseLatestPackageReferences
-        Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' == 'true' AND '$(IsPackable)' == 'true' ">true</UseLatestPackageReferences>
+        Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsServicingBuild)' == 'true' AND '$(IsImplementationProject)' == 'true' AND '$(IsPackable)' == 'true' ">true</UseLatestPackageReferences>
     <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' ">false</UseLatestPackageReferences>
 
     <!--

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -40,11 +40,9 @@
 
     <!--
       Projects should only use the project references instead of baseline package references when:
-        * preparing a new major or minor release (i.e. a non-servicing builds)
         * when a project is a test or sample project
       We don't use project references between components in servicing builds between compontents to preserve the baseline as much as possible.
     -->
-    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsServicingBuild)' != 'true' ">true</UseProjectReferences>
     <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseProjectReferences>
     <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">false</UseProjectReferences>
 

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -39,12 +39,9 @@
     <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' ">false</UseLatestPackageReferences>
 
     <!--
-      Projects should only use the project references instead of baseline package references when:
-        * when a project is a test or sample project
-      We don't use project references between components in servicing builds between compontents to preserve the baseline as much as possible.
+      Always use project references. When building against the baseline, prioritize picking baseline packages over ProjectReferences.
     -->
-    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseProjectReferences>
-    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">false</UseProjectReferences>
+    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">true</UseProjectReferences>
 
     <ReferenceReferenceAssemblies Condition=" '$(ReferenceReferenceAssemblies)' == '' AND '$(IsReferenceAssemblyProject)' == 'true'">true</ReferenceReferenceAssemblies>
     <ReferenceReferenceAssemblies Condition=" '$(ReferenceReferenceAssemblies)' == '' ">false</ReferenceReferenceAssemblies>
@@ -71,8 +68,6 @@
     <_AllowedExplicitPackageReference Include="FSharp.Core" Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />
     <_ExplicitPackageReference Include="@(PackageReference)" Exclude="@(_ImplicitPackageReference);@(_AllowedExplicitPackageReference)" />
 
-    <_UnusedProjectReferenceProvider Include="@(ProjectReferenceProvider)" Exclude="@(Reference)" />
-
     <_CompilationOnlyReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="@(Reference->WithMetadataValue('NuGetPackageId','NETStandard.Library'))" />
 
     <_InvalidReferenceToNonSharedFxAssembly Condition="'$(IsAspNetCoreApp)' == 'true'"
@@ -84,24 +79,6 @@
         @(_CompilationOnlyReference);
         @(Reference->WithMetadataValue('IsSharedSource', 'true'))" />
     <_OriginalReferences Include="@(Reference)" />
-    <!--
-      Turn Reference items into a ProjectReference when UseProjectReferences is true.
-      Order matters. This comes before package resolution because projects should be used when possible instead of packages.
-    -->
-    <_ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
-      Include="@(ProjectReferenceProvider)"
-      Exclude="@(_UnusedProjectReferenceProvider)" />
-
-    <!-- Use ref assembly project paths for ref assembly projects -->
-    <ProjectReference Condition="'$(ReferenceImplementationAssemblies)' == 'true'" Include="@(_ProjectReferenceByAssemblyName->'%(ProjectPath)')" >
-      <IsReferenceAssembly>false</IsReferenceAssembly>
-    </ProjectReference>
-
-    <ProjectReference Condition="'$(ReferenceReferenceAssemblies)' == 'true'" Include="@(_ProjectReferenceByAssemblyName->'%(RefProjectPath)')" >
-      <IsReferenceAssembly>true</IsReferenceAssembly>
-    </ProjectReference>
-
-    <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
   </ItemGroup>
 
   <!--
@@ -137,7 +114,7 @@
       </Reference>
 
       <!-- Identify if any references were present in the last release of this package, but have been removed. -->
-      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(_ProjectReferenceByAssemblyName);@(PackageReference)" />
+      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(PackageReference)" />
       <!-- Only allow suppressing baseline changes in non-servicing builds. -->
       <UnusedBaselinePackageReference Remove="@(SuppressBaselineReference)" Condition="'$(IsServicingBuild)' != 'true'"/>
 
@@ -178,6 +155,27 @@
       <!-- Remove reference items that have been resolved to a LatestPackageReference item. -->
       <PackageReference Include="@(_PrivatePackageReferenceWithVersion)" IsImplicitlyDefined="true" />
       <Reference Remove="@(_PrivatePackageReferenceWithVersion)" />
+
+      <_UnusedProjectReferenceProvider Include="@(ProjectReferenceProvider)" Exclude="@(Reference)" />
+
+      <!--
+        Turn Reference items into a ProjectReference when UseProjectReferences is true.
+        Order matters. This comes after package resolution because packages should be used when possible instead of projects in this branch.
+      -->
+      <_ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
+        Include="@(ProjectReferenceProvider)"
+        Exclude="@(_UnusedProjectReferenceProvider)" />
+
+      <!-- Use ref assembly project paths for ref assembly projects -->
+      <ProjectReference Condition="'$(ReferenceImplementationAssemblies)' == 'true'" Include="@(_ProjectReferenceByAssemblyName->'%(ProjectPath)')" >
+        <IsReferenceAssembly>false</IsReferenceAssembly>
+      </ProjectReference>
+
+      <ProjectReference Condition="'$(ReferenceReferenceAssemblies)' == 'true'" Include="@(_ProjectReferenceByAssemblyName->'%(RefProjectPath)')" >
+        <IsReferenceAssembly>true</IsReferenceAssembly>
+      </ProjectReference>
+
+      <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
 
       <!-- Free up memory for unnecessary items -->
       <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" />

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -29,17 +29,12 @@
 
   <PropertyGroup>
     <!--
-      Projects should only use the latest package references when:
-        * when a project is a test or sample project
-        * when a package is releasing a new patch (we like to update external dependencies in patches when possible)
+      Always use LatestPackageReferences, but prioritize baseline packages, then ProjectReferences.
     -->
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseLatestPackageReferences>
-    <UseLatestPackageReferences
-        Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsServicingBuild)' == 'true' AND '$(IsImplementationProject)' == 'true' AND '$(IsPackable)' == 'true' ">true</UseLatestPackageReferences>
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' ">false</UseLatestPackageReferences>
+    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' ">true</UseLatestPackageReferences>
 
     <!--
-      Always use project references. When building against the baseline, prioritize picking baseline packages over ProjectReferences.
+      Always use project references. When building against the baseline, prioritize picking baseline packages over ProjectReferences, and ProjectReferences over LatestPackageReferences.
     -->
     <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">true</UseProjectReferences>
 
@@ -122,15 +117,6 @@
         MSBuild does not provide a way to join on matching identities in a Condition,
         but you can do a cartesian product of two item groups and filter out mismatched id's in a second pass.
       -->
-      <_LatestPackageReferenceWithVersion Include="@(Reference)" Condition=" '$(UseLatestPackageReferences)' == 'true' ">
-        <Id>%(LatestPackageReference.Identity)</Id>
-        <Version>%(LatestPackageReference.Version)</Version>
-      </_LatestPackageReferenceWithVersion>
-      <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
-
-      <!-- Remove reference items that have been resolved to a LatestPackageReference item. -->
-      <Reference Remove="@(_LatestPackageReferenceWithVersion)" />
-      <PackageReference Include="@(_LatestPackageReferenceWithVersion)" IsImplicitlyDefined="true" />
 
       <!-- Resolve references from BaselinePackageReference for servicing builds. -->
       <_BaselinePackageReferenceWithVersion Include="@(Reference)" Condition=" '$(IsServicingBuild)' == 'true' OR '$(UseLatestPackageReferences)' != 'true' ">
@@ -176,6 +162,16 @@
       </ProjectReference>
 
       <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
+
+      <_LatestPackageReferenceWithVersion Include="@(Reference)" Condition=" '$(UseLatestPackageReferences)' == 'true' ">
+        <Id>%(LatestPackageReference.Identity)</Id>
+        <Version>%(LatestPackageReference.Version)</Version>
+      </_LatestPackageReferenceWithVersion>
+      <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
+
+      <!-- Remove reference items that have been resolved to a LatestPackageReference item. -->
+      <Reference Remove="@(_LatestPackageReferenceWithVersion)" />
+      <PackageReference Include="@(_LatestPackageReferenceWithVersion)" IsImplicitlyDefined="true" />
 
       <!-- Free up memory for unnecessary items -->
       <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" />

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -100,7 +100,7 @@
     This target resolves remaining Referene items to Packages, if possible. If not, they are left as Reference items fo the SDK to resolve.
     This executes on NuGet restore and during DesignTimeBuild. It should not run in the outer, cross-targeting build.
    -->
-  <Target Name="ResolveCustomReferences" BeforeTargets="CollectPackageReferences;ResolveAssemblyReferencesDesignTime;ResolveAssemblyReferences" Condition=" '$(TargetFramework)' != '' AND '$(EnableCustomReferenceResolution)' == 'true' ">
+  <Target Name="ResolveCustomReferences" BeforeTargets="CollectPackageReferences;ResolveAssemblyReferencesDesignTime;ResolveAssemblyReferences;Restore" Condition=" '$(TargetFramework)' != '' AND '$(EnableCustomReferenceResolution)' == 'true' ">
     <ItemGroup>
       <!-- Ensure only content asset are consumed from .Sources packages -->
       <Reference>

--- a/src/Components/Blazor/Blazor.Version.props
+++ b/src/Components/Blazor/Blazor.Version.props
@@ -3,6 +3,5 @@
     <!-- Override version labels -->
     <VersionPrefix>3.2.0</VersionPrefix>
     <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
-    <DotNetFinalVersionKind />
   </PropertyGroup>
 </Project>

--- a/src/Components/Blazor/Blazor/src/Microsoft.AspNetCore.Blazor.csproj
+++ b/src/Components/Blazor/Blazor/src/Microsoft.AspNetCore.Blazor.csproj
@@ -12,6 +12,12 @@
     <Reference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <!-- References to Blazor projects are explicitly ProjectReferences, so that our reference resolution never tries to use the baseline -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\Mono.WebAssembly.Interop\src\Mono.WebAssembly.Interop.csproj" />
+  </ItemGroup>
+
+
   <ItemGroup>
     <Compile Include="$(ComponentsSharedSourceRoot)src\BrowserNavigationManagerInterop.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\JsonSerializerOptionsProvider.cs" />

--- a/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
+++ b/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
@@ -17,8 +17,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore.Blazor.Server" />
     <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
+  </ItemGroup>
+
+  <!-- References to Blazor projects are explicitly ProjectReferences, so that our reference resolution never tries to use the baseline -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\Server\src\Microsoft.AspNetCore.Blazor.Server.csproj" />
   </ItemGroup>
 
   <!-- Pack settings -->

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -5,6 +5,6 @@
   <PropertyGroup>
     <!-- This property points to the latest released Microsoft.AspNetCore.App version it needs to be updated to
          target the latest patch before a preview release. -->
-    <LatestAspNetCoreReferenceVersion>3.1.0</LatestAspNetCoreReferenceVersion>
+    <LatestAspNetCoreReferenceVersion>3.1.1</LatestAspNetCoreReferenceVersion>
   </PropertyGroup>
 </Project>

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -14,7 +14,7 @@
 
     <!-- This property points to the latest released Microsoft.AspNetCore.App version it needs to be updated to
          target the latest patch before a preview release. -->
-    <LatestAspNetCoreReferenceVersion>3.1.0</LatestAspNetCoreReferenceVersion>
+    <LatestAspNetCoreReferenceVersion>3.1.1</LatestAspNetCoreReferenceVersion>
 
     <ComponentsSharedSourceRoot>$(MSBuildThisFileDirectory)Shared\</ComponentsSharedSourceRoot>
 

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -15,7 +15,7 @@
         <DefaultRuntimeFrameworkVersion>$(LatestAspNetCoreReferenceVersion)</DefaultRuntimeFrameworkVersion>
         <LatestRuntimeFrameworkVersion>$(LatestAspNetCoreReferenceVersion)</LatestRuntimeFrameworkVersion>
         <TargetingPackName>Microsoft.AspNetCore.App.Ref</TargetingPackName>
-        <TargetingPackVersion>$(LatestAspNetCoreReferenceVersion)</TargetingPackVersion>
+        <TargetingPackVersion>3.1.0</TargetingPackVersion>
         <RuntimePackNamePatterns>Microsoft.AspNetCore.App.Runtime.**RID**</RuntimePackNamePatterns>
         <RuntimePackRuntimeIdentifiers>linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86</RuntimePackRuntimeIdentifiers>
         <IsTrimmable>true</IsTrimmable>


### PR DESCRIPTION
WIP of using servicing features without stablizing.

Right now, every build of the `blazor-wasm` branch is marked stable, which means every build publishes packages to a unique feed. The goal is to have all blazor-wasm packages published to one feed (except when we _actually_ want to build stable packages). We still need to enable servicing features, though, because we need to always build against the latest stable packages available (that is, what's in the baseline).

This PR does the following things:

- Always build against what's in the baseline for implementation assemblies (never use latestPackageReference or ProjectReference)
- Add explicit ProjectReferences between Blazor projects
- Update the baseline to 3.1.1
- Use baseline package versions for projects trying to determine PackageVersions of other projects