### PR TITLE
Use StatusCodes.Status404NotFound instead of 404

### DIFF
--- a/src/Http/Http/src/Builder/ApplicationBuilder.cs
+++ b/src/Http/Http/src/Builder/ApplicationBuilder.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Builder
                     throw new InvalidOperationException(message);
                 }
 
-                context.Response.StatusCode = 404;
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
                 return Task.CompletedTask;
             };
 


### PR DESCRIPTION
This is a minor change to improve consistency and use `StatusCodes` members instead of raw harcoded status code numbers. It may help beginners browsing through the code-base to find where the default 404 response comes from for unmatched requests.

Summary of the changes (Less than 80 chars)
 - Changed on occurrence of `404` with `StatusCodes.Status404NotFound`
