### PR TITLE
Workaround to possibly fix flaky tests?

### DIFF
--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -89,6 +89,8 @@ if [ -e /proc/self/coredump_filter ]; then
   echo -n 0x3F > /proc/self/coredump_filter
 fi
 
+sync
+
 $DOTNET_ROOT/dotnet vstest $test_binary_path -lt >discovered.txt
 if grep -q "Exception thrown" discovered.txt; then
     echo -e "${RED}Exception thrown during test discovery${RESET}".


### PR DESCRIPTION
Locally this seems to fix some unknown issue (on helix) that is causing the dotnet test process to stop running for a few seconds which can result in test failures.
