### PR TITLE
[Blazor] Adds support for statically pre-compressing assets using gzip

### DIFF
--- a/src/Components/WebAssembly/Build/src/Tasks/CompressBlazorApplicationFiles.cs
+++ b/src/Components/WebAssembly/Build/src/Tasks/CompressBlazorApplicationFiles.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.IO.Compression;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.Build
+{
+    public class CompressBlazorApplicationFiles : Task
+    {
+        [Required]
+        public ITaskItem StaticWebAsset { get; set; }
+
+        public override bool Execute()
+        {
+            var targetCompressionPath = StaticWebAsset.GetMetadata("TargetCompressionPath");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(targetCompressionPath));
+
+            using var sourceStream = File.OpenRead(StaticWebAsset.GetMetadata("FullPath"));
+            using var fileStream = new FileStream(targetCompressionPath, FileMode.Create);
+            using var stream = new GZipStream(fileStream, CompressionLevel.Optimal);
+
+            sourceStream.CopyTo(stream);
+
+            return true;
+        }
+    }
+}
+

--- a/src/Components/WebAssembly/Build/src/targets/All.props
+++ b/src/Components/WebAssembly/Build/src/targets/All.props
@@ -10,5 +10,7 @@
 
     <!-- When using IISExpress with a standalone app, there's no point restarting IISExpress after build. It slows things unnecessarily and breaks in-flight HTTP requests. -->
     <NoRestartServerOnBuild>true</NoRestartServerOnBuild>
+
+    <BlazorEnableCompresion Condition="'$(BlazorEnableCompresion)' == ''">true</BlazorEnableCompresion>
   </PropertyGroup>
 </Project>

--- a/src/Components/WebAssembly/Build/src/targets/All.props
+++ b/src/Components/WebAssembly/Build/src/targets/All.props
@@ -11,6 +11,6 @@
     <!-- When using IISExpress with a standalone app, there's no point restarting IISExpress after build. It slows things unnecessarily and breaks in-flight HTTP requests. -->
     <NoRestartServerOnBuild>true</NoRestartServerOnBuild>
 
-    <BlazorEnableCompresion Condition="'$(BlazorEnableCompresion)' == ''">true</BlazorEnableCompresion>
+    <BlazorEnableCompression Condition="'$(BlazorEnableCompression)' == ''">true</BlazorEnableCompression>
   </PropertyGroup>
 </Project>

--- a/src/Components/WebAssembly/Build/src/targets/All.targets
+++ b/src/Components/WebAssembly/Build/src/targets/All.targets
@@ -22,5 +22,6 @@
   <Import Project="Publish.targets" />
   <Import Project="StaticWebAssets.targets" />
   <Import Project="ServiceWorkerAssetsManifest.targets" />
+  <Import Project="Compression.targets" />
 
 </Project>

--- a/src/Components/WebAssembly/Build/src/targets/All.targets
+++ b/src/Components/WebAssembly/Build/src/targets/All.targets
@@ -22,6 +22,6 @@
   <Import Project="Publish.targets" />
   <Import Project="StaticWebAssets.targets" />
   <Import Project="ServiceWorkerAssetsManifest.targets" />
-  <Import Project="Compression.targets" />
+  <Import Project="Compression.targets" Condition="'$(BlazorEnableCompression)' == 'true'" />
 
 </Project>

