### PR TITLE
Use the analyzer from the SDK when available

### DIFF
--- a/src/Components/Analyzers/src/Microsoft.AspNetCore.Components.Analyzers.csproj
+++ b/src/Components/Analyzers/src/Microsoft.AspNetCore.Components.Analyzers.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="build/netstandard2.0/*" Pack="true" PackagePath="build/netstandard2.0" />
+    <None Include="buildTransitive/netstandard2.0/*" Pack="true" PackagePath="buildTransitive/netstandard2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.props
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <DisableImplicitComponentsAnalyzers>true</DisableImplicitComponentsAnalyzers>
-  </PropertyGroup>
-</Project>

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -13,21 +13,21 @@
   Note: Prior to 3.1.3, this package prevented the analyzer from the SDK from being used by setting DisableImplicitComponentsAnalyzers=true. This would have prevented newer versions of the analyzer
   from the SDK from ever being used. A compilation of SDK and package version combinations:
 
-  Package Version    SDK Version     Result
-  -------------------------------------------------
-  < 3.1.3              Any            Package wins
-  >= 3.1.3             Any            SDK wins
+  Package Version         SDK Version     Result
+  ==================================================
+  Earlier than 3.1.3      Any            Package wins
+  3.1.3 or newer          Any            SDK wins
   -->
   <Target Name="_RemoveComponentAnalyzer" BeforeTargets="ResolveLockFileAnalyzers" Condition="'@(Analyzer->Count())' != '0'">
     <ItemGroup>
-      <_AnalyzerName Include="$([System.IO.Path]::GetFileNameWithoutExtension('%(Analyzer.Identity)'))" />
+      <_AspNetCoreComponentsAnalyzerName Include="$([System.IO.Path]::GetFileNameWithoutExtension('%(Analyzer.Identity)'))" />
     </ItemGroup>
 
     <PropertyGroup>
       <_AspNetCoreComponentsAnalyzerPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../../analyzers/dotnet/cs/Microsoft.AspNetCore.Components.Analyzers.dll'))</_AspNetCoreComponentsAnalyzerPath>
     </PropertyGroup>
 
-    <ItemGroup Condition="'@(_AnalyzerName->AnyHaveMetadataValue('Identity', 'Microsoft.AspNetCore.Components.Analyzers'))' == 'true'">
+    <ItemGroup Condition="'@(_AspNetCoreComponentsAnalyzerName->AnyHaveMetadataValue('Identity', 'Microsoft.AspNetCore.Components.Analyzers'))' == 'true'">
       <ResolvedAnalyzers Remove="$(_AspNetCoreComponentsAnalyzerPath)" />
     </ItemGroup>
   </Target>

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -5,11 +5,11 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_AnalyzerPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../../analyzers/dotnet/cs/Microsoft.AspNetCore.Components.Analyzers.dll'))</_AnalyzerPath>
+      <_ComponentsAnalyzerPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../../analyzers/dotnet/cs/Microsoft.AspNetCore.Components.Analyzers.dll'))</_ComponentsAnalyzerPath>
     </PropertyGroup>
 
     <ItemGroup Condition="'@(_AnalyzerName->AnyHaveMetadataValue('Identity', 'Microsoft.AspNetCore.Components.Analyzers'))' == 'true'">
-      <ResolvedAnalyzers Remove="$(_AnalyzerPath)" />
+      <ResolvedAnalyzers Remove="$(_ComponentsAnalyzerPath)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -5,11 +5,11 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_ComponentsAnalyzerPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../../analyzers/dotnet/cs/Microsoft.AspNetCore.Components.Analyzers.dll'))</_ComponentsAnalyzerPath>
+      <_AspNetCoreComponentsAnalyzerPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../../analyzers/dotnet/cs/Microsoft.AspNetCore.Components.Analyzers.dll'))</_AspNetCoreComponentsAnalyzerPath>
     </PropertyGroup>
 
     <ItemGroup Condition="'@(_AnalyzerName->AnyHaveMetadataValue('Identity', 'Microsoft.AspNetCore.Components.Analyzers'))' == 'true'">
-      <ResolvedAnalyzers Remove="$(_ComponentsAnalyzerPath)" />
+      <ResolvedAnalyzers Remove="$(_AspNetCoreComponentsAnalyzerPath)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -1,4 +1,23 @@
 <Project>
