### PR TITLE
Capture file-backed mappings in Linux core dumps

### DIFF
--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -82,6 +82,13 @@ if [ $? -ne 0 ]; then
     done
 fi
 
+if [ -e /proc/self/coredump_filter ]; then
+  # Include memory in private and shared file-backed mappings in the dump.
+  # This ensures that we can see disassembly from our shared libraries when
+  # inspecting the contents of the dump. See 'man core' for details.
+  echo -n 0x3F > /proc/self/coredump_filter
+fi
+
 $DOTNET_ROOT/dotnet vstest $test_binary_path -lt >discovered.txt
 if grep -q "Exception thrown" discovered.txt; then
     echo -e "${RED}Exception thrown during test discovery${RESET}".


### PR DESCRIPTION
> Dumps created with gdb or gcore do not have all the managed state so various SOS or dotnet-dump commands may display "UNKNOWN" for type and function names. This can also happen with Linux system generated core dumps if the coredump_filter for the process is not set to at least 0x3f. See [core](http://man7.org/linux/man-pages/man5/core.5.html) for more information. 

-- [Debugging Linux or MacOS Core Dump guide](https://github.com/dotnet/diagnostics/blob/06f3cbfb426178850dd9245f2fcda679df89ead8/documentation/debugging-coredump.md).

Not having coredump_filter set correctly has caused issues when investigating a core dump generated due to a "double free or corruption (fasttop)” crash during an Ubuntu.1604.Amd64.Open Helix job. We get output like the following from `clrstack` and `dumpheap -stat`:

```
> clrstack
OS Thread Id: 0xb58b (1)
        Child SP               IP Call Site
00007F60627B1860 00007F62F50AE743 /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B1890 00007F62F50ADD58 /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B18B0 00007F62F50AD1BE /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B1A30 00007F62F514C79D /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B1A50 00007F62F51205FE /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B1BD0 00007F62F51204AC /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown
00007F60627B1C60 00007F62F51203D5 /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown
00007F60627B1CA0 00007F62F5120351 /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B1D50 00007F62F511FB6D /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B1EF0 00007F62F511F81C /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown
00007F60627B1F80 00007F62F511F745 /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown
00007F60627B1FC0 00007F62F511F2BA /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B2040 00007F62F514B6C8 /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B22D0 00007F62F514AE4C /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown
00007F60627B2360 00007F62F514AD75 /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown
00007F60627B23A0 00007F62F514ACEC /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B2440 00007F62F514A622 /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B24F0 00007F62F516CDF8 /datadisks/disk1/work/A79C094A/w/B61D099A/e/Microsoft.AspNetCore.Server.Kestrel.Core.dll!Unknown
00007F60627B29E0 00007F62F5187A7E /datadisks/disk1/work/A79C094A/w/B61D099A/e/.dotnet28339/shared/Microsoft.NETCore.App/5.0.0-alpha.1.20103.10/System.Private.CoreLib.dll!Unknown

>dumpheap -stat
...
00007f62eeb23960     1852       148160 UNKNOWN
00007f62eea43748     3690       248168 UNKNOWN
00007f62eea42e10     2514       299528 UNKNOWN
00007f62eeb22518     3709       385736 UNKNOWN
00007f62eeb30358     1519       584734 UNKNOWN
00007f62eea25750     2429       585160 UNKNOWN
00007f62eea235a8    17422       696880 UNKNOWN
00007f62eea41790    22478      2832226 UNKNOWN
00007f62eeab7290     3441      4811998 UNKNOWN
00005558fd7f0130     6812     24757680      Free
```

I copied this logic from [eng/testing/RunnerTemplate.sh](https://github.com/dotnet/runtime/blob/e0409deadf81fca523da69410cb246bf1f3705a4/eng/testing/RunnerTemplate.sh#L142-L147) in dotnet/runtime. RunnerTemplate.sh does more to configure the core dump (like calling "ulimit -c unlimited") and manually copying the core dump afterwards, but since we're getting the core dump as an artifact from Helix already (not sure how), I figure just setting coredump_filter should be sufficient to get useful dumps.

We probably will be able to remove this once https://github.com/dotnet/core-eng/issues/8888 is addressed.