--- a/src/Components/WebAssembly/Build/src/targets/Compression.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Compression.targets
@@ -1,0 +1,61 @@
+<Project>
+  <PropertyGroup>
+
+    <ResolveCurrentProjectStaticWebAssetsDependsOn>
+      $(ResolveCurrentProjectStaticWebAssetsDependsOn);
+      _CompressBlazorApplicationFiles;
+    </ResolveCurrentProjectStaticWebAssetsDependsOn>
+
+  </PropertyGroup>
+
+  <Target Name="_ResolveAssetsToCompress" AfterTargets="_ResolveBlazorGeneratedAssets">
+
+    <PropertyGroup>
+      <StaticResourcesIntermediateOutputPath>$(IntermediateOutputPath)compressed\</StaticResourcesIntermediateOutputPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(StaticResourcesIntermediateOutputPath)" />
+    <ItemGroup>
+      <_StaticResourceToCompress Include="@(StaticWebAsset)" Condition="'%(SourceType)' == '' and $([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith('_framework/'))" KeepDuplicates="false">
+        <TargetCompressionPath>$(StaticResourcesIntermediateOutputPath)%(RelativePath).gz</TargetCompressionPath>
+        <TargetOutputPath>%(RelativePath).gz</TargetOutputPath>
+        <RelativePath>%(RelativePath).gz</RelativePath>
+        <InputSource>%(FullPath)</InputSource>
+      </_StaticResourceToCompress>
+
+      <_StaticResourceToCompress Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
+        <InputSource>$([MSBuild]::NormalizePath('$(StaticResourcesIntermediateOutputPath)%(RelativePath).hash'))</InputSource>
+      </_StaticResourceToCompress>
+
+      <_CompressedStaticWebAsset Include="@(_StaticResourceToCompress->'%(TargetCompressionPath)')" RemoveMetadata="TargetOutputPath;TargetCompressionPath" />
+
+      <StaticWebAsset Include="@(_CompressedStaticWebAsset->'%(FullPath)')" KeepMetadata="SourceType;SourceId;ContentRoot;BasePath;RelativePath" />
+      <FileWrites Include="@(_CompressedStaticWebAsset)" />
+
+    </ItemGroup>
+
+    <GetFileHash Files="@(_StaticResourceToCompress)" Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
+      <Output TaskParameter="Items" ItemName="_LinkerOutputHashes" />
+    </GetFileHash>
+
+    <WriteLinesToFile Condition="'@(_LinkerOutputHashes)' != ''" Lines="%(_LinkerOutputHashes.FileHash)" File="%(_LinkerOutputHashes.InputSource)" WriteOnlyWhenDifferent="true" Overwrite="true" />
+
+    <ItemGroup>
+      <FileWrites Include="%(_LinkerOutputHashes.InputSource)" />
+    </ItemGroup>
+
+  </Target>
+
+  <UsingTask TaskName="CompressBlazorApplicationFiles" AssemblyFile="$(BlazorTasksPath)" />
+
+  <Target
+    Name="_CompressBlazorApplicationFiles"
+    AfterTargets="_ResolveAssetsToCompress"
+    Inputs="%(_StaticResourceToCompress.InputSource)"
+    Outputs="%(_StaticResourceToCompress.TargetCompressionPath)">
+
+    <CompressBlazorApplicationFiles StaticWebAsset="@(_StaticResourceToCompress)" />
+
+  </Target>
+
+</Project>

--- a/src/Components/WebAssembly/Build/src/targets/Compression.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Compression.targets
@@ -8,33 +8,35 @@
 
   </PropertyGroup>
 
-  <Target Name="_ResolveAssetsToCompress" AfterTargets="_ResolveBlazorGeneratedAssets">
+  <Target Name="_ResolveBlazorFilesToCompress" AfterTargets="_ResolveBlazorGeneratedAssets">
 
     <PropertyGroup>
-      <StaticResourcesIntermediateOutputPath>$(IntermediateOutputPath)compressed\</StaticResourcesIntermediateOutputPath>
+      <_BlazorFilesIntermediateOutputPath>$(IntermediateOutputPath)compressed\</_BlazorFilesIntermediateOutputPath>
     </PropertyGroup>
 
-    <MakeDir Directories="$(StaticResourcesIntermediateOutputPath)" />
+    <MakeDir Directories="$(_BlazorFilesIntermediateOutputPath)" />
     <ItemGroup>
-      <_StaticResourceToCompress Include="@(StaticWebAsset)" Condition="'%(SourceType)' == '' and $([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith('_framework/'))" KeepDuplicates="false">
-        <TargetCompressionPath>$(StaticResourcesIntermediateOutputPath)%(RelativePath).gz</TargetCompressionPath>
+      <_BlazorFileToCompress Include="@(StaticWebAsset)" Condition="'%(SourceType)' == '' and $([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith('_framework/'))" KeepDuplicates="false">
+        <TargetCompressionPath>$(_BlazorFilesIntermediateOutputPath)%(RelativePath).gz</TargetCompressionPath>
         <TargetOutputPath>%(RelativePath).gz</TargetOutputPath>
         <RelativePath>%(RelativePath).gz</RelativePath>
         <InputSource>%(FullPath)</InputSource>
-      </_StaticResourceToCompress>
+      </_BlazorFileToCompress>
 
