### PR TITLE
Replace calls to get first span to using FirstSpan method

### DIFF
--- a/src/Http/WebUtilities/src/FormPipeReader.cs
+++ b/src/Http/WebUtilities/src/FormPipeReader.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         {
             if (buffer.IsSingleSegment)
             {
-                ParseFormValuesFast(buffer.First.Span,
+                ParseFormValuesFast(buffer.FirstSpan,
                     ref accumulator,
                     isFinalBlock,
                     out var consumed);
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         {
             if (ros.IsSingleSegment)
             {
-                return GetDecodedString(ros.First.Span);
+                return GetDecodedString(ros.FirstSpan);
             }
 
             if (ros.Length < StackAllocThreshold)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             if (readableBuffer.IsSingleSegment)
             {
-                writableBuffer.Write(readableBuffer.First.Span);
+                writableBuffer.Write(readableBuffer.FirstSpan);
             }
             else
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             examined = buffer.End;
 
             // Prepare the first span
-            var span = buffer.First.Span;
+            var span = buffer.FirstSpan;
             var lineIndex = span.IndexOf(ByteLF);
             if (lineIndex >= 0)
             {

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -21,7 +21,7 @@ namespace System.Buffers
         {
             if (buffer.IsSingleSegment)
             {
-                return buffer.First.Span;
+                return buffer.FirstSpan;
             }
             return buffer.ToArray();
         }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Replace calls to `buffer.First.Span` with `buffer.FirstSpan`

Addresses #18587 
