### PR TITLE
Add AddOptions to AddAuthorizationCore

### DIFF
--- a/src/Security/Authorization/Core/src/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class AuthorizationServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds authorization services to the specified <see cref="IServiceCollection" />. 
+        /// Adds authorization services to the specified <see cref="IServiceCollection" />.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
@@ -24,7 +24,11 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services));
             }
-            
+
+            // These services depend on options, and they are used in Blazor WASM, where options
+            // aren't included by default.
+            services.AddOptions();
+
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationHandlerProvider, DefaultAuthorizationHandlerProvider>());
@@ -35,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds authorization services to the specified <see cref="IServiceCollection" />. 
+        /// Adds authorization services to the specified <see cref="IServiceCollection" />.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <param name="configure">An action delegate to configure the provided <see cref="AuthorizationOptions"/>.</param>

--- a/src/Security/build.sh
+++ b/src/Security/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/build.sh" --projects "$DIR/**/*.*proj" "$@"


### PR DESCRIPTION
Fixes: #18471

AddAuthorizationCore previously assumed that options were already
registered. This isn't the case in 5.0 in Blazor WASM.

We don't want Blazor to register options in the default host because it
prevents options from being linked out.

note: we will have some remaining work for this issue after this change
is merged. The Blazor WASM hosting changes haven't landed in master yet,
so we'll need to update that code to remove options from the host.
