### PR TITLE
Add SocketTransportOption to enable/disable WaitForData

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/ref/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.netcoreapp.cs
@@ -31,5 +31,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public long? MaxReadBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public long? MaxWriteBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public bool NoDelay { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public bool WaitForDataBeforeAllocatingBuffer { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
@@ -62,7 +62,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 PipeScheduler.ThreadPool,
                 _trace,
                 _options.MaxReadBufferSize,
-                _options.MaxWriteBufferSize);
+                _options.MaxWriteBufferSize,
+                _options.WaitForDataBeforeAllocatingBuffer);
 
             socketConnection.Start();
             return socketConnection;

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -112,7 +112,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                         acceptSocket.NoDelay = _options.NoDelay;
                     }
 
-                    var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[_schedulerIndex], _trace, _options.MaxReadBufferSize, _options.MaxWriteBufferSize);
+                    var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[_schedulerIndex], _trace,
+                        _options.MaxReadBufferSize, _options.MaxWriteBufferSize, _options.WaitForDataBeforeAllocatingBuffer);
 
                     connection.Start();
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// <remarks>
         /// Defaults to true.
         /// </remarks>
-        public bool WaitForDataBeforeAllocatingBuffer { get; set; } = false;
+        public bool WaitForDataBeforeAllocatingBuffer { get; set; } = true;
 
         /// <summary>
         /// Set to false to enable Nagle's algorithm for all connections.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// <remarks>
         /// Defaults to true.
         /// </remarks>
-        public bool WaitForDataBeforeAllocatingBuffer { get; set; } = true;
+        public bool WaitForDataBeforeAllocatingBuffer { get; set; } = false;
 
         /// <summary>
         /// Set to false to enable Nagle's algorithm for all connections.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// <remarks>
         /// Defaults to true.
         /// </remarks>
-        public bool WaitForDataBeforeAllocatingBuffer = true;
+        public bool WaitForDataBeforeAllocatingBuffer { get; set; } = true;
 
         /// <summary>
         /// Set to false to enable Nagle's algorithm for all connections.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
         /// <summary>
-        /// Wait until there is data available to allocate a buffer. Set this to true to reduce memory used for idle connections.
+        /// Wait until there is data available to allocate a buffer. Setting this to false can increase throughput at the cost of increased memory usage.
         /// </summary>
         /// <remarks>
         /// Defaults to true.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -17,6 +17,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
         /// <summary>
+        /// Wait until there is data available to allocate a buffer. Set this to true to reduce memory used for idle connections.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to true.
+        /// </remarks>
+        public bool WaitForDataBeforeAllocatingBuffer = true;
+
+        /// <summary>
         /// Set to false to enable Nagle's algorithm for all connections.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This allows to opt-out of the zero-byte read that is performed to reduce memory usage for idle connections.
This read has a measurable impact on TE JSON benchmark.

cc @halter73 @davidfowl @sebastienros @adamsitnik