### PR TITLE
Test run of excluding Microsoft.Aspnetcore.testing ref assembly

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,12 +3,12 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-pub-dotnet-efcore-7ae89d6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-7ae89d6a/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-da9869c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-da9869cc/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-core-setup-916b5cb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-916b5cba/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-corefx-e946ceb-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-e946cebe-1/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-corefx-0f7f38c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-0f7f38c4/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-aspnetcore-tooling-2dab42e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-tooling-2dab42e1/nuget/v3/index.json" />
-    <add key="darc-pub-aspnet-Extensions-1286a6f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-Extensions-1286a6ff/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-aspnetcore-tooling-bfb2ccb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-tooling-bfb2ccba/nuget/v3/index.json" />
+    <add key="darc-pub-aspnet-Extensions-28c68e2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-Extensions-28c68e28/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,279 +15,279 @@
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="3.1.2">
       <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>2dab42e151ea8020a75cdaaa8c46bf5d9093b8c0</Sha>
+      <Sha>bfb2ccba5952c67dc53d281acb0407e1c27b1343</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.2">
       <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>2dab42e151ea8020a75cdaaa8c46bf5d9093b8c0</Sha>
+      <Sha>bfb2ccba5952c67dc53d281acb0407e1c27b1343</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="3.1.2">
       <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>2dab42e151ea8020a75cdaaa8c46bf5d9093b8c0</Sha>
+      <Sha>bfb2ccba5952c67dc53d281acb0407e1c27b1343</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.2">
       <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>2dab42e151ea8020a75cdaaa8c46bf5d9093b8c0</Sha>
+      <Sha>bfb2ccba5952c67dc53d281acb0407e1c27b1343</Sha>
     </Dependency>
     <Dependency Name="dotnet-ef" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="3.1.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ae89d6adb7433b6ae9c37091e57a1226092ef46</Sha>
+      <Sha>da9869cc0559903949babc979389a272ced4810b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Analyzer.Testing" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.AspNetCore.Analyzer.Testing" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ActivatorUtilities.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.ActivatorUtilities.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.SqlServer" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Hosting" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Http" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Localization.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Localization" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Testing" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.Logging.Testing" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.ObjectPool" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Primitives" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TypeNameHelper.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.TypeNameHelper.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ValueStopwatch.Sources" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.ValueStopwatch.Sources" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.WebEncoders" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.JSInterop" Version="3.1.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
-    <Dependency Name="Mono.WebAssembly.Interop" Version="3.1.2-preview4.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Mono.WebAssembly.Interop" Version="3.1.2-preview4.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -413,9 +413,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
-    <Dependency Name="Internal.AspNetCore.Analyzers" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Internal.AspNetCore.Analyzers" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19607.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -429,9 +429,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4d80b9cfa53e309c8f685abff3512f60c3d8a3d1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.1.2-servicing.20067.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.1.2-servicing.20067.4" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>1286a6ff55e300352dabeb6d778c9fcdd258bd08</Sha>
+      <Sha>28c68e2850248e479cc2c484eca31e52f8d76484</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.4.1-beta4-19614-01" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -99,16 +99,16 @@
     <!-- Packages from aspnet/Blazor -->
     <MicrosoftAspNetCoreBlazorMonoPackageVersion>3.1.0-preview4.19605.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from aspnet/Extensions -->
-    <InternalAspNetCoreAnalyzersPackageVersion>3.1.2-servicing.20067.6</InternalAspNetCoreAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>3.1.2-servicing.20067.6</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
-    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>3.1.2-servicing.20067.6</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>
+    <InternalAspNetCoreAnalyzersPackageVersion>3.1.2-servicing.20067.4</InternalAspNetCoreAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>3.1.2-servicing.20067.4</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>3.1.2-servicing.20067.4</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>
     <MicrosoftExtensionsCachingAbstractionsPackageVersion>3.1.2</MicrosoftExtensionsCachingAbstractionsPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>3.1.2</MicrosoftExtensionsCachingMemoryPackageVersion>
     <MicrosoftExtensionsCachingSqlServerPackageVersion>3.1.2</MicrosoftExtensionsCachingSqlServerPackageVersion>
     <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>3.1.2</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
