### PR TITLE
ClientCertificateMode now read from config

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,16 +15,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         private const string EndpointDefaultsKey = "EndpointDefaults";
         private const string EndpointsKey = "Endpoints";
         private const string UrlKey = "Url";
+        private const string ClientCertificateModeKey = "ClientCertificateMode";
 
         private IConfiguration _configuration;
         private IDictionary<string, CertificateConfig> _certificates;
         private IList<EndpointConfig> _endpoints;
         private EndpointDefaults _endpointDefaults;
-
+        private string _clientCertificateMode;
         public ConfigurationReader(IConfiguration configuration)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
+
+
+        public string ClientCertificateMode
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_clientCertificateMode))
+                {
+                    ReadClientCertificateMode();
+                }
+                return _clientCertificateMode;
+            }
+        }
+
 
         public IDictionary<string, CertificateConfig> Certificates
         {
@@ -65,6 +80,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             }
         }
 
+        private void ReadClientCertificateMode()
+        {
+            _clientCertificateMode = _configuration[ClientCertificateModeKey];
+        }
         private void ReadCertificates()
         {
             _certificates = new Dictionary<string, CertificateConfig>(0);
@@ -121,8 +140,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 _endpoints.Add(endpoint);
             }
         }
-
-        private static HttpProtocols? ParseProtocols(string protocols)
+       
+    private static HttpProtocols? ParseProtocols(string protocols)
         {
             if (Enum.TryParse<HttpProtocols>(protocols, ignoreCase: true, out var result))
             {

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -244,6 +244,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     // Specified
                     httpsOptions.ServerCertificate = LoadCertificate(endpoint.Certificate, endpoint.Name)
                         ?? httpsOptions.ServerCertificate;
+                    httpsOptions.ClientCertificateMode = LoadClientCertificateMode(ConfigurationReader) ?? httpsOptions.ClientCertificateMode;
 
                     // Fallback
                     Options.ApplyDefaultCert(httpsOptions);
@@ -273,6 +274,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             {
                 action();
             }
+        }
+
+        private ClientCertificateMode? LoadClientCertificateMode(ConfigurationReader configReader)
+        {
+            if (Enum.TryParse<ClientCertificateMode>(configReader.ClientCertificateMode, ignoreCase: true, out var clientCertificateMode))
+            {
+                return clientCertificateMode;
+            }
+            return null;
         }
 
         private void LoadDefaultCert(ConfigurationReader configReader)

--- a/src/Servers/Kestrel/Kestrel/test/ConfigurationReaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/ConfigurationReaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,6 +12,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
 {
     public class ConfigurationReaderTests
     {
+        
+        [Fact]
+        public void ReadClientCertificateMode_ReturnsValue()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(
+                new[]
+            {
+                new KeyValuePair<string, string>("ClientCertificateMode", "AllowCertificate")
+                }
+                ).Build();
+            var reader = new ConfigurationReader(config);
+            var clientCertificateMode = reader.ClientCertificateMode;
+            Assert.NotNull(clientCertificateMode);
+        }
+        [Fact]
+        public void ReadClientCertificateModeWhenNoClientCertificateMode_ReturnsNull()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var reader = new ConfigurationReader(config);
+            var clientCertificateMode = reader.ClientCertificateMode;
+            Assert.Null(clientCertificateMode);
+        }
         [Fact]
         public void ReadCertificatesWhenNoCertificatesSection_ReturnsEmptyCollection()
         {


### PR DESCRIPTION
Client certificate mode can now be read from config file.
It uses, `connectionreader.cs`
Addresses #18660 