### PR TITLE
Fix flaky timeout test in TS client

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -679,7 +679,6 @@ describe("hubConnection", () => {
             if (transportType !== HttpTransportType.LongPolling) {
                 it("terminates if no messages received within timeout interval", async (done) => {
                     const hubConnection = getConnectionBuilder(transportType).build();
-                    hubConnection.serverTimeoutInMilliseconds = 100;
 
                     hubConnection.onclose((error) => {
                         expect(error).toEqual(new Error("Server timeout elapsed without receiving a message from the server."));
@@ -687,6 +686,12 @@ describe("hubConnection", () => {
                     });
 
                     await hubConnection.start();
+
+                    // set this after start completes to avoid network issues with the handshake taking over 100ms and causing a failure
+                    hubConnection.serverTimeoutInMilliseconds = 1;
+
+                    // invoke a method with a response to reset the timeout using the new value
+                    await hubConnection.invoke("Echo", "");
                 });
             }
 


### PR DESCRIPTION
The timeout could happen while waiting for the handshake which would cause `await hubConnection.start()` to throw. Now we only set the short timeout after the connection has started so we observe connection close in the `onclose(...)` handler like expected.