### PR TITLE
Remove mvcOptionsAccessor from PageActionDescriptorProvider

### DIFF
--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionDescriptorProvider.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionDescriptorProvider.cs
@@ -16,16 +16,13 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
     public class PageActionDescriptorProvider : IActionDescriptorProvider
     {
         private readonly IPageRouteModelProvider[] _routeModelProviders;
-        private readonly MvcOptions _mvcOptions;
         private readonly IPageRouteModelConvention[] _conventions;
 
         public PageActionDescriptorProvider(
             IEnumerable<IPageRouteModelProvider> pageRouteModelProviders,
-            IOptions<MvcOptions> mvcOptionsAccessor,
             IOptions<RazorPagesOptions> pagesOptionsAccessor)
         {
             _routeModelProviders = pageRouteModelProviders.OrderBy(p => p.Order).ToArray();
-            _mvcOptions = mvcOptionsAccessor.Value;
 
             _conventions = pagesOptionsAccessor.Value.Conventions
                 .OfType<IPageRouteModelConvention>()


### PR DESCRIPTION
I see you inject IOptions<MvcOptions> into `PageActionDescriptorProvider`. But never use it.
I'm not sure if this is by design or just simply forget about it.
Open a PR for your attention.