### PR TITLE
Eliminate allocation during HTTP2 path validation

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -318,8 +318,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             try
             {
                 // The decoder operates only on raw bytes
-                var pathBuffer = new byte[pathSegment.Length].AsSpan();
-                for (int i = 0; i < pathSegment.Length; i++)
+                Span<byte> pathBuffer = stackalloc byte[pathSegment.Length];
+                for (var i = 0; i < pathSegment.Length; i++)
                 {
                     var ch = pathSegment[i];
                     // The header parser should already be checking this

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -324,6 +324,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     // A constant size plus slice generates better code
                     // https://github.com/dotnet/aspnetcore/pull/19273#discussion_r383159929
                     ? stackalloc byte[MaxPathBufferStackAllocSize].Slice(0, pathSegment.Length)
+                    // TODO - Consider pool here for less than 4096
+                    // https://github.com/dotnet/aspnetcore/pull/19273#discussion_r383604184
                     : new byte[pathSegment.Length];
 
                 for (var i = 0; i < pathSegment.Length; i++)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -451,8 +451,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             try
             {
                 // The decoder operates only on raw bytes
-                var pathBuffer = new byte[pathSegment.Length].AsSpan();
-                for (int i = 0; i < pathSegment.Length; i++)
+                Span<byte> pathBuffer = stackalloc byte[pathSegment.Length];
+                for (var i = 0; i < pathSegment.Length; i++)
                 {
                     var ch = pathSegment[i];
                     // The header parser should already be checking this

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -450,8 +450,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             try
             {
+                const int MaxPathBufferStackAllocSize = 256;
+
                 // The decoder operates only on raw bytes
-                Span<byte> pathBuffer = stackalloc byte[pathSegment.Length];
+                Span<byte> pathBuffer = pathSegment.Length <= MaxPathBufferStackAllocSize
+                    // A constant size plus slice generates better code
+                    // https://github.com/dotnet/aspnetcore/pull/19273#discussion_r383159929
+                    ? stackalloc byte[MaxPathBufferStackAllocSize].Slice(0, pathSegment.Length)
+                    : new byte[pathSegment.Length];
+
                 for (var i = 0; i < pathSegment.Length; i++)
                 {
                     var ch = pathSegment[i];

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -457,6 +457,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     // A constant size plus slice generates better code
                     // https://github.com/dotnet/aspnetcore/pull/19273#discussion_r383159929
                     ? stackalloc byte[MaxPathBufferStackAllocSize].Slice(0, pathSegment.Length)
+                    // TODO - Consider pool here for less than 4096
+                    // https://github.com/dotnet/aspnetcore/pull/19273#discussion_r383604184
                     : new byte[pathSegment.Length];
 
                 for (var i = 0; i < pathSegment.Length; i++)


### PR DESCRIPTION
Showed up in profile:

![image](https://user-images.githubusercontent.com/303201/75136782-9f4c5e00-574a-11ea-9564-b8c9734d3420.png)

Also is in HTTP/3 code and I changed it there. There seems to be a lot of copy and paste between HTTP/2 and 3. Is there a plan to improve that?