### PR TITLE
Use index-style modelName if QueryStringValueProvider

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -408,7 +408,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                     = ((System.Collections.ObjectModel.Collection<IValueProvider>)
                             bindingContext.ValueProvider)[0].GetType();
                 string modelName;
-                if ( valueProviderType == "QueryStringValueProvider" )
+                if ( valueProviderType.Name == "QueryStringValueProvider" )
                 {
                     modelName = ModelNames.CreateIndexModelName(bindingContext.ModelName, fieldName);
                 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -403,7 +403,19 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
                 // Otherwise, check whether the (perhaps filtered) value providers have a match.
                 var fieldName = propertyMetadata.BinderModelName ?? propertyMetadata.PropertyName;
-                var modelName = ModelNames.CreatePropertyModelName(bindingContext.ModelName, fieldName);
+
+                Type valueProviderType
+                    = ((System.Collections.ObjectModel.Collection<IValueProvider>)
+                            bindingContext.ValueProvider)[0].GetType();
+                string modelName;
+                if ( valueProviderType == "QueryStringValueProvider" )
+                {
+                    modelName = ModelNames.CreateIndexModelName(bindingContext.ModelName, fieldName);
+                }
+                else
+                {
+                    modelName = ModelNames.CreatePropertyModelName(bindingContext.ModelName, fieldName);
+                }
                 using (bindingContext.EnterNestedScope(
                     modelMetadata: propertyMetadata,
                     fieldName: fieldName,


### PR DESCRIPTION
Since I don't have resources to build this or test it, this is merely a suggestion. Something like this seems like a better solution than my last pull-request in PrefixContainer. Ideally, something polymorphic through IValueProvider might be good, but I don't have resources to implement a multi-file change like that while unable to build this code.

Summary of the changes
 - If model-binding value comes from a QueryStringValueProvider, then build keys using index notation

Addresses #19220 

This approach seems preferable because any url query string generated in a manner similar to [jQuery.param()](https://api.jquery.com/jQuery.param/) (and that is likely a majority) is going to use *index* notation and encounter bug #19220 . Can it be assumed that other ValueProviders are not encountering bug #19220 ? If so, then we don't want to apply index notation to them.