### PR TITLE
Updated all AzureAD and AzureADB2C views to give ids to all taged htm…

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/AccessDenied.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/AccessDenied.cshtml
@@ -5,6 +5,6 @@
 }
 
 <header>
-    <h1 class="text-danger">@ViewData["Title"]</h1>
-    <p class="text-danger">You do not have access to this resource.</p>
+    <h1 id="AzureADAccessDeniedTitle" class="text-danger">@ViewData["Title"]</h1>
+    <p id="AzureADAccessDeniedText" class="text-danger">You do not have access to this resource.</p>
 </header>

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/Error.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/Error.cshtml
@@ -4,20 +4,20 @@
     ViewData["Title"] = "Error";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 id="AzureADErrorTitle" class="text-danger">Error.</h1>
+<h2 id="AzureADErrorSub" class="text-danger">An error occurred while processing your request.</h2>
 
 @if (Model.ShowRequestId)
 {
-<p>
+<p id="AzureADErrorRequestId">
     <strong>Request ID:</strong> <code>@Model.RequestId</code>
 </p>
 }
 
-<h3>Development Mode</h3>
-<p>
+<h3 id="AzureADErrorDevNoticeTitle">Development Mode</h3>
+<p id="AzureADErrorDevNoticeText1">
     Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
 </p>
-<p>
+<p id="AzureADErrorDevNoticeText2">
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/SignedOut.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/SignedOut.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Signed out";
 }
 
-<h2 id="AzureADB2CSignoutTitle">@ViewData["Title"]</h2>
-<p id="AzureADB2CSignoutText">
+<h2 id="AzureADSignedOutTitle">@ViewData["Title"]</h2>
+<p id="AzureADSignedOutText">
     You have successfully signed out.
 </p>

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/AccessDenied.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/AccessDenied.cshtml
@@ -5,6 +5,6 @@
 }
 
 <header>
-    <h1 class="text-danger">@ViewData["Title"]</h1>
-    <p class="text-danger">You do not have access to this resource.</p>
+    <h1 id="AzureADB2CAccessDeniedTitle" class="text-danger">@ViewData["Title"]</h1>
+    <p id="AzureADB2CAccessDeniedText" class="text-danger">You do not have access to this resource.</p>
 </header>

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/Error.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/Error.cshtml
@@ -4,20 +4,20 @@
     ViewData["Title"] = "Error";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 id="AzureADB2CErrorTitle" class="text-danger">Error.</h1>
+<h2 id="AzureADB2CErrorSub" class="text-danger">An error occurred while processing your request.</h2>
 
 @if (Model.ShowRequestId)
 {
-<p>
+<p id="AzureADB2CRequestId">
     <strong>Request ID:</strong> <code>@Model.RequestId</code>
 </p>
 }
 
-<h3>Development Mode</h3>
-<p>
+<h3 id="AzureADB2CErrorDevNoticeTitle">Development Mode</h3>
+<p id="AzureADB2CErrorDevNoticeText1">
     Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
 </p>
-<p>
+<p id="AzureADB2CErrorDevNoticeText2">
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/SignedOut.cshtml
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/SignedOut.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Signed out";
 }
 
-<h2>@ViewData["Title"]</h2>
-<p>
+<h2 id="AzureADB2CSignedOutTitle">@ViewData["Title"]</h2>
+<p id="AzureADB2CSignedOutText">
     You have successfully signed out.
 </p>


### PR DESCRIPTION
…l objects.  Again, for easy css use.  All views are now updated and named appropiately for which auth system being used.

Summary of the changes (Less than 80 chars)
In the views for the AzureAD auth system, both AD/B2C. Tagged the objects with an 'id' tag.

Addresses #18909
