### PR TITLE
Ref pack fix [3.1]

### DIFF
--- a/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj
@@ -130,13 +130,13 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <!-- Exclude transitive external dependencies that are not directly referenced by projects in AspNetCore or Extensions -->
       <AspNetCoreReferenceAssemblyPath
           Include="@(ReferencePathWithRefAssemblies)"
+          Condition="'%(ReferencePathWithRefAssemblies.IsReferenceAssembly)' == 'true'"
           Exclude="
             @(_ReferencedExtensionsRefAssemblies);
             @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.NETCore.App.Ref'));
             @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'System.Security.Cryptography.Pkcs'));
             @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'System.Drawing.Common'));
             @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.Win32.SystemEvents'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('IsReferenceAssembly', 'false'));
             @(ReferencePathWithRefAssemblies->WithMetadataValue('ReferenceGrouping', 'Microsoft.NETCore.App'));" />
 
       <AspNetCoreReferenceAssemblyPath


### PR DESCRIPTION
It seems like the issue in the 3.1 template tests are caused by malformed targeting pack. In fact no ref assemblies were included in the targeting pack:
![image](https://user-images.githubusercontent.com/2030323/72499451-bfe9d580-37e6-11ea-9b90-bdab8af1d1d4.png)


Indeed it seems like we weren't capturing aspnetcore ref assemblies in the ref pack contents at https://github.com/dotnet/aspnetcore/blob/release/3.1/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj#L131-L140
![image](https://user-images.githubusercontent.com/2030323/72499505-e871cf80-37e6-11ea-9f56-c751a25e342a.png)


It turns out that the items ReferencePathWithRefAssemblies had the same identity (but different metadata) between implementation assemblies and ref assemblies and were therefore being excluded by the line https://github.com/dotnet/aspnetcore/blob/release/3.1/src/Framework/ref/Microsoft.AspNetCore.App.Ref.csproj#L139 
![image](https://user-images.githubusercontent.com/2030323/72499463-cd06c480-37e6-11ea-867d-aefa43d37aea.png)

I haven't tracked down how or when this broke but it would have been something that was between the branding changes and when https://github.com/dotnet/aspnetcore/pull/17970 was first opened. 