### PR TITLE
Allow use of a default MemoryPoolFeature on ConnectionContext

### DIFF
--- a/src/Servers/Kestrel/Core/src/Middleware/Http3ConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Http3ConnectionMiddleware.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 ConnectionContext = connectionContext,
                 ServiceContext = _serviceContext,
                 ConnectionFeatures = connectionContext.Features,
-                MemoryPool = memoryPoolFeature.MemoryPool,
+                MemoryPool = memoryPoolFeature?.MemoryPool ?? System.Buffers.MemoryPool<byte>.Shared,
                 LocalEndPoint = connectionContext.LocalEndPoint as IPEndPoint,
                 RemoteEndPoint = connectionContext.RemoteEndPoint as IPEndPoint
             };

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -33,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 Protocols = _protocols,
                 ServiceContext = _serviceContext,
                 ConnectionFeatures = connectionContext.Features,
-                MemoryPool = memoryPoolFeature.MemoryPool,
+                MemoryPool = memoryPoolFeature?.MemoryPool ?? System.Buffers.MemoryPool<byte>.Shared,
                 Transport = connectionContext.Transport,
                 LocalEndPoint = connectionContext.LocalEndPoint as IPEndPoint,
                 RemoteEndPoint = connectionContext.RemoteEndPoint as IPEndPoint
@@ -43,5 +44,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
             return connection.ProcessRequestsAsync(_application);
         }
+
     }
 }

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Buffers;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -44,6 +43,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
             return connection.ProcessRequestsAsync(_application);
         }
-
     }
 }


### PR DESCRIPTION
davidfowl/BedrockFramework#65


This facilitates the use of other Transports other than sockets.
When kestrel bound to MemoryTransport (Bedrock davidfowl/BedrockFramework#65) a NullReferenceException is thrown since the MemoryPoolFeature is not set on the ConnectionContext set in that Transport

Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
