### PR TITLE
Cleanup version.details.xml

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -381,10 +381,6 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>65f04fb6db7a5e198d05dbebd5c4ad21eb018f89</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.1.0" Pinned="true">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>65f04fb6db7a5e198d05dbebd5c4ad21eb018f89</Sha>
-    </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -69,19 +69,19 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.SqlServer" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Caching.SqlServer" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
@@ -89,91 +89,91 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
@@ -181,11 +181,11 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Hosting" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
@@ -193,47 +193,47 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Http" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Localization.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Localization.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Localization" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Localization" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
@@ -241,23 +241,23 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Options" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
@@ -265,7 +265,7 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
@@ -277,11 +277,11 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.WebEncoders" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.WebEncoders" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="3.1.0" CoherentParentDependency="Microsoft.EntityFrameworkCore" Pinned="true">
+    <Dependency Name="Microsoft.JSInterop" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>1c5c7777ea9a19d54ab67ec1521665c99460efc5</Sha>
     </Dependency>


### PR DESCRIPTION
- Remove duplicate entry of `Microsoft.Netcore.App.Ref`
- Remove `CoherentParentDependency` attributes on pinned dependencies

Hopefully this'll unblock automatic dependency flow from dotnet/blazor. CC @SteveSandersonMS @pranavkm @javiercn 