### PR TITLE
Adding "AzureADB2CSignoutTitle" and "AzureADB2CSignoutText" tags to A…

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/SignedOut.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/SignedOut.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Signed out";
 }
 
-<h2>@ViewData["Title"]</h2>
-<p>
+<h2 id="AzureADB2CSignoutTitle">@ViewData["Title"]</h2>
+<p id="AzureADB2CSignoutText">
     You have successfully signed out.
 </p>


### PR DESCRIPTION
Adding tags to AzureADB2C's SignedOut.cshtml page for Css styling considerations.  Causing Css conflicts on some parts of our site.  Made sure the change would have minimal impact on other users.

Summary of the changes (Less than 80 chars)
 - Add "AzureADB2CSignoutTitle" to the h2 tag in SignedOut.cshtml
 - Add "AzureADB2CSignoutText" to the p tag in SignedOut.cshtml

Addresses #18825
