### PR TITLE
Fix for PWA + auth template

### DIFF
--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
@@ -8,7 +8,7 @@ self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
-const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/ ];
+const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 async function onInstall(event) {

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
@@ -19,6 +19,12 @@ async function onInstall(event) {
         .filter(asset => offlineAssetsInclude.some(pattern => pattern.test(asset.url)))
         .filter(asset => !offlineAssetsExclude.some(pattern => pattern.test(asset.url)))
         .map(asset => new Request(asset.url, { integrity: asset.hash }));
+//#if(IndividualLocalAuth && Hosted)
+
+    // Also cache authentication configuration
+    assetsRequests.push(new Request('_configuration/ComponentsWebAssembly-CSharp.Client'));
+
+//#endif
     await caches.open(cacheName).then(cache => cache.addAll(assetsRequests));
 }
 


### PR DESCRIPTION
Without this change, if you're offline you get a yellow bar on app startup, even if you're not visiting a page that requires auth.

With this change, you're free to use parts of the app that don't require auth while you're offline. If you do trigger an auth flow while offline, you should get the "login failed" UI, which is customizable by the developer.

As far as I can tell, this change is only necessary in the "hosted+individual auth" case.

 * It doesn't apply in any standalone case, because in that case the auth config is hardcoded inside `Program.cs` so we didn't have to fetch it anyway
 * It doesn't apply in the AAD/B2C cases because the MSAL provider doesn't need to fetch any config file like this

I'm also rolling in a small fix to do with `favicon.ico` for convenience.