### PR TITLE
Capture test output for tools tests

### DIFF
--- a/src/Tools/Shared/TestHelpers/TestConsole.cs
+++ b/src/Tools/Shared/TestHelpers/TestConsole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,12 +15,13 @@ namespace Microsoft.Extensions.Tools.Internal
     {
         private event ConsoleCancelEventHandler _cancelKeyPress;
         private readonly TaskCompletionSource<bool> _cancelKeySubscribed = new TaskCompletionSource<bool>();
+        private readonly TestOutputWriter _testWriter;
 
         public TestConsole(ITestOutputHelper output)
         {
-            var writer = new TestOutputWriter(output);
-            Error = writer;
-            Out = writer;
+            _testWriter = new TestOutputWriter(output);
+            Error = _testWriter;
+            Out = _testWriter;
         }
 
         public event ConsoleCancelEventHandler CancelKeyPress
@@ -35,8 +36,8 @@ namespace Microsoft.Extensions.Tools.Internal
 
         public Task CancelKeyPressSubscribed => _cancelKeySubscribed.Task;
 
-        public TextWriter Error { get; set; }
-        public TextWriter Out { get; set; }
+        public TextWriter Error { get; }
+        public TextWriter Out { get; }
         public TextReader In { get; set; } = new StringReader(string.Empty);
         public bool IsInputRedirected { get; set; } = false;
         public bool IsOutputRedirected { get; } = false;
@@ -58,10 +59,21 @@ namespace Microsoft.Extensions.Tools.Internal
         {
         }
 
+        public string GetOutput()
+        {
+            return _testWriter.GetOutput();
+        }
+
+        public void ClearOutput()
+        {
+            _testWriter.ClearOutput();
+        }
+
         private class TestOutputWriter : TextWriter
         {
             private readonly ITestOutputHelper _output;
             private readonly StringBuilder _sb = new StringBuilder();
+            private readonly StringBuilder _currentOutput = new StringBuilder();
 
             public TestOutputWriter(ITestOutputHelper output)
             {
@@ -83,7 +95,18 @@ namespace Microsoft.Extensions.Tools.Internal
                 else
                 {
                     _sb.Append(value);
+                    _currentOutput.Append(value);
                 }
+            }
+
+            public string GetOutput()
+            {
+                return _currentOutput.ToString();
+            }
+
+            public void ClearOutput()
+            {
+                _currentOutput.Clear();
             }
         }
     }

--- a/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
                 _reporter.Verbose($"Invoking '{psi.FileName} {psi.Arguments}'");
 #endif
 
-                var process = Process.Start(psi);
+                using var process = Process.Start(psi);
                 process.WaitForExit();
 
                 if (process.ExitCode != 0)

--- a/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
@@ -19,19 +19,13 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         private UserSecretsTestFixture _fixture;
         private ITestOutputHelper _output;
         private TestConsole _console;
-        private StringBuilder _textOutput;
 
         public InitCommandTests(UserSecretsTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _output = output;
-            _textOutput = new StringBuilder();
 
-            _console = new TestConsole(output)
-            {
-                Error = new StringWriter(_textOutput),
-                Out = new StringWriter(_textOutput),
-            };
+            _console = new TestConsole(output);
         }
 
         private CommandContext MakeCommandContext() => new CommandContext(null, new TestReporter(_output), _console);

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -18,17 +18,15 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
     {
         private readonly TestConsole _console;
         private readonly UserSecretsTestFixture _fixture;
-        private readonly StringBuilder _output = new StringBuilder();
+        private readonly ITestOutputHelper _testOut;
 
         public SecretManagerTests(UserSecretsTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
 
-            _console = new TestConsole(output)
-            {
-                Error = new StringWriter(_output),
-                Out = new StringWriter(_output),
-            };
+            _testOut = output;
+
+            _console = new TestConsole(output);
         }
 
         private Program CreateProgram()
@@ -45,8 +43,8 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var project = Path.Combine(_fixture.CreateProject(id), "TestProject.csproj");
             var secretManager = CreateProgram();
 
-            secretManager.RunInternal("list", "-p", project);
-            Assert.Contains(Resources.FormatError_ProjectMissingId(project), _output.ToString());
+            secretManager.RunInternal("list", "-p", project, "--verbose");
+            Assert.Contains(Resources.FormatError_ProjectMissingId(project), _console.GetOutput());
         }
 
         [Fact]
