### PR TITLE
Fix boot json on mac/linux

### DIFF
--- a/src/Components/WebAssembly/Build/src/Tasks/GenerateBlazorBootJson.cs
+++ b/src/Components/WebAssembly/Build/src/Tasks/GenerateBlazorBootJson.cs
@@ -70,10 +70,10 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             {
                 foreach (var resource in Resources)
                 {
-                    var resourceTypeMetadata = resource.GetMetadata("BootResourceType");
+                    var resourceTypeMetadata = resource.GetMetadata("BootManifestResourceType");
                     if (!Enum.TryParse<ResourceType>(resourceTypeMetadata, out var resourceType))
                     {
-                        throw new NotSupportedException($"Unsupported BootResourceType metadata value: {resourceTypeMetadata}");
+                        throw new NotSupportedException($"Unsupported BootManifestResourceType metadata value: {resourceTypeMetadata}");
                     }
 
                     if (!result.resources.TryGetValue(resourceType, out var resourceList))
@@ -82,10 +82,10 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
                         result.resources.Add(resourceType, resourceList);
                     }
 
-                    var resourceFileRelativePath = GetResourceFileRelativePath(resource);
-                    if (!resourceList.ContainsKey(resourceFileRelativePath))
+                    var resourceName = GetResourceName(resource);
+                    if (!resourceList.ContainsKey(resourceName))
                     {
-                        resourceList.Add(resourceFileRelativePath, $"sha256-{resource.GetMetadata("FileHash")}");
+                        resourceList.Add(resourceName, $"sha256-{resource.GetMetadata("FileHash")}");
                     }
                 }
             }
@@ -99,21 +99,16 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             serializer.WriteObject(writer, result);
         }
 
-        private static string GetResourceFileRelativePath(ITaskItem item)
+        private static string GetResourceName(ITaskItem item)
         {
-            // The build targets use RelativeOutputPath in the case of satellite assemblies, which
-            // will have relative paths like "fr\\SomeAssembly.resources.dll". If RelativeOutputPath
-            // is specified, we want to use all of it.
-            var outputPath = item.GetMetadata("RelativeOutputPath");
+            var name = item.GetMetadata("BootManifestResourceName");
 
-            if (string.IsNullOrEmpty(outputPath))
+            if (string.IsNullOrEmpty(name))
             {
-                // If RelativeOutputPath was not specified, we assume the item will be placed at the
-                // root of whatever directory is used for its resource type (e.g., assemblies go in _bin)
-                outputPath = Path.GetFileName(item.GetMetadata("TargetOutputPath"));
+                throw new Exception($"No BootManifestResourceName was specified for item '{item.ItemSpec}'");
             }
-
-            return outputPath.Replace('\\', '/');
+            
+            return name.Replace('\\', '/');
         }
 
 #pragma warning disable IDE1006 // Naming Styles

--- a/src/Components/WebAssembly/Build/src/Tasks/GenerateBlazorBootJson.cs
+++ b/src/Components/WebAssembly/Build/src/Tasks/GenerateBlazorBootJson.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             {
                 throw new Exception($"No BootManifestResourceName was specified for item '{item.ItemSpec}'");
             }
-            
+
             return name.Replace('\\', '/');
         }
 

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -83,17 +83,18 @@
       <_BlazorCopyLocalPaths Remove="@(_BlazorManagedRuntimeAssemby)" />
 
       <_BlazorOutputWithTargetPath Include="@(_BlazorCopyLocalPaths)">
-        <BlazorBootManifestResourceType Condition="'%(Extension)' == '.dll'">assembly</BlazorBootManifestResourceType>
-        <BlazorBootManifestResourceType Condition="'%(Extension)' == '.pdb'">pdb</BlazorBootManifestResourceType>
+        <!-- This group is for satellite assemblies. We set the resource name to include a path, e.g. "fr\\SomeAssembly.resources.dll" -->
+        <BootManifestResourceType Condition="'%(Extension)' == '.dll'">assembly</BootManifestResourceType>
+        <BootManifestResourceType Condition="'%(Extension)' == '.pdb'">pdb</BootManifestResourceType>
+        <BootManifestResourceName>%(_BlazorCopyLocalPaths.DestinationSubDirectory)%(FileName)%(Extension)</BootManifestResourceName>
         <TargetOutputPath>$(_BlazorRuntimeBinOutputPath)%(_BlazorCopyLocalPaths.DestinationSubDirectory)%(FileName)%(Extension)</TargetOutputPath>
-        <RelativeOutputPath>%(_BlazorCopyLocalPaths.DestinationSubDirectory)%(FileName)%(Extension)</RelativeOutputPath>
       </_BlazorOutputWithTargetPath>
 
       <_BlazorOutputWithTargetPath Include="@(_BlazorResolvedAssembly)">
-        <BlazorBootManifestResourceType Condition="'%(Extension)' == '.dll'">assembly</BlazorBootManifestResourceType>
-        <BlazorBootManifestResourceType Condition="'%(Extension)' == '.pdb'">pdb</BlazorBootManifestResourceType>
+        <BootManifestResourceType Condition="'%(Extension)' == '.dll'">assembly</BootManifestResourceType>
+        <BootManifestResourceType Condition="'%(Extension)' == '.pdb'">pdb</BootManifestResourceType>
+        <BootManifestResourceName>%(FileName)%(Extension)</BootManifestResourceName>
         <TargetOutputPath>$(_BlazorRuntimeBinOutputPath)%(FileName)%(Extension)</TargetOutputPath>
-        <RelativeOutputPath>%(FileName)%(Extension)</RelativeOutputPath>
       </_BlazorOutputWithTargetPath>
     </ItemGroup>
 
