### PR TITLE
Stop service worker interfering with Identity UI

### DIFF
--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
@@ -43,7 +43,13 @@ async function onFetch(event) {
     if (event.request.method === 'GET') {
         // For all navigation requests, try to serve index.html from cache
         // If you need some URLs to be server-rendered, edit the following check to exclude those URLs
+//#if(IndividualLocalAuth && Hosted)
+        const shouldServeIndexHtml = event.request.mode === 'navigate'
+            && !event.request.url.includes('/connect/')
+            && !event.request.url.includes('/Identity/');
+//#else
         const shouldServeIndexHtml = event.request.mode === 'navigate';
+//#endif
 
         const request = shouldServeIndexHtml ? 'index.html' : event.request;
         const cache = await caches.open(cacheName);


### PR DESCRIPTION
The service worker has its own SPA fallback routing (as is necessary). Unfortunately that means it has to know about any parts of the URL space where you *don't* want to do SPA fallback.

I didn't track down what the requests into `/connect/*` are for. If this is something we control, we should consider moving it under `/_framework/connect/*` so that, as we keep on adding more stuff like this, there's only one prefix that developers need to know about. 