### PR TITLE
[release/3.1] Update dependencies from EFCore

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,12 +3,15 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-pub-dotnet-efcore-58ffe7b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-58ffe7b8/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-core-setup-8ac9495" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-8ac94955/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-a286361" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-a286361b/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-core-setup-34f6927" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-34f6927f/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-corefx-e946ceb-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-e946cebe-1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-corefx-bcfd3d3-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-bcfd3d34-2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-corefx-bcfd3d3-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-bcfd3d34-1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-corefx-bcfd3d3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-bcfd3d34/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-corefx-0f7f38c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-0f7f38c4/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-aspnetcore-tooling-d954615" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-tooling-d954615b/nuget/v3/index.json" />
-    <add key="darc-pub-aspnet-Extensions-dcbe039" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-Extensions-dcbe0394/nuget/v3/index.json" />
+    <add key="darc-pub-aspnet-Extensions-833a144" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-Extensions-833a1443/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -285,10 +285,6 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
     </Dependency>
-    <Dependency Name="Mono.WebAssembly.Interop" Version="3.1.3-preview4.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
-      <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,259 +31,259 @@
     </Dependency>
     <Dependency Name="dotnet-ef" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="3.1.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>58ffe7b8b2e26f25e49b75224d6e6908b3e9036f</Sha>
+      <Sha>a286361ba7527141bb42c289ea6f8768fca72553</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Analyzer.Testing" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.AspNetCore.Analyzer.Testing" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ActivatorUtilities.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.ActivatorUtilities.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.SqlServer" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.CommandLineUtils.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.HashCodeCombiner.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Hosting" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Http" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Localization.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Localization" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Testing" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.Logging.Testing" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.ObjectPool" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.ParameterDefaultValue.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Primitives" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TypeNameHelper.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.TypeNameHelper.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ValueStopwatch.Sources" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.Extensions.ValueStopwatch.Sources" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.WebEncoders" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.JSInterop" Version="3.1.3" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -313,9 +313,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.7.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.IO.Pipelines" Version="4.7.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+      <Sha>bcfd3d34f519fc1369294304747c82f643be6ff1</Sha>
     </Dependency>
     <Dependency Name="System.Net.Http.WinHttpHandler" Version="4.7.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -329,9 +329,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+      <Sha>bcfd3d34f519fc1369294304747c82f643be6ff1</Sha>
     </Dependency>
     <Dependency Name="System.Security.Cryptography.Cng" Version="4.7.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -375,7 +375,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.1.3" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8ac9495536a53010b68b4deabe27844afcdd8c20</Sha>
+      <Sha>34f6927fe83b2d6cb2003d6577853482ceee25ec</Sha>
     </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
@@ -383,15 +383,15 @@
     -->
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="3.1.3" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8ac9495536a53010b68b4deabe27844afcdd8c20</Sha>
+      <Sha>34f6927fe83b2d6cb2003d6577853482ceee25ec</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="3.1.3-servicing.20114.3" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="3.1.3-servicing.20119.2" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8ac9495536a53010b68b4deabe27844afcdd8c20</Sha>
+      <Sha>34f6927fe83b2d6cb2003d6577853482ceee25ec</Sha>
     </Dependency>
     <!-- Keep these dependencies at the bottom of ProductDependencies, else they will be picked as the parent for CoherentParentDependencies -->
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.1.0" Pinned="true">
@@ -409,9 +409,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
-    <Dependency Name="Internal.AspNetCore.Analyzers" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Internal.AspNetCore.Analyzers" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.20113.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -425,9 +425,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>15f00efd583eab4372b2e9ca25bd80ace5b119ad</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.1.3-servicing.20118.2" CoherentParentDependency="Microsoft.EntityFrameworkCore">
+    <Dependency Name="Microsoft.AspNetCore.Testing" Version="3.1.3-servicing.20119.6" CoherentParentDependency="Microsoft.EntityFrameworkCore">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>dcbe0394509f96c2b15920aa1af15d31ab140c96</Sha>
+      <Sha>833a1443de43cb00c7a389388a76c8e2cd14e86e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.4.1-beta4-19614-01" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,6 +204,7 @@
     <!-- Packages developed by @aspnet, but manually updated as necessary. -->
     <LibuvPackageVersion>1.10.0</LibuvPackageVersion>
     <MicrosoftAspNetWebApiClientPackageVersion>5.2.6</MicrosoftAspNetWebApiClientPackageVersion>
