### PR TITLE
Remove ProjectTemplates ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 /src/Hosting/                   @tratcher @anurse
 /src/Http/                      @tratcher @jkotalik @anurse
 /src/Middleware/                @tratcher @anurse
+# /src/ProjectTemplates/          @ryanbrandenburg
 /src/Security/                  @tratcher @anurse
 /src/Servers/                   @tratcher @jkotalik @anurse @halter73
 /src/Middleware/Rewrite         @jkotalik @anurse

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,6 @@
 /src/Hosting/                   @tratcher @anurse
 /src/Http/                      @tratcher @jkotalik @anurse
 /src/Middleware/                @tratcher @anurse
-/src/ProjectTemplates/          @ryanbrandenburg
 /src/Security/                  @tratcher @anurse
 /src/Servers/                   @tratcher @jkotalik @anurse @halter73
 /src/Middleware/Rewrite         @jkotalik @anurse

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /src/Hosting/                   @tratcher @anurse
 /src/Http/                      @tratcher @jkotalik @anurse
 /src/Middleware/                @tratcher @anurse
-# /src/ProjectTemplates/          @ryanbrandenburg
+# ProjectTemplates is owned by @ryanbrandenburg, but is not included here to reduce email notifications.
 /src/Security/                  @tratcher @anurse
 /src/Servers/                   @tratcher @jkotalik @anurse @halter73
 /src/Middleware/Rewrite         @jkotalik @anurse


### PR DESCRIPTION
Already done [in master](https://github.com/dotnet/aspnetcore/blob/master/.github/CODEOWNERS#L19). Being marked as CodeOwner for this area automatically puts my name as a reviewer on a lot of PRs on which I don't have useful input/context. People are always welcome to manually request my review if they believe my input would be useful.