### PR TITLE
Use non-stable versioning in blazor-wasm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,8 +84,8 @@
     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
-    <!-- Used to only produce targeting pack installers/packages once per major.minor. -->
-    <IsTargetingPackBuilding Condition="'$(AspNetCorePatchVersion)' != '0' OR '$(DotNetBuildFromSource)' == 'true'">false</IsTargetingPackBuilding>
+    <!-- This branch will never build the targeting pack. -->
+    <IsTargetingPackBuilding>false</IsTargetingPackBuilding>
 
     <!--
       Archives and installers using this prefix are intended for internal-use only.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -105,9 +105,8 @@
     <Compile Include="$(SharedSourceRoot)ReferenceAssemblyInfo.cs" LinkBase="Properties" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Language)' == 'C#'">
+  <PropertyGroup Condition="'$(Language)' == 'C#' AND '$(IsReferenceAssemblyProject)' == 'true'">
     <!-- Reference assemblies should always use Major.Minor.0.0 for assembly versions even during servicing. Only the package version should be updated. -->
-    <!-- Pinning the implementation assemblies at Major.Minor.0.0 as we figure out compiling against ref assemblies. -->
     <AssemblyVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -15,13 +15,14 @@ Directory.Build.props checks this property using the following condition:
 
   <PropertyGroup Condition=" '$(VersionPrefix)' == '3.0.1' ">
     <PackagesInPatch>
-      Microsoft.AspNetCore.Blazor;
-      Microsoft.AspNetCore.Blazor.Build;
-      Microsoft.AspNetCore.Blazor.DataAnnotations.Validation;
-      Microsoft.AspNetCore.Blazor.DevServer;
-      Microsoft.AspNetCore.Blazor.HttpClient;
-      Microsoft.AspNetCore.Blazor.Server;
-      Microsoft.AspNetCore.Blazor.Templates;
+      Microsoft.Net.Http.Headers;
+      Microsoft.AspNetCore.CookiePolicy;
+      Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+      @microsoft/signalr;
+      Microsoft.Net.Http.Headers;
+      Microsoft.AspNetCore.Http.Abstractions;
+      Microsoft.AspNetCore.Http.Features;
+      Microsoft.AspNetCore.CookiePolicy;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -15,14 +15,13 @@ Directory.Build.props checks this property using the following condition:
 
   <PropertyGroup Condition=" '$(VersionPrefix)' == '3.0.1' ">
     <PackagesInPatch>
-      Microsoft.Net.Http.Headers;
-      Microsoft.AspNetCore.CookiePolicy;
-      Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
-      @microsoft/signalr;
-      Microsoft.Net.Http.Headers;
-      Microsoft.AspNetCore.Http.Abstractions;
-      Microsoft.AspNetCore.Http.Features;
-      Microsoft.AspNetCore.CookiePolicy;
+      Microsoft.AspNetCore.Blazor;
+      Microsoft.AspNetCore.Blazor.Build;
+      Microsoft.AspNetCore.Blazor.DataAnnotations.Validation;
+      Microsoft.AspNetCore.Blazor.DevServer;
+      Microsoft.AspNetCore.Blazor.HttpClient;
+      Microsoft.AspNetCore.Blazor.Server;
+      Microsoft.AspNetCore.Blazor.Templates;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
     <AspNetCoreMajorVersion>3</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>2</AspNetCoreMinorVersion>
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
-    <PreReleasePreviewNumber>1</PreReleasePreviewNumber>
+    <PreReleasePreviewNumber>2</PreReleasePreviewNumber>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,13 +7,13 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <AspNetCoreMajorVersion>3</AspNetCoreMajorVersion>
-    <AspNetCoreMinorVersion>1</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>2</AspNetCorePatchVersion>
-    <PreReleasePreviewNumber>0</PreReleasePreviewNumber>
+    <AspNetCoreMinorVersion>2</AspNetCoreMinorVersion>
+    <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
+    <PreReleasePreviewNumber>1</PreReleasePreviewNumber>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
     <IncludePreReleaseLabelInPackageVersion Condition=" '$(DotNetFinalVersionKind)' == 'release' ">false</IncludePreReleaseLabelInPackageVersion>

--- a/src/Components/Blazor/Blazor.Version.props
+++ b/src/Components/Blazor/Blazor.Version.props
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- Override version labels -->
-    <VersionPrefix>3.2.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
-    <DotNetFinalVersionKind />
-  </PropertyGroup>
-</Project>

--- a/src/Components/Blazor/Directory.Build.props
+++ b/src/Components/Blazor/Directory.Build.props
@@ -1,4 +1,3 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-  <Import Project="Blazor.Version.props" />
 </Project>

--- a/src/ProjectTemplates/BlazorWasm.ProjectTemplates/Microsoft.AspNetCore.Blazor.Templates.csproj
+++ b/src/ProjectTemplates/BlazorWasm.ProjectTemplates/Microsoft.AspNetCore.Blazor.Templates.csproj
@@ -3,8 +3,6 @@
     <BlazorProjectsRoot>$(RepoRoot)src\Components\Blazor\</BlazorProjectsRoot>
   </PropertyGroup>
 
-  <Import Project="$(BlazorProjectsRoot)Blazor.Version.props" />
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsShippingPackage>true</IsShippingPackage>


### PR DESCRIPTION
Supercedes https://github.com/dotnet/aspnetcore/pull/18280

Marks packages as non-stable in the `blazor-wasm` branch. With this, packages will all be published to the https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet3.1-blazor feed, rather than being published to unique feeds per-build. I also set the global repo version to 3.2.0-preview2, rather than doing it only for the blazor packages.

@pranavkm @mkArtakMSFT @javiercn @JunTaoLuo @dougbu PTAL

Validated with internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=512337

Worth noting - all the Blazor projects are building against Implementation assemblies. The only Blazor project that produces a Ref assembly is `Microsoft.AspNetCore.Blazor`, which isn't referenced by anything. All the other references get resolved to either ProjectReferences to Blazor projects without ref assemblies, or to PackageReferences, which resolve implementation assemblies. All projects we're building here get AssemblyVersion `3.2.0.0`, and references generally are to version `3.1.2.0`