+    <MonoWebAssemblyInteropPackageVersion>3.1.1-preview4.19614.4</MonoWebAssemblyInteropPackageVersion>
     <!-- Partner teams -->
     <MicrosoftAzureKeyVaultPackageVersion>2.3.2</MicrosoftAzureKeyVaultPackageVersion>
     <MicrosoftAzureStorageBlobPackageVersion>10.0.1</MicrosoftAzureStorageBlobPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,7 +67,7 @@
     <MicrosoftNetCompilersToolsetPackageVersion>3.4.1-beta4-19614-01</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- Packages from dotnet/core-setup -->
     <MicrosoftExtensionsDependencyModelPackageVersion>3.1.3</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreAppInternalPackageVersion>3.1.3-servicing.20114.3</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>3.1.3-servicing.20119.2</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>3.1.0</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.1.3</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
@@ -79,11 +79,11 @@
     <SystemComponentModelAnnotationsPackageVersion>4.7.0</SystemComponentModelAnnotationsPackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>4.7.0</SystemDiagnosticsEventLogPackageVersion>
     <SystemDrawingCommonPackageVersion>4.7.0</SystemDrawingCommonPackageVersion>
-    <SystemIOPipelinesPackageVersion>4.7.0</SystemIOPipelinesPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.7.1</SystemIOPipelinesPackageVersion>
     <SystemNetHttpWinHttpHandlerPackageVersion>4.7.0</SystemNetHttpWinHttpHandlerPackageVersion>
     <SystemNetWebSocketsWebSocketProtocolPackageVersion>4.7.0</SystemNetWebSocketsWebSocketProtocolPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.8.0</SystemReflectionMetadataPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.7.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.7.1</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>4.7.0</SystemSecurityCryptographyCngPackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>4.7.0</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>4.7.0</SystemSecurityCryptographyXmlPackageVersion>
@@ -99,16 +99,16 @@
     <!-- Packages from aspnet/Blazor -->
     <MicrosoftAspNetCoreBlazorMonoPackageVersion>3.1.0-preview4.19605.1</MicrosoftAspNetCoreBlazorMonoPackageVersion>
     <!-- Packages from aspnet/Extensions -->
-    <InternalAspNetCoreAnalyzersPackageVersion>3.1.3-servicing.20118.2</InternalAspNetCoreAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>3.1.3-servicing.20118.2</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
-    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>3.1.3-servicing.20118.2</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>
+    <InternalAspNetCoreAnalyzersPackageVersion>3.1.3-servicing.20119.6</InternalAspNetCoreAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>3.1.3-servicing.20119.6</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>3.1.3-servicing.20119.6</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>
     <MicrosoftExtensionsCachingAbstractionsPackageVersion>3.1.3</MicrosoftExtensionsCachingAbstractionsPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>3.1.3</MicrosoftExtensionsCachingMemoryPackageVersion>
     <MicrosoftExtensionsCachingSqlServerPackageVersion>3.1.3</MicrosoftExtensionsCachingSqlServerPackageVersion>
     <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>3.1.3</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
-    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>3.1.3</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>3.1.3</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>3.1.3</MicrosoftExtensionsConfigurationBinderPackageVersion>
@@ -131,10 +131,10 @@
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>3.1.3</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>3.1.3</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>3.1.3</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
+    <MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsHashCodeCombinerSourcesPackageVersion>
     <MicrosoftExtensionsHostingAbstractionsPackageVersion>3.1.3</MicrosoftExtensionsHostingAbstractionsPackageVersion>
     <MicrosoftExtensionsHostingPackageVersion>3.1.3</MicrosoftExtensionsHostingPackageVersion>
