### PR TITLE
Start pooling Http2Streams

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -37,8 +37,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private int _remainingRequestHeadersBytesAllowed;
 
         public Http1Connection(HttpConnectionContext context)
-            : base(context)
         {
+            Initialize(context);
+
             _context = context;
             _parser = ServiceContext.HttpParser;
             _keepAliveTicks = ServerOptions.Limits.KeepAliveTimeout.Ticks;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -80,8 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
-            HttpRequestHeaders = new HttpRequestHeaders(reuseHeaderValues: !ServerOptions.DisableStringReuse);
-            RequestHeaders = HttpRequestHeaders;
+            HttpRequestHeaders.ReuseHeaderValues = !ServerOptions.DisableStringReuse;
 
             HttpResponseControl = this;
         }
@@ -308,7 +307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public bool HasResponseCompleted => _requestProcessingStatus == RequestProcessingStatus.ResponseCompleted;
 
-        protected HttpRequestHeaders HttpRequestHeaders { get; set; }
+        protected HttpRequestHeaders HttpRequestHeaders { get; } = new HttpRequestHeaders();
 
         protected HttpResponseHeaders HttpResponseHeaders { get; } = new HttpResponseHeaders();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -362,7 +362,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             var remoteEndPoint = RemoteEndPoint;
             RemoteIpAddress = remoteEndPoint?.Address;
             RemotePort = remoteEndPoint?.Port ?? 0;
-
             var localEndPoint = LocalEndPoint;
             LocalIpAddress = localEndPoint?.Address;
             LocalPort = localEndPoint?.Port ?? 0;
@@ -380,6 +379,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _hasAdvanced = false;
             _canWriteResponseBody = true;
             _keepAlive = true;
