### PR TITLE
Use nonshipping package to determine publish location for installers

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -30,8 +30,11 @@
   </ItemGroup>
 
   <Target Name="_PublishInstallers">
-    <!-- This target is defined in eng/targets/Packaging.targets and included in every C# and F# project. -->
-    <MSBuild Projects="$(RepoRoot)src\Mvc\Mvc\src\Microsoft.AspNetCore.Mvc.csproj"
+    <!-- 
+      This target is defined in eng/targets/Packaging.targets and included in every C# and F# project.
+      We use Microsoft.AspNetCore.DeveloperCertificates.XPlat because it is a nonshipping package, and we need a non-stable version string to use as our publish location.
+    -->
+    <MSBuild Projects="$(RepoRoot)src\Tools\FirstRunCertGenerator\src\Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj"
         Targets="_GetPackageVersionInfo"
         SkipNonexistentProjects="false">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/18767 changed our convention from marking packages as `nonshipping`, to marking them as non-packable. This had the side effect of giving all of our non-packable projects stable versioning, since the arcade default of `IsShipping` is `true`. Because of this, our installer publishing behavior changed - we were using the `Microsoft.AspNetCore.Mvc` project to calculate a version string, and using that string as part of the URL we publish our installers to. However, the version of that project now stabilizes when the rest of the repo does, which means stable builds would all publish to the same URL in blob storage, overwriting each other. We want to use a project that does _not_ stabilize its version - I chose `Microsoft.AspNetCore.DeveloperCertificates.XPlat` because that's what core-sdk uses to calculate our non-stable version: https://github.com/dotnet/core-sdk/blob/30fe5121471cc99ba006e87b7709093d7e6e3365/eng/Version.Details.xml#L52

@dougbu @JunTaoLuo PTAL

Tell-mode for 3.1.3, we should merge this as soon as possible since core-sdk can't ingest us without it (see https://github.com/dotnet/core-sdk/pull/6395)

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=522072