### PR TITLE
Fix GenerateTypeGranularityLinkingConfig build incrementalism

### DIFF
--- a/src/Components/Blazor/Build/src/Tasks/GenerateTypeGranularityLinkingConfig.cs
+++ b/src/Components/Blazor/Build/src/Tasks/GenerateTypeGranularityLinkingConfig.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
@@ -27,9 +28,18 @@ namespace Microsoft.AspNetCore.Blazor.Build.Tasks
                 linkerElement.Add(assemblyElement);
             }
 
-            using var fileStream = File.Open(OutputPath, FileMode.Create);
-            new XDocument(linkerElement).Save(fileStream);
+            var contentsToWrite = new XDocument(linkerElement).ToString();
+            if (File.Exists(OutputPath))
+            {
+                var existingContent = File.ReadAllText(OutputPath);
+                if (string.Equals(contentsToWrite, existingContent, StringComparison.Ordinal))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Skipping unchanged file {0}", OutputPath);
+                    return true;
+                }
+            }
 
+            File.WriteAllText(OutputPath, contentsToWrite);
             return true;
         }
 

--- a/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/Blazor/Build/src/targets/Blazor.MonoRuntime.targets
@@ -211,9 +211,7 @@
   </Target>
 
   <UsingTask TaskName="GenerateTypeGranularityLinkingConfig" AssemblyFile="$(BlazorTasksPath)" />
-  <Target Name="_GenerateTypeGranularLinkerDescriptor"
-          Inputs="@(_BlazorAssemblyToLink->WithMetadataValue('TypeGranularity', 'true'))"
-          Outputs="$(_TypeGranularityLinkerDescriptor)">
+  <Target Name="_GenerateTypeGranularLinkerDescriptor">
 
     <GenerateTypeGranularityLinkingConfig
       Assemblies="@(_BlazorAssemblyToLink->WithMetadataValue('TypeGranularity', 'true'))"

--- a/src/Components/Blazor/Build/test/GenerateTypeGranularityLinkingConfigTest.cs
+++ b/src/Components/Blazor/Build/test/GenerateTypeGranularityLinkingConfigTest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.Blazor.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Blazor.Build
+{
+    public class GenerateTypeGranularityLinkingConfigTest : IDisposable
+    {
+        private readonly DirectoryInfo TempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "blazor-granular"));
+
+        [Fact]
+        public void Execute_WritesFilesToDisk()
+        {
+            //  Arrange
+            var assemblyNames = new[]
+            {
+                "Microsoft.Extensions.Configuration",
+                "Microsoft.Extensions.Logging",
+            };
+
+            var assemblies = assemblyNames.Select(name => new TaskItem($"{name}.dll")).ToArray();
+            var outputPath = Path.Combine(TempDir.FullName, Path.GetRandomFileName());
+            var task = new GenerateTypeGranularityLinkingConfig
+            {
+                BuildEngine = Mock.Of<IBuildEngine>(),
+                Assemblies = assemblies,
+                OutputPath = outputPath,
+            };
+
+            // Act
+            task.Execute();
+
+            // Assert
+            Assert.True(File.Exists(outputPath), $"No file found at {outputPath}.");
+            var xml = XDocument.Load(outputPath).Root;
+
+            for (var i = 0; i < assemblyNames.Length; i++)
+            {
+                Assert.Equal(assemblyNames[i], xml.Elements("assembly").ElementAt(i).Attribute("fullname").Value);
+            }
+        }
+
+        [Fact]
+        public void Execute_DoesNotWriteFileToDisk_IfContentsAreIdentical()
+        {
+            //  Arrange
+            var assemblyNames = new[]
+            {
+                "Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Configuration",
+            };
+
+            var assemblies = assemblyNames.Select(name => new TaskItem($"{name}.dll")).ToArray();
+            var outputPath = Path.Combine(TempDir.FullName, Path.GetRandomFileName());
+            var task = new GenerateTypeGranularityLinkingConfig
+            {
+                BuildEngine = Mock.Of<IBuildEngine>(),
+                Assemblies = assemblies,
+                OutputPath = outputPath,
+            };
+            task.Execute();
+            var thumbPrint = FileThumbPrint.Create(outputPath);
+
+            // Act
+            task.Execute();
+            Assert.Equal(thumbPrint, FileThumbPrint.Create(outputPath));
+        }
+
+        [Fact]
+        public void Execute_UpdatesFile()
+        {
+            //  Arrange
+            var assemblyNames = new[]
+            {
+                "Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Configuration",
+            };
+
+            var assemblies = assemblyNames.Select(name => new TaskItem($"{name}.dll")).ToArray();
+            var outputPath = Path.Combine(TempDir.FullName, Path.GetRandomFileName());
+            var task = new GenerateTypeGranularityLinkingConfig
+            {
+                BuildEngine = Mock.Of<IBuildEngine>(),
+                Assemblies = assemblies,
+                OutputPath = outputPath,
+            };
+            task.Execute();
+            var thumbPrint = FileThumbPrint.Create(outputPath);
+
+            assemblyNames = new[]
+            {
+                "Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Configuration",
+                "Microsoft.AspNetCore.SignalR.Client",
+            };
+            task.Assemblies = assemblyNames.Select(name => new TaskItem($"{name}.dll")).ToArray();
+
+            // Act
+            task.Execute();
+
+            // Assert
+            Assert.NotEqual(thumbPrint, FileThumbPrint.Create(outputPath));
+            var xml = XDocument.Load(outputPath).Root;
+            for (var i = 0; i < assemblyNames.Length; i++)
+            {
+                Assert.Equal(assemblyNames[i], xml.Elements("assembly").ElementAt(i).Attribute("fullname").Value);
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                TempDir.Delete();
+            }
+            catch
+            {
+                // Don't fail
+            }
+        }
+    }
+}


### PR DESCRIPTION
The target that invokes GenerateTypeGranularLinkerDescriptor is build incremented on the time stamp of
references. However, it needs to be incremented on the sequence of names. If a reference is added or removed,
the file needs to be regenerated.

Fixes https://github.com/dotnet/aspnetcore/issues/18721
