### PR TITLE
Use typeof() rather than caching Type in static

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -13,34 +13,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal partial class HttpProtocol : IFeatureCollection
     {
-        private static readonly Type IHttpRequestFeatureType = typeof(IHttpRequestFeature);
-        private static readonly Type IHttpResponseFeatureType = typeof(IHttpResponseFeature);
-        private static readonly Type IHttpResponseBodyFeatureType = typeof(IHttpResponseBodyFeature);
-        private static readonly Type IRequestBodyPipeFeatureType = typeof(IRequestBodyPipeFeature);
-        private static readonly Type IHttpRequestIdentifierFeatureType = typeof(IHttpRequestIdentifierFeature);
-        private static readonly Type IServiceProvidersFeatureType = typeof(IServiceProvidersFeature);
-        private static readonly Type IHttpRequestLifetimeFeatureType = typeof(IHttpRequestLifetimeFeature);
-        private static readonly Type IHttpConnectionFeatureType = typeof(IHttpConnectionFeature);
-        private static readonly Type IRouteValuesFeatureType = typeof(IRouteValuesFeature);
-        private static readonly Type IEndpointFeatureType = typeof(IEndpointFeature);
-        private static readonly Type IHttpAuthenticationFeatureType = typeof(IHttpAuthenticationFeature);
-        private static readonly Type IHttpRequestTrailersFeatureType = typeof(IHttpRequestTrailersFeature);
-        private static readonly Type IQueryFeatureType = typeof(IQueryFeature);
-        private static readonly Type IFormFeatureType = typeof(IFormFeature);
-        private static readonly Type IHttpUpgradeFeatureType = typeof(IHttpUpgradeFeature);
-        private static readonly Type IHttp2StreamIdFeatureType = typeof(IHttp2StreamIdFeature);
-        private static readonly Type IHttpResponseTrailersFeatureType = typeof(IHttpResponseTrailersFeature);
-        private static readonly Type IResponseCookiesFeatureType = typeof(IResponseCookiesFeature);
-        private static readonly Type IItemsFeatureType = typeof(IItemsFeature);
-        private static readonly Type ITlsConnectionFeatureType = typeof(ITlsConnectionFeature);
-        private static readonly Type IHttpWebSocketFeatureType = typeof(IHttpWebSocketFeature);
-        private static readonly Type ISessionFeatureType = typeof(ISessionFeature);
-        private static readonly Type IHttpMaxRequestBodySizeFeatureType = typeof(IHttpMaxRequestBodySizeFeature);
-        private static readonly Type IHttpMinRequestBodyDataRateFeatureType = typeof(IHttpMinRequestBodyDataRateFeature);
-        private static readonly Type IHttpMinResponseDataRateFeatureType = typeof(IHttpMinResponseDataRateFeature);
-        private static readonly Type IHttpBodyControlFeatureType = typeof(IHttpBodyControlFeature);
-        private static readonly Type IHttpResetFeatureType = typeof(IHttpResetFeature);
-
         private object _currentIHttpRequestFeature;
         private object _currentIHttpResponseFeature;
         private object _currentIHttpResponseBodyFeature;
@@ -157,111 +129,111 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 object feature = null;
-                if (key == IHttpRequestFeatureType)
+                if (key == typeof(IHttpRequestFeature))
                 {
                     feature = _currentIHttpRequestFeature;
                 }
-                else if (key == IHttpResponseFeatureType)
+                else if (key == typeof(IHttpResponseFeature))
                 {
                     feature = _currentIHttpResponseFeature;
                 }
-                else if (key == IHttpResponseBodyFeatureType)
+                else if (key == typeof(IHttpResponseBodyFeature))
                 {
                     feature = _currentIHttpResponseBodyFeature;
                 }
-                else if (key == IRequestBodyPipeFeatureType)
+                else if (key == typeof(IRequestBodyPipeFeature))
                 {
                     feature = _currentIRequestBodyPipeFeature;
                 }
-                else if (key == IHttpRequestIdentifierFeatureType)
+                else if (key == typeof(IHttpRequestIdentifierFeature))
                 {
                     feature = _currentIHttpRequestIdentifierFeature;
                 }
-                else if (key == IServiceProvidersFeatureType)
+                else if (key == typeof(IServiceProvidersFeature))
                 {
                     feature = _currentIServiceProvidersFeature;
                 }
-                else if (key == IHttpRequestLifetimeFeatureType)
+                else if (key == typeof(IHttpRequestLifetimeFeature))
                 {
                     feature = _currentIHttpRequestLifetimeFeature;
                 }
-                else if (key == IHttpConnectionFeatureType)
+                else if (key == typeof(IHttpConnectionFeature))
                 {
                     feature = _currentIHttpConnectionFeature;
                 }
-                else if (key == IRouteValuesFeatureType)
+                else if (key == typeof(IRouteValuesFeature))
                 {
                     feature = _currentIRouteValuesFeature;
                 }
-                else if (key == IEndpointFeatureType)
+                else if (key == typeof(IEndpointFeature))
                 {
                     feature = _currentIEndpointFeature;
                 }
-                else if (key == IHttpAuthenticationFeatureType)
+                else if (key == typeof(IHttpAuthenticationFeature))
                 {
                     feature = _currentIHttpAuthenticationFeature;
                 }
-                else if (key == IHttpRequestTrailersFeatureType)
+                else if (key == typeof(IHttpRequestTrailersFeature))
                 {
                     feature = _currentIHttpRequestTrailersFeature;
                 }
-                else if (key == IQueryFeatureType)
+                else if (key == typeof(IQueryFeature))
                 {
                     feature = _currentIQueryFeature;
                 }
-                else if (key == IFormFeatureType)
+                else if (key == typeof(IFormFeature))
                 {
                     feature = _currentIFormFeature;
                 }
-                else if (key == IHttpUpgradeFeatureType)
+                else if (key == typeof(IHttpUpgradeFeature))
                 {
                     feature = _currentIHttpUpgradeFeature;
                 }
-                else if (key == IHttp2StreamIdFeatureType)
+                else if (key == typeof(IHttp2StreamIdFeature))
                 {
                     feature = _currentIHttp2StreamIdFeature;
                 }
-                else if (key == IHttpResponseTrailersFeatureType)
+                else if (key == typeof(IHttpResponseTrailersFeature))
                 {
                     feature = _currentIHttpResponseTrailersFeature;
                 }
-                else if (key == IResponseCookiesFeatureType)
+                else if (key == typeof(IResponseCookiesFeature))
                 {
                     feature = _currentIResponseCookiesFeature;
                 }
-                else if (key == IItemsFeatureType)
+                else if (key == typeof(IItemsFeature))
                 {
                     feature = _currentIItemsFeature;
                 }
-                else if (key == ITlsConnectionFeatureType)
+                else if (key == typeof(ITlsConnectionFeature))
                 {
                     feature = _currentITlsConnectionFeature;
                 }
-                else if (key == IHttpWebSocketFeatureType)
+                else if (key == typeof(IHttpWebSocketFeature))
                 {
                     feature = _currentIHttpWebSocketFeature;
                 }
-                else if (key == ISessionFeatureType)
+                else if (key == typeof(ISessionFeature))
                 {
                     feature = _currentISessionFeature;
                 }
-                else if (key == IHttpMaxRequestBodySizeFeatureType)
+                else if (key == typeof(IHttpMaxRequestBodySizeFeature))
                 {
                     feature = _currentIHttpMaxRequestBodySizeFeature;
                 }
-                else if (key == IHttpMinRequestBodyDataRateFeatureType)
+                else if (key == typeof(IHttpMinRequestBodyDataRateFeature))
                 {
                     feature = _currentIHttpMinRequestBodyDataRateFeature;
                 }
-                else if (key == IHttpMinResponseDataRateFeatureType)
+                else if (key == typeof(IHttpMinResponseDataRateFeature))
                 {
                     feature = _currentIHttpMinResponseDataRateFeature;
                 }
-                else if (key == IHttpBodyControlFeatureType)
+                else if (key == typeof(IHttpBodyControlFeature))
                 {
                     feature = _currentIHttpBodyControlFeature;
                 }
-                else if (key == IHttpResetFeatureType)
+                else if (key == typeof(IHttpResetFeature))
                 {
                     feature = _currentIHttpResetFeature;
                 }
@@ -277,111 +249,111 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _featureRevision++;
 
-                if (key == IHttpRequestFeatureType)
+                if (key == typeof(IHttpRequestFeature))
                 {
                     _currentIHttpRequestFeature = value;
                 }
-                else if (key == IHttpResponseFeatureType)
+                else if (key == typeof(IHttpResponseFeature))
                 {
                     _currentIHttpResponseFeature = value;
                 }
-                else if (key == IHttpResponseBodyFeatureType)
+                else if (key == typeof(IHttpResponseBodyFeature))
                 {
                     _currentIHttpResponseBodyFeature = value;
                 }
-                else if (key == IRequestBodyPipeFeatureType)
+                else if (key == typeof(IRequestBodyPipeFeature))
                 {
                     _currentIRequestBodyPipeFeature = value;
                 }
-                else if (key == IHttpRequestIdentifierFeatureType)
+                else if (key == typeof(IHttpRequestIdentifierFeature))
                 {
                     _currentIHttpRequestIdentifierFeature = value;
                 }
-                else if (key == IServiceProvidersFeatureType)
+                else if (key == typeof(IServiceProvidersFeature))
                 {
                     _currentIServiceProvidersFeature = value;
                 }
-                else if (key == IHttpRequestLifetimeFeatureType)
+                else if (key == typeof(IHttpRequestLifetimeFeature))
                 {
                     _currentIHttpRequestLifetimeFeature = value;
                 }
-                else if (key == IHttpConnectionFeatureType)
+                else if (key == typeof(IHttpConnectionFeature))
                 {
                     _currentIHttpConnectionFeature = value;
                 }
-                else if (key == IRouteValuesFeatureType)
+                else if (key == typeof(IRouteValuesFeature))
                 {
                     _currentIRouteValuesFeature = value;
                 }
-                else if (key == IEndpointFeatureType)
+                else if (key == typeof(IEndpointFeature))
                 {
                     _currentIEndpointFeature = value;
                 }
-                else if (key == IHttpAuthenticationFeatureType)
+                else if (key == typeof(IHttpAuthenticationFeature))
                 {
                     _currentIHttpAuthenticationFeature = value;
                 }
-                else if (key == IHttpRequestTrailersFeatureType)
+                else if (key == typeof(IHttpRequestTrailersFeature))
                 {
                     _currentIHttpRequestTrailersFeature = value;
                 }
-                else if (key == IQueryFeatureType)
+                else if (key == typeof(IQueryFeature))
                 {
                     _currentIQueryFeature = value;
                 }
-                else if (key == IFormFeatureType)
+                else if (key == typeof(IFormFeature))
                 {
                     _currentIFormFeature = value;
                 }
-                else if (key == IHttpUpgradeFeatureType)
+                else if (key == typeof(IHttpUpgradeFeature))
                 {
                     _currentIHttpUpgradeFeature = value;
                 }
-                else if (key == IHttp2StreamIdFeatureType)
+                else if (key == typeof(IHttp2StreamIdFeature))
                 {
                     _currentIHttp2StreamIdFeature = value;
                 }
-                else if (key == IHttpResponseTrailersFeatureType)
+                else if (key == typeof(IHttpResponseTrailersFeature))
                 {
                     _currentIHttpResponseTrailersFeature = value;
                 }
-                else if (key == IResponseCookiesFeatureType)
+                else if (key == typeof(IResponseCookiesFeature))
                 {
                     _currentIResponseCookiesFeature = value;
                 }
-                else if (key == IItemsFeatureType)
+                else if (key == typeof(IItemsFeature))
                 {
                     _currentIItemsFeature = value;
                 }
-                else if (key == ITlsConnectionFeatureType)
+                else if (key == typeof(ITlsConnectionFeature))
                 {
                     _currentITlsConnectionFeature = value;
                 }
-                else if (key == IHttpWebSocketFeatureType)
+                else if (key == typeof(IHttpWebSocketFeature))
                 {
                     _currentIHttpWebSocketFeature = value;
                 }
-                else if (key == ISessionFeatureType)
+                else if (key == typeof(ISessionFeature))
                 {
                     _currentISessionFeature = value;
                 }
-                else if (key == IHttpMaxRequestBodySizeFeatureType)
+                else if (key == typeof(IHttpMaxRequestBodySizeFeature))
                 {
                     _currentIHttpMaxRequestBodySizeFeature = value;
                 }
-                else if (key == IHttpMinRequestBodyDataRateFeatureType)
+                else if (key == typeof(IHttpMinRequestBodyDataRateFeature))
                 {
                     _currentIHttpMinRequestBodyDataRateFeature = value;
                 }
-                else if (key == IHttpMinResponseDataRateFeatureType)
+                else if (key == typeof(IHttpMinResponseDataRateFeature))
                 {
                     _currentIHttpMinResponseDataRateFeature = value;
                 }
-                else if (key == IHttpBodyControlFeatureType)
+                else if (key == typeof(IHttpBodyControlFeature))
                 {
                     _currentIHttpBodyControlFeature = value;
                 }
-                else if (key == IHttpResetFeatureType)
+                else if (key == typeof(IHttpResetFeature))
                 {
                     _currentIHttpResetFeature = value;
                 }
@@ -637,111 +609,111 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             if (_currentIHttpRequestFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpRequestFeatureType, _currentIHttpRequestFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestFeature), _currentIHttpRequestFeature);
             }
             if (_currentIHttpResponseFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpResponseFeatureType, _currentIHttpResponseFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpResponseFeature), _currentIHttpResponseFeature);
             }
             if (_currentIHttpResponseBodyFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpResponseBodyFeatureType, _currentIHttpResponseBodyFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpResponseBodyFeature), _currentIHttpResponseBodyFeature);
             }
             if (_currentIRequestBodyPipeFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IRequestBodyPipeFeatureType, _currentIRequestBodyPipeFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IRequestBodyPipeFeature), _currentIRequestBodyPipeFeature);
             }
             if (_currentIHttpRequestIdentifierFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpRequestIdentifierFeatureType, _currentIHttpRequestIdentifierFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestIdentifierFeature), _currentIHttpRequestIdentifierFeature);
             }
             if (_currentIServiceProvidersFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IServiceProvidersFeatureType, _currentIServiceProvidersFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IServiceProvidersFeature), _currentIServiceProvidersFeature);
             }
             if (_currentIHttpRequestLifetimeFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpRequestLifetimeFeatureType, _currentIHttpRequestLifetimeFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestLifetimeFeature), _currentIHttpRequestLifetimeFeature);
             }
             if (_currentIHttpConnectionFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpConnectionFeatureType, _currentIHttpConnectionFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpConnectionFeature), _currentIHttpConnectionFeature);
             }
             if (_currentIRouteValuesFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IRouteValuesFeatureType, _currentIRouteValuesFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IRouteValuesFeature), _currentIRouteValuesFeature);
             }
             if (_currentIEndpointFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IEndpointFeatureType, _currentIEndpointFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IEndpointFeature), _currentIEndpointFeature);
             }
             if (_currentIHttpAuthenticationFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpAuthenticationFeatureType, _currentIHttpAuthenticationFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpAuthenticationFeature), _currentIHttpAuthenticationFeature);
             }
             if (_currentIHttpRequestTrailersFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpRequestTrailersFeatureType, _currentIHttpRequestTrailersFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestTrailersFeature), _currentIHttpRequestTrailersFeature);
             }
             if (_currentIQueryFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IQueryFeatureType, _currentIQueryFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IQueryFeature), _currentIQueryFeature);
             }
             if (_currentIFormFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IFormFeatureType, _currentIFormFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IFormFeature), _currentIFormFeature);
             }
             if (_currentIHttpUpgradeFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpUpgradeFeatureType, _currentIHttpUpgradeFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpUpgradeFeature), _currentIHttpUpgradeFeature);
             }
             if (_currentIHttp2StreamIdFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttp2StreamIdFeatureType, _currentIHttp2StreamIdFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttp2StreamIdFeature), _currentIHttp2StreamIdFeature);
             }
             if (_currentIHttpResponseTrailersFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpResponseTrailersFeatureType, _currentIHttpResponseTrailersFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpResponseTrailersFeature), _currentIHttpResponseTrailersFeature);
             }
             if (_currentIResponseCookiesFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IResponseCookiesFeatureType, _currentIResponseCookiesFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IResponseCookiesFeature), _currentIResponseCookiesFeature);
             }
             if (_currentIItemsFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IItemsFeatureType, _currentIItemsFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IItemsFeature), _currentIItemsFeature);
             }
             if (_currentITlsConnectionFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(ITlsConnectionFeatureType, _currentITlsConnectionFeature);
+                yield return new KeyValuePair<Type, object>(typeof(ITlsConnectionFeature), _currentITlsConnectionFeature);
             }
             if (_currentIHttpWebSocketFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpWebSocketFeatureType, _currentIHttpWebSocketFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpWebSocketFeature), _currentIHttpWebSocketFeature);
             }
             if (_currentISessionFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(ISessionFeatureType, _currentISessionFeature);
+                yield return new KeyValuePair<Type, object>(typeof(ISessionFeature), _currentISessionFeature);
             }
             if (_currentIHttpMaxRequestBodySizeFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpMaxRequestBodySizeFeatureType, _currentIHttpMaxRequestBodySizeFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpMaxRequestBodySizeFeature), _currentIHttpMaxRequestBodySizeFeature);
             }
             if (_currentIHttpMinRequestBodyDataRateFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpMinRequestBodyDataRateFeatureType, _currentIHttpMinRequestBodyDataRateFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpMinRequestBodyDataRateFeature), _currentIHttpMinRequestBodyDataRateFeature);
             }
             if (_currentIHttpMinResponseDataRateFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpMinResponseDataRateFeatureType, _currentIHttpMinResponseDataRateFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpMinResponseDataRateFeature), _currentIHttpMinResponseDataRateFeature);
             }
             if (_currentIHttpBodyControlFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpBodyControlFeatureType, _currentIHttpBodyControlFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpBodyControlFeature), _currentIHttpBodyControlFeature);
             }
             if (_currentIHttpResetFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IHttpResetFeatureType, _currentIHttpResetFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpResetFeature), _currentIHttpResetFeature);
             }
 
             if (MaybeExtra != null)

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -12,12 +12,6 @@ namespace Microsoft.AspNetCore.Connections
 {
     internal partial class TransportConnection : IFeatureCollection
     {
-        private static readonly Type IConnectionIdFeatureType = typeof(IConnectionIdFeature);
-        private static readonly Type IConnectionTransportFeatureType = typeof(IConnectionTransportFeature);
-        private static readonly Type IConnectionItemsFeatureType = typeof(IConnectionItemsFeature);
-        private static readonly Type IMemoryPoolFeatureType = typeof(IMemoryPoolFeature);
-        private static readonly Type IConnectionLifetimeFeatureType = typeof(IConnectionLifetimeFeature);
-
         private object _currentIConnectionIdFeature;
         private object _currentIConnectionTransportFeature;
         private object _currentIConnectionItemsFeature;
@@ -90,23 +84,23 @@ namespace Microsoft.AspNetCore.Connections
             get
             {
                 object feature = null;
-                if (key == IConnectionIdFeatureType)
+                if (key == typeof(IConnectionIdFeature))
                 {
                     feature = _currentIConnectionIdFeature;
                 }
-                else if (key == IConnectionTransportFeatureType)
+                else if (key == typeof(IConnectionTransportFeature))
                 {
                     feature = _currentIConnectionTransportFeature;
                 }
-                else if (key == IConnectionItemsFeatureType)
+                else if (key == typeof(IConnectionItemsFeature))
                 {
                     feature = _currentIConnectionItemsFeature;
                 }
-                else if (key == IMemoryPoolFeatureType)
+                else if (key == typeof(IMemoryPoolFeature))
                 {
                     feature = _currentIMemoryPoolFeature;
                 }
-                else if (key == IConnectionLifetimeFeatureType)
+                else if (key == typeof(IConnectionLifetimeFeature))
                 {
                     feature = _currentIConnectionLifetimeFeature;
                 }
@@ -122,23 +116,23 @@ namespace Microsoft.AspNetCore.Connections
             {
                 _featureRevision++;
 
-                if (key == IConnectionIdFeatureType)
+                if (key == typeof(IConnectionIdFeature))
                 {
                     _currentIConnectionIdFeature = value;
                 }
-                else if (key == IConnectionTransportFeatureType)
+                else if (key == typeof(IConnectionTransportFeature))
                 {
                     _currentIConnectionTransportFeature = value;
                 }
-                else if (key == IConnectionItemsFeatureType)
+                else if (key == typeof(IConnectionItemsFeature))
                 {
                     _currentIConnectionItemsFeature = value;
                 }
-                else if (key == IMemoryPoolFeatureType)
+                else if (key == typeof(IMemoryPoolFeature))
                 {
                     _currentIMemoryPoolFeature = value;
                 }
-                else if (key == IConnectionLifetimeFeatureType)
+                else if (key == typeof(IConnectionLifetimeFeature))
                 {
                     _currentIConnectionLifetimeFeature = value;
                 }
@@ -213,23 +207,23 @@ namespace Microsoft.AspNetCore.Connections
         {
             if (_currentIConnectionIdFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IConnectionIdFeatureType, _currentIConnectionIdFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IConnectionIdFeature), _currentIConnectionIdFeature);
             }
             if (_currentIConnectionTransportFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IConnectionTransportFeatureType, _currentIConnectionTransportFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IConnectionTransportFeature), _currentIConnectionTransportFeature);
             }
             if (_currentIConnectionItemsFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IConnectionItemsFeatureType, _currentIConnectionItemsFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IConnectionItemsFeature), _currentIConnectionItemsFeature);
             }
             if (_currentIMemoryPoolFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IMemoryPoolFeatureType, _currentIMemoryPoolFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IMemoryPoolFeature), _currentIMemoryPoolFeature);
             }
             if (_currentIConnectionLifetimeFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(IConnectionLifetimeFeatureType, _currentIConnectionLifetimeFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IConnectionLifetimeFeature), _currentIConnectionLifetimeFeature);
             }
 
             if (MaybeExtra != null)

