### PR TITLE
Only download chrome driver

### DIFF
--- a/src/Components/test/E2ETest/package.json
+++ b/src/Components/test/E2ETest/package.json
@@ -6,11 +6,11 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install --singleDriverInstall=chrome"
+    "prepare": "selenium-standalone install --config ..\\..\\..\\Shared\\E2ETesting\\selenium-config.json"
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "selenium-standalone": "^6.15.4"
+    "selenium-standalone": "^6.17.0"
   }
 }

--- a/src/Components/test/E2ETest/package.json
+++ b/src/Components/test/E2ETest/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install"
+    "prepare": "selenium-standalone install --singleDriverInstall=chrome"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/Components/test/E2ETest/package.json
+++ b/src/Components/test/E2ETest/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install --config ..\\..\\..\\Shared\\E2ETesting\\selenium-config.json"
+    "prepare": "selenium-standalone install --config ../../../Shared/E2ETesting/selenium-config.json"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/Components/test/E2ETest/yarn.lock
+++ b/src/Components/test/E2ETest/yarn.lock
@@ -432,10 +432,10 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-selenium-standalone@^6.15.4:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-6.16.0.tgz#ffcf02665c58ff7a7472427ae819ba79c15967ac"
-  integrity sha512-tl7HFH2FOxJD1is7Pzzsl0pY4vuePSdSWiJdPn+6ETBkpeJDiuzou8hBjvWYWpD+eIVcOrmy3L0R3GzkdHLzDw==
+selenium-standalone@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-6.17.0.tgz#0f24b691836205ee9bc3d7a6f207ebcb28170cd9"
+  integrity sha512-5PSnDHwMiq+OCiAGlhwQ8BM9xuwFfvBOZ7Tfbw+ifkTnOy0PWbZmI1B9gPGuyGHpbQ/3J3CzIK7BYwrQ7EjtWQ==
   dependencies:
     async "^2.6.2"
     commander "^2.19.0"

--- a/src/ProjectTemplates/test/package.json
+++ b/src/ProjectTemplates/test/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "selenium-standalone": "^6.15.4"
+    "selenium-standalone": "^6.17.0"
   }
 }

--- a/src/ProjectTemplates/test/package.json
+++ b/src/ProjectTemplates/test/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install"
+    "prepare": "selenium-standalone install --singleDriverInstall=chrome"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/ProjectTemplates/test/package.json
+++ b/src/ProjectTemplates/test/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install --config ../../../Shared/E2ETesting/selenium-config.json"
+    "prepare": "selenium-standalone install --config ../../Shared/E2ETesting/selenium-config.json"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/ProjectTemplates/test/package.json
+++ b/src/ProjectTemplates/test/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install --singleDriverInstall=chrome"
+    "prepare": "selenium-standalone install --config ../../../Shared/E2ETesting/selenium-config.json"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/Shared/E2ETesting/E2ETesting.props
+++ b/src/Shared/E2ETesting/E2ETesting.props
@@ -6,6 +6,9 @@
     <SeleniumProcessTrackingFolder Condition="'$(SeleniumProcessTrackingFolder)' == ''">$([MSBuild]::EnsureTrailingSlash('$(RepoRoot)'))artifacts\tmp\selenium\</SeleniumProcessTrackingFolder>
     <SeleniumE2ETestsSupported Condition="'$(SeleniumE2ETestsSupported)' == '' and '$(TargetArchitecture)' != 'arm' and '$(OS)' == 'Windows_NT'">true</SeleniumE2ETestsSupported>
 
+    <!-- Config that limits driver to chrome-->
+    <SeleniumConfigPath>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)selenium-config.json))</SeleniumConfigPath>
+
     <!-- We want to enforce prerequisites when we build from the CI or within Visual Studio -->
     <EnforcedE2EBuildEnvironment Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true'">true</EnforcedE2EBuildEnvironment>
 
@@ -39,12 +42,12 @@
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>Microsoft.AspNetCore.E2ETesting.CI</_Parameter1>
-      <_Parameter2>$(ContinuousIntegrationBuild)</_Parameter2>      
+      <_Parameter2>$(ContinuousIntegrationBuild)</_Parameter2>
     </AssemblyAttribute>