+            _connectionAborted = false;
 
             if (_scheme == null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private Stack<KeyValuePair<Func<object, Task>, object>> _onCompleted;
 
         private readonly object _abortLock = new object();
-        private volatile bool _connectionAborted;
+        protected volatile bool _connectionAborted;
         private bool _preventRequestAbortedCancellation;
         private CancellationTokenSource _abortedCts;
         private CancellationToken? _manuallySetRequestAbortToken;
@@ -381,8 +381,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _isLeasedMemoryInvalid = true;
             _hasAdvanced = false;
             _canWriteResponseBody = true;
-            _keepAlive = true;
-            _connectionAborted = false;
 
             if (_scheme == null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -80,7 +80,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
+
+            Reset();
+
             HttpRequestHeaders.ReuseHeaderValues = !ServerOptions.DisableStringReuse;
+            RequestHeaders = RequestHeaders;
 
             HttpResponseControl = this;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -84,7 +84,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             Reset();
 
             HttpRequestHeaders.ReuseHeaderValues = !ServerOptions.DisableStringReuse;
-            RequestHeaders = RequestHeaders;
 
             HttpResponseControl = this;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private long _responseBytesWritten;
 
-        private readonly HttpConnectionContext _context;
+        private HttpConnectionContext _context;
         private RouteValueDictionary _routeValues;
         private Endpoint _endpoint;
 
@@ -75,12 +75,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private Stream _requestStreamInternal;
         private Stream _responseStreamInternal;
 
-        public HttpProtocol(HttpConnectionContext context)
+        public void Initialize(HttpConnectionContext context)
         {
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
             HttpRequestHeaders = new HttpRequestHeaders(reuseHeaderValues: !ServerOptions.DisableStringReuse);
+            RequestHeaders = HttpRequestHeaders;
+
             HttpResponseControl = this;
         }
 
@@ -97,7 +99,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected IKestrelTrace Log => ServiceContext.Log;
         private DateHeaderValueManager DateHeaderValueManager => ServiceContext.DateHeaderValueManager;
         // Hold direct reference to ServerOptions since this is used very often in the request processing path
-        protected KestrelServerOptions ServerOptions { get; }
+        protected KestrelServerOptions ServerOptions { get; set; }
         protected string ConnectionId => _context.ConnectionId;
 
         public string ConnectionIdFeature { get; set; }
@@ -306,7 +308,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public bool HasResponseCompleted => _requestProcessingStatus == RequestProcessingStatus.ResponseCompleted;
 
-        protected HttpRequestHeaders HttpRequestHeaders { get; }
+        protected HttpRequestHeaders HttpRequestHeaders { get; set; }
 
         protected HttpResponseHeaders HttpResponseHeaders { get; } = new HttpResponseHeaders();
 
@@ -378,6 +380,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _isLeasedMemoryInvalid = true;
             _hasAdvanced = false;
             _canWriteResponseBody = true;
+            _keepAlive = true;
 
             if (_scheme == null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -376,6 +376,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             RequestHeaders = HttpRequestHeaders;
             ResponseHeaders = HttpResponseHeaders;
             RequestTrailers.Clear();
+            ResponseTrailers?.Reset();
             RequestTrailersAvailable = false;
 
             _isLeasedMemoryInvalid = true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -14,13 +14,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal sealed partial class HttpRequestHeaders : HttpHeaders
     {
-        private readonly bool _reuseHeaderValues;
         private long _previousBits = 0;
 
         public HttpRequestHeaders(bool reuseHeaderValues = true)
         {
-            _reuseHeaderValues = reuseHeaderValues;
+            ReuseHeaderValues = reuseHeaderValues;
         }
+
+        public bool ReuseHeaderValues { get; set; }
 
         public void OnHeadersComplete()
         {
@@ -40,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected override void ClearFast()
         {
-            if (!_reuseHeaderValues)
+            if (!ReuseHeaderValues)
             {
                 // If we aren't reusing headers clear them all
                 Clear(_bits);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private Http2StreamStack _streamPool;
 
         internal const int InitialStreamPoolSize = 20;
-        internal const int MaxStreamPoolSize = 20;
+        internal const int MaxStreamPoolSize = 50;
 
         public Http2Connection(HttpConnectionContext context)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private Http2StreamStack _streamPool;
 
         internal const int InitialStreamPoolSize = 20;
-        internal const int MaxStreamPoolSize = 200;
+        internal const int MaxStreamPoolSize = 50;
 
         public Http2Connection(HttpConnectionContext context)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private int _gracefulCloseInitiator;
         private int _isClosed;
 
-        private readonly Http2StreamStack _streamPool;
+        private Http2StreamStack _streamPool;
 
         internal const int InitialStreamPoolSize = 20;
         internal const int MaxStreamPoolSize = 200;
@@ -574,7 +574,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private Http2Stream GetStream<TContext>(IHttpApplication<TContext> application)
         {
-
             if (_streamPool.TryPop(out var stream))
             {
                 stream.Initialize(CreateHttp2StreamContext());

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private Http2StreamStack _streamPool;
 
         internal const int InitialStreamPoolSize = 20;
-        internal const int MaxStreamPoolSize = 50;
+        internal const int MaxStreamPoolSize = 20;
 
         public Http2Connection(HttpConnectionContext context)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -578,16 +578,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             Http2Stream<TContext> stream = null;
 
-            lock (_streamPool)
-            {
-                if (_pooledStreamCount > 0)
-                {
-                    _pooledStreamCount--;
-                    stream = (Http2Stream<TContext>)_streamPool[_pooledStreamCount];
-                    stream.Reset();
-                    stream.Initialize(GetHttp2StreamContext());
-                }
-            }
+            //lock (_streamPool)
+            //{
+            //    if (_pooledStreamCount > 0)
+            //    {
+            //        _pooledStreamCount--;
+            //        stream = (Http2Stream<TContext>)_streamPool[_pooledStreamCount];
+            //        stream.Reset();
+            //        stream.Initialize(GetHttp2StreamContext());
+            //    }
+            //}
 
             if (stream == null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -578,16 +578,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             Http2Stream<TContext> stream = null;
 
-            //lock (_streamPool)
-            //{
-            //    if (_pooledStreamCount > 0)
-            //    {
-            //        _pooledStreamCount--;
-            //        stream = (Http2Stream<TContext>)_streamPool[_pooledStreamCount];
-            //        stream.Reset();
-            //        stream.Initialize(GetHttp2StreamContext());
-            //    }
-            //}
+            lock (_streamPool)
+            {
+                if (_pooledStreamCount > 0)
+                {
+                    _pooledStreamCount--;
+                    stream = (Http2Stream<TContext>)_streamPool[_pooledStreamCount];
+                    stream.Reset();
+                    stream.Initialize(GetHttp2StreamContext());
+                }
+            }
 
             if (stream == null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private Http2StreamStack _streamPool;
 
-        internal const int InitialStreamPoolSize = 10;
+        internal const int InitialStreamPoolSize = 5;
         internal const int MaxStreamPoolSize = 40;
 
         public Http2Connection(HttpConnectionContext context)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -96,6 +96,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         protected override void OnReset()
         {
+            _keepAlive = true;
+            _connectionAborted = false;
+
             ResetHttp2Features();
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private StreamCompletionFlags _completionState;
         private readonly object _completionLock = new object();
 
-        public virtual void Initialize(Http2StreamContext context)
+        public void Initialize(Http2StreamContext context)
         {
             base.Initialize(context);
 
@@ -66,6 +66,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
             RequestBodyPipe = CreateRequestBodyPipe(context.ServerPeerSettings.InitialWindowSize);
             Output = _http2Output;
+        }
+
+        public void InitializeWithExistingContext(int streamId)
+        {
+            _context.StreamId = streamId;
+            Initialize(_context);
         }
 
         public int StreamId => _context.StreamId;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -19,22 +19,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem
     {
-        private readonly Http2StreamContext _context;
-        private readonly Http2OutputProducer _http2Output;
-        private readonly StreamInputFlowControl _inputFlowControl;
-        private readonly StreamOutputFlowControl _outputFlowControl;
+        private Http2StreamContext _context;
+        private Http2OutputProducer _http2Output;
+        private StreamInputFlowControl _inputFlowControl;
+        private StreamOutputFlowControl _outputFlowControl;
 
         private bool _decrementCalled;
-        public Pipe RequestBodyPipe { get; }
+
+        public Pipe RequestBodyPipe { get; set; }
 
         internal long DrainExpirationTicks { get; set; }
 
         private StreamCompletionFlags _completionState;
         private readonly object _completionLock = new object();
 
-        public Http2Stream(Http2StreamContext context)
-            : base(context)
+        public virtual void Initialize(Http2StreamContext context)
         {
+            base.Initialize(context);
+
+            _decrementCalled = false;
+            _completionState = StreamCompletionFlags.None;
+            InputRemaining = null;
+            RequestBodyStarted = false;
+            DrainExpirationTicks = 0;
+
             _context = context;
 
             _inputFlowControl = new StreamInputFlowControl(

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -11,8 +11,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context) : base(context)
+        public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context) 
         {
+            Initialize(context);
             _application = application;
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamStack.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamStack.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
+{
+    internal struct Http2StreamStack
+    {
+        private Http2StreamAsValueType[] _array;
+        private int _size;
+
+        public Http2StreamStack(int size)
+        {
+            _array = new Http2StreamAsValueType[size];
+            _size = 0;
+        }
+
+        public int Count => _size;
+
+        public bool TryPop(out Http2Stream result)
+        {
+            int size = _size - 1;
+            Http2StreamAsValueType[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
+            {
+                result = default;
+                return false;
+            }
+
+            _size = size;
+            result = array[size];
+            array[size] = default;
+            return true;
+        }
+
+        // Pushes an item to the top of the stack.
+        public void Push(Http2Stream item)
+        {
+            int size = _size;
+            Http2StreamAsValueType[] array = _array;
+
+            if ((uint)size < (uint)array.Length)
+            {
+                array[size] = item;
+                _size = size + 1;
+            }
+            else
+            {
+                PushWithResize(item);
+            }
+        }
+
+        // Non-inline from Stack.Push to improve its code quality as uncommon path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void PushWithResize(Http2Stream item)
+        {
+            Array.Resize(ref _array, 2 * _array.Length);
+            _array[_size] = item;
+            _size++;
+        }
+
+        private readonly struct Http2StreamAsValueType
+        {
+            private readonly Http2Stream _value;
+            private Http2StreamAsValueType(Http2Stream value) => _value = value;
+            public static implicit operator Http2StreamAsValueType(Http2Stream s) => new Http2StreamAsValueType(s);
+            public static implicit operator Http2Stream(Http2StreamAsValueType s) => s._value;
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamStack.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamStack.cs
@@ -1,8 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    // See https://github.com/dotnet/runtime/blob/master/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
     internal struct Http2StreamStack
     {
         private Http2StreamAsValueType[] _array;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -116,7 +116,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
             try
             {
-
                 while (_isClosed == 0)
                 {
                     var result = await Input.ReadAsync();

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -31,8 +31,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private bool _receivedHeaders;
         public Pipe RequestBodyPipe { get; }
 
-        public Http3Stream(Http3Connection http3Connection, HttpConnectionContext context) : base(context)
+        public Http3Stream(Http3Connection http3Connection, HttpConnectionContext context) 
         {
+            Initialize(context);
             // First, determine how we know if an Http3stream is unidirectional or bidirectional
             var httpLimits = context.ServiceContext.ServerOptions.Limits;
             var http3Limits = httpLimits.Http3;

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -69,7 +69,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
 
             _http1Connection = new TestHttp1Connection(_http1ConnectionContext);
-            _http1Connection.Reset();
         }
 
         public void Dispose()

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -249,8 +249,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         private class TestHttp2Stream : Http2Stream
         {
-            public TestHttp2Stream(Http2StreamContext context) : base(context)
+            public TestHttp2Stream(Http2StreamContext context) 
             {
+                Initialize(context);
             }
 
             public override void Execute()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/6192, however, I'd like to discuss the tradeoffs here with this change before adding tests and doing some cleanup work.

The perf generally seems to have improved a slight amount. I've run it multiple times and here are the results I'm seeing.
Before:
```
RequestsPerSecond:           476,895
Max CPU (%):                 72
WorkingSet (MB):             411
Avg. Latency (ms):           12
Startup (ms):                538
First Request (ms):          128.86
Latency (ms):                0.19
Total Requests:              7,153,420
Duration: (ms)               15,000
Socket Errors:               0
Bad Responses:               0
Build Time (ms):             5,029
Published Size (KB):         105,302
SDK:                         5.0.100-alpha.1.20073.4
Runtime:                     5.0.0-alpha.1.20074.1
ASP.NET Core:                5.0.0-alpha.1.20076.1

Counters:
CPU Usage (%):               71
Working Set (MB):            430
GC Heap Size (MB):           177
Gen 0 GC (#/s):              9
Gen 1 GC (#/s):              4
Gen 2 GC (#/s):              0
Time in GC (%):              2
Gen 0 Size (B):              672
Gen 1 Size (B):              10,007,008
Gen 2 Size (B):              4,207,584
LOH Size (B):                1,294,856
Allocation Rate (B/sec):     2,760,162,909
# of Assemblies Loaded:      112
Exceptions (#/s):            2
ThreadPool Threads Count:    63
Lock Contention (#/s):       81,659
ThreadPool Queue Length:     342
ThreadPool Items (#/s):      481,982
```

After:
```
RequestsPerSecond:           487,742
Max CPU (%):                 71
WorkingSet (MB):             434
Avg. Latency (ms):           18.18
Startup (ms):                546
First Request (ms):          202.5
Latency (ms):                0.23
Total Requests:              7,316,135
Duration: (ms)               15,000
Socket Errors:               0
Bad Responses:               0
Build Time (ms):             11,557
Published Size (KB):         105,302
SDK:                         5.0.100-alpha.1.20073.4
Runtime:                     5.0.0-alpha.1.20074.1
ASP.NET Core:                5.0.0-alpha.1.20076.1

Counters:
CPU Usage (%):               70
Working Set (MB):            456
GC Heap Size (MB):           197
Gen 0 GC (#/s):              6
Gen 1 GC (#/s):              3
Gen 2 GC (#/s):              0
Time in GC (%):              1
Gen 0 Size (B):              672
Gen 1 Size (B):              13,007,064
Gen 2 Size (B):              8,319,032
LOH Size (B):                901,472
Allocation Rate (B/sec):     1,862,939,990
# of Assemblies Loaded:      112
Exceptions (#/s):            2
ThreadPool Threads Count:    54
Lock Contention (#/s):       78,246
```

As you can see, the Allocation Rate has dropped by around 30%. However, there is a lot more idle memory per connection. The GC Generations aren't exactly indicative of the amount of memory, as GCs can happen at any time, however, there is a lot more memory in Gen 1 and Gen 2, presumably due to the pooled streams not being GC'd. cc @anurse @davidfowl @Tratcher @halter73 for your thoughts 😄 

I'm curious to see what other people think about pooling strategies to reduce idle memory. Few things I have thought of:
- Having a global pool; reduces idle memory but requires lock safe access across multiple connections
- Pruning pool over time for long running connections - At that point, why not just let the objects get GC'd

There are also some other wins we could get by pooling other objects; I'll explore them as well.