### PR TITLE
Remove unsafe use ASCII.GetBytes for WriteAscii

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -11538,7 +11538,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if (value != null)
                         {
                             output.Write(headerKey);
-                            output.WriteAsciiNoValidation(value);
+                            output.WriteAscii(value);
                         }
                     }
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if (value != null)
                         {
                             buffer.Write(CrLf);
-                            buffer.WriteAsciiNoValidation(kv.Key);
+                            buffer.WriteAscii(kv.Key);
                             buffer.Write(ColonSpace);
-                            buffer.WriteAsciiNoValidation(value);
+                            buffer.WriteAscii(value);
                         }
                     }
                 }

--- a/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
+++ b/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var pipeWriter = _pipe.Writer;
             var writer = new BufferWriter<PipeWriter>(pipeWriter);
-            writer.WriteAsciiNoValidation(input);
+            writer.WriteAscii(input);
             writer.Commit();
             pipeWriter.FlushAsync().GetAwaiter().GetResult();
             pipeWriter.Complete();
@@ -111,13 +111,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("𤭢𐐝")]
         // non-ascii characters stored in 16 bits
         [InlineData("ñ٢⛄⛵")]
-        public void WriteAsciiNoValidationWritesOnlyOneBytePerChar(string input)
+        public void WriteAsciiWritesOnlyOneBytePerChar(string input)
         {
             // WriteAscii doesn't validate if characters are in the ASCII range
             // but it shouldn't produce more than one byte per character
             var writerBuffer = _pipe.Writer;
             var writer = new BufferWriter<PipeWriter>(writerBuffer);
-            writer.WriteAsciiNoValidation(input);
+            writer.WriteAscii(input);
             writer.Commit();
             writerBuffer.FlushAsync().GetAwaiter().GetResult();
             var reader = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
@@ -126,14 +126,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void WriteAsciiNoValidation()
+        public void WriteAscii()
         {
             const byte maxAscii = 0x7f;
             var writerBuffer = _pipe.Writer;
             var writer = new BufferWriter<PipeWriter>(writerBuffer);
             for (var i = 0; i < maxAscii; i++)
             {
-                writer.WriteAsciiNoValidation(new string((char)i, 1));
+                writer.WriteAscii(new string((char)i, 1));
             }
             writer.Commit();
             writerBuffer.FlushAsync().GetAwaiter().GetResult();
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(gapSize, writer.Span.Length);
 
             var bufferLength = writer.Span.Length;
-            writer.WriteAsciiNoValidation(testString);
+            writer.WriteAscii(testString);
             Assert.NotEqual(bufferLength, writer.Span.Length);
             writer.Commit();
             writerBuffer.FlushAsync().GetAwaiter().GetResult();

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -945,7 +945,7 @@ $@"        private void Clear(long bitsToClear)
                         if (value != null)
                         {{
                             output.Write(headerKey);
-                            output.WriteAsciiNoValidation(value);
+                            output.WriteAscii(value);
                         }}
                     }}
                 }}

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -146,7 +146,6 @@ namespace System.Buffers
                 Encoding.ASCII.GetBytes(data.AsSpan(offset, writable), bytes);
                 buffer.Advance(writable);
 
-                // The `add` will macro-op fuse with `if` test.
                 offset += writable;
                 if (offset >= dataLength)
                 {


### PR DESCRIPTION
ResponseHeadersWritingBenchmark

```
                       Type | branch |      Mean |     Error |         Op/s | Precent |
--------------------------- |------- |----------:|----------:|-------------:|--------:|
                 LiveAspNet | master | 347.71 ns | 0.7750 ns |  2,875,994.1 |         |
                 LiveAspNet |     pr | 357.18 ns | 1.3362 ns |  2,799,723.0 |     97% |
           PlaintextChunked | master |  56.30 ns | 0.0803 ns | 17,760,761.0 |         |
           PlaintextChunked |     pr |  56.88 ns | 0.1912 ns | 17,581,284.2 |     98% |
 PlaintextChunkedWithCookie | master | 126.62 ns | 0.3121 ns |  7,897,881.3 |         |
 PlaintextChunkedWithCookie |     pr | 102.36 ns | 0.2788 ns |  9,768,985.8 |    123% |
        PlaintextWithCookie | master | 120.31 ns | 0.4068 ns |  8,312,171.8 |         |
        PlaintextWithCookie |     pr |  91.83 ns | 0.2701 ns | 10,890,175.9 |    131% |
       TechEmpowerPlaintext | master |  50.50 ns | 0.2020 ns | 19,801,547.7 |         |
       TechEmpowerPlaintext |     pr |  50.87 ns | 0.2549 ns | 19,657,723.3 |     99% |
```

/cc @halter73 @GrabYourPitchforks @gfoidl
