### PR TITLE
HeaderPropagation: reset AsyncLocal per request

### DIFF
--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationMiddleware.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationMiddleware.cs
@@ -33,7 +33,8 @@ namespace Microsoft.AspNetCore.HeaderPropagation
             _values = values ?? throw new ArgumentNullException(nameof(values));
         }
 
-        public Task Invoke(HttpContext context)
+        // This needs to be async as otherwise the AsyncLocal could bleed across requests, see https://github.com/aspnet/AspNetCore/issues/13991.
+        public async Task Invoke(HttpContext context)
         {
             // We need to intialize the headers because the message handler will use this to detect misconfiguration.
             var headers = _values.Headers ??= new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
@@ -56,7 +57,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
                 }
             }
 
-            return _next.Invoke(context);
+            await _next.Invoke(context);
         }
 
         private static StringValues GetValue(HttpContext context, HeaderPropagationEntry entry)


### PR DESCRIPTION
As Kestrel can bleed the AsyncLocal across requests, see #13991.

Backported from #15435, this change will not be needed on master, as the underlying Kestrel issue will be probably fixed with #14146.

Addresses #15384

/cc @anurse 