+  <!--
+  The Web.SDK unconditionally adds the components analyzer to all qualifying Web projects. A project qualifiies if it targets netcoreapp3.0 or later and does not have a flag that
+  prevents the implicit analyzer from being added. We want to ensure that when a Web project also references this package, typically as the result of referencing a component class library,
+  the analyzer in the SDK always wins.
+
+  "ResolvedAnalyzers" contains the list of analyzers that are resolved from package references. "Analyzer" contains the list of of analyzers used by the compiler.
+  The ResolveLockFileAnalyzers target copies items from ResolvedAnalyzers to Analyzer.
+
+  The target below runs before ResolveLockFileAnalyzers executes. If it discovers that the Analyzer item group was previously populated by the WebSDK, it prevents the analyzer from the package
+  from being used by removing it from the ResolvedAnalyzers list.
+
+  Note: Prior to 3.1.3, this package prevented the analyzer from the SDK from being used by setting DisableImplicitComponentsAnalyzers=true. This would have prevented newer versions of the analyzer
+  from the SDK from ever being used. A compilation of SDK and package version combinations:
+
+  Package Version    SDK Version     Result
+  -------------------------------------------------
+  < 3.1.3              Any            Package wins
+  >= 3.1.3             Any            SDK wins
+  -->
   <Target Name="_RemoveComponentAnalyzer" BeforeTargets="ResolveLockFileAnalyzers" Condition="'@(Analyzer->Count())' != '0'">
     <ItemGroup>
       <_AnalyzerName Include="$([System.IO.Path]::GetFileNameWithoutExtension('%(Analyzer.Identity)'))" />

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -1,0 +1,15 @@
+<Project>
+  <Target Name="_RemoveComponentAnalyzer" BeforeTargets="ResolveLockFileAnalyzers" Condition="'@(Analyzer->Count())' != '0'">
+    <ItemGroup>
+      <_AnalyzerName Include="$([System.IO.Path]::GetFileNameWithoutExtension('%(Analyzer.Identity)'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_AnalyzerPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../../analyzers/dotnet/cs/Microsoft.AspNetCore.Components.Analyzers.dll'))</_AnalyzerPath>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'@(_AnalyzerName->AnyHaveMetadataValue('Identity', 'Microsoft.AspNetCore.Components.Analyzers'))' == 'true'">
+      <ResolvedAnalyzers Remove="$(_AnalyzerPath)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Components/Analyzers/src/buildTransitive/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/buildTransitive/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\..\build\netstandard2.0\Microsoft.AspNetCore.Components.Analyzers.targets" />
+</Project>


### PR DESCRIPTION
This prevents a build warning when building a project that contains a reference to
Microsoft.AspNetCore.Components and a netcoreapp3.0 or newer targeting Web project.

The Web SDK implicitly adds the Components.Analyzer for netcoreapp3.0 or newer targeting projects.
If the project additionally referenced this package (directly or transitively), the package would
set up a property that prevented the implicit analyzer reference. This prevented the analyzer from
being referenced twice.

There were two issues with the current approach:

a) The props file wasn't propogated via buildTransitive. Consequently transitive project references
would reference two copies of the analyzer. When these were different versions, it resulted in a compiler
warning.

b) Forward looking, this prevents newer versions of the analyzer shipped from the SDK from ever being used.
This is particularly problematic since apps are likely to reference component libraries that were previously
compiled against 3.x.

This change attempts to mitigate both of these issues:

a) We add a buildTransitive so our build targets flow
b) We knock out the analyzer added by the package if the SDK's already added it.

Fixes https://github.com/dotnet/aspnetcore/issues/18563

-----------------------------------------------------------------

### Description

Building a .NET Core 3.0 or newer Web project references the Microsoft.AspNetCore.Components.Analyzer package via a project reference causes a build warning to be produced. 

[Project A - Microsoft.NET.SDK.Web, netcoreapp3.1] -> [Project B - netstandard2.1] -> [Microsoft.AspNetCore.Components package]

This happens regularly with Blazor Wasm hosted projects, but also applies to Blazor Server projects that reference component class library projects. 

### Customer Impact
Build warnings are produced. While these could be ignored, it's confusing especially seeing this in templates produced out of the box.

### Risk
Low. We're making a change to a package. Users have to update the package to benefit from the fix

### Packaging impact
Additional `buildTransitive` folder added to the package.