### PR TITLE
[Helix] Add more metadata

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -43,6 +43,8 @@
   <!-- NOTE: These are global to the whole Job, so don't include project-specific content here. -->
   <ItemGroup>
     <HelixProperties Include="buildNumber" Value="$(BUILD_BUILDNUMBER)" />
+    <HelixProperties Include="buildId" Value="$(BUILD_BUILDID)" />
+    <HelixProperties Include="azdoProject" Value="$(SYSTEM_TEAMPROJECT)" />
     <HelixProperties Include="buildDefinition" Value="$(BUILD_DEFINITIONNAME)" />
     <HelixProperties Include="commitSha" Value="$(BUILD_SOURCEVERSION)" />
     <HelixProperties Include="branch" Value="$(BUILD_SOURCEBRANCH)" />


### PR DESCRIPTION
The Build ID and Project Name will let me craft a build URL with only string-concatenation which is preferable to looking up the URL for each failure :).