### PR TITLE
Handling libuv thread unhandled exception gracefully

### DIFF
--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnectionListener.cs
@@ -157,6 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
                     var listenerPrimary = new ListenerPrimary(TransportContext);
                     _listeners.Add(listenerPrimary);
+
                     await listenerPrimary.StartAsync(pipeName, pipeMessage, EndPoint, Threads[0]).ConfigureAwait(false);
                     EndPoint = listenerPrimary.EndPoint;
 
@@ -180,7 +181,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 throw;
             }
         }
-
+        
         private async IAsyncEnumerator<LibuvConnection> AcceptConnections()
         {
             var slots = new Task<(LibuvConnection, int)>[_listeners.Count];

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/ListenerSecondary.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/ListenerSecondary.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         public ILibuvTrace Log => TransportContext.Log;
 
-        public Task StartAsync(
+        public async Task StartAsync(
             string pipeName,
             byte[] pipeMessage,
             EndPoint endPoint,
@@ -48,7 +48,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
             var tcs = new TaskCompletionSource<int>(this, TaskCreationOptions.RunContinuationsAsynchronously);
             Thread.Post(StartCallback, tcs);
-            return tcs.Task;
+
+            var completedTask = await Task.WhenAny(tcs.Task, thread.ThreadLifetimeTask);
+            //awaiting the completed task will throw if there is an exception
+            await completedTask;
         }
 
         private static void StartCallback(TaskCompletionSource<int> tcs)


### PR DESCRIPTION
Summary of the changes
 - When Libuv threads fail it executes a callback registered by the listener context
 - The listener context stops accepting connections and executes its stopped callback
 - The connection listener logs the error 

Addresses #12650

I tried but wasn't sure how to reproduce this in a test. I am very happy to write a test to confirm if its possible.