### PR TITLE
allow valid error message to be displayed on linux

### DIFF
--- a/src/Components/Blazor/Server/src/MonoDebugProxy/BlazorMonoDebugProxyAppBuilderExtensions.cs
+++ b/src/Components/Blazor/Server/src/MonoDebugProxy/BlazorMonoDebugProxyAppBuilderExtensions.cs
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Builder
             }
             else
             {
-                throw new InvalidOperationException("Unknown OS platform");
+                return $@"<p>Edge is not current supported on your platform</p>";
             }
         }
 


### PR DESCRIPTION
* Attempting to debug blazor-wasm causes an ¨Unknown OS platform¨

Addresses #12970 aspnet/AspNetCore.Docs#16366
