### PR TITLE
ExceptionHandlerMiddleware: Set GET method for exceptions

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -148,6 +148,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             context.SetEndpoint(endpoint: null);
             var routeValuesFeature = context.Features.Get<IRouteValuesFeature>();
             routeValuesFeature?.RouteValues?.Clear();
+            context.Request.Method = "GET";
         }
 
         private static Task ClearCacheHeaders(object state)


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
- ExceptionHandlerMiddleware now sets the context request method to GET when an exception is thrown even if the initial request was a POST

Addresses #18186