@@ -56,7 +54,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var secretManager = CreateProgram();
 
             secretManager.RunInternal("list", "-p", project);
-            Assert.Contains(Resources.FormatError_ProjectFailedToLoad(project), _output.ToString());
+            Assert.Contains(Resources.FormatError_ProjectFailedToLoad(project), _console.GetOutput());
         }
 
         [Fact]
@@ -66,7 +64,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var secretManager = CreateProgram();
 
             secretManager.RunInternal("list", "--project", projectPath);
-            Assert.Contains(Resources.FormatError_ProjectPath_NotFound(projectPath), _output.ToString());
+            Assert.Contains(Resources.FormatError_ProjectPath_NotFound(projectPath), _console.GetOutput());
         }
 
         [Fact]
@@ -79,7 +77,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
 
             secretManager.RunInternal("list", "-p", ".." + Path.DirectorySeparatorChar, "--verbose");
 
-            Assert.Contains(Resources.FormatMessage_Project_File_Path(Path.Combine(cwd, "..", "TestProject.csproj")), _output.ToString());
+            Assert.Contains(Resources.FormatMessage_Project_File_Path(Path.Combine(cwd, "..", "TestProject.csproj")), _console.GetOutput());
         }
 
         [Theory]
@@ -90,12 +88,12 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         {
             var secrets = new KeyValuePair<string, string>[]
                         {
-                            new KeyValuePair<string, string>("key1", Guid.NewGuid().ToString()),
-                            new KeyValuePair<string, string>("Facebook:AppId", Guid.NewGuid().ToString()),
-                            new KeyValuePair<string, string>(@"key-@\/.~123!#$%^&*())-+==", @"key-@\/.~123!#$%^&*())-+=="),
-                            new KeyValuePair<string, string>("key2", string.Empty),
-                            new KeyValuePair<string, string>("-oneDashedKey", "-oneDashedValue"),
-                            new KeyValuePair<string, string>("--twoDashedKey", "--twoDashedValue")
+                        new KeyValuePair<string, string>("key1", Guid.NewGuid().ToString()),
+                        new KeyValuePair<string, string>("Facebook:AppId", Guid.NewGuid().ToString()),
+                        new KeyValuePair<string, string>(@"key-@\/.~123!#$%^&*())-+==", @"key-@\/.~123!#$%^&*())-+=="),
+                        new KeyValuePair<string, string>("key2", string.Empty),
+                        new KeyValuePair<string, string>("-oneDashedKey", "-oneDashedValue"),
+                        new KeyValuePair<string, string>("--twoDashedKey", "--twoDashedValue")
                         };
 
             var projectPath = _fixture.GetTempSecretProject();
@@ -107,8 +105,8 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             foreach (var secret in secrets)
             {
                 var parameters = fromCurrentDirectory ?
-                    new string[] { "set", secret.Key, secret.Value } :
-                    new string[] { "set", secret.Key, secret.Value, "-p", projectPath };
+                    new string[] { "set", secret.Key, secret.Value, "--verbose" } :
+                    new string[] { "set", secret.Key, secret.Value, "-p", projectPath, "--verbose" };
                 secretManager.RunInternal(parameters);
             }
 
@@ -116,38 +114,38 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             {
                 Assert.Contains(
                     string.Format("Successfully saved {0} = {1} to the secret store.", keyValue.Key, keyValue.Value),
-                    _output.ToString());
+                    _console.GetOutput());
             }
 
-            _output.Clear();
+            _console.ClearOutput();
             var args = fromCurrentDirectory
-                ? new string[] { "list" }
-                : new string[] { "list", "-p", projectPath };
+                ? new string[] { "list", "--verbose" }
+                : new string[] { "list", "-p", projectPath, "--verbose" };
             secretManager.RunInternal(args);
             foreach (var keyValue in secrets)
             {
                 Assert.Contains(
                     string.Format("{0} = {1}", keyValue.Key, keyValue.Value),
-                    _output.ToString());
+                    _console.GetOutput());
             }
 
             // Remove secrets.
