### PR TITLE
HttpRequestStreamReader overrides for Read Span, ReadAsync Memory, ReadLine and ReadLineAsync

### DIFF
--- a/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/HttpRequestStreamReaderReadLineBenchmark.cs
+++ b/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/HttpRequestStreamReaderReadLineBenchmark.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Jobs;
+
+namespace Microsoft.AspNetCore.WebUtilities
+{
+    [SimpleJob]
+    public class HttpRequestStreamReaderReadLineBenchmark
+    {
+        private MemoryStream _stream;
+
+        [Params(200, 1000, 1025, 1600)]  // Default buffer length is 1024
+        public int Length { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var data = new char[Length];
+
+            data[Length - 2] = '\r';
+            data[Length - 1] = '\n';
+
+            _stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
+        }
+
+        [Benchmark]
+        public async Task<string> ReadLineAsync()
+        {
+            var reader = CreateReader();
+            var result = await reader.ReadLineAsync();
+            Debug.Assert(result.Length == Length - 2);
+            return result;
+        }
+
+        [Benchmark]
+        public string ReadLine()
+        {
+            var reader = CreateReader();
+            var result = reader.ReadLine();
+            Debug.Assert(result.Length == Length - 2);
+            return result;
+        }
+
+        [Benchmark]
+        public HttpRequestStreamReader CreateReader()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            return new HttpRequestStreamReader(_stream, Encoding.UTF8);
+        }
+    }
+}

--- a/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/HttpRequestStreamReaderReadLineBenchmark.cs
+++ b/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/HttpRequestStreamReaderReadLineBenchmark.cs
@@ -3,11 +3,9 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 
 namespace Microsoft.AspNetCore.WebUtilities
 {
-    [SimpleJob]
     public class HttpRequestStreamReaderReadLineBenchmark
     {
         private MemoryStream _stream;

--- a/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/Microsoft.AspNetCore.WebUtilities.Performance.csproj
+++ b/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/Microsoft.AspNetCore.WebUtilities.Performance.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>

--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
@@ -145,8 +145,12 @@ namespace Microsoft.AspNetCore.WebUtilities
         public override int Peek() { throw null; }
         public override int Read() { throw null; }
         public override int Read(char[] buffer, int index, int count) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public override int Read(System.Span<char> buffer) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public override System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
     }
     public partial class HttpResponseStreamWriter : System.IO.TextWriter
     {

--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
@@ -149,6 +149,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         public override System.Threading.Tasks.Task<int> ReadAsync(char[] buffer, int index, int count) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override string ReadLine() { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.Task<string> ReadLineAsync() { throw null; }
     }

--- a/src/Http/WebUtilities/test/HttpRequestStreamReaderTest.cs
+++ b/src/Http/WebUtilities/test/HttpRequestStreamReaderTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.WebUtilities
 {
-    public class HttpResponseStreamReaderTest
+    public class HttpRequestStreamReaderTest
     {
         private static readonly char[] CharData = new char[]
         {
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
-        public static async Task Read_ReadInTwoChunks()
+        public static async Task ReadAsync_ReadInTwoChunks()
         {
             // Arrange
             var reader = CreateReader();
@@ -224,6 +224,44 @@ namespace Microsoft.AspNetCore.WebUtilities
 
             // Act
             var read = reader.Read(span);
+
+            // Assert
+            Assert.Equal(chars.Length, read);
+            for (var i = 0; i < CharData.Length; i++)
+            {
+                Assert.Equal(CharData[i], chars[i]);
+            }
+        }
+
+        [Fact]
+        public async static Task ReadAsync_Memory_ReadAllCharactersAtOnce()
+        {
+            // Arrange
+            var reader = CreateReader();
+            var chars = new char[CharData.Length];
+            var memory = new Memory<char>(chars);
+
+            // Act
+            var read = await reader.ReadAsync(memory);
+
+            // Assert
+            Assert.Equal(chars.Length, read);
+            for (var i = 0; i < CharData.Length; i++)
+            {
+                Assert.Equal(CharData[i], chars[i]);
+            }
+        }
+
+        [Fact]
+        public async static Task ReadAsync_Memory_WithMoreDataThanInternalBufferSize()
+        {
+            // Arrange
+            var reader = CreateReader(10);
+            var chars = new char[CharData.Length];
+            var memory = new Memory<char>(chars);
+
+            // Act
+            var read = await reader.ReadAsync(memory);
 
             // Assert
             Assert.Equal(chars.Length, read);


### PR DESCRIPTION
This is the corresponding change of #18451 (HttpResponseStreamWriter)

Currently the `HttpRequestStreamReader` relies on the base class implementation which cause a sync over async call.

This include a change on the sync implementation of `Read(char[] buffer, int index, int count)` to reuse the `Span<char>` implementation and consolidate the code, but I'm not sure if there are performance concern with this change.

Related to #2895 and #16740