-    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
+    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
     <MicrosoftExtensionsHttpPackageVersion>3.1.3</MicrosoftExtensionsHttpPackageVersion>
     <MicrosoftExtensionsLocalizationAbstractionsPackageVersion>3.1.3</MicrosoftExtensionsLocalizationAbstractionsPackageVersion>
     <MicrosoftExtensionsLocalizationPackageVersion>3.1.3</MicrosoftExtensionsLocalizationPackageVersion>
@@ -146,16 +146,16 @@
     <MicrosoftExtensionsLoggingEventSourcePackageVersion>3.1.3</MicrosoftExtensionsLoggingEventSourcePackageVersion>
     <MicrosoftExtensionsLoggingEventLogPackageVersion>3.1.3</MicrosoftExtensionsLoggingEventLogPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>3.1.3</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsLoggingTestingPackageVersion>
     <MicrosoftExtensionsLoggingTraceSourcePackageVersion>3.1.3</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
     <MicrosoftExtensionsObjectPoolPackageVersion>3.1.3</MicrosoftExtensionsObjectPoolPackageVersion>
     <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>3.1.3</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>3.1.3</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>3.1.3</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>
+    <MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsParameterDefaultValueSourcesPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>3.1.3</MicrosoftExtensionsPrimitivesPackageVersion>
-    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
-    <MicrosoftExtensionsValueStopwatchSourcesPackageVersion>3.1.3-servicing.20118.2</MicrosoftExtensionsValueStopwatchSourcesPackageVersion>
+    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
+    <MicrosoftExtensionsValueStopwatchSourcesPackageVersion>3.1.3-servicing.20119.6</MicrosoftExtensionsValueStopwatchSourcesPackageVersion>
     <MicrosoftExtensionsWebEncodersPackageVersion>3.1.3</MicrosoftExtensionsWebEncodersPackageVersion>
     <MicrosoftInternalExtensionsRefsPackageVersion>3.1.0-rtm.19565.4</MicrosoftInternalExtensionsRefsPackageVersion>
     <MicrosoftJSInteropPackageVersion>3.1.3</MicrosoftJSInteropPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,7 +159,6 @@
     <MicrosoftExtensionsWebEncodersPackageVersion>3.1.3</MicrosoftExtensionsWebEncodersPackageVersion>
     <MicrosoftInternalExtensionsRefsPackageVersion>3.1.0-rtm.19565.4</MicrosoftInternalExtensionsRefsPackageVersion>
     <MicrosoftJSInteropPackageVersion>3.1.3</MicrosoftJSInteropPackageVersion>
-    <MonoWebAssemblyInteropPackageVersion>3.1.3-preview4.20118.2</MonoWebAssemblyInteropPackageVersion>
     <!-- Packages from aspnet/EntityFrameworkCore -->
     <dotnetefPackageVersion>3.1.3</dotnetefPackageVersion>
     <MicrosoftEntityFrameworkCoreInMemoryPackageVersion>3.1.3</MicrosoftEntityFrameworkCoreInMemoryPackageVersion>


### PR DESCRIPTION
After Extensions removed the `Mono.WebAssembly.Interop` package yesterday, Maestro silently failed to update our dependencies from EFCore, because we still listed a dependency on that package despite it not being produced (thanks @riarenas for helping figure this out). I deleted that package from our version files & ran `darc update-dependencies` locally. Here's the issue tracking making these types of failures less difficult to notice/track down: https://github.com/dotnet/arcade/issues/1387

CC @dougbu @JunTaoLuo - after this I can validate https://github.com/dotnet/aspnetcore/pull/19161 (since this updates `System.IO.Pipelines` to `4.7.1`)