### PR TITLE
Fix nullref in ComponentsAnalyzer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,9 @@
     -->
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition=" '$(DotNetFinalVersionKind)' == 'release' ">true</IsStableBuild>
+
+    <!-- Workaround issue with ComponentsAnalyzer throwing for interfaces -->
+    <DisableImplicitComponentsAnalyzers>true</DisableImplicitComponentsAnalyzers>
   </PropertyGroup>
 
   <Import Project="eng\FlakyTests.BeforeArcade.props" />

--- a/src/Components/Analyzers/src/InternalUsageAnalyzer.cs
+++ b/src/Components/Analyzers/src/InternalUsageAnalyzer.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Internal
         // Similar logic here to VisitDeclarationSymbol, keep these in sync.
         private void VisitOperationSymbol(OperationAnalysisContext context, ISymbol symbol)
         {
-            if (symbol.ContainingAssembly == context.Compilation.Assembly)
+            if (symbol == null || symbol.ContainingAssembly == context.Compilation.Assembly)
             {
                 // The type is being referenced within the same assembly. This is valid use of an "internal" type
                 return;
@@ -155,7 +155,7 @@ namespace Microsoft.Extensions.Internal
         // Similar logic here to VisitOperationSymbol, keep these in sync.
         private void VisitDeclarationSymbol(SymbolAnalysisContext context, ISymbol symbol, ISymbol symbolForDiagnostic)
         {
-            if (symbol.ContainingAssembly == context.Compilation.Assembly)
+            if (symbol == null || symbol.ContainingAssembly == context.Compilation.Assembly)
             {
                 // This is part of the compilation, avoid this analyzer when building from source.
                 return;

--- a/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererTypesInDeclarations.cs
+++ b/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererTypesInDeclarations.cs
@@ -22,11 +22,15 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Tests.TestFiles.ComponentInt
             throw new NotImplementedException();
         }
 
-        /*MMParameter*/protected override Task UpdateDisplayAsync(in RenderBatch renderBatch) 
+        /*MMParameter*/protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
         {
             throw new NotImplementedException();
         }
 
         /*MMReturnType*/private Renderer GetRenderer() => _field;
+
+        public interface ITestInterface
+        {
+        }
     }
 }


### PR DESCRIPTION
Nullref was always there, but consuming a newer SDK/roslyn bits causes this to fail builds.