--- a/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
@@ -31,8 +31,6 @@ namespace {namespaceName}
 {{
     internal partial class {className} : IFeatureCollection
     {{{Each(features, feature => $@"
-        private static readonly Type {feature.Name}Type = typeof({feature.Name});")}
-{Each(features, feature => $@"
         private object _current{feature.Name};")}
 
         private int _featureRevision;
@@ -98,7 +96,7 @@ namespace {namespaceName}
             get
             {{
                 object feature = null;{Each(features, feature => $@"
-                {(feature.Index != 0 ? "else " : "")}if (key == {feature.Name}Type)
+                {(feature.Index != 0 ? "else " : "")}if (key == typeof({feature.Name}))
                 {{
                     feature = _current{feature.Name};
                 }}")}
@@ -114,7 +112,7 @@ namespace {namespaceName}
             {{
                 _featureRevision++;
 {Each(features, feature => $@"
-                {(feature.Index != 0 ? "else " : "")}if (key == {feature.Name}Type)
+                {(feature.Index != 0 ? "else " : "")}if (key == typeof({feature.Name}))
                 {{
                     _current{feature.Name} = value;
                 }}")}
@@ -162,7 +160,7 @@ namespace {namespaceName}
         {{{Each(features, feature => $@"
             if (_current{feature.Name} != null)
             {{
-                yield return new KeyValuePair<Type, object>({feature.Name}Type, _current{feature.Name});
+                yield return new KeyValuePair<Type, object>(typeof({feature.Name}), _current{feature.Name});
             }}")}
 
             if (MaybeExtra != null)


### PR DESCRIPTION
From https://github.com/dotnet/corert/pull/7962/files#r373850627

> It would be better to deleted these and convert the few places that use it to use `typeof`, e.g. `if (type == typeof(Decimal))`.
> 
> Caching these in statics is actually a deoptimization.
> 
> The JIT has optimization for `operator==` on System.Type that kicks in when one of the sides is typeof. It should compile this into a simple vtable compare.

/cc @jkotas 