### PR TITLE
Update Grpc.AspNetCore template reference to 2.27.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -237,7 +237,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.8.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>2.24.0</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>2.27.0</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0</IdentityServer4PackageVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/18994

#### Description

The Grpc.AspNetCore package referenced by the template is version 2.24.0. This was released Oct 2019. Since then there have been many bug fixes, some of which are still being reported by users who have old versions of the package.

We should update Grpc.AspNetCore package in the template to 2.27.0 so new projects created by the template don't run into these fixed issues.

#### Customer Impact

* Was the bug reported by a customer?
    Customers have run into problems and created issues for bugs that have been fixed.
* How does the bug impact the customer
    Need to update to the latest version on NuGet. Some devs might do this straight away, some might waste time trying to find a solution.
* Are there any workarounds? If so, why are they not acceptable alternatives?
    Devs can update to the latest version on NuGet

#### Regression?

No

#### Risk

Low. Update is to a package version that is only used in templates. This version is successfully being used by many customers.