### PR TITLE
Initialize the runtime state correctly for wasm debugging

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -215,7 +215,7 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
     MONO.mono_wasm_setenv("MONO_URI_DOTNETRELATIVEORABSOLUTE", "true");
     const load_runtime = Module.cwrap('mono_wasm_load_runtime', null, ['string', 'number']);
     load_runtime(appBinDirName, hasDebuggingEnabled() ? 1 : 0);
-    MONO.mono_wasm_runtime_is_ready = true;
+    MONO.mono_wasm_runtime_ready ();
     attachInteropInvoker();
     onReady();
   });

--- a/src/Components/Web.JS/src/Platform/Mono/MonoTypes.d.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoTypes.d.ts
@@ -22,6 +22,7 @@ declare namespace Mono {
 declare namespace MONO {
   var loaded_files: string[];
   var mono_wasm_runtime_is_ready: boolean;
+  function mono_wasm_runtime_ready (): void;
   function mono_wasm_setenv (name: string, value: string): void;
 }
 


### PR DESCRIPTION
On startup the DebugProxy needs to know when the runtime
has initialized enough to be able to begin interaction
this is accomplished by breaking in mono_wasm_runtime_ready()
which the Proxy sees does initialization and then resumes from.
Simply setting mono_wasm_runtime_is_ready breaks that logic,
but even worse it appears that the variable is linked out
in the release version

The changes call MONO.mono_wasm_runtime_ready () as expected

Addresses #19378
