### PR TITLE
Support binding short values to InputNumber component

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Components
         public static string FormatValue(System.DateTimeOffset value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(decimal value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(double value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(short value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(int value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(long value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static bool? FormatValue(bool? value, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -21,6 +22,7 @@ namespace Microsoft.AspNetCore.Components
         public static string FormatValue(System.DateTime? value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(decimal? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(double? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(short? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(int? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(long? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(float? value, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -47,6 +49,8 @@ namespace Microsoft.AspNetCore.Components
         public static bool TryConvertToNullableFloat(object obj, System.Globalization.CultureInfo culture, out float? value) { throw null; }
         public static bool TryConvertToNullableInt(object obj, System.Globalization.CultureInfo culture, out int? value) { throw null; }
         public static bool TryConvertToNullableLong(object obj, System.Globalization.CultureInfo culture, out long? value) { throw null; }
+        public static bool TryConvertToNullableShort(object obj, System.Globalization.CultureInfo culture, out short? value) { throw null; }
+        public static bool TryConvertToShort(object obj, System.Globalization.CultureInfo culture, out short value) { throw null; }
         public static bool TryConvertToString(object obj, System.Globalization.CultureInfo culture, out string value) { throw null; }
         public static bool TryConvertTo<T>(object obj, System.Globalization.CultureInfo culture, out T value) { throw null; }
     }
@@ -165,6 +169,7 @@ namespace Microsoft.AspNetCore.Components
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime> setter, System.DateTime existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<decimal> setter, decimal existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<double> setter, double existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<short> setter, short existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<int> setter, int existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<long> setter, long existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<bool?> setter, bool? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -174,6 +179,7 @@ namespace Microsoft.AspNetCore.Components
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime?> setter, System.DateTime? existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<decimal?> setter, decimal? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<double?> setter, double? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<short?> setter, short? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<int?> setter, int? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<long?> setter, long? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<float?> setter, float? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }

--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Components
         public static string FormatValue(System.DateTimeOffset value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(decimal value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(double value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(short value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(int value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(long value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static bool? FormatValue(bool? value, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -21,6 +22,7 @@ namespace Microsoft.AspNetCore.Components
         public static string FormatValue(System.DateTime? value, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(decimal? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(double? value, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static string FormatValue(short? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(int? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(long? value, System.Globalization.CultureInfo culture = null) { throw null; }
         public static string FormatValue(float? value, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -47,6 +49,8 @@ namespace Microsoft.AspNetCore.Components
         public static bool TryConvertToNullableFloat(object obj, System.Globalization.CultureInfo culture, out float? value) { throw null; }
         public static bool TryConvertToNullableInt(object obj, System.Globalization.CultureInfo culture, out int? value) { throw null; }
         public static bool TryConvertToNullableLong(object obj, System.Globalization.CultureInfo culture, out long? value) { throw null; }
+        public static bool TryConvertToNullableShort(object obj, System.Globalization.CultureInfo culture, out short? value) { throw null; }
+        public static bool TryConvertToShort(object obj, System.Globalization.CultureInfo culture, out short value) { throw null; }
         public static bool TryConvertToString(object obj, System.Globalization.CultureInfo culture, out string value) { throw null; }
         public static bool TryConvertTo<T>(object obj, System.Globalization.CultureInfo culture, out T value) { throw null; }
     }
@@ -165,6 +169,7 @@ namespace Microsoft.AspNetCore.Components
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime> setter, System.DateTime existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<decimal> setter, decimal existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<double> setter, double existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<short> setter, short existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<int> setter, int existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<long> setter, long existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<bool?> setter, bool? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
@@ -174,6 +179,7 @@ namespace Microsoft.AspNetCore.Components
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<System.DateTime?> setter, System.DateTime? existingValue, string format, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<decimal?> setter, decimal? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<double?> setter, double? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
+        public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<short?> setter, short? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<int?> setter, int? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<long?> setter, long? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory factory, object receiver, System.Action<float?> setter, float? existingValue, System.Globalization.CultureInfo culture = null) { throw null; }

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Components
     //
     // Perf: our conversion routines present a regular API surface that allows us to specialize on types to avoid boxing.
     // for instance, many of these types could be cast to IFormattable to do the appropriate formatting, but that's going
-    // to allocate. 
+    // to allocate.
     public static class BindConverter
     {
         private static object BoxedTrue = true;
@@ -149,6 +149,41 @@ namespace Microsoft.AspNetCore.Components
         public static string FormatValue(long? value, CultureInfo culture = null) => FormatNullableLongValueCore(value, culture);
 
         private static string FormatNullableLongValueCore(long? value, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="culture">
+        /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+        /// </param>
+        /// <returns>The formatted value.</returns>
+        public static string FormatValue(short value, CultureInfo culture = null) => FormatShortValueCore(value, culture);
+
+        private static string FormatShortValueCore(short value, CultureInfo culture)
+        {
+            return value.ToString(culture ?? CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="culture">
+        /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+        /// </param>
+        /// <returns>The formatted value.</returns>
+        public static string FormatValue(short? value, CultureInfo culture = null) => FormatNullableShortValueCore(value, culture);
+
+        private static string FormatNullableShortValueCore(short? value, CultureInfo culture)
         {
             if (value == null)
             {
@@ -640,6 +675,71 @@ namespace Microsoft.AspNetCore.Components
             }
 
             if (!long.TryParse(text, NumberStyles.Number, culture ?? CultureInfo.CurrentCulture, out var converted))
+            {
+                value = default;
+                return false;
+            }
+
+            value = converted;
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to convert a value to a <see cref="System.Int16"/>.
+        /// </summary>
+        /// <param name="obj">The object to convert.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> to use for conversion.</param>
+        /// <param name="value">The converted value.</param>
+        /// <returns><c>true</c> if conversion is successful, otherwise <c>false</c>.</returns>
+        public static bool TryConvertToShort(object obj, CultureInfo culture, out short value)
+        {
+            return ConvertToShortCore(obj, culture, out value);
+        }
+
+        /// <summary>
+        /// Attempts to convert a value to a nullable <see cref="System.Int16"/>.
+        /// </summary>
+        /// <param name="obj">The object to convert.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> to use for conversion.</param>
+        /// <param name="value">The converted value.</param>
+        /// <returns><c>true</c> if conversion is successful, otherwise <c>false</c>.</returns>
+        public static bool TryConvertToNullableShort(object obj, CultureInfo culture, out short? value)
+        {
+            return ConvertToNullableShort(obj, culture, out value);
+        }
+
+        internal static BindParser<short> ConvertToShort = ConvertToShortCore;
+        internal static BindParser<short?> ConvertToNullableShort = ConvertToNullableShortCore;
+
+        private static bool ConvertToShortCore(object obj, CultureInfo culture, out short value)
+        {
+            var text = (string)obj;
+            if (string.IsNullOrEmpty(text))
+            {
+                value = default;
+                return false;
+            }
+
+            if (!short.TryParse(text, NumberStyles.Number, culture ?? CultureInfo.CurrentCulture, out var converted))
+            {
+                value = default;
+                return false;
+            }
+
+            value = converted;
+            return true;
+        }
+
+        private static bool ConvertToNullableShortCore(object obj, CultureInfo culture, out short? value)
+        {
+            var text = (string)obj;
+            if (string.IsNullOrEmpty(text))
+            {
+                value = default;
+                return true;
+            }
+
+            if (!short.TryParse(text, NumberStyles.Number, culture ?? CultureInfo.CurrentCulture, out var converted))
             {
                 value = default;
                 return false;
@@ -1198,6 +1298,14 @@ namespace Microsoft.AspNetCore.Components
                     {
                         formatter = (BindFormatter<long?>)FormatNullableLongValueCore;
                     }
+                    else if (typeof(T) == typeof(short))
+                    {
+                        formatter = (BindFormatter<short>)FormatShortValueCore;
+                    }
+                    else if (typeof(T) == typeof(short?))
+                    {
+                        formatter = (BindFormatter<short?>)FormatNullableShortValueCore;
+                    }
                     else if (typeof(T) == typeof(float))
                     {
                         formatter = (BindFormatter<float>)FormatFloatValueCore;
@@ -1322,6 +1430,14 @@ namespace Microsoft.AspNetCore.Components
                     else if (typeof(T) == typeof(long?))
                     {
                         parser = ConvertToNullableLong;
+                    }
+                    else if (typeof(T) == typeof(short))
+                    {
+                        parser = ConvertToShort;
+                    }
+                    else if (typeof(T) == typeof(short?))
+                    {
+                        parser = ConvertToNullableShort;
                     }
                     else if (typeof(T) == typeof(float))
                     {

--- a/src/Components/Components/src/EventCallbackFactoryBinderExtensions.cs
+++ b/src/Components/Components/src/EventCallbackFactoryBinderExtensions.cs
@@ -148,11 +148,49 @@ namespace Microsoft.AspNetCore.Components
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
+            Action<short> setter,
+            short existingValue,
+            CultureInfo culture = null)
+        {
+            return CreateBinderCore<short>(factory, receiver, setter, culture, ConvertToShort);
+        }
+
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="receiver"></param>
+        /// <param name="setter"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        public static EventCallback<ChangeEventArgs> CreateBinder(
+            this EventCallbackFactory factory,
+            object receiver,
             Action<long?> setter,
             long? existingValue,
             CultureInfo culture = null)
         {
             return CreateBinderCore<long?>(factory, receiver, setter, culture, ConvertToNullableLong);
+        }
+
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="receiver"></param>
+        /// <param name="setter"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        public static EventCallback<ChangeEventArgs> CreateBinder(
+            this EventCallbackFactory factory,
+            object receiver,
+            Action<short?> setter,
+            short? existingValue,
+            CultureInfo culture = null)
+        {
+            return CreateBinderCore<short?>(factory, receiver, setter, culture, ConvertToNullableShort);
         }
 
         /// <summary>

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 {
     /// <summary>
     /// An input component for editing numeric values.
-    /// Supported numeric types are <see cref="int"/>, <see cref="long"/>, <see cref="float"/>, <see cref="double"/>, <see cref="decimal"/>.
+    /// Supported numeric types are <see cref="int"/>, <see cref="long"/>, <see cref="short"/>, <see cref="float"/>, <see cref="double"/>, <see cref="decimal"/>.
     /// </summary>
     public class InputNumber<TValue> : InputBase<TValue>
     {
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             var targetType = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
             if (targetType == typeof(int) ||
                 targetType == typeof(long) ||
+                targetType == typeof(short) ||
                 targetType == typeof(float) ||
                 targetType == typeof(double) ||
                 targetType == typeof(decimal))
@@ -85,6 +86,9 @@ namespace Microsoft.AspNetCore.Components.Forms
 
                 case long @long:
                     return BindConverter.FormatValue(@long, CultureInfo.InvariantCulture);
+
+                case short @short:
+                    return BindConverter.FormatValue(@short, CultureInfo.InvariantCulture);
 
                 case float @float:
                     return BindConverter.FormatValue(@float, CultureInfo.InvariantCulture);

--- a/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/GlobalizationTest.cs
@@ -186,6 +186,18 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal(90000000000.ToString(cultureInfo), () => display.Text);
             Browser.Equal(90000000000.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
+            // short
+            input = Browser.FindElement(By.Id("inputnumber_short"));
+            display = Browser.FindElement(By.Id("inputnumber_short_value"));
+            Browser.Equal(42.ToString(cultureInfo), () => display.Text);
+            Browser.Equal(42.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
+
+            input.Clear();
+            input.SendKeys(127.ToString(CultureInfo.InvariantCulture));
+            input.SendKeys("\t");
+            Browser.Equal(127.ToString(cultureInfo), () => display.Text);
+            Browser.Equal(127.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
+
             // decimal
             input = Browser.FindElement(By.Id("inputnumber_decimal"));
             display = Browser.FindElement(By.Id("inputnumber_decimal_value"));

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -356,6 +356,65 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void CanBindTextboxShort()
+        {
+            var target = Browser.FindElement(By.Id("textbox-short"));
+            var boundValue = Browser.FindElement(By.Id("textbox-short-value"));
+            var mirrorValue = Browser.FindElement(By.Id("textbox-short-mirror"));
+            Assert.Equal("-42", target.GetAttribute("value"));
+            Assert.Equal("-42", boundValue.Text);
+            Assert.Equal("-42", mirrorValue.GetAttribute("value"));
+
+            // Clear target; value resets to zero
+            target.Clear();
+            Browser.Equal("0", () => target.GetAttribute("value"));
+            Assert.Equal("0", boundValue.Text);
+            Assert.Equal("0", mirrorValue.GetAttribute("value"));
+
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
+            // Leading zeros are not preserved
+            target.SendKeys("42");
+            Browser.Equal("042", () => target.GetAttribute("value"));
+            target.SendKeys("\t");
+            Browser.Equal("42", () => target.GetAttribute("value"));
+            Assert.Equal("42", boundValue.Text);
+            Assert.Equal("42", mirrorValue.GetAttribute("value"));
+        }
+
+        [Fact]
+        public void CanBindTextboxNullableShort()
+        {
+            var target = Browser.FindElement(By.Id("textbox-nullable-short"));
+            var boundValue = Browser.FindElement(By.Id("textbox-nullable-short-value"));
+            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-short-mirror"));
+            Assert.Equal(string.Empty, target.GetAttribute("value"));
+            Assert.Equal(string.Empty, boundValue.Text);
+            Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
+
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
+            target.Clear();
+            Browser.Equal("", () => boundValue.Text);
+            Assert.Equal("", mirrorValue.GetAttribute("value"));
+
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
+            target.SendKeys("-42\t");
+            Browser.Equal("-42", () => boundValue.Text);
+            Assert.Equal("-42", mirrorValue.GetAttribute("value"));
+
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
+            target.Clear();
+            target.SendKeys("42\t");
+            Browser.Equal("42", () => boundValue.Text);
+            Assert.Equal("42", mirrorValue.GetAttribute("value"));
+
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
+            target.Clear();
+            target.SendKeys("\t");
+            Browser.Equal(string.Empty, () => boundValue.Text);
+            Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
+        }
+
+        [Fact]
         public void CanBindTextboxFloat()
         {
             var target = Browser.FindElement(By.Id("textbox-float"));

--- a/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
@@ -51,6 +51,18 @@
     <input id="textbox-nullable-long-mirror" @bind="textboxNullableLongValue" readonly />
 </p>
 <p>
+    short:
+    <input id="textbox-short" @bind="textboxShortValue" type="number" />
+    <span id="textbox-short-value">@textboxLongValue</span>
+    <input id="textbox-short-mirror" @bind="textboxShortValue" readonly />
+</p>
+<p>
+    Nullable short:
+    <input id="textbox-nullable-short" @bind="textboxNullableShortValue" type="number" />
+    <span id="textbox-nullable-short-value">@textboxNullableShortValue</span>
+    <input id="textbox-nullable-short-mirror" @bind="textboxNullableShortValue" readonly />
+</p>
+<p>
     float:
     <input id="textbox-float" @bind-value="textboxFloatValue" type="number" />
     <span id="textbox-float-value">@textboxFloatValue</span>
@@ -328,6 +340,8 @@
     int? textboxNullableIntValue = null;
     long textboxLongValue = 3_000_000_000;
     long? textboxNullableLongValue = null;
+    short textboxShortValue = -42;
+    short? textboxNullableShortValue = null;
     float textboxFloatValue = 3.141f;
     float? textboxNullableFloatValue = null;
     double textboxDoubleValue = 3.14159265359d;

--- a/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
@@ -53,7 +53,7 @@
 <p>
     short:
     <input id="textbox-short" @bind="textboxShortValue" type="number" />
-    <span id="textbox-short-value">@textboxLongValue</span>
+    <span id="textbox-short-value">@textboxShortValue</span>
     <input id="textbox-short-mirror" @bind="textboxShortValue" readonly />
 </p>
 <p>

--- a/src/Components/test/testassets/BasicTestApp/GlobalizationBindCases.razor
+++ b/src/Components/test/testassets/BasicTestApp/GlobalizationBindCases.razor
@@ -67,6 +67,10 @@
             <span id="inputnumber_long_value">@inputNumberLong</span>
         </div>
         <div>
+            short: <InputNumber id="inputnumber_short" @bind-Value="inputNumberShort" />
+            <span id="inputnumber_short_value">@inputNumberShort</span>
+        </div>
+        <div>
             decimal: <InputNumber id="inputnumber_decimal" @bind-Value="inputNumberDecimal" />
             <span id="inputnumber_decimal_value">@inputNumberDecimal</span>
         </div>
@@ -104,6 +108,7 @@
 
     int inputNumberInt = 42;
     long inputNumberLong = 4200;
+    short inputNumberShort = 42;
     decimal inputNumberDecimal = 4.2m;
 
     DateTime inputDateDateTime = new DateTime(1985, 3, 4);


### PR DESCRIPTION
**Changes in this PR**
 - Adds binding for Int16 values to BindConverters
 - Adds two-way data binding for on change events for number inputs with Int16 values
- Updates static constructor and format cases in InputNumber
- Updates reference assemblies
- Add tests for short values in InputNumber component
- Add tests for short values in BindTests

Addresses #15437
