### PR TITLE
Removed usage of BMI2 pdep with SSE2 alternative

### DIFF
--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -132,13 +132,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 #else
                     if (Sse2.X64.IsSupported)
                     {
+                        Vector128<byte> zero = Vector128<byte>.Zero;
+
                         Vector128<byte> vecNarrow = Sse2.ConvertScalarToVector128Int32((int)value).AsByte();
-                        Vector128<ulong> vecWide = Sse2.UnpackLow(vecNarrow, Vector128<byte>.Zero).AsUInt64();
+                        Vector128<ulong> vecWide = Sse2.UnpackLow(vecNarrow, zero).AsUInt64();
                         Unsafe.WriteUnaligned(output, Sse2.X64.ConvertToUInt64(vecWide));
 
                         vecNarrow = Sse2.ConvertScalarToVector128Int32((int)(value >> 32)).AsByte();
-                        vecWide = Sse2.UnpackLow(vecNarrow, Vector128<byte>.Zero).AsUInt64();
-                        Unsafe.WriteUnaligned(output+sizeof(int), Sse2.X64.ConvertToUInt64(vecWide));
+                        vecWide = Sse2.UnpackLow(vecNarrow, zero).AsUInt64();
+                        Unsafe.WriteUnaligned(output + sizeof(int), Sse2.X64.ConvertToUInt64(vecWide));
                     }
 #endif
                     else
@@ -150,7 +152,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                         output[4] = (char)input[4];
                         output[5] = (char)input[5];
                         output[6] = (char)input[6];
-                        output[7] = (char)input[7];
+                        output[7] = (char)input[7]; 
                     }
 
                     input += sizeof(long);
@@ -596,12 +598,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             return (((check - 0x0101010101010101L) | check) & HighBits) == 0;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool CheckBytesInAsciiRange(int check)
         {
             const int HighBits = unchecked((int)0x80808080);
             return (((check - 0x01010101) | check) & HighBits) == 0;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool CheckBytesInAsciiRange(short check)
         {
             const short HighBits = unchecked((short)0x8080);

--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -133,13 +133,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 #else
                     if (Sse2.X64.IsSupported)
                     {
-                        Vector128<sbyte> vecNarrow = Sse2.ConvertScalarToVector128Int32((int)value).AsSByte();
+                        Vector128<sbyte> vecNarrow = Sse2.X64.ConvertScalarToVector128Int64(value).AsSByte();
                         Vector128<ulong> vecWide = Sse2.UnpackLow(vecNarrow, zero).AsUInt64();
-                        Unsafe.WriteUnaligned(output, Sse2.X64.ConvertToUInt64(vecWide));
-
-                        vecNarrow = Sse2.ConvertScalarToVector128Int32((int)(value >> 32)).AsSByte();
-                        vecWide = Sse2.UnpackLow(vecNarrow, zero).AsUInt64();
-                        Unsafe.WriteUnaligned(output + sizeof(int), Sse2.X64.ConvertToUInt64(vecWide));
+                        Sse2.Store((ulong*)output, vecWide);
                     }
 #endif
                     else


### PR DESCRIPTION
## Description

Replaced `Bmi2.ParallelBitDeposit` with SSE2 alternative.

* Perf-win on Intel (see benchmark results)
* Bmi2 `pdep` has bad perf on AMD, so this issue can be sailed around
* SSE2 has broader support than BMI2

Addresses #18949

## Benchmarks

[Code](https://github.com/gfoidl/Benchmarks/tree/8b6328fbce3ffe3e70e32e7d720ab690af88481b/aspnet/Kestrel/Infrastructure/GetHeaderName/GetHeaderName)
For the benchmarks the vectorized path are disabled, so only sequential processing is performed, to have better figures for replacing BMI2. With the vectorized path only the "remainder" is processed by BMI2, so the gain won't be as huge.

I don't have access to any AMD machine, so can't run a benchmark for this.
But according to the results from the runtime-repo for a similar change, this should be a huge boost for AMD-machines.

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-alpha1-015774
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


```
|         Method | BytesLen |      Mean |     Error |    StdDev | Ratio | RatioSD |
|--------------- |--------- |----------:|----------:|----------:|------:|--------:|
| Current_master |        4 |  6.431 ns | 0.1013 ns | 0.0846 ns |  1.00 |    0.00 |
|        This_PR |        4 |  5.083 ns | 0.0531 ns | 0.0471 ns |  0.79 |    0.01 |
|                |          |           |           |           |       |         |
| Current_master |        8 |  5.446 ns | 0.0757 ns | 0.0671 ns |  1.00 |    0.00 |
|        This_PR |        8 |  5.071 ns | 0.0529 ns | 0.0495 ns |  0.93 |    0.01 |
|                |          |           |           |           |       |         |
| Current_master |       16 |  7.341 ns | 0.1798 ns | 0.1766 ns |  1.00 |    0.00 |
|        This_PR |       16 |  6.341 ns | 0.1068 ns | 0.0999 ns |  0.86 |    0.03 |
|                |          |           |           |           |       |         |
| Current_master |       32 | 10.612 ns | 0.0405 ns | 0.0379 ns |  1.00 |    0.00 |
|        This_PR |       32 |  8.439 ns | 0.0964 ns | 0.0902 ns |  0.80 |    0.01 |
|                |          |           |           |           |       |         |
| Current_master |      100 | 26.499 ns | 0.2693 ns | 0.2519 ns |  1.00 |    0.00 |
|        This_PR |      100 | 18.494 ns | 0.1560 ns | 0.1459 ns |  0.70 |    0.01 |