-    
+
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>Microsoft.AspNetCore.E2ETesting.ScreenshotsPath</_Parameter1>
-      <_Parameter2>$(SeleniumScreenShotsFolderPath)</_Parameter2>      
+      <_Parameter2>$(SeleniumScreenShotsFolderPath)</_Parameter2>
     </AssemblyAttribute>
 
   </ItemGroup>

--- a/src/Shared/E2ETesting/E2ETesting.targets
+++ b/src/Shared/E2ETesting/E2ETesting.targets
@@ -51,7 +51,7 @@
 
     <PropertyGroup>
       <_PackageJsonLinesContent>@(_PackageJsonLines)</_PackageJsonLinesContent>
-      <_PackageJsonSeleniumPackage>&quot;selenium-standalone&quot;: &quot;^6.15.4&quot;</_PackageJsonSeleniumPackage>
+      <_PackageJsonSeleniumPackage>&quot;selenium-standalone&quot;: &quot;^6.17.0&quot;</_PackageJsonSeleniumPackage>
     </PropertyGroup>
 
     <Error
@@ -108,6 +108,12 @@
         Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>Microsoft.AspNetCore.Testing.Selenium.Supported</_Parameter1>
         <_Parameter2>$(_SeleniumE2ETestsSupportedAttributeValue)</_Parameter2>
+      </AssemblyAttribute>
+
+      <AssemblyAttribute
+        Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>Microsoft.AspNetCore.Testing.SeleniumConfigPath</_Parameter1>
+        <_Parameter2>$(SeleniumConfigPath)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Shared/E2ETesting/SeleniumStandaloneServer.cs
+++ b/src/Shared/E2ETesting/SeleniumStandaloneServer.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.E2ETesting
 
             if (seleniumConfigPath == null)
             {
-                throw new InvalidOperationException("Selenium config path not configured. Does this project import the E2ETesting.targets");
+                throw new InvalidOperationException("Selenium config path not configured. Does this project import the E2ETesting.targets?");
             }
 
             var psi = new ProcessStartInfo

--- a/src/Shared/E2ETesting/SeleniumStandaloneServer.cs
+++ b/src/Shared/E2ETesting/SeleniumStandaloneServer.cs
@@ -86,10 +86,20 @@ namespace Microsoft.AspNetCore.E2ETesting
             var port = FindAvailablePort();
             var uri = new UriBuilder("http", "localhost", port, "/wd/hub").Uri;
 
+            var seleniumConfigPath = typeof(SeleniumStandaloneServer).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .FirstOrDefault(k => k.Key == "Microsoft.AspNetCore.Testing.SeleniumConfigPath")
+                ?.Value;
+
+            if (seleniumConfigPath == null)
+            {
+                throw new InvalidOperationException("Selenium config path not configured. Does this project import the E2ETesting.targets");
+            }
+
             var psi = new ProcessStartInfo
             {
                 FileName = "npm",
-                Arguments = $"run selenium-standalone start -- -- -port {port}",
+                Arguments = $"run selenium-standalone start -- --config \"{seleniumConfigPath}\" -- -port {port}",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };

--- a/src/Shared/E2ETesting/selenium-config.json
+++ b/src/Shared/E2ETesting/selenium-config.json
@@ -1,0 +1,6 @@
+{
+  "drivers": {
+    "chrome": {}
+  },
+  "ignoreExtraDrivers": true  
+}


### PR DESCRIPTION
This should avoid extra web traffic by only installing the chrome driver. Inspired by a build failure due to transient network issue:

```
2020-01-28T21:33:29.0255009Z YARN : error : Could not download https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-win64.zip [F:\workspace\_work\1\s\src\Components\test\E2ETest\Microsoft.AspNetCore.Components.E2ETests.csproj]
2020-01-28T21:33:29.0257959Z F:\workspace\_work\1\s\src\Shared\E2ETesting\E2ETesting.targets(23,5): error : Command failed with exit code 1. [F:\workspace\_work\1\s\src\Components\test\E2ETest\Microsoft.AspNetCore.Components.E2ETests.csproj]
2020-01-28T21:33:29.2096369Z ##[error]Build failed.
```
