### PR TITLE
Pin dependency on Microsoft.CSharp

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -289,11 +289,6 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>29d49b4c7434ca4b01f3b5e297fc3fa1e38d7a07</Sha>
     </Dependency>
-    <!-- This package was dead-ended, pinning it until we decide whether or not to replace it with something else -->
-    <Dependency Name="Microsoft.CSharp" Version="5.0.0-alpha.1.20103.10" Pinned="true">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a7f8cdc0de945561ae3fcaa72440c0ec56d69060</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.1.20112.12" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>3158b52d4ef4d0d339084fcf667e03a37224fb8f</Sha>
@@ -397,6 +392,11 @@
     <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview.1.20112.12" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>3158b52d4ef4d0d339084fcf667e03a37224fb8f</Sha>
+    </Dependency>
+    <!-- This package was dead-ended, pinning it until we decide whether or not to replace it with something else -->
+    <Dependency Name="Microsoft.CSharp" Version="4.7.0" Pinned="true">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -289,9 +289,10 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>29d49b4c7434ca4b01f3b5e297fc3fa1e38d7a07</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CSharp" Version="5.0.0-alpha.1.19563.6" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+    <!-- This package was dead-ended, pinning it until we decide whether or not to replace it with something else -->
+    <Dependency Name="Microsoft.CSharp" Version="5.0.0-alpha.1.20103.10" Pinned="true">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>a7f8cdc0de945561ae3fcaa72440c0ec56d69060</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.1.20112.12" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -393,11 +393,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0f3f8e1930c28b67f29990126bc2e8527e959a2e</Sha>
     </Dependency>
-    <!-- This package was dead-ended, pinning it until we decide whether or not to replace it with something else -->
-    <Dependency Name="Microsoft.CSharp" Version="4.7.0" Pinned="true">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.1.20112.12</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0-preview.1.20112.12</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->
-    <MicrosoftCSharpPackageVersion>5.0.0-alpha.1.20103.10</MicrosoftCSharpPackageVersion>
+    <MicrosoftCSharpPackageVersion>4.7.0</MicrosoftCSharpPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.1.20112.12</MicrosoftWin32RegistryPackageVersion>
     <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.1.20112.12</MicrosoftWin32SystemEventsPackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>5.0.0-preview.1.20112.12</SystemComponentModelAnnotationsPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.1.20112.12</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0-preview.1.20112.12</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->
-    <MicrosoftCSharpPackageVersion>5.0.0-alpha.1.19563.6</MicrosoftCSharpPackageVersion>
+    <MicrosoftCSharpPackageVersion>5.0.0-alpha.1.20103.10</MicrosoftCSharpPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.1.20112.12</MicrosoftWin32RegistryPackageVersion>
     <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.1.20112.12</MicrosoftWin32SystemEventsPackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>5.0.0-preview.1.20112.12</SystemComponentModelAnnotationsPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,14 +63,12 @@
     <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.20113.3</MicrosoftDotNetGenAPIPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetPackageVersion>3.5.0-beta3-20114-02</MicrosoftNetCompilersToolsetPackageVersion>
-    <!-- Packages from dotnet/core-setup -->
+    <!-- Packages from dotnet/runtime -->
     <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-preview.1.20113.7</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-preview.1.20113.7</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>5.0.0-preview.1.20113.7</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.1.20113.7</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0-preview.1.20113.7</NETStandardLibraryRefPackageVersion>
-    <!-- Packages from dotnet/corefx -->
-    <MicrosoftCSharpPackageVersion>4.7.0</MicrosoftCSharpPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.1.20113.7</MicrosoftWin32RegistryPackageVersion>
     <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.1.20113.7</MicrosoftWin32SystemEventsPackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>5.0.0-preview.1.20113.7</SystemComponentModelAnnotationsPackageVersion>
@@ -192,6 +190,7 @@
     <MicrosoftSymbolUploaderBuildTaskPackageVersion>1.0.0-beta-64023-03</MicrosoftSymbolUploaderBuildTaskPackageVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.9.3032</MicrosoftVSSDKBuildToolsVersion>
     <!-- Stable dotnet/corefx packages no longer updated for .NET Core 3 -->
+    <MicrosoftCSharpPackageVersion>4.7.0</MicrosoftCSharpPackageVersion>
     <SystemBuffersPackageVersion>4.5.0</SystemBuffersPackageVersion>
     <SystemCodeDomPackageVersion>4.4.0</SystemCodeDomPackageVersion>
     <SystemCommandlineExperimentalPackageVersion>0.3.0-alpha.19317.1</SystemCommandlineExperimentalPackageVersion>


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/2354 dead-ended this package. Darc did a weird thing and downgraded it to a 5-month old version here: https://github.com/dotnet/aspnetcore/pull/19035/files#diff-5c6a1c77fe216efcfbbdccb11b863063L292-R294. So let's pin it for now until we decide what to do about this package (@BrennanConroy is chatting with @jkotas, @Anipik offline about this).

Also, @mmitche @riarenas @JohnTortugo, any ideas why Darc downgraded this to such an old version of the package?