### PR TITLE
Fixup RuntimeDependenciesResolver test

### DIFF
--- a/src/Components/WebAssembly/Build/test/Microsoft.AspNetCore.Components.WebAssembly.Build.Tests.csproj
+++ b/src/Components/WebAssembly/Build/test/Microsoft.AspNetCore.Components.WebAssembly.Build.Tests.csproj
@@ -56,16 +56,4 @@
         MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion)" />
   </Target>
 
-  <!-- A bit of msbuild magic to support reference resolver tests -->
-  <Target Name="CreateReferenceHintPathsList" AfterTargets="Build">
-    <ItemGroup>
-      <_BclDirectory Include="$(ComponentsWebAssemblyBaseClassLibraryPath)" />
-      <_BclDirectory Include="$(ComponentsWebAssemblyBaseClassLibraryFacadesPath)" />
-      <_BclDirectory Include="$(ComponentsWebAssemblyFrameworkPath)" />
-    </ItemGroup>
-
-    <WriteLinesToFile Lines="@(ReferencePath)" File="$(TargetDir)referenceHints.txt" WriteOnlyWhenDifferent="true" Overwrite="true" />
-    <WriteLinesToFile Lines="@(_BclDirectory)" File="$(TargetDir)bclLocations.txt" WriteOnlyWhenDifferent="true" Overwrite="true" />
-  </Target>
-
 </Project>

--- a/src/Components/WebAssembly/testassets/StandaloneApp/StandaloneApp.csproj
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/StandaloneApp.csproj
@@ -10,4 +10,22 @@
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <Reference Include="Microsoft.AspNetCore.Blazor.HttpClient" />
   </ItemGroup>
+
+  <!-- A bit of msbuild magic to support reference resolver tests -->
+  <Target Name="CreateReferenceHintPathsList" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_BclFile Include="$(ComponentsWebAssemblyBaseClassLibraryPath)*" />
+      <_BclFile Include="$(ComponentsWebAssemblyBaseClassLibraryFacadesPath)*" />
+      <_BclFile Include="$(ComponentsWebAssemblyFrameworkPath)*" />
+    </ItemGroup>
+
+    <WriteLinesToFile Lines="@(ReferencePath);@(ReferenceDependencyPaths)" File="$(IntermediateOutputPath)referenceHints.txt" WriteOnlyWhenDifferent="true" Overwrite="true" />
+    <WriteLinesToFile Lines="@(_BclFile)" File="$(IntermediateOutputPath)bclLocations.txt" WriteOnlyWhenDifferent="true" Overwrite="true" />
+
+    <ItemGroup>
+      <EmbeddedResource Include="$(IntermediateOutputPath)bclLocations.txt" Link="bclLocations.txt" Type="Non-Resx" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)referenceHints.txt" Link="referenceHints.txt" Type="Non-Resx" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
* Changed the test to be rooted on the standalone app (versus the test which has a different reference graph)
* Use embedded resources which was easier to transfer around and should likely fix the helix issue.

Fixes https://github.com/dotnet/aspnetcore/issues/12059
