### PR TITLE
Revert flaky tests that seems to have been fixed

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -591,6 +591,7 @@ stages:
 
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['Build.Reason'], 'PullRequest')
       jobName: Helix_x64_daily
       jobDisplayName: 'Tests: Helix x64 Daily'
       agentOs: Windows

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public void OpenApi_NoProjectExists()
         {
             var app = GetApplication();
@@ -40,7 +39,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public void OpenApi_ExplicitProject_Missing()
         {
             var app = GetApplication();
@@ -75,7 +73,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Add_ReuseItemGroup()
         {
             var project = CreateBasicProject(withOpenApi: true);
@@ -105,7 +102,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public void OpenApi_Add_File_EquivilentPaths()
         {
             var project = CreateBasicProject(withOpenApi: true);
@@ -131,7 +127,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Add_NSwagTypeScript()
         {
             var project = CreateBasicProject(withOpenApi: true);
@@ -152,7 +147,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Add_FromJson()
         {
             var project = CreateBasicProject(withOpenApi: true);
@@ -173,7 +167,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Add_File_UseProjectOption()
         {
             var project = CreateBasicProject(withOpenApi: true);
@@ -194,7 +187,6 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Add_MultipleTimes_OnlyOneReference()
         {
             var project = CreateBasicProject(withOpenApi: true);

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRemoveTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRemoveTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
         public OpenApiRemoveTests(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Remove_File()
         {
             var nswagJsonFile = "openapi.json";
@@ -62,7 +61,6 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Remove_ViaUrl()
         {
             _tempDir
@@ -151,7 +149,6 @@ namespace Microsoft.DotNet.OpenApi.Remove.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task OpenApi_Remove_Multiple()
         {
             var nswagJsonFile = "openapi.json";


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/18969.

I looked at stats that (I believe) indicate this hasn't failed in two weeks. Unfortunately I'm not aware of any way to link to my filtered AZDO results, does someone have a link to the query used to make the quarantine decisions that I can double check with?

Baring my looking at the wrong data it seem that either my mitigation worked or the frequency of failure has gone down for another reason, so it's time for these tests to rejoin polite society.

Also in this PR, re-adding a ci.yml restriction that was accidentally removed in [this PR](https://github.com/dotnet/aspnetcore/pull/17663/files#diff-097cdf55e1a931b74fbfe48d7e41c8beL594) (removed THERE to try to test those changes before merging).