### PR TITLE
[DefaultBuilder] Allow disabling reloadOnChange for WebHost's CreateDefaultBuilder

### DIFF
--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -169,8 +169,11 @@ namespace Microsoft.AspNetCore
             {
                 var env = hostingContext.HostingEnvironment;
 
-                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+                var reloadOnChange = Convert.ToBoolean(
+                    Environment.GetEnvironmentVariable("ASPNETCORE_BUILDER_CONFIG_RELOAD") ?? "true");
+
+                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
+                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
 
                 if (env.IsDevelopment())
                 {

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebHostTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebHostTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Tests
             var secondResult = await client.GetAsync($"http://localhost{testEndpoint}");
             var secondResponseBody = await secondResult.Content.ReadAsStringAsync();
             Assert.Equal(secondResponseBody, firstResponseBody); // Configuration did not change.
-            firstResult.EnsureSuccessStatusCode();
+            secondResult.EnsureSuccessStatusCode();
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Tests
             var secondResponseBody = await secondResult.Content.ReadAsStringAsync();
             Assert.NotEqual(secondResponseBody, firstResponseBody); // Configuration DID reload at runtime.
             Assert.Equal(newDynamicMessage, secondResponseBody); // New config value is what was returned on second request.
-            firstResult.EnsureSuccessStatusCode();
+            secondResult.EnsureSuccessStatusCode();
         }
 
         [Fact]


### PR DESCRIPTION
- Add `ASPNETCORE_BUILDER_CONFIG_RELOAD` environment flag to allow disabling live reload in default builder.
- Add two tests to assert two different cases (live reload on, live reload off) work.

Added in reference to created issue https://github.com/dotnet/aspnetcore/issues/18836

