### PR TITLE
Use Microsoft.AspNetCore.Razor.Language for all CPDs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -293,95 +293,95 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>c7ccbfb3ad05e54eae71f5323a0f51732ee06ad2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CSharp" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.CSharp" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">>
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">>
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">>
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.ComponentModel.Annotations" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">>
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.IO.Pipelines" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Net.Http.WinHttpHandler" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Net.Http.WinHttpHandler" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Net.WebSockets.WebSocketProtocol" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Net.WebSockets.WebSocketProtocol" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Reflection.Metadata" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Channels" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Threading.Channels" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
@@ -389,22 +389,22 @@
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.20075.5" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf109642300c1acc7b885de5412f2e30669dea8e</Sha>
     </Dependency>


### PR DESCRIPTION
Use `Microsoft.AspNetCore.Razor.Language` for all CoherentParentDependencies, except for the dependency on Roslyn (which isn't depended on by AspNetCore-Tooling). This will allow us to avoid DARC choosing EFCore as the parent for any CPDs, which would cause us to downgrade to 3.1 versions of corefx (now runtime) dependencies.

@mmitche @dougbu @JunTaoLuo PTAL