-      <_StaticResourceToCompress Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
-        <InputSource>$([MSBuild]::NormalizePath('$(StaticResourcesIntermediateOutputPath)%(RelativePath).hash'))</InputSource>
-      </_StaticResourceToCompress>
+      <!-- The linker is not incremental, so to support incremental compression in addition to linking we need to compute the hashes of the dlls and
+           pdbs, write them to a file when they change and use that as input for the compression task instead. -->
+      <_BlazorFileToCompress Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
+        <InputSource>$([MSBuild]::NormalizePath('$(_BlazorFilesIntermediateOutputPath)%(RelativePath).hash'))</InputSource>
+      </_BlazorFileToCompress>
 
-      <_CompressedStaticWebAsset Include="@(_StaticResourceToCompress->'%(TargetCompressionPath)')" RemoveMetadata="TargetOutputPath;TargetCompressionPath" />
+      <_CompressedStaticWebAsset Include="@(_BlazorFileToCompress->'%(TargetCompressionPath)')" RemoveMetadata="TargetOutputPath;TargetCompressionPath" />
 
       <StaticWebAsset Include="@(_CompressedStaticWebAsset->'%(FullPath)')" KeepMetadata="SourceType;SourceId;ContentRoot;BasePath;RelativePath" />
       <FileWrites Include="@(_CompressedStaticWebAsset)" />
 
     </ItemGroup>
 
-    <GetFileHash Files="@(_StaticResourceToCompress)" Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
+    <GetFileHash Files="@(_BlazorFileToCompress)" Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
       <Output TaskParameter="Items" ItemName="_LinkerOutputHashes" />
     </GetFileHash>
 
@@ -50,11 +52,11 @@
 
   <Target
     Name="_CompressBlazorApplicationFiles"
-    AfterTargets="_ResolveAssetsToCompress"
-    Inputs="%(_StaticResourceToCompress.InputSource)"
-    Outputs="%(_StaticResourceToCompress.TargetCompressionPath)">
+    AfterTargets="_ResolveBlazorFilesToCompress"
+    Inputs="%(_BlazorFileToCompress.InputSource)"
+    Outputs="%(_BlazorFileToCompress.TargetCompressionPath)">
 
