### PR TITLE
Fix ANCM search for dotnet.exe

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -145,9 +145,10 @@ HostFxrResolver::GetHostFxrParameters(
 }
 
 BOOL
-HostFxrResolver::IsDotnetExecutable(const std::filesystem::path & dotnetPath)
+HostFxrResolver::IsDotnetExecutable(const std::filesystem::path& dotnetPath)
 {
-    return ends_with(dotnetPath, L"dotnet.exe", true);
+    std::wstring filename = dotnetPath.filename().wstring();
+    return equals_ignore_case(filename, L"dotnet.exe");
 }
 
 void

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ConfigUtilityTests.cpp" />
+    <ClCompile Include="dotnet_exe_path_tests.cpp" />
     <ClCompile Include="GlobalVersionTests.cpp" />
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="inprocess_application_tests.cpp" />
@@ -70,6 +71,17 @@
     <ProjectReference Include="..\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
       <Project>{d57ea297-6dc2-4bc0-8c91-334863327863}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Fake\hello-dotnet.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fake\hello-dotnet.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fake\hostfxr.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/Fake/hello-dotnet.dll
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/Fake/hello-dotnet.dll
@@ -1,0 +1,1 @@
+this a is faked hello-dotnet.dll used for tests

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/Fake/hello-dotnet.exe
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/Fake/hello-dotnet.exe
@@ -1,0 +1,1 @@
+this a is faked hello-dotnet.exe used for tests

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/Fake/hostfxr.dll
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/Fake/hostfxr.dll
@@ -1,0 +1,1 @@
+this a is faked hostfxr.dll used for tests

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/dotnet_exe_path_tests.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/dotnet_exe_path_tests.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+
+#include <array>
+#include "fakeclasses.h"
+#include "HostFxrResolver.h"
+
+using ::testing::_;
+using ::testing::NiceMock;
+
+// Externals defined in inprocess
+namespace InprocessTests
+{
+
+    TEST(Dotnet_EXE_Path_Tests, EndWith_dotnet)
+    {
+        HostFxrResolver resolver;
+        std::filesystem::path hostFxrDllPath;
+        std::vector<std::wstring> arguments;
+        ErrorContext errorContext;
+        auto currentPath = std::filesystem::current_path();
+        auto appPath= currentPath /= L"Fake";
+        auto processPath = L"hello-dotnet";
+        auto args = L"-a --tag t -x";
+        std::filesystem::path knownDotnetLocation=L"C:/Program Files/dotnet";
+        // expected no exception should be thrown
+        HostFxrResolver::GetHostFxrParameters(
+            processPath,
+            appPath,
+            args,
+            hostFxrDllPath,
+            knownDotnetLocation,
+            arguments,
+            errorContext);
+
+        ASSERT_TRUE(ends_with(arguments[0], L"\\Fake\\hello-dotnet.exe", true));
+        ASSERT_STREQ(arguments[1].c_str(), L"-a");
+        ASSERT_STREQ(arguments[2].c_str(), L"--tag");
+        ASSERT_STREQ(arguments[3].c_str(), L"t");
+        ASSERT_STREQ(arguments[4].c_str(), L"-x");
+    }
+}


### PR DESCRIPTION

 - Change to [`IsDotnetExecutable()`](https://github.com/dotnet/aspnetcore/blob/605c522fa3e875fd6d3aefa783a71d1745b7e4c7/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp#L148-L151) to determine by the filename instead of by ends_with()
 - add an Unit Test

Addresses #17393  (It was caused by [this line](https://github.com/dotnet/aspnetcore/blob/605c522fa3e875fd6d3aefa783a71d1745b7e4c7/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp#L148-L151):
```
return ends_with(dotnetPath, L"dotnet.exe", true);
```

