### PR TITLE
Add primary branch triggers to helix-test

### DIFF
--- a/.azure/pipelines/helix-test.yml
+++ b/.azure/pipelines/helix-test.yml
@@ -1,5 +1,9 @@
-# Don't run CI for this config yet. We're not ready to move official builds on to Azure Pipelines
-trigger: none
+# We want to run quarantined tests on master as well as on PRs
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
 
 # Run PR validation on all branches
 pr:


### PR DESCRIPTION
We want to run the quarantined tests on the "primary" branches (just master for now) to ensure we're getting full coverage.

I noticed we're not seeing data for quarantined tests in `master` in Kusto so we should do this.