### PR TITLE
Update precedence and Identity of templates for 5.0

### DIFF
--- a/src/ProjectTemplates/BlazorWasm.ProjectTemplates/content/BlazorWasm-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/BlazorWasm.ProjectTemplates/content/BlazorWasm-CSharp/.template.config/template.json
@@ -10,7 +10,7 @@
   "defaultName": "WebApplication",
   "description": "A project template for creating a Blazor app that runs on WebAssembly and is optionally hosted by an ASP.NET Core app. This template can be used for web apps with rich dynamic user interfaces (UIs).",
   "groupIdentity": "Microsoft.Web.Blazor.Wasm",
-  "precedence": "6001",
+  "precedence": "7001",
   "guids": [
     "4C26868E-5E7C-458D-82E3-040509D0C71F",
     "5990939C-7E7B-4CFA-86FF-44CA5756498A",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
@@ -9,10 +9,10 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating a Blazor server app that runs server-side inside an ASP.NET Core app and handles user interactions over a SignalR connection. This template can be used for web apps with rich dynamic user interfaces (UIs).",
   "groupIdentity": "Microsoft.Web.Blazor.Server",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.Blazor.Server.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.Blazor.Server.CSharp.5.0",
   "shortName": "blazorserver",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/3.1-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/5.0-third-party-notices",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -9,8 +9,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
   "groupIdentity": "Microsoft.Web.Empty",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.Empty.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.Empty.CSharp.5.0",
   "shortName": "web",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -8,8 +8,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
   "groupIdentity": "Microsoft.Web.Empty",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.Empty.FSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.Empty.FSharp.5.0",
   "shortName": "web",
   "tags": {
     "language": "F#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
@@ -9,8 +9,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating a gRPC ASP.NET Core service.",
   "groupIdentity": "Microsoft.Web.Grpc",
-  "precedence": "6000",
-  "identity": "Microsoft.Grpc.Service.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Grpc.Service.CSharp.5.0",
   "shortName": "grpc",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -10,8 +10,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a Razor class library that targets .NET Standard",
   "groupIdentity": "Microsoft.Web.Razor",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.Razor.Library.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.Razor.Library.CSharp.5.0",
   "shortName": "razorclasslib",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -10,13 +10,13 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core Razor Pages content",
   "groupIdentity": "Microsoft.Web.RazorPages",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.RazorPages.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.RazorPages.CSharp.5.0",
   "shortName": [
     "webapp",
     "razor"
   ],
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/3.1-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/5.0-third-party-notices",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -9,10 +9,10 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.Mvc.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.Mvc.CSharp.5.0",
   "shortName": "mvc",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/3.1-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/5.0-third-party-notices",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -9,10 +9,10 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.Mvc.FSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.Mvc.FSharp.5.0",
   "shortName": "mvc",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/3.1-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/5.0-third-party-notices",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -9,8 +9,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers.",
   "groupIdentity": "Microsoft.Web.WebApi",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.WebApi.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.WebApi.CSharp.5.0",
   "shortName": "webapi",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -8,8 +8,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers.",
   "groupIdentity": "Microsoft.Web.WebApi",
-  "precedence": "6000",
-  "identity": "Microsoft.Web.WebApi.FSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Web.WebApi.FSharp.5.0",
   "shortName": "webapi",
   "tags": {
     "language": "F#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/template.json
@@ -10,8 +10,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating a worker service.",
   "groupIdentity": "Microsoft.Worker.Empty",
-  "precedence": "6000",
-  "identity": "Microsoft.Worker.Empty.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.Worker.Empty.CSharp.5.0",
   "shortName": "worker",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
     "SPA"
   ],
   "groupIdentity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.Angular",
-  "precedence": "6000",
-  "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.Angular.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.Angular.CSharp.5.0",
   "name": "ASP.NET Core with Angular",
   "preferNameDirectory": true,
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
     "SPA"
   ],
   "groupIdentity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.React",
-  "precedence": "6000",
-  "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.React.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.React.CSharp.5.0",
   "name": "ASP.NET Core with React.js",
   "preferNameDirectory": true,
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
     "SPA"
   ],
   "groupIdentity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.ReactRedux",
-  "precedence": "6000",
-  "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.ReactRedux.CSharp.3.1",
+  "precedence": "7000",
+  "identity": "Microsoft.DotNet.Web.Spa.ProjectTemplates.ReactRedux.CSharp.5.0",
   "name": "ASP.NET Core with React.js and Redux",
   "preferNameDirectory": true,
   "primaryOutputs": [


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/17553.

@mkArtakMSFT I believe it was you who created the mapping for `https://aka.ms/aspnetcore/5.0-third-party-notices last` time? We need to do that again. This is basically a copy of https://github.com/dotnet/aspnetcore/pull/14637/files, plus the fact that we have a new template.