-            _output.Clear();
+            _console.ClearOutput();
             foreach (var secret in secrets)
             {
                 var parameters = fromCurrentDirectory ?
-                    new string[] { "remove", secret.Key } :
-                    new string[] { "remove", secret.Key, "-p", projectPath };
+                    new string[] { "remove", secret.Key, "--verbose" } :
+                    new string[] { "remove", secret.Key, "-p", projectPath, "--verbose" };
                 secretManager.RunInternal(parameters);
             }
 
             // Verify secrets are removed.
-            _output.Clear();
+            _console.ClearOutput();
             args = fromCurrentDirectory
-                ? new string[] { "list" }
-                : new string[] { "list", "-p", projectPath };
+                ? new string[] { "list", "--verbose" }
+                : new string[] { "list", "-p", projectPath, "--verbose" };
             secretManager.RunInternal(args);
-            Assert.Contains(Resources.Error_No_Secrets_Found, _output.ToString());
+            Assert.Contains(Resources.Error_No_Secrets_Found, _console.GetOutput());
         }
 
         [Fact]
@@ -157,14 +155,14 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var secretManager = CreateProgram();
 
             secretManager.RunInternal("set", "secret1", "value1", "-p", projectPath);
-            Assert.Contains("Successfully saved secret1 = value1 to the secret store.", _output.ToString());
+            Assert.Contains("Successfully saved secret1 = value1 to the secret store.", _console.GetOutput());
             secretManager.RunInternal("set", "secret1", "value2", "-p", projectPath);
-            Assert.Contains("Successfully saved secret1 = value2 to the secret store.", _output.ToString());
+            Assert.Contains("Successfully saved secret1 = value2 to the secret store.", _console.GetOutput());
 
-            _output.Clear();
+            _console.ClearOutput();
 
             secretManager.RunInternal("list", "-p", projectPath);
-            Assert.Contains("secret1 = value2", _output.ToString());
+            Assert.Contains("secret1 = value2", _console.GetOutput());
         }
 
         [Fact]
@@ -175,16 +173,16 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var secretManager = CreateProgram();
 
             secretManager.RunInternal("-v", "set", "secret1", "value1", "-p", projectPath);
-            Assert.Contains(string.Format("Project file path {0}.", Path.Combine(projectPath, "TestProject.csproj")), _output.ToString());
-            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPathFromSecretsId(secretId)), _output.ToString());
-            Assert.Contains("Successfully saved secret1 = value1 to the secret store.", _output.ToString());
-            _output.Clear();
+            Assert.Contains(string.Format("Project file path {0}.", Path.Combine(projectPath, "TestProject.csproj")), _console.GetOutput());
+            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPathFromSecretsId(secretId)), _console.GetOutput());
+            Assert.Contains("Successfully saved secret1 = value1 to the secret store.", _console.GetOutput());
+            _console.ClearOutput();
 
             secretManager.RunInternal("-v", "list", "-p", projectPath);
 
-            Assert.Contains(string.Format("Project file path {0}.", Path.Combine(projectPath, "TestProject.csproj")), _output.ToString());
-            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPathFromSecretsId(secretId)), _output.ToString());
-            Assert.Contains("secret1 = value1", _output.ToString());
+            Assert.Contains(string.Format("Project file path {0}.", Path.Combine(projectPath, "TestProject.csproj")), _console.GetOutput());
+            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPathFromSecretsId(secretId)), _console.GetOutput());
+            Assert.Contains("secret1 = value1", _console.GetOutput());
         }
 
         [Fact]
@@ -193,8 +191,8 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         {
             var projectPath = _fixture.GetTempSecretProject();
             var secretManager = CreateProgram();
-            secretManager.RunInternal("remove", "secret1", "-p", projectPath);
-            Assert.Contains("Cannot find 'secret1' in the secret store.", _output.ToString());
+            secretManager.RunInternal("remove", "secret1", "-p", projectPath, "--verbose");
+            Assert.Contains("Cannot find 'secret1' in the secret store.", _console.GetOutput());
         }
 
         [Fact]
