### PR TITLE
In debug mode, don't enable the linker by default

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -66,7 +66,7 @@
 
   <Target Name="_ResolveBlazorOutputs" DependsOnTargets="_ResolveBlazorOutputsWhenLinked;_ResolveBlazorOutputsWhenNotLinked">
     <Error
-      Message="Unrecongnized value for BlazorWebAssemblyEnableLinking: '$(BlazorWebAssemblyEnableLinking)'. Valid values are 'true' or 'false'."
+      Text="Unrecongnized value for BlazorWebAssemblyEnableLinking: '$(BlazorWebAssemblyEnableLinking)'. Valid values are 'true' or 'false'."
       Condition="'$(BlazorWebAssemblyEnableLinking)' != 'true' AND '$(BlazorWebAssemblyEnableLinking)' != 'false'" />
 
     <!--

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BlazorWebAssemblyEnableLinking Condition="$(BlazorWebAssemblyEnableLinking) == ''">true</BlazorWebAssemblyEnableLinking>
+    <BlazorWebAssemblyEnableLinking Condition="'$(BlazorWebAssemblyEnableLinking)' == '' AND '$(Configuration)' != 'Debug'">true</BlazorWebAssemblyEnableLinking>
   </PropertyGroup>
 
   <Target

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <BlazorWebAssemblyEnableLinking Condition="'$(BlazorWebAssemblyEnableLinking)' == '' AND '$(Configuration)' != 'Debug'">true</BlazorWebAssemblyEnableLinking>
+    <BlazorWebAssemblyEnableLinking Condition="'$(BlazorWebAssemblyEnableLinking)' == ''">false</BlazorWebAssemblyEnableLinking>
   </PropertyGroup>
 
   <Target
@@ -9,12 +10,8 @@
   </Target>
 
   <Target Name="_ResolveBlazorInputs" DependsOnTargets="ResolveReferences;ResolveRuntimePackAssets">
-    <Warning Text="BlazorLinkOnBuild has been renamed to BlazorWebAssemblyEnableLinking. Please update your project files to use the new property."
-             Condition="'$(BlazorLinkOnBuild)' != ''" />
-
-    <PropertyGroup Condition="'$(BlazorLinkOnBuild)' != ''">
-      <BlazorWebAssemblyEnableLinking>$(BlazorLinkOnBuild)</BlazorWebAssemblyEnableLinking>
-    </PropertyGroup>
+    <Error Text="BlazorLinkOnBuild has been renamed to BlazorWebAssemblyEnableLinking. Please update your project files to use the new property."
+           Condition="'$(BlazorLinkOnBuild)' != ''" />
 
     <PropertyGroup>
       <!-- /obj/<<configuration>>/<<targetframework>>/blazor -->

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -65,10 +65,6 @@
   </Target>
 
   <Target Name="_ResolveBlazorOutputs" DependsOnTargets="_ResolveBlazorOutputsWhenLinked;_ResolveBlazorOutputsWhenNotLinked">
-    <Error
-      Text="Unrecongnized value for BlazorWebAssemblyEnableLinking: '$(BlazorWebAssemblyEnableLinking)'. Valid values are 'true' or 'false'."
-      Condition="'$(BlazorWebAssemblyEnableLinking)' != 'true' AND '$(BlazorWebAssemblyEnableLinking)' != 'false'" />
-
     <!--
       These are the items calculated as the closure of the runtime assemblies, either by calling the linker
       or by calling our custom ResolveBlazorRuntimeDependencies task if the linker was disabled. Other than

--- a/src/Components/WebAssembly/Build/src/targets/Compression.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Compression.targets
@@ -25,7 +25,7 @@
 
       <!-- The linker is not incremental, so to support incremental compression in addition to linking we need to compute the hashes of the dlls and
            pdbs, write them to a file when they change and use that as input for the compression task instead. -->
-      <_BlazorFileToCompress Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
+      <_BlazorFileToCompress Condition="'$(BlazorWebAssemblyEnableLinking)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
         <InputSource>$([MSBuild]::NormalizePath('$(_BlazorFilesIntermediateOutputPath)%(RelativePath).hash'))</InputSource>
       </_BlazorFileToCompress>
 
@@ -36,7 +36,7 @@
 
     </ItemGroup>
 
-    <GetFileHash Files="@(_BlazorFileToCompress)" Condition="'$(BlazorLinkOnBuild)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
+    <GetFileHash Files="@(_BlazorFileToCompress)" Condition="'$(BlazorWebAssemblyEnableLinking)' == 'true' and ('%(Extension)' == '.dll' or '%(Extension)' == '.pdb')">
       <Output TaskParameter="Items" ItemName="_LinkerOutputHashes" />
     </GetFileHash>
 

--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -19,6 +19,7 @@
   <UsingTask TaskName="GenerateServiceWorkerAssetsManifest" AssemblyFile="$(_BlazorTasksPath)" />
 
   <Target Name="_WriteServiceWorkerAssetsManifest"
+          Condition="'$(ServiceWorkerAssetsManifest)' != ''"
           Inputs="@(ServiceWorkerAssetsManifestItem)"
           Outputs="$(_ServiceWorkerAssetsManifestIntermediateOutputPath)"
           BeforeTargets="_BlazorStaticWebAssetsCopyGeneratedFilesToOutputDirectory"

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildCompressionTests.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildCompressionTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
         {
             // Arrange
             using var project = ProjectDirectory.Create("standalone");
-            var result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorLinkOnBuild=false");
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorWebAssemblyEnableLinking=false");
 
             Assert.BuildPassed(result);
 
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             // Assert
             for (var i = 0; i < 3; i++)
             {
-                result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorLinkOnBuild=false");
+                result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/p:BlazorWebAssemblyEnableLinking=false");
                 Assert.BuildPassed(result);
 
                 var newThumbPrint = FileThumbPrint.CreateFolderThumbprint(project, compressedFilesFolder);

--- a/src/Components/WebAssembly/testassets/MonoSanityClient/MonoSanityClient.csproj
+++ b/src/Components/WebAssembly/testassets/MonoSanityClient/MonoSanityClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor" TreatAsLocalProperty="BlazorLinkOnBuild">
+<Project Sdk="Microsoft.NET.Sdk.Razor" TreatAsLocalProperty="BlazorWebAssemblyEnableLinking">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>


### PR DESCRIPTION
This makes the inner-loop dev experience much better. We're also clearer these days about logging a warning about the effect on app size and the need to test published/release builds regularly.