### PR TITLE
Make kestrel not use the modified Http Protocol

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -37,8 +37,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         string IHttpRequestFeature.Protocol
         {
-            get => HttpVersion;
-            set => HttpVersion = value;
+            get => _httpProtocol ??= HttpVersion;
+            set => _httpProtocol = value;
         }
 
         string IHttpRequestFeature.Scheme

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -57,6 +57,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private BadHttpRequestException _requestRejectedException;
 
         protected HttpVersion _httpVersion;
+        // This should only be used by the application, not the server. This is settable on HttpRequest but we don't want that to affect
+        // how Kestrel processes requests/responses.
+        private string _httpProtocol;
 
         private string _requestId;
         private int _requestHeadersParsed;
@@ -351,6 +354,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             RawTarget = null;
             QueryString = null;
             _httpVersion = Http.HttpVersion.Unknown;
+            _httpProtocol = null;
             _statusCode = StatusCodes.Status200OK;
             _reasonPhrase = null;
 


### PR DESCRIPTION
#17975 @JamesNK found that when he was implementing grpc-web and pretending the HTTP/1.1 requests were HTTP/2, Kestrel's response generation logic would break. Kestrel should not use the user-modifiable request protocol field when generating responses, it will confuse the client.