@@ -204,13 +202,13 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var secretManager = CreateProgram();
             secretManager.RunInternal("set", "SeCreT1", "value", "-p", projectPath);
             secretManager.RunInternal("list", "-p", projectPath);
-            Assert.Contains("SeCreT1 = value", _output.ToString());
+            Assert.Contains("SeCreT1 = value", _console.GetOutput());
             secretManager.RunInternal("remove", "secret1", "-p", projectPath);
 
-            _output.Clear();
+            _console.ClearOutput();
             secretManager.RunInternal("list", "-p", projectPath);
 
-            Assert.Contains(Resources.Error_No_Secrets_Found, _output.ToString());
+            Assert.Contains(Resources.Error_No_Secrets_Found, _console.GetOutput());
         }
 
         [Fact]
@@ -223,8 +221,8 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             Directory.CreateDirectory(Path.GetDirectoryName(secretsFile));
             File.WriteAllText(secretsFile, @"{ ""AzureAd"": { ""ClientSecret"": ""abcdéƒ©˙î""} }", Encoding.UTF8);
             var secretManager = CreateProgram();
-            secretManager.RunInternal("list", "-p", projectPath);
-            Assert.Contains("AzureAd:ClientSecret = abcdéƒ©˙î", _output.ToString());
+            secretManager.RunInternal("list", "-p", projectPath, "--verbose");
+            Assert.Contains("AzureAd:ClientSecret = abcdéƒ©˙î", _console.GetOutput());
         }
 
         [Fact]
@@ -237,7 +235,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             File.WriteAllText(secretsFile, @"{ ""AzureAd"": { ""ClientSecret"": ""abcdéƒ©˙î""} }", Encoding.UTF8);
             var secretManager = new Program(_console, Path.GetDirectoryName(projectPath));
             secretManager.RunInternal("list", "--id", id, "--json");
-            var stdout = _output.ToString();
+            var stdout = _console.GetOutput();
             Assert.Contains("//BEGIN", stdout);
             Assert.Contains(@"""AzureAd:ClientSecret"": ""abcdéƒ©˙î""", stdout);
             Assert.Contains("//END", stdout);
@@ -255,7 +253,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             secretManager.RunInternal("set", "AzureAd:ClientSecret", "¡™£¢∞", "-p", projectPath);
             secretManager.RunInternal("list", "-p", projectPath);
 
-            Assert.Contains("AzureAd:ClientSecret = ¡™£¢∞", _output.ToString());
+            Assert.Contains("AzureAd:ClientSecret = ¡™£¢∞", _console.GetOutput());
             var fileContents = File.ReadAllText(secretsFile, Encoding.UTF8);
             Assert.Equal(@"{
     ""AzureAd:ClientSecret"": ""¡™£¢∞""
@@ -269,7 +267,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             var projectPath = _fixture.GetTempSecretProject();
             var secretManager = CreateProgram();
             secretManager.RunInternal("list", "-p", projectPath);
-            Assert.Contains(Resources.Error_No_Secrets_Found, _output.ToString());
+            Assert.Contains(Resources.Error_No_Secrets_Found, _console.GetOutput());
         }
 
         [Flaky("<No longer needed, tracked in Kusto>", FlakyOn.All)]
@@ -297,8 +295,8 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             foreach (var secret in secrets)
             {
                 var parameters = fromCurrentDirectory ?
-                    new string[] { "set", secret.Key, secret.Value } :
-                    new string[] { "set", secret.Key, secret.Value, "-p", projectPath };
+                    new string[] { "set", secret.Key, secret.Value, "--verbose" } :
+                    new string[] { "set", secret.Key, secret.Value, "-p", projectPath, "--verbose" };
                 secretManager.RunInternal(parameters);
             }
 
@@ -306,30 +304,30 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             {
                 Assert.Contains(
                     string.Format("Successfully saved {0} = {1} to the secret store.", keyValue.Key, keyValue.Value),
-                    _output.ToString());
+                    _console.GetOutput());
             }
 
             // Verify secrets are persisted.
-            _output.Clear();
+            _console.ClearOutput();
             var args = fromCurrentDirectory ?
