### PR TITLE
Update shared code for HTTP/2 and HTTP/3

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.Http;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Shared/Http2/IHttpHeadersHandler.cs
+++ b/src/Shared/Http2/IHttpHeadersHandler.cs
@@ -2,9 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Don't ever change this unless we are explicitly trying to remove IHttpHeadersHandler as public API.
+#if KESTREL
 using System;
 
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
+#else
 namespace System.Net.Http
+#endif
 {
 #if KESTREL
     public

--- a/src/Shared/Http2/IHttpHeadersHandler.cs
+++ b/src/Shared/Http2/IHttpHeadersHandler.cs
@@ -2,13 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if KESTREL
 using System;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
-#else
 namespace System.Net.Http
-#endif
 {
 #if KESTREL
     public

--- a/src/Shared/Http2/ReadMe.SharedCode.md
+++ b/src/Shared/Http2/ReadMe.SharedCode.md
@@ -14,7 +14,7 @@ aspnet/AspNetCore code paths:
 
 ## Building dotnet/runtime code:
 - https://github.com/dotnet/runtime/tree/master/docs/workflow
-- Run libraries.cmd from the root once: `PS D:\github\runtime> .\libraries.cmd`
+- Run *build.cmd* from the root once: `PS D:\github\runtime> .\build.cmd -subsetCategory libraries`
 - Build the individual projects:
 - `PS D:\github\dotnet\src\libraries\Common\tests> dotnet msbuild /t:rebuild`
 - `PS D:\github\dotnet\src\libraries\System.Net.Http\src> dotnet msbuild /t:rebuild`

--- a/src/Shared/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/Http3/QPack/QPackDecoder.cs
@@ -7,6 +7,10 @@ using System.Diagnostics;
 using System.Net.Http.HPack;
 using System.Numerics;
 
+#if KESTREL
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+#endif
+
 namespace System.Net.Http.QPack
 {
     internal class QPackDecoder : IDisposable

--- a/src/Shared/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/Http3/QPack/QPackDecoder.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Net.Http.HPack;
 using System.Numerics;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace System.Net.Http.QPack
 {
@@ -221,9 +220,9 @@ namespace System.Net.Http.QPack
                     }
                     break;
                 case State.CompressedHeaders:
-                    switch (BitOperations.LeadingZeroCount(b))
+                    switch (BitOperations.LeadingZeroCount(b) - 24)
                     {
-                        case 24: // Indexed Header Field
+                        case 0: // Indexed Header Field
                             prefixInt = IndexedHeaderFieldPrefixMask & b;
 
                             bool useStaticTable = (b & IndexedHeaderStaticMask) == IndexedHeaderStaticRepresentation;
@@ -242,7 +241,7 @@ namespace System.Net.Http.QPack
                                 _state = State.HeaderFieldIndex;
                             }
                             break;
-                        case 25: // Literal Header Field With Name Reference
+                        case 1: // Literal Header Field With Name Reference
                             useStaticTable = (LiteralHeaderFieldStaticMask & b) == LiteralHeaderFieldStaticMask;
 
                             if (!useStaticTable)
@@ -260,7 +259,7 @@ namespace System.Net.Http.QPack
                                 _state = State.HeaderNameIndex;
                             }
                             break;
-                        case 26: // Literal Header Field Without Name Reference
+                        case 2: // Literal Header Field Without Name Reference
                             _huffman = (b & LiteralHeaderFieldWithoutNameReferenceHuffmanMask) != 0;
                             prefixInt = b & LiteralHeaderFieldWithoutNameReferencePrefixMask;
 
@@ -273,7 +272,7 @@ namespace System.Net.Http.QPack
                                 _state = State.HeaderNameLength;
                             }
                             break;
-                        case 27: // Indexed Header Field With Post-Base Index
+                        case 3: // Indexed Header Field With Post-Base Index
                             prefixInt = ~PostBaseIndexMask & b;
                             if (_integerDecoder.BeginTryDecode((byte)prefixInt, PostBaseIndexPrefix, out intResult))
                             {

--- a/src/Shared/Http3/ReadMe.SharedCode.md
+++ b/src/Shared/Http3/ReadMe.SharedCode.md
@@ -14,7 +14,7 @@ To copy code from aspnet/AspNetCore to dotnet/runtime, set RUNTIME_REPO to the r
 ## Building dotnet/runtime code:
 - https://github.com/dotnet/runtime/blob/master/docs/libraries/building/windows-instructions.md
 - https://github.com/dotnet/runtime/blob/master/docs/libraries/project-docs/developer-guide.md
-- Run libraries.cmd from the root once: `PS D:\github\runtime> .\libraries.cmd`
+- Run *build.cmd* from the root once: `PS D:\github\runtime> .\build.cmd -subsetCategory libraries`
 - Build the individual projects:
 - `PS D:\github\dotnet\src\libraries\Common\tests> dotnet msbuild /t:rebuild`
 - `PS D:\github\dotnet\src\libraries\System.Net.Http\src> dotnet msbuild /t:rebuild`


### PR DESCRIPTION
I did an oopsie and merged code that updated shared code without updating the runtime. 

Parallel PR: https://github.com/dotnet/runtime/pull/32133