-    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>3.1.2</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>3.1.2</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>3.1.2</MicrosoftExtensionsConfigurationBinderPackageVersion>
@@ -131,10 +131,10 @@
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>3.1.2</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>3.1.2</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>3.1.2</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <MicrosoftExtensionsHostingAbstractionsPackageVersion>3.1.2</MicrosoftExtensionsHostingAbstractionsPackageVersion>
     <MicrosoftExtensionsHostingPackageVersion>3.1.2</MicrosoftExtensionsHostingPackageVersion>
-    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
+    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
     <MicrosoftExtensionsHttpPackageVersion>3.1.2</MicrosoftExtensionsHttpPackageVersion>
     <MicrosoftExtensionsLocalizationAbstractionsPackageVersion>3.1.2</MicrosoftExtensionsLocalizationAbstractionsPackageVersion>
     <MicrosoftExtensionsLocalizationPackageVersion>3.1.2</MicrosoftExtensionsLocalizationPackageVersion>
@@ -146,20 +146,20 @@
     <MicrosoftExtensionsLoggingEventSourcePackageVersion>3.1.2</MicrosoftExtensionsLoggingEventSourcePackageVersion>
     <MicrosoftExtensionsLoggingEventLogPackageVersion>3.1.2</MicrosoftExtensionsLoggingEventLogPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>3.1.2</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsLoggingTestingPackageVersion>
     <MicrosoftExtensionsLoggingTraceSourcePackageVersion>3.1.2</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
     <MicrosoftExtensionsObjectPoolPackageVersion>3.1.2</MicrosoftExtensionsObjectPoolPackageVersion>
     <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>3.1.2</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>3.1.2</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>3.1.2</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>
+    <MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>3.1.2</MicrosoftExtensionsPrimitivesPackageVersion>
-    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
-    <MicrosoftExtensionsValueStopwatchSourcesPackageVersion>3.1.2-servicing.20067.6</MicrosoftExtensionsValueStopwatchSourcesPackageVersion>
+    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
+    <MicrosoftExtensionsValueStopwatchSourcesPackageVersion>3.1.2-servicing.20067.4</MicrosoftExtensionsValueStopwatchSourcesPackageVersion>
     <MicrosoftExtensionsWebEncodersPackageVersion>3.1.2</MicrosoftExtensionsWebEncodersPackageVersion>
     <MicrosoftInternalExtensionsRefsPackageVersion>3.1.0-rtm.19565.4</MicrosoftInternalExtensionsRefsPackageVersion>
     <MicrosoftJSInteropPackageVersion>3.1.2</MicrosoftJSInteropPackageVersion>
-    <MonoWebAssemblyInteropPackageVersion>3.1.2-preview4.20067.6</MonoWebAssemblyInteropPackageVersion>
+    <MonoWebAssemblyInteropPackageVersion>3.1.2-preview4.20067.4</MonoWebAssemblyInteropPackageVersion>
     <!-- Packages from aspnet/EntityFrameworkCore -->
     <dotnetefPackageVersion>3.1.2</dotnetefPackageVersion>
     <MicrosoftEntityFrameworkCoreInMemoryPackageVersion>3.1.2</MicrosoftEntityFrameworkCoreInMemoryPackageVersion>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -293,7 +293,7 @@
     <ItemGroup>
       <ReferencePath>
         <ReferenceAssembly
-            Condition=" '%(ReferencePath.ReferenceAssembly)' == '' AND Exists('$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll') ">$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll</ReferenceAssembly>
+            Condition=" '%(ReferencePath.ReferenceAssembly)' == '' AND Exists('$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll') AND '%(FileName)' != 'Microsoft.AspNetCore.Testing' ">$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll</ReferenceAssembly>
       </ReferencePath>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Proof-of-concept of excluding the Microsoft.AspNetCore.Testing ref assembly from the bad 3.1.0 extensions ref pack. The versions files have been downgraded to consume the version of extensions where we deleted that ref assembly from the project.

CC @dougbu @JunTaoLuo 