### PR TITLE
Typo in the exception message that's returned

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             {
                 throw new InvalidOperationException(
                     "JavaScript interop calls cannot be issued at this time. This is because the component is being " +
-                    $"statically rendererd. When prerendering is enabled, JavaScript interop calls can only be performed " +
+                    $"statically rendered. When prerendering is enabled, JavaScript interop calls can only be performed " +
                     $"during the OnAfterRenderAsync lifecycle method.");
             }
 


### PR DESCRIPTION
Typo in the exception message that's returned
Rendererd should be Rendered

Summary of the changes (Less than 80 chars)
Very simple typo fix

low risk change
