### PR TITLE
Add example for UserLoginInfo's ProviderDisplayName property

### DIFF
--- a/src/Identity/Extensions.Core/src/UserLoginInfo.cs
+++ b/src/Identity/Extensions.Core/src/UserLoginInfo.cs
@@ -47,6 +47,9 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The display name for the provider.
         /// </value>
+        /// <remarks>
+        /// Examples of the display name may be local, FACEBOOK, Google, etc.
+        /// </remarks>
         public string ProviderDisplayName { get; set; }
     }
 }


### PR DESCRIPTION
Summary of the changes:
 - Added `remarks` to the `UserLoginInfo.ProviderDisplayName` property with an example of stored values

It's unclear what should be stored in the `ProviderDisplayName` property. So I think it would be nice to add some examples to the doc.

Here are examples of the usage:
https://github.com/dotnet/aspnetcore/blob/c95ee2b051814b787b07f55ff224d03d550aafeb/src/Identity/samples/IdentitySample.Mvc/Views/Manage/ManageLogins.cshtml#L26
https://github.com/dotnet/aspnetcore/blob/90231e7290b22cd99bfba5e0970d2dd679ac4ff8/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml#L12
So I assume the `ProviderDisplayName` can have values like Facebook, Google, Microsoft, etc.