-    <CompressBlazorApplicationFiles StaticWebAsset="@(_StaticResourceToCompress)" />
+    <CompressBlazorApplicationFiles StaticWebAsset="@(_BlazorFileToCompress)" />
 
   </Target>
 

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildCompressionTests.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildCompressionTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.Build
+{
+    public class BuildCompressionTests
+    {
+        [Fact]
+        public async Task Build_WithLinkerAndCompression_IsIncremental()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone");
+            var result = await MSBuildProcessManager.DotnetMSBuild(project);
+
+            Assert.BuildPassed(result);
+
+            var buildOutputDirectory = project.BuildOutputDirectory;
+
+            // Act
+            var compressedFilesFolder = Path.Combine(project.IntermediateOutputDirectory, "compressed");
+            var thumbPrint = FileThumbPrint.CreateFolderThumbprint(project, compressedFilesFolder);
+
+            // Assert
+            for (var i = 0; i < 3; i++)
+            {
+                result = await MSBuildProcessManager.DotnetMSBuild(project);
+                Assert.BuildPassed(result);
+
+                var newThumbPrint = FileThumbPrint.CreateFolderThumbprint(project, compressedFilesFolder);
+                Assert.Equal(thumbPrint.Count, newThumbPrint.Count);
+                for (var j = 0; j < thumbPrint.Count; j++)
+                {
+                    Assert.Equal(thumbPrint[j], newThumbPrint[j]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Build_WithoutLinkerAndCompression_IsIncremental()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone");
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorLinkOnBuild=false");
+
+            Assert.BuildPassed(result);
+
+            var buildOutputDirectory = project.BuildOutputDirectory;
+
+            // Act
+            var compressedFilesFolder = Path.Combine(project.IntermediateOutputDirectory, "compressed");
+            var thumbPrint = FileThumbPrint.CreateFolderThumbprint(project, compressedFilesFolder);
+
+            // Assert
+            for (var i = 0; i < 3; i++)
+            {
+                result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorLinkOnBuild=false");
+                Assert.BuildPassed(result);
+
+                var newThumbPrint = FileThumbPrint.CreateFolderThumbprint(project, compressedFilesFolder);
+                Assert.Equal(thumbPrint.Count, newThumbPrint.Count);
+                for (var j = 0; j < thumbPrint.Count; j++)
+                {
+                    Assert.Equal(thumbPrint[j], newThumbPrint[j]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Build_CompressesAllFrameworkFiles()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone");
+            var result = await MSBuildProcessManager.DotnetMSBuild(project);
+
+            Assert.BuildPassed(result);
+
+            var buildOutputDirectory = project.BuildOutputDirectory;
+
+            var extensions = new[] { ".dll", ".js", ".pdb", ".wasm", ".map", ".json" };
+            // Act
+            var compressedFilesPath = Path.Combine(
+                project.DirectoryPath,
+                project.IntermediateOutputDirectory,
+                "compressed",
+                "_framework");
+            var compressedFiles = Directory.EnumerateFiles(
+                compressedFilesPath,
+                "*",
+                SearchOption.AllDirectories)
+                .Where(f => Path.GetExtension(f) == ".gz")
+                .Select(f => Path.GetRelativePath(compressedFilesPath, f[0..^3]))
+                .OrderBy(f => f)
+                .ToArray();
+
+            var frameworkFilesPath = Path.Combine(
+                project.DirectoryPath,
+                project.BuildOutputDirectory,
+                "wwwroot",
+                "_framework");
+            var frameworkFiles = Directory.EnumerateFiles(
+                frameworkFilesPath,
+                "*",
+                SearchOption.AllDirectories)
+                .Where(f => extensions.Contains(Path.GetExtension(f)))
+                .Select(f => Path.GetRelativePath(frameworkFilesPath, f))
+                .OrderBy(f => f)
+                .ToArray();
+
+            Assert.Equal(frameworkFiles.Length, compressedFiles.Length);
+            Assert.Equal(frameworkFiles, compressedFiles);
+        }
+
+        [Fact]
+        public async Task Build_DisabledCompression_DoesNotCompressFiles()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone");
+
+            // Act
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorEnableCompression=false");
+
+            //Assert
+            Assert.BuildPassed(result);
+
+            var compressedFilesPath = Path.Combine(
+                project.DirectoryPath,
+                project.IntermediateOutputDirectory,
+                "compressed");
+
+            Assert.False(Directory.Exists(compressedFilesPath));
+        }
+    }
+}

--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -28,20 +28,11 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server
         {
             services.AddRouting();
 
-            services.AddResponseCompression(options =>
-            {
-                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[]
-                {
-                    MediaTypeNames.Application.Octet,
-                    "application/wasm",
-                });
-            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment environment, IConfiguration configuration)
         {
             app.UseDeveloperExceptionPage();
-            app.UseResponseCompression();
             EnableConfiguredPathbase(app, configuration);
 
             app.UseBlazorDebugging();

--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Builder
             if (StringSegment.Equals("gzip", selectedEncoding, StringComparison.OrdinalIgnoreCase))
             {
                 var targetPath = context.Request.Path + ".gz";
-                if (webHost.WebRootFileProvider.GetFileInfo(targetPath) != null)
+                if (webHost.WebRootFileProvider.GetFileInfo(targetPath).Exists)
                 {
                     // We only try to serve the pre-compressed file if it's actually there.
                     context.Request.Path = targetPath;
@@ -188,6 +188,6 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         private static bool ResourceExists(HttpContext context, IWebHostEnvironment webHost, string extension) =>
-            webHost.WebRootFileProvider.GetFileInfo(context.Request.Path + extension) != null;
+            webHost.WebRootFileProvider.GetFileInfo(context.Request.Path + extension).Exists;
     }
 }

--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Client/HostedInAspNet.Client.csproj
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Client/HostedInAspNet.Client.csproj
@@ -1,10 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <ReferenceBlazorBuildLocally>true</ReferenceBlazorBuildLocally>
     <RazorLangVersion>3.0</RazorLangVersion>
+    <!-- Disable compression in this project so that we can validate that it can be disabled -->
+    <BlazorEnableCompression>false</BlazorEnableCompression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
@@ -1,8 +1,6 @@
-using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,18 +36,11 @@ namespace Wasm.Authentication.Server
                 .AddIdentityServerJwt();
 
             services.AddMvc();
-            services.AddResponseCompression(opts =>
-            {
-                opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
-                    new[] { "application/octet-stream" });
-            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseResponseCompression();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
* We pre-compress things into a file with the same name and `.gz` extension.
* Only for framework files for now.
* We serve the pre-compressed file directly when asked for the regular file version.

This is the effect that it has on our build, in a clean and on a dirty build with linking enabled:
![image](https://user-images.githubusercontent.com/6995051/75042551-6b83e680-5473-11ea-989e-2939b954110c.png)

* On a clean build it barely adds a few MS.
* On an incremental build it doesn't even show up.