### PR TITLE
Build against the 3.1.0 AspNetCore

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>3.1.2</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>3.1.2-servicing.20067.4</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>3.1.0</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>3.1.0</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>3.1.2</MicrosoftAspNetCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.1.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>3.1.2</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>3.1.2-servicing.20067.4</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>3.1.0</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>3.1.2</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>3.1.0</MicrosoftAspNetCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.1.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->

--- a/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
+++ b/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
@@ -14,6 +14,7 @@
 
     <!-- This is so that we add the FrameworkReference to Microsoft.AspNetCore.App -->
     <UseLatestAspNetCoreReference>true</UseLatestAspNetCoreReference>
+    <MicrosoftAspNetCoreAppVersion>3.1.0</MicrosoftAspNetCoreAppVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/DevServer/src/runtimeconfig.template.json
+++ b/src/Components/Blazor/DevServer/src/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -14,7 +14,7 @@
 
     <!-- This property points to the latest released Microsoft.AspNetCore.App version it needs to be updated to
          target the latest patch before a preview release. -->
-    <LatestAspNetCoreReferenceVersion>3.1.2</LatestAspNetCoreReferenceVersion>
+    <LatestAspNetCoreReferenceVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</LatestAspNetCoreReferenceVersion>
 
     <ComponentsSharedSourceRoot>$(MSBuildThisFileDirectory)Shared\</ComponentsSharedSourceRoot>
 

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -12,8 +12,8 @@
       <KnownFrameworkReference Include="Microsoft.AspNetCore.App">
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <RuntimeFrameworkName>Microsoft.AspNetCore.App</RuntimeFrameworkName>
-        <DefaultRuntimeFrameworkVersion>$(LatestAspNetCoreReferenceVersion)</DefaultRuntimeFrameworkVersion>
-        <LatestRuntimeFrameworkVersion>$(LatestAspNetCoreReferenceVersion)</LatestRuntimeFrameworkVersion>
+        <DefaultRuntimeFrameworkVersion>$(MicrosoftAspNetCoreAppVersion)</DefaultRuntimeFrameworkVersion>
+        <LatestRuntimeFrameworkVersion>$(MicrosoftAspNetCoreAppVersion)</LatestRuntimeFrameworkVersion>
         <TargetingPackName>Microsoft.AspNetCore.App.Ref</TargetingPackName>
         <TargetingPackVersion>$(LatestAspNetCoreReferenceVersion)</TargetingPackVersion>
         <RuntimePackNamePatterns>Microsoft.AspNetCore.App.Runtime.**RID**</RuntimePackNamePatterns>


### PR DESCRIPTION
The version of the runtime that projects compile against
is stamped in to the runtimeconfig.json. In an earlier change, the AspNetCoreRef version
was bumped up to 3.1.2 which causes running dotnet dev-serve to fail
if you do not have the runtime installed.

In addition, the template json allows roll-forwards to major version (5.0 versions) if that's the only version
available. We do this with the razor compiler:
https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.AspNetCore.Razor.Tools/runtimeconfig.template.json