@@ -120,10 +121,10 @@
       <_BlazorCopyLocalPaths Remove="@(_BlazorManagedRuntimeAssemby)" Condition="'%(Extension)' == '.dll'" />
 
       <_BlazorOutputWithTargetPath Include="@(_BlazorCopyLocalPaths)">
-        <BlazorBootManifestResourceType Condition="'%(Extension)' == '.dll'">assembly</BlazorBootManifestResourceType>
-        <BlazorBootManifestResourceType Condition="'%(Extension)' == '.pdb'">pdb</BlazorBootManifestResourceType>
+        <BootManifestResourceType Condition="'%(Extension)' == '.dll'">assembly</BootManifestResourceType>
+        <BootManifestResourceType Condition="'%(Extension)' == '.pdb'">pdb</BootManifestResourceType>
+        <BootManifestResourceName>%(_BlazorCopyLocalPaths.DestinationSubDirectory)%(FileName)%(Extension)</BootManifestResourceName>
         <TargetOutputPath>$(_BlazorRuntimeBinOutputPath)%(_BlazorCopyLocalPaths.DestinationSubDirectory)%(FileName)%(Extension)</TargetOutputPath>
-        <RelativeOutputPath>%(_BlazorCopyLocalPaths.DestinationSubDirectory)%(FileName)%(Extension)</RelativeOutputPath>
       </_BlazorOutputWithTargetPath>
     </ItemGroup>
 
@@ -144,13 +145,15 @@
       <_DotNetWasmRuntimeFile Include="$(ComponentsWebAssemblyRuntimePath)*.wasm" />
       <_BlazorOutputWithTargetPath Include="@(_DotNetWasmRuntimeFile)">
         <TargetOutputPath>$(_BlazorRuntimeWasmOutputPath)%(FileName)%(Extension)</TargetOutputPath>
-        <BlazorBootManifestResourceType>runtime</BlazorBootManifestResourceType>
+        <BootManifestResourceType>runtime</BootManifestResourceType>
+        <BootManifestResourceName>%(FileName)%(Extension)</BootManifestResourceName>
       </_BlazorOutputWithTargetPath>
 
       <_DotNetWasmJsFile Include="$(ComponentsWebAssemblyRuntimePath)*.js" />
       <_BlazorOutputWithTargetPath Include="@(_DotNetWasmJsFile)">
         <TargetOutputPath>$(_BlazorRuntimeWasmOutputPath)%(FileName).$(TemporaryDotNetJsFileVersion)%(Extension)</TargetOutputPath>
-        <BlazorBootManifestResourceType>runtime</BlazorBootManifestResourceType>
+        <BootManifestResourceType>runtime</BootManifestResourceType>
+        <BootManifestResourceName>%(FileName).$(TemporaryDotNetJsFileVersion)%(Extension)</BootManifestResourceName>
       </_BlazorOutputWithTargetPath>
 
       <_BlazorJSFile Include="$(_BlazorJSPath)" />
@@ -329,9 +332,7 @@
     Inputs="$(MSBuildAllProjects);@(_BlazorOutputWithTargetPath)"
     Outputs="$(_BlazorBootJsonIntermediateOutputPath)">
     <ItemGroup>
-      <_BlazorBootResource Include="@(_BlazorOutputWithTargetPath->HasMetadata('BlazorBootManifestResourceType'))">
-        <BootResourceType>%(_BlazorOutputWithTargetPath.BlazorBootManifestResourceType)</BootResourceType>
-      </_BlazorBootResource>
+      <_BlazorBootResource Include="@(_BlazorOutputWithTargetPath->HasMetadata('BootManifestResourceType'))" />
     </ItemGroup>
 
     <GetFileHash Files="@(_BlazorBootResource)" Algorithm="SHA256" HashEncoding="base64">


### PR DESCRIPTION
Bug discovered in conjunction with @lewing 

The new logic for generating `blazor.boot.json` is broken on Mac/Linux. Instead of producing resource names like `dotnet.wasm`, it produces `dist/_framework/wasm/dotnet.wasm`. This fails at runtime because our startup JS isn't looking for those names.

I was at first surprised that this is possible, considering how we have tests for this and they do run on Mac/Linux. The reason is a mismatch between MSBuild conventions and .NET ones:

 * Our MSBuild targets work in terms of Windows paths, even on Linux (in this case, `$(_BlazorRuntimeWasmOutputPath)` is constructed with `\` separators)
 * Our custom build target tries to parse paths using `Path.GetFileName`, which assumes you'll have Linux paths on Linux
 * Our unit tests didn't accurately simulate what MSBuild will give us. They were constructing inputs using `Path.Combine` which uses OS's directory separator. This meant that `Path.GetFileName` was able to succeed in tests even though it would fail in reality when given Windows-style paths on Linux.

### The fix

Rather than just special-casing this and handling all the path formats in this one place, I changed how we determine the resource names. Instead of inferring them from a combination of `RelativePath` and `TargetOutputPath` metadata (with differing rules about how to interpret each), I defined a different metadata item `BootResourceName` which now lets the MSBuild targets completely determine what name to use for each resource. We no longer have to do any path manipulation inside the custom task. This also eliminates the need for `RelativeOutputPath` metadata, so that's now removed.

I also eliminated the duplication of `BlazorBootManifestResourceType` metadata, and renamed `BlazorBootManifestResourceType` to `BootManifestResourceType`.

All this renaming makes the diff look big, but the amount of logical change is small - it's just changing where the responsibilities lies for determining the resource name so now it's done on the MSBuild side and not inside the custom target.