### PR TITLE
Eliminate enum boxing allocations from Kestrel HTTP2 logging

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -272,12 +272,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public void Http2FrameReceived(string connectionId, Http2Frame frame)
         {
-            _http2FrameReceived(_logger, connectionId, frame.Type, frame.StreamId, frame.PayloadLength, frame.ShowFlags(), null);
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                _http2FrameReceived(_logger, connectionId, frame.Type, frame.StreamId, frame.PayloadLength, frame.ShowFlags(), null);
+            }
         }
 
         public void Http2FrameSending(string connectionId, Http2Frame frame)
         {
-            _http2FrameSending(_logger, connectionId, frame.Type, frame.StreamId, frame.PayloadLength, frame.ShowFlags(), null);
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                _http2FrameSending(_logger, connectionId, frame.Type, frame.StreamId, frame.PayloadLength, frame.ShowFlags(), null);
+            }
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)


### PR DESCRIPTION
`ShowFlags` boxes an enum. Unnecessary boxing is happening when log level won't output anything:

![image](https://user-images.githubusercontent.com/303201/75144263-7ed8cf80-575b-11ea-9dc8-4ad24e046f2d.png)
