### PR TITLE
[Blazor] Remove compression middleware from the template

### DIFF
--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="builder">The <see cref="IApplicationBuilder"/>.</param>
         /// <param name="pathPrefix">The <see cref="PathString"/> that indicates the prefix for the Blazor WebAssembly application.</param>
         /// <returns>The <see cref="IApplicationBuilder"/></returns>
-        public static IApplicationBuilder MapBlazorFrameworkFiles(this IApplicationBuilder builder, PathString pathPrefix)
+        public static IApplicationBuilder UseBlazorFrameworkFiles(this IApplicationBuilder builder, PathString pathPrefix)
         {
             if (builder is null)
             {
@@ -53,8 +53,6 @@ namespace Microsoft.AspNetCore.Builder
             {
                 subBuilder.Use(async (ctx, next) =>
                 {
-                    // At this point we mapped something from the /_framework
-                    ctx.Response.Headers.Append(HeaderNames.CacheControl, "no-cache");
                     // This will invoke the static files middleware plugged-in below.
                     NegotiateEncoding(ctx, webHostEnvironment);
                     await next();
@@ -73,7 +71,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pathPrefix">The <see cref="PathString"/> that indicates the prefix for the Blazor WebAssembly application.</param>
         /// <returns>The <see cref="IApplicationBuilder"/></returns>
         public static IApplicationBuilder UseBlazorFrameworkFiles(this IApplicationBuilder applicationBuilder) =>
-            MapBlazorFrameworkFiles(applicationBuilder, default);
+            UseBlazorFrameworkFiles(applicationBuilder, default);
 
         private static StaticFileOptions CreateStaticFilesOptions(IFileProvider webRootFileProvider)
         {
@@ -92,6 +90,9 @@ namespace Microsoft.AspNetCore.Builder
             // sending the file.
             options.OnPrepareResponse = fileContext =>
             {
+                // At this point we mapped something from the /_framework
+                fileContext.Context.Response.Headers.Append(HeaderNames.CacheControl, "no-cache");
+
                 var requestPath = fileContext.Context.Request.Path;
                 if (string.Equals(Path.GetExtension(requestPath.Value), ".gz"))
                 {

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
@@ -76,19 +76,11 @@ namespace ComponentsWebAssembly_CSharp.Server
 #if (IndividualLocalAuth)
             services.AddRazorPages();
 #endif
-
-            services.AddResponseCompression(opts =>
-            {
-                opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
-                    new[] { "application/octet-stream" });
-            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseResponseCompression();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
I found this while performing verification. We don't need this as static compression already makes up for the download size of the entire app
* Static compression + runtime compression
  * 1946694 Bytes (not sure if this is due to interactions between pre-compressed files and the RC middleware, but it should not affect, I believe. Will investigate though)
* Static compression only
  * 1916559 Bytes
* Runtime compression
  * 2233515 Bytes