### PR TITLE
Update static HTML with name ASP.NET Core Module instead of ANCM

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -56,7 +56,7 @@ HandlerResolver::LoadRequestHandlerAssembly(const IHttpApplication &pApplication
     {
         if (pConfiguration.QueryHostingModel() == APP_HOSTING_MODEL::HOSTING_IN_PROCESS)
         {
-            errorContext.generalErrorType = "ASP.NET Core Module In-Process Handler Load Failure";
+            errorContext.generalErrorType = "ASP.NET Core IIS hosting failure (in-process)";
             std::unique_ptr<HostFxrResolutionResult> options;
 
             RETURN_IF_FAILED(HostFxrResolutionResult::Create(
@@ -86,7 +86,7 @@ HandlerResolver::LoadRequestHandlerAssembly(const IHttpApplication &pApplication
         }
         else
         {
-            errorContext.generalErrorType = "ASP.NET Core Module Out-Of-Process Handler Load Failure";
+            errorContext.generalErrorType = "ASP.NET Core IIS hosting failure (out-of-process)";
 
             if (FAILED_LOG(hr = FindNativeAssemblyFromGlobalLocation(pConfiguration, pstrHandlerDllName, handlerDllPath)))
             {
@@ -136,8 +136,8 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, std
             errorContext.detailedErrorContent = to_multi_byte_string(format(ASPNETCORE_EVENT_MIXED_HOSTING_MODEL_ERROR_MSG, pApplication.GetApplicationId(), options.QueryHostingModel()), CP_UTF8);
             errorContext.statusCode = 500i16;
             errorContext.subStatusCode = 34i16;
-            errorContext.generalErrorType = "ASP.NET Core Module Mixed Hosting Models Not Supported";
-            errorContext.errorReason = "Select a different application pool to create another application.";
+            errorContext.generalErrorType = "ASP.NET Core does not support mixing hosting models";
+            errorContext.errorReason = "Select a different app pool to host this app.";
 
             EventLog::Error(
                 ASPNETCORE_EVENT_MIXED_HOSTING_MODEL_ERROR,
@@ -154,8 +154,8 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, std
 
             errorContext.statusCode = 500i16;
             errorContext.subStatusCode = 35i16;
-            errorContext.generalErrorType = "ASP.NET Core Module Multiple In-Process Applications in same Process";
-            errorContext.errorReason = "Select a different application pool to create another in-process application.";
+            errorContext.generalErrorType = "ASP.NET Core does not support multiple apps in the same app pool";
+            errorContext.errorReason = "Select a different app pool to host this app.";
 
             EventLog::Error(
                 ASPNETCORE_EVENT_DUPLICATED_INPROCESS_APP,
@@ -251,8 +251,8 @@ try
         errorContext.detailedErrorContent = "Could not load hostfxr.dll.";
         errorContext.statusCode = 500i16;
         errorContext.subStatusCode = 32i16;
-        errorContext.generalErrorType = "ASP.NET Core Module Failed to Load dll";
-        errorContext.errorReason = "The application was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as.";
+        errorContext.generalErrorType = "Failed to load .NET Core host";
+        errorContext.errorReason = "The app was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as.";
         throw;
     }
     {
@@ -302,7 +302,7 @@ try
 
                 errorContext.statusCode = 500i16;
                 errorContext.subStatusCode = 31i16;
-                errorContext.generalErrorType = "ASP.NET Core Module Failed to Find Native Dependencies";
+                errorContext.generalErrorType = "Failed to load ASP.NET Core runtime";
                 errorContext.errorReason = "The specified version of Microsoft.NetCore.App or Microsoft.AspNetCore.App was not found.";
 
                 EventLog::Error(
@@ -347,7 +347,7 @@ try
         // This only occurs if the request handler isn't referenced by the app, which rarely happens if they are targeting the shared framework.
         errorContext.statusCode = 500i16;
         errorContext.subStatusCode = 33i16;
-        errorContext.generalErrorType = "ASP.NET Core Module Request Handler Load Failure";
+        errorContext.generalErrorType = "Failed to load ASP.NET Core request handler";
         errorContext.detailedErrorContent = to_multi_byte_string(format(ASPNETCORE_EVENT_INPROCESS_RH_REFERENCE_MSG, handlerDllPath.empty()
                 ? s_pwzAspnetcoreInProcessRequestHandlerName
                 : handlerDllPath.c_str()),

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -56,7 +56,7 @@ HandlerResolver::LoadRequestHandlerAssembly(const IHttpApplication &pApplication
     {
         if (pConfiguration.QueryHostingModel() == APP_HOSTING_MODEL::HOSTING_IN_PROCESS)
         {
-            errorContext.generalErrorType = "ANCM In-Process Handler Load Failure";
+            errorContext.generalErrorType = "ASP.NET Core Module In-Process Handler Load Failure";
             std::unique_ptr<HostFxrResolutionResult> options;
 
             RETURN_IF_FAILED(HostFxrResolutionResult::Create(
@@ -86,7 +86,7 @@ HandlerResolver::LoadRequestHandlerAssembly(const IHttpApplication &pApplication
         }
         else
         {
-            errorContext.generalErrorType = "ANCM Out-Of-Process Handler Load Failure";
+            errorContext.generalErrorType = "ASP.NET Core Module Out-Of-Process Handler Load Failure";
 
             if (FAILED_LOG(hr = FindNativeAssemblyFromGlobalLocation(pConfiguration, pstrHandlerDllName, handlerDllPath)))
             {
@@ -136,7 +136,7 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, std
             errorContext.detailedErrorContent = to_multi_byte_string(format(ASPNETCORE_EVENT_MIXED_HOSTING_MODEL_ERROR_MSG, pApplication.GetApplicationId(), options.QueryHostingModel()), CP_UTF8);
             errorContext.statusCode = 500i16;
             errorContext.subStatusCode = 34i16;
-            errorContext.generalErrorType = "ANCM Mixed Hosting Models Not Supported";
+            errorContext.generalErrorType = "ASP.NET Core Module Mixed Hosting Models Not Supported";
             errorContext.errorReason = "Select a different application pool to create another application.";
 
             EventLog::Error(
@@ -154,7 +154,7 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, std
 
             errorContext.statusCode = 500i16;
             errorContext.subStatusCode = 35i16;
-            errorContext.generalErrorType = "ANCM Multiple In-Process Applications in same Process";
+            errorContext.generalErrorType = "ASP.NET Core Module Multiple In-Process Applications in same Process";
             errorContext.errorReason = "Select a different application pool to create another in-process application.";
 
             EventLog::Error(
@@ -251,7 +251,7 @@ try
         errorContext.detailedErrorContent = "Could not load hostfxr.dll.";
         errorContext.statusCode = 500i16;
         errorContext.subStatusCode = 32i16;
-        errorContext.generalErrorType = "ANCM Failed to Load dll";
+        errorContext.generalErrorType = "ASP.NET Core Module Failed to Load dll";
         errorContext.errorReason = "The application was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as.";
         throw;
     }
@@ -302,7 +302,7 @@ try
 
                 errorContext.statusCode = 500i16;
                 errorContext.subStatusCode = 31i16;
-                errorContext.generalErrorType = "ANCM Failed to Find Native Dependencies";
+                errorContext.generalErrorType = "ASP.NET Core Module Failed to Find Native Dependencies";
                 errorContext.errorReason = "The specified version of Microsoft.NetCore.App or Microsoft.AspNetCore.App was not found.";
 
                 EventLog::Error(
@@ -347,7 +347,7 @@ try
         // This only occurs if the request handler isn't referenced by the app, which rarely happens if they are targeting the shared framework.
         errorContext.statusCode = 500i16;
         errorContext.subStatusCode = 33i16;
-        errorContext.generalErrorType = "ANCM Request Handler Load Failure";
+        errorContext.generalErrorType = "ASP.NET Core Module Request Handler Load Failure";
         errorContext.detailedErrorContent = to_multi_byte_string(format(ASPNETCORE_EVENT_INPROCESS_RH_REFERENCE_MSG, handlerDllPath.empty()
                 ? s_pwzAspnetcoreInProcessRequestHandlerName
                 : handlerDllPath.c_str()),

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -95,11 +95,11 @@ HostFxrResolver::GetHostFxrParameters(
             if (!is_regular_file(applicationDllPath))
             {
                 errorContext.subStatusCode = 38;
-                errorContext.errorReason = "Application DLL not found. Confirm the application dll is present. Single-file deployments are not supported in IIS.";
-                errorContext.generalErrorType = "ASP.NET Core Module Application DLL Not Found";
-                errorContext.detailedErrorContent = format("Application DLL was not found at %s.", to_multi_byte_string(applicationDllPath, CP_UTF8).c_str());
+                errorContext.errorReason = "The app couldn't be found. Confirm the app's main DLL is present. Single-file deployments are not supported in IIS.";
+                errorContext.generalErrorType = "Failed to locate ASP.NET Core app";
+                errorContext.detailedErrorContent = format("Application was not found at %s.", to_multi_byte_string(applicationDllPath, CP_UTF8).c_str());
                 throw InvalidOperationException(
-                    format(L"Application DLL was not found at %s. Confirm the application dll is present. Single-file deployments are not supported in IIS.",
+                    format(L"The app couldn't be found at %s. Confirm the app's main DLL is present. Single-file deployments are not supported in IIS.",
                         applicationDllPath.c_str()));
             }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -96,7 +96,7 @@ HostFxrResolver::GetHostFxrParameters(
             {
                 errorContext.subStatusCode = 38;
                 errorContext.errorReason = "Application DLL not found. Confirm the application dll is present. Single-file deployments are not supported in IIS.";
-                errorContext.generalErrorType = "ANCM Application DLL Not Found";
+                errorContext.generalErrorType = "ASP.NET Core Module Application DLL Not Found";
                 errorContext.detailedErrorContent = format("Application DLL was not found at %s.", to_multi_byte_string(applicationDllPath, CP_UTF8).c_str());
                 throw InvalidOperationException(
                     format(L"Application DLL was not found at %s. Confirm the application dll is present. Single-file deployments are not supported in IIS.",

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/dllmain.cpp
@@ -125,8 +125,8 @@ CreateApplication(
         ErrorContext errorContext;
         errorContext.statusCode = 500;
         errorContext.subStatusCode = 30;
-        errorContext.generalErrorType = "ASP.NET Core Module In-Process Start Failure";
-        errorContext.errorReason = "<ul><li>The application failed to start</li><li>The application started but then stopped</li><li>The application started but threw an exception during startup</li></ul>";
+        errorContext.generalErrorType = "ASP.NET Core app failed to start";
+        errorContext.errorReason = "<ul><li>The app failed to start</li><li>The app started but then stopped</li><li>The app started but threw an exception during startup</li></ul>";
 
         if (!FAILED_LOG(hr = IN_PROCESS_APPLICATION::Start(*pServer, pSite, *pHttpApplication, pParameters, nParameters, inProcessApplication, errorContext)))
         {

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/dllmain.cpp
@@ -125,7 +125,7 @@ CreateApplication(
         ErrorContext errorContext;
         errorContext.statusCode = 500;
         errorContext.subStatusCode = 30;
-        errorContext.generalErrorType = "ANCM In-Process Start Failure";
+        errorContext.generalErrorType = "ASP.NET Core Module In-Process Start Failure";
         errorContext.errorReason = "<ul><li>The application failed to start</li><li>The application started but then stopped</li><li>The application started but threw an exception during startup</li></ul>";
 
         if (!FAILED_LOG(hr = IN_PROCESS_APPLICATION::Start(*pServer, pSite, *pHttpApplication, pParameters, nParameters, inProcessApplication, errorContext)))

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -165,8 +165,8 @@ IN_PROCESS_APPLICATION::LoadManagedApplication(ErrorContext& errorContext)
         // If server wasn't initialized in time shut application down without waiting for CLR thread to exit
         errorContext.statusCode = 500;
         errorContext.subStatusCode = 37;
-        errorContext.generalErrorType = "ANCM Failed to Start Within Startup Time Limit";
-        errorContext.errorReason = format("ANCM failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
+        errorContext.generalErrorType = "ASP.NET Core Module Failed to Start Within Startup Time Limit";
+        errorContext.errorReason = format("ASP.NET Core Module failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
 
         m_waitForShutdown = false;
         StopClr();

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -165,8 +165,8 @@ IN_PROCESS_APPLICATION::LoadManagedApplication(ErrorContext& errorContext)
         // If server wasn't initialized in time shut application down without waiting for CLR thread to exit
         errorContext.statusCode = 500;
         errorContext.subStatusCode = 37;
-        errorContext.generalErrorType = "ASP.NET Core Module Failed to Start Within Startup Time Limit";
-        errorContext.errorReason = format("ASP.NET Core Module failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
+        errorContext.generalErrorType = "ASP.NET Core app failed to start within startup time limit";
+        errorContext.errorReason = format("ASP.NET Core app failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
 
         m_waitForShutdown = false;
         StopClr();

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ErrorPagesTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ErrorPagesTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             StopServer();
 
             var responseString = await response.Content.ReadAsStringAsync();
-            Assert.Contains("HTTP Error 500.0 - ANCM In-Process Handler Load Failure", responseString);
+            Assert.Contains("500.0", responseString);
             VerifyNoExtraTrailingBytes(responseString);
 
             await AssertLink(response);
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             StopServer();
 
             var responseString = await response.Content.ReadAsStringAsync();
-            Assert.Contains("HTTP Error 500.0 - ANCM Out-Of-Process Handler Load Failure", responseString);
+            Assert.Contains("500.0", responseString);
             VerifyNoExtraTrailingBytes(responseString);
 
             await AssertLink(response);
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             StopServer();
 
             var responseString = await response.Content.ReadAsStringAsync();
-            Assert.Contains("HTTP Error 500.30 - ANCM In-Process Start Failure", responseString);
+            Assert.Contains("500.30", responseString);
             VerifyNoExtraTrailingBytes(responseString);
 
             await AssertLink(response);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupExceptionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupExceptionTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
             var responseText = await response.Content.ReadAsStringAsync();
-            Assert.Contains("500.30 - ANCM In-Process Start Failure", responseText);
+            Assert.Contains("500.30", responseText);
         }
     }
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -62,8 +62,14 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             StopServer();
 
             EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
-
-            Assert.Contains("HTTP Error 500.0 - ANCM In-Process Handler Load Failure", await response.Content.ReadAsStringAsync());
+            if (DeployerSelector.HasNewShim)
+            {
+                Assert.Contains("HTTP Error 500.0 - ASP.NET Core Module In-Process Handler Load Failure", await response.Content.ReadAsStringAsync());
+            }
+            else 
+            {
+                Assert.Contains("HTTP Error 500.0 - ANCM In-Process Handler Load Failure", await response.Content.ReadAsStringAsync());
+            }
         }
 
         [ConditionalFact]
@@ -271,7 +277,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.32 - ANCM Failed to Load dll");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.32 - ASP.NET Core Module Failed to Load dll");
             }
             else
             {
@@ -314,7 +320,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32 - ANCM Failed to Load dll");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32 - ASP.NET Core Module Failed to Load dll");
             }
             else
             {
@@ -335,7 +341,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.32 - ANCM Failed to Load dll");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.32 - ASP.NET Core Module Failed to Load dll");
             }
             else
             {
@@ -354,7 +360,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ANCM Failed to Find Native Dependencies");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ASP.NET Core Module Failed to Find Native Dependencies");
             }
             else
             {
@@ -374,7 +380,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             File.Delete(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.dll"));
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.38 - ANCM Application DLL Not Found");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.38 - ASP.NET Core Module Application DLL Not Found");
             }
             else
             {
@@ -396,7 +402,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
                 var responseContent = await response.Content.ReadAsStringAsync();
-                Assert.Contains("HTTP Error 500.31 - ANCM Failed to Find Native Dependencies", responseContent);
+                Assert.Contains("HTTP Error 500.31 - ASP.NET Core Module Failed to Find Native Dependencies", responseContent);
                 Assert.Contains("The framework 'Microsoft.NETCore.App', version '2.9.9'", responseContent);
             }
             else
@@ -416,14 +422,14 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim && DeployerSelector.HasNewHandler)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.33 - ANCM Request Handler Load Failure ");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.33 - ASP.NET Core Module Request Handler Load Failure ");
 
                 EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
             }
             else if (DeployerSelector.HasNewShim)
             {
                 // Forwards compat tests fail earlier due to a error with the M.AspNetCore.Server.IIS package.
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ANCM Failed to Find Native Dependencies");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ASP.NET Core Module Failed to Find Native Dependencies");
 
                 EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
             }
@@ -462,7 +468,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 if (DeployerSelector.HasNewHandler)
                 {
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    Assert.Contains("ANCM Failed to Start Within Startup Time Limit", responseContent);
+                    Assert.Contains("ASP.NET Core Module Failed to Start Within Startup Time Limit", responseContent);
                 }
             }
         }
@@ -765,7 +771,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Assert.Contains("InvalidOperationException", content);
             Assert.Contains("TestSite.Program.Main", content);
             Assert.Contains("From Configure", content);
-            Assert.DoesNotContain("ANCM In-Process Start Failure", content);
+            Assert.DoesNotContain("ASP.NET Core Module In-Process Start Failure", content);
 
             StopServer();
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -64,11 +64,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
             if (DeployerSelector.HasNewShim)
             {
-                Assert.Contains("HTTP Error 500.0 - ASP.NET Core Module In-Process Handler Load Failure", await response.Content.ReadAsStringAsync());
+                Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
             }
             else 
             {
-                Assert.Contains("HTTP Error 500.0 - ANCM In-Process Handler Load Failure", await response.Content.ReadAsStringAsync());
+                Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
             }
         }
 
@@ -277,7 +277,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.32 - ASP.NET Core Module Failed to Load dll");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
             }
             else
             {
@@ -320,11 +320,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32 - ASP.NET Core Module Failed to Load dll");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
             }
             else
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.0 - ANCM In-Process Handler Load Failure");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.0");
             }
         }
 
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.32 - ASP.NET Core Module Failed to Load dll");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
             }
             else
             {
@@ -360,7 +360,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ASP.NET Core Module Failed to Find Native Dependencies");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31");
             }
             else
             {
@@ -380,7 +380,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             File.Delete(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.dll"));
             if (DeployerSelector.HasNewShim)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.38 - ASP.NET Core Module Application DLL Not Found");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.38");
             }
             else
             {
@@ -402,7 +402,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
                 var responseContent = await response.Content.ReadAsStringAsync();
-                Assert.Contains("HTTP Error 500.31 - ASP.NET Core Module Failed to Find Native Dependencies", responseContent);
+                Assert.Contains("500.31", responseContent);
                 Assert.Contains("The framework 'Microsoft.NETCore.App', version '2.9.9'", responseContent);
             }
             else
@@ -422,14 +422,14 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             if (DeployerSelector.HasNewShim && DeployerSelector.HasNewHandler)
             {
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.33 - ASP.NET Core Module Request Handler Load Failure ");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.33");
 
                 EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
             }
             else if (DeployerSelector.HasNewShim)
             {
                 // Forwards compat tests fail earlier due to a error with the M.AspNetCore.Server.IIS package.
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.31 - ASP.NET Core Module Failed to Find Native Dependencies");
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31");
 
                 EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
             }
@@ -468,7 +468,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 if (DeployerSelector.HasNewHandler)
                 {
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    Assert.Contains("ASP.NET Core Module Failed to Start Within Startup Time Limit", responseContent);
+                    Assert.Contains("500.37", responseContent);
                 }
             }
         }
@@ -771,7 +771,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
             Assert.Contains("InvalidOperationException", content);
             Assert.Contains("TestSite.Program.Main", content);
             Assert.Contains("From Configure", content);
-            Assert.DoesNotContain("ASP.NET Core Module In-Process Start Failure", content);
 
             StopServer();
 
@@ -938,7 +937,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
         private Task AssertSiteFailsToStartWithInProcessStaticContent(IISDeploymentResult deploymentResult)
         {
-            return AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "HTTP Error 500.0 - ANCM In-Process Handler Load Failure");
+            return AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.0");
         }
 
         private async Task AssertSiteFailsToStartWithInProcessStaticContent(IISDeploymentResult deploymentResult, string error)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
             if (DeployerSelector.HasNewShim)
             {
-                Assert.Contains("500.35 - ANCM Multiple In-Process Applications in same Process", await result2.Content.ReadAsStringAsync());
+                Assert.Contains("500.35", await result2.Content.ReadAsStringAsync());
             }
 
             EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.OnlyOneAppPerAppPool(), Logger);
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
             if (DeployerSelector.HasNewShim)
             {
-                Assert.Contains("500.34 - ANCM Mixed Hosting Models Not Supported", await result2.Content.ReadAsStringAsync());
+                Assert.Contains("500.34", await result2.Content.ReadAsStringAsync());
             }
 
             EventLogHelpers.VerifyEventLogEvent(result, "Mixed hosting model is not supported.", Logger);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/GlobalVersionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/GlobalVersionTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
             var response = await deploymentResult.HttpClient.GetAsync(_helloWorldRequest);
             Assert.False(response.IsSuccessStatusCode);
             var responseString = await response.Content.ReadAsStringAsync();
-            Assert.Contains("HTTP Error 500.0 - ANCM Out-Of-Process Handler Load Failure", responseString);
+            Assert.Contains("500.0", responseString);
         }
 
         [ConditionalTheory]


### PR DESCRIPTION
Suggestion by @RickStrahl on twitter. ANCM isn't clear what it is referring to.

There will probably be a few tests to shake out as I didn't run tests locally.