### PR TITLE
Don't include ref assembly from Microsoft.AspNetCore.Testing

### DIFF
--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -293,7 +293,7 @@
     <ItemGroup>
       <ReferencePath>
         <ReferenceAssembly
-            Condition=" '%(ReferencePath.ReferenceAssembly)' == '' AND Exists('$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll') ">$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll</ReferenceAssembly>
+            Condition=" '%(ReferencePath.ReferenceAssembly)' == '' AND Exists('$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll') AND '%(FileName)' != 'Microsoft.AspNetCore.Testing' ">$(MicrosoftInternalExtensionsRefsPath)%(FileName).dll</ReferenceAssembly>
       </ReferencePath>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
The 3.1.0 Extensions ref pack should not have included a ref assembly for `Microsoft.AspNetCore.Testing`. Excluding it here is easier than re-building the ref pack, and is required to ingest https://github.com/dotnet/extensions/pull/2936 (which removes that ref project). Part of https://github.com/dotnet/extensions/issues/2784.

Proof-of-concept here: https://github.com/dotnet/aspnetcore/pull/18720

@dougbu @JunTaoLuo PTAL

CC @Pilchie - marking this as infra-tell-mode for 3.1.3 as it's an extension of https://github.com/dotnet/extensions/pull/2936