### PR TITLE
Remove non-existing dependency in Identity.Specification.Tests

### DIFF
--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Identity" />
-    <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />

--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -20,4 +20,8 @@
     <Reference Include="xunit.analyzers" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Removing nonexistent package -->
+    <SuppressBaselineReference Include="Microsoft.AspNetCore.Testing" />
+  </ItemGroup>
 </Project>

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -1634,7 +1634,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         /// Test.
         /// </summary>
         /// <returns>Task</returns>
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1766")]
+        [Fact]
         public async Task EmailFactorFailsAfterSecurityStampChangeTest()
         {
             var manager = CreateManager();

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -1635,8 +1634,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         /// Test.
         /// </summary>
         /// <returns>Task</returns>
-        [Fact]
-        [Flaky("https://github.com/aspnet/AspNetCore-Internal/issues/1766", FlakyOn.All)]
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1766")]
         public async Task EmailFactorFailsAfterSecurityStampChangeTest()
         {
             var manager = CreateManager();


### PR DESCRIPTION
AspNetCore.Testing is not a shipping package so we shouldn't include it a shipping package. Not sure why this wasn't caught by the build system which should be enforcing that all stable packages are not referencing non-stable packages.