### PR TITLE
Fix build warnings in MonoProxy

### DIFF
--- a/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/MonoProxy.cs
+++ b/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/MonoProxy.cs
@@ -461,7 +461,7 @@ namespace WsProxy {
 				{
 					result = var_list
 				});
-			} catch (Exception e) {
+			} catch (Exception) {
 				Debug ($"failed to parse {res.Value}");
 			}
 			SendResponse(msg_id, Result.Ok(o), token);
@@ -534,7 +534,7 @@ namespace WsProxy {
 				});
 				SendResponse (msg_id, Result.Ok (o), token);
 			}
-			catch (Exception exc) {
+			catch (Exception) {
 				SendResponse (msg_id, res, token);
 			}
 		}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
