### PR TITLE
Change MapBlazorWebAssemblyApplication to UseBlazorFrameworkFiles

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -46,13 +46,13 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server
 
             app.UseBlazorDebugging();
 
+            app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
 
             app.UseRouting();
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapBlazorWebAssemblyApplication();
                 endpoints.MapFallbackToFile("index.html");
             });
         }

--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -18,10 +18,10 @@ namespace Microsoft.AspNetCore.Builder
     public static class ComponentsWebAssemblyApplicationBuilderExtensions
     {
         /// <summary>
-        /// Maps a Blazor webassembly application to the <paramref name="pathPrefix"/>.
+        /// Configures the application to serve Blazor WebAssembly framework files from the path <paramref name="pathPrefix"/>. This path must correspond to a referenced Blazor WebAssembly application project.
         /// </summary>
         /// <param name="builder">The <see cref="IApplicationBuilder"/>.</param>
-        /// <param name="pathPrefix">The <see cref="PathString"/> that indicates the prefix for the Blazor application.</param>
+        /// <param name="pathPrefix">The <see cref="PathString"/> that indicates the prefix for the Blazor WebAssembly application.</param>
         /// <returns>The <see cref="IApplicationBuilder"/></returns>
         public static IApplicationBuilder MapBlazorFrameworkFiles(this IApplicationBuilder builder, PathString pathPrefix)
         {
@@ -52,10 +52,10 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
-        /// Maps a Blazor webassembly application to the root path of the application "/".
+        /// Configures the application to serve Blazor WebAssembly framework files from the root path "/".
         /// </summary>
         /// <param name="applicationBuilder">The <see cref="IApplicationBuilder"/>.</param>
-        /// <param name="pathPrefix">The <see cref="PathString"/> that indicates the prefix for the Blazor application.</param>
+        /// <param name="pathPrefix">The <see cref="PathString"/> that indicates the prefix for the Blazor WebAssembly application.</param>
         /// <returns>The <see cref="IApplicationBuilder"/></returns>
         public static IApplicationBuilder UseBlazorFrameworkFiles(this IApplicationBuilder applicationBuilder) =>
             MapBlazorFrameworkFiles(applicationBuilder, default);

--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Server/Startup.cs
@@ -33,11 +33,13 @@ namespace HostedInAspNet.Server
                 app.UseBlazorDebugging();
             }
 
+            app.UseBlazorFrameworkFiles();
+            app.UseStaticFiles();
+
             app.UseRouting();
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapBlazorWebAssemblyApplication();
                 endpoints.MapFallbackToFile("index.html");
             });
         }

--- a/src/Components/WebAssembly/testassets/MonoSanity/Startup.cs
+++ b/src/Components/WebAssembly/testassets/MonoSanity/Startup.cs
@@ -16,11 +16,11 @@ namespace MonoSanity
         {
             app.UseDeveloperExceptionPage();
             app.UseFileServer(new FileServerOptions() { EnableDefaultFiles = true, });
+            app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapBlazorWebAssemblyApplication();
                 endpoints.MapFallbackToFile("index.html");
             });
         }

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
@@ -56,6 +56,9 @@ namespace Wasm.Authentication.Server
                 app.UseBlazorDebugging();
             }
 
+            app.UseBlazorFrameworkFiles();
+            app.UseStaticFiles();
+
             app.UseRouting();
 
             app.UseAuthentication();
@@ -67,7 +70,6 @@ namespace Wasm.Authentication.Server
                 endpoints.MapControllers();
                 endpoints.MapRazorPages();
 
-                endpoints.MapBlazorWebAssemblyApplication();
                 endpoints.MapFallbackToFile("index.html");
             });
         }

--- a/src/Components/test/testassets/TestServer/AuthenticationStartup.cs
+++ b/src/Components/test/testassets/TestServer/AuthenticationStartup.cs
@@ -49,12 +49,12 @@ namespace TestServer
             // Mount the server-side Blazor app on /subdir
             app.Map("/subdir", app =>
             {
+                app.UseBlazorFrameworkFiles();
                 app.UseStaticFiles();
 
                 app.UseRouting();
                 app.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapBlazorWebAssemblyApplication();
                     endpoints.MapControllers();
                     endpoints.MapRazorPages();
                     endpoints.MapBlazorHub();

--- a/src/Components/test/testassets/TestServer/ClientStartup.cs
+++ b/src/Components/test/testassets/TestServer/ClientStartup.cs
@@ -37,13 +37,12 @@ namespace TestServer
             app.Map("/subdir", app =>
             {
                 // Add it before to ensure it takes priority over files in wwwroot
+                app.UseBlazorFrameworkFiles();
                 app.UseStaticFiles();
 
                 app.UseRouting();
                 app.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapBlazorWebAssemblyApplication();
-
                     endpoints.MapRazorPages();
                     endpoints.MapControllers();
                     endpoints.MapFallbackToFile("index.html");

--- a/src/Components/test/testassets/TestServer/CorsStartup.cs
+++ b/src/Components/test/testassets/TestServer/CorsStartup.cs
@@ -45,6 +45,7 @@ namespace TestServer
             // Mount the server-side Blazor app on /subdir
             app.Map("/subdir", app =>
             {
+                app.UseBlazorFrameworkFiles();
                 app.UseStaticFiles();
 
                 app.UseRouting();
@@ -53,8 +54,6 @@ namespace TestServer
 
                 app.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapBlazorWebAssemblyApplication();
-
                     endpoints.MapControllers();
                     endpoints.MapFallbackToFile("index.html");
                 });

--- a/src/Components/test/testassets/TestServer/InternationalizationStartup.cs
+++ b/src/Components/test/testassets/TestServer/InternationalizationStartup.cs
@@ -36,6 +36,7 @@ namespace TestServer
             // Mount the server-side Blazor app on /subdir
             app.Map("/subdir", app =>
             {
+                app.UseBlazorFrameworkFiles();
                 app.UseStaticFiles();
 
                 app.UseRequestLocalization(options =>
@@ -54,8 +55,6 @@ namespace TestServer
                 app.UseRouting();
                 app.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapBlazorWebAssemblyApplication();
-
                     endpoints.MapControllers();
                     endpoints.MapBlazorHub();
                     endpoints.MapFallbackToPage("/_ServerHost");

--- a/src/Components/test/testassets/TestServer/StartupWithMapFallbackToClientSideBlazor.cs
+++ b/src/Components/test/testassets/TestServer/StartupWithMapFallbackToClientSideBlazor.cs
@@ -33,12 +33,8 @@ namespace TestServer
             // The client-side files middleware needs to be here because the base href in hardcoded to /subdir/
             app.Map("/subdir", app =>
             {
-                app.UseRouting();
-
-                app.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapBlazorWebAssemblyApplication();
-                });
+                app.UseBlazorFrameworkFiles();
+                app.UseStaticFiles();
             });
 
             // The calls to `Map` allow us to test each of these overloads, while keeping them isolated.

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
@@ -104,6 +104,7 @@ namespace ComponentsWebAssembly_CSharp.Server
             }
 
 #endif
+            app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
 
             app.UseRouting();
@@ -124,8 +125,6 @@ namespace ComponentsWebAssembly_CSharp.Server
                 endpoints.MapRazorPages();
 #endif
                 endpoints.MapControllers();
-
-                endpoints.MapBlazorWebAssemblyApplication();
                 endpoints.MapFallbackToFile("index.html");
             });
         }


### PR DESCRIPTION
* We discovered some issues with the interactions between static files and endpoint routing and we need to re-assess the design.
* In the mean time, we go back to MapBlazorFrameworkFiles that only handles _framework files