### PR TITLE
[release/3.1] Mark Blazor packages as nonshipping

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,7 +9,7 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.AspNetCore.Blazor.Mono" Version="3.1.0-preview4.19605.1">
+    <Dependency Name="Microsoft.AspNetCore.Blazor.Mono" Version="3.1.0-preview4.19605.1" Pinned="true">
       <Uri>https://github.com/aspnet/Blazor</Uri>
       <Sha>7868699de745fd30a654c798a99dc541b77b95c0</Sha>
     </Dependency>

--- a/src/Components/Blazor/Blazor/src/Microsoft.AspNetCore.Blazor.csproj
+++ b/src/Components/Blazor/Blazor/src/Microsoft.AspNetCore.Blazor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Build client-side single-page applications (SPAs) with Blazor running under WebAssembly.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Blazor/src/Microsoft.AspNetCore.Blazor.csproj
+++ b/src/Components/Blazor/Blazor/src/Microsoft.AspNetCore.Blazor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Build client-side single-page applications (SPAs) with Blazor running under WebAssembly.</Description>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Build mechanism for ASP.NET Core Blazor applications.</Description>
     <OutputType>Exe</OutputType>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
   </PropertyGroup>
 

--- a/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Build mechanism for ASP.NET Core Blazor applications.</Description>
     <OutputType>Exe</OutputType>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
   </PropertyGroup>
 

--- a/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
+++ b/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>blazor-devserver</AssemblyName>
     <PackageId>Microsoft.AspNetCore.Blazor.DevServer</PackageId>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <StartupObject>Microsoft.AspNetCore.Blazor.DevServer.Program</StartupObject>
     <Description>Development server for use when building Blazor applications.</Description>

--- a/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
+++ b/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>blazor-devserver</AssemblyName>
     <PackageId>Microsoft.AspNetCore.Blazor.DevServer</PackageId>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <StartupObject>Microsoft.AspNetCore.Blazor.DevServer.Program</StartupObject>
     <Description>Development server for use when building Blazor applications.</Description>

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <!-- Override prerelease label and use preview 4, even in the final build -->
     <PreReleaseVersionLabel>$(BlazorClientPreReleaseVersionLabel)</PreReleaseVersionLabel>
-    <!-- These packages ship from the blazor-wasm branch -->
-    <IsShipping>false</IsShipping>
     <DotNetFinalVersionKind></DotNetFinalVersionKind>
   </PropertyGroup>
 </Project>

--- a/src/Components/Blazor/Http/src/Microsoft.AspNetCore.Blazor.HttpClient.csproj
+++ b/src/Components/Blazor/Http/src/Microsoft.AspNetCore.Blazor.HttpClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Provides experimental support for using System.Text.Json with HttpClient. Intended for use with Blazor running under WebAssembly.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Http/src/Microsoft.AspNetCore.Blazor.HttpClient.csproj
+++ b/src/Components/Blazor/Http/src/Microsoft.AspNetCore.Blazor.HttpClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Provides experimental support for using System.Text.Json with HttpClient. Intended for use with Blazor running under WebAssembly.</Description>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Server/src/Microsoft.AspNetCore.Blazor.Server.csproj
+++ b/src/Components/Blazor/Server/src/Microsoft.AspNetCore.Blazor.Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Runtime server features for ASP.NET Core Blazor applications.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Server/src/Microsoft.AspNetCore.Blazor.Server.csproj
+++ b/src/Components/Blazor/Server/src/Microsoft.AspNetCore.Blazor.Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Runtime server features for ASP.NET Core Blazor applications.</Description>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Templates/src/Microsoft.AspNetCore.Blazor.Templates.csproj
+++ b/src/Components/Blazor/Templates/src/Microsoft.AspNetCore.Blazor.Templates.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NuspecFile>Microsoft.AspNetCore.Blazor.Templates.nuspec</NuspecFile>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <EnableDefaultItems>False</EnableDefaultItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IncludeBuildOutput>False</IncludeBuildOutput>

--- a/src/Components/Blazor/Templates/src/Microsoft.AspNetCore.Blazor.Templates.csproj
+++ b/src/Components/Blazor/Templates/src/Microsoft.AspNetCore.Blazor.Templates.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NuspecFile>Microsoft.AspNetCore.Blazor.Templates.nuspec</NuspecFile>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
     <EnableDefaultItems>False</EnableDefaultItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IncludeBuildOutput>False</IncludeBuildOutput>

--- a/src/Components/Blazor/Validation/src/Microsoft.AspNetCore.Blazor.DataAnnotations.Validation.csproj
+++ b/src/Components/Blazor/Validation/src/Microsoft.AspNetCore.Blazor.DataAnnotations.Validation.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Provides experimental support for validation using DataAnnotations.</Description>
-    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
   </PropertyGroup>
 

--- a/src/Components/Blazor/Validation/src/Microsoft.AspNetCore.Blazor.DataAnnotations.Validation.csproj
+++ b/src/Components/Blazor/Validation/src/Microsoft.AspNetCore.Blazor.DataAnnotations.Validation.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Provides experimental support for validation using DataAnnotations.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShipping)' == ''">true</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
   </PropertyGroup>
 


### PR DESCRIPTION
We intended to mark these packages as non-shipping in 3.1.1, but the value set in `Directory.Build.props` was getting overwritten by the values in the individual projects. Local build confirms that these projects are now marked as nonshipping. 

CC @mkArtakMSFT @danroth27 @dotnet/aspnet-build 