### PR TITLE
Eliminate TraceIdentifer allocation when there is a request body

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
@@ -93,7 +94,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             if (!RequestUpgrade)
             {
-                Log.RequestBodyStart(_context.ConnectionIdFeature, _context.TraceIdentifier);
+                // Accessing TraceIdentifier will lazy-allocate a string ID.
+                // Don't access TraceIdentifer unless logging is enabled.
+                if (Log.IsEnabled(LogLevel.Debug))
+                {
+                    Log.RequestBodyStart(_context.ConnectionIdFeature, _context.TraceIdentifier);
+                }
 
                 if (_context.MinRequestBodyDataRate != null)
                 {
@@ -116,7 +122,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             if (!RequestUpgrade)
             {
-                Log.RequestBodyDone(_context.ConnectionIdFeature, _context.TraceIdentifier);
+                // Accessing TraceIdentifier will lazy-allocate a string ID
+                // Don't access TraceIdentifer unless logging is enabled.
+                if (Log.IsEnabled(LogLevel.Debug))
+                {
+                    Log.RequestBodyDone(_context.ConnectionIdFeature, _context.TraceIdentifier);
+                }
 
                 if (_timingEnabled)
                 {

--- a/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
+++ b/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
@@ -810,6 +810,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             using (var input = new TestInput())
             {
                 var mockLogger = new Mock<IKestrelTrace>();
+                mockLogger
+                    .Setup(logger => logger.IsEnabled(Extensions.Logging.LogLevel.Debug))
+                    .Returns(true);
                 input.Http1Connection.ServiceContext.Log = mockLogger.Object;
                 input.Http1Connection.ConnectionIdFeature = "ConnectionId";
                 input.Http1Connection.TraceIdentifier = "RequestId";
@@ -841,6 +844,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 mockLogger
                     .Setup(logger => logger.RequestBodyDone("ConnectionId", "RequestId"))
                     .Callback(() => logEvent.SetResult(null));
+                mockLogger
+                    .Setup(logger => logger.IsEnabled(Extensions.Logging.LogLevel.Debug))
+                    .Returns(true);
                 input.Http1Connection.ServiceContext.Log = mockLogger.Object;
                 input.Http1Connection.ConnectionIdFeature = "ConnectionId";
                 input.Http1Connection.TraceIdentifier = "RequestId";


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/19323