### PR TITLE
Use reference equality to compare model instances in EditContext (#1872)

### DIFF
--- a/src/Components/Forms/src/FieldIdentifier.cs
+++ b/src/Components/Forms/src/FieldIdentifier.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Components.Forms
 {
@@ -35,7 +36,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <param name="fieldName">The name of the editable field.</param>
         public FieldIdentifier(object model, string fieldName)
         {
-            if (model == null)
+            if (model is null)
             {
                 throw new ArgumentNullException(nameof(model));
             }
@@ -64,7 +65,16 @@ namespace Microsoft.AspNetCore.Components.Forms
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (Model, FieldName).GetHashCode();
+        {
+            // We want to compare Model instances by reference. RuntimeHelpers.GetHashCode returns identical hashes for equal object references (ignoring any `Equals`/`GetHashCode` overrides) which is what we want.
+            var modelHash = RuntimeHelpers.GetHashCode(Model);
+            var fieldHash = StringComparer.Ordinal.GetHashCode(FieldName);
+            return (
+                modelHash,
+                fieldHash
+            )
+            .GetHashCode();
+        }
 
         /// <inheritdoc />
         public override bool Equals(object obj)
@@ -75,7 +85,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         public bool Equals(FieldIdentifier otherIdentifier)
         {
             return
-                otherIdentifier.Model == Model &&
+                ReferenceEquals(otherIdentifier.Model, Model) &&
                 string.Equals(otherIdentifier.FieldName, FieldName, StringComparison.Ordinal);
         }
 

--- a/src/Components/Forms/test/EditContextTest.cs
+++ b/src/Components/Forms/test/EditContextTest.cs
@@ -236,5 +236,35 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.False(isValid);
             Assert.Equal(new[] { "Some message" }, editContext.GetValidationMessages());
         }
+
+        [Fact]
+        public void LookingUpModel_ThatOverridesGetHashCodeAndEquals_Works()
+        {
+            // Test for https://github.com/aspnet/AspNetCore/issues/18069
+            // Arrange
+            var model = new EquatableModel();
+            var editContext = new EditContext(model);
+
+            editContext.NotifyFieldChanged(editContext.Field(nameof(EquatableModel.Property)));
+
+            model.Property = "new value";
+
+            Assert.True(editContext.IsModified(editContext.Field(nameof(EquatableModel.Property))));
+        }
+
+        class EquatableModel : IEquatable<EquatableModel>
+        {
+            public string Property { get; set; } = "";
+
+            public bool Equals(EquatableModel other)
+            {
+                return string.Equals(Property, other?.Property, StringComparison.Ordinal);
+            }
+
+            public override int GetHashCode()
+            {
+                return StringComparer.Ordinal.GetHashCode(Property);
+            }
+        }
     }
 }

--- a/src/Components/Forms/test/FieldIdentifierTest.cs
+++ b/src/Components/Forms/test/FieldIdentifierTest.cs
@@ -77,12 +77,39 @@ namespace Microsoft.AspNetCore.Components.Forms
         }
 
         [Fact]
+        public void FieldIdentifier_ForModelWithoutField_ProduceSameHashCodesAndEquality()
+        {
+            // Arrange
+            var model = new object();
+            var fieldIdentifier1 = new FieldIdentifier(model, fieldName: string.Empty);
+            var fieldIdentifier2 = new FieldIdentifier(model, fieldName: string.Empty);
+
+            // Act/Assert
+            Assert.Equal(fieldIdentifier1.GetHashCode(), fieldIdentifier2.GetHashCode());
+            Assert.True(fieldIdentifier1.Equals(fieldIdentifier2));
+        }
+
+        [Fact]
         public void SameContentsProduceSameHashCodesAndEquality()
         {
             // Arrange
             var model = new object();
             var fieldIdentifier1 = new FieldIdentifier(model, "field");
             var fieldIdentifier2 = new FieldIdentifier(model, "field");
+
+            // Act/Assert
+            Assert.Equal(fieldIdentifier1.GetHashCode(), fieldIdentifier2.GetHashCode());
+            Assert.True(fieldIdentifier1.Equals(fieldIdentifier2));
+        }
+
+        [Fact]
+        public void SameContents_WithOverridenEqualsAndGetHashCode_ProduceSameHashCodesAndEquality()
+        {
+            // Arrange
+            var model = new EquatableModel();
+            var fieldIdentifier1 = new FieldIdentifier(model, nameof(EquatableModel.Property));
+            model.Property = "changed value"; // To show it makes no difference if the overridden `GetHashCode` result changes
+            var fieldIdentifier2 = new FieldIdentifier(model, nameof(EquatableModel.Property));
 
             // Act/Assert
             Assert.Equal(fieldIdentifier1.GetHashCode(), fieldIdentifier2.GetHashCode());
@@ -193,6 +220,21 @@ namespace Microsoft.AspNetCore.Components.Forms
         class ParentModel
         {
             public TestModel Child { get; set; }
+        }
+
+        class EquatableModel : IEquatable<EquatableModel>
+        {
+            public string Property { get; set; } = "";
+
+            public bool Equals(EquatableModel other)
+            {
+                return string.Equals(Property, other?.Property, StringComparison.Ordinal);
+            }
+
+            public override int GetHashCode()
+            {
+                return StringComparer.Ordinal.GetHashCode(Property);
+            }
         }
     }
 }


### PR DESCRIPTION
* Use reference equality to compare model instances in EditContext

Fixes https://github.com/aspnet/AspNetCore/issues/18069

### Description

EditContext uses FieldIdentifiers for lookups. The equality and hashcode for `FieldIdentifer` attempts to compare instances of an application model, but uses the model's virtual `Equals` and `GetHashCode` methods. If a model overrides these methods, lookups will fail and you get incorrect validation results. This change uses the non-virtualized methods to compare model instances.

### Customer impact

Models overriding Equals or GetHashCode cannot be used with a Blazor (server) application.

### Regression

No. This behavior has been present since Blazor shipped in 3.0.

#### Risk

Low. There's a small chance that users may have inadvertently relied on the incorrect behavior and built their application around it. However, we don't commonly see the pattern of users overriding these methods. In the original user reported issue, these methods were code-gen from GRPC proto files.