-                new string[] { "list" } :
-                new string[] { "list", "-p", projectPath };
+                new string[] { "list", "--verbose" } :
+                new string[] { "list", "-p", projectPath, "--verbose" };
             secretManager.RunInternal(args);
             foreach (var keyValue in secrets)
             {
                 Assert.Contains(
                     string.Format("{0} = {1}", keyValue.Key, keyValue.Value),
-                    _output.ToString());
+                    _console.GetOutput());
             }
 
             // Clear secrets.
-            _output.Clear();
-            args = fromCurrentDirectory ? new string[] { "clear" } : new string[] { "clear", "-p", projectPath };
+            _console.ClearOutput();
+            args = fromCurrentDirectory ? new string[] { "clear", "--verbose" } : new string[] { "clear", "-p", projectPath, "--verbose" };
             secretManager.RunInternal(args);
 
-            args = fromCurrentDirectory ? new string[] { "list" } : new string[] { "list", "-p", projectPath };
+            args = fromCurrentDirectory ? new string[] { "list", "--verbose" } : new string[] { "list", "-p", projectPath, "--verbose" };
             secretManager.RunInternal(args);
-            Assert.Contains(Resources.Error_No_Secrets_Found, _output.ToString());
+            Assert.Contains(Resources.Error_No_Secrets_Found, _console.GetOutput());
         }
 
         [Fact]
@@ -341,8 +339,8 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
 
             secretManager.RunInternal("init", "-p", project);
 
-            Assert.DoesNotContain(Resources.FormatError_ProjectMissingId(project), _output.ToString());
-            Assert.DoesNotContain("--help", _output.ToString());
+            Assert.DoesNotContain(Resources.FormatError_ProjectMissingId(project), _console.GetOutput());
+            Assert.DoesNotContain("--help", _console.GetOutput());
         }
     }
 }

--- a/src/Tools/dotnet-watch/test/CommandLineOptionsTests.cs
+++ b/src/Tools/dotnet-watch/test/CommandLineOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -13,15 +13,11 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 {
     public class CommandLineOptionsTests
     {
-        private readonly IConsole _console;
-        private readonly StringBuilder _stdout = new StringBuilder();
+        private readonly TestConsole _console;
 
         public CommandLineOptionsTests(ITestOutputHelper output)
         {
-            _console = new TestConsole(output)
-            {
-                Out = new StringWriter(_stdout),
-            };
+            _console = new TestConsole(output);
         }
 
         [Theory]
@@ -36,7 +32,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
             var options = CommandLineOptions.Parse(args, _console);
 
             Assert.True(options.IsHelp);
-            Assert.Contains("Usage: dotnet watch ", _stdout.ToString());
+            Assert.Contains("Usage: dotnet watch ", _console.GetOutput());
         }
 
         [Theory]
@@ -50,7 +46,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
             Assert.Equal(expected, options.RemainingArguments.ToArray());
             Assert.False(options.IsHelp);
-            Assert.Empty(_stdout.ToString());
+            Assert.Empty(_console.GetOutput());
         }
 
         [Fact]

--- a/src/Tools/dotnet-watch/test/ProgramTests.cs
+++ b/src/Tools/dotnet-watch/test/ProgramTests.cs
@@ -34,8 +34,6 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
                 .WithFile("Program.cs")
                 .Create();
 
-            var output = new StringBuilder();
-            _console.Error = _console.Out = new StringWriter(output);
             using (var app = new Program(_console, _tempDir.Root))
             {
                 var run = app.RunAsync(new[] { "run" });
@@ -45,7 +43,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
 
                 var exitCode = await run.TimeoutAfter(TimeSpan.FromSeconds(30));
 
-                Assert.Contains("Shutdown requested. Press Ctrl+C again to force exit.", output.ToString());
+                Assert.Contains("Shutdown requested. Press Ctrl+C again to force exit.", _console.GetOutput());
                 Assert.Equal(0, exitCode);
             }
         }


### PR DESCRIPTION
A lot of the tools tests were overriding the `ITestOutputHelper` and using a `StringBuilder`. Converted them to use both together so we can now see test output on failures. Also added `--verbose` to the flaky user secrets tests to see if we can figure out whats happening.
