### PR TITLE
Suppress ExecutionContext flow in SocketAwaitableEventArgs

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
-    internal class SocketAwaitableEventArgs : SocketAsyncEventArgs, ICriticalNotifyCompletion
+    internal sealed class SocketAwaitableEventArgs : SocketAsyncEventArgs, ICriticalNotifyCompletion
     {
         private static readonly Action _callbackCompleted = () => { };
 
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private Action _callback;
 
         public SocketAwaitableEventArgs(PipeScheduler ioScheduler)
+            : base(unsafeSuppressExecutionContextFlow: true)
         {
             _ioScheduler = ioScheduler;
         }


### PR DESCRIPTION
Take advantage of the newly-exposed dotnet/runtime#706.

Currently does an unnecessary EC capture; then on callback an unnecessary restore which is then thrown away on the queue to threadpool

![image](https://user-images.githubusercontent.com/1142958/72573398-6e604a00-38bd-11ea-8426-f968e521fa19.png)


Requested by @davidfowl in https://github.com/dotnet/runtime/issues/937