### PR TITLE
[Blazor][Wasm] Add missing state callbacks

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
@@ -75,6 +75,16 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         [Parameter] public RenderFragment LogOutSucceeded { get; set; } = DefaultLoggedOutFragment;
 
         /// <summary>
+        /// Gets or sets an event callback that will be invoked with the stored authentication state when a log in operation succeeds.
+        /// </summary>
+        [Parameter] public EventCallback<TAuthenticationState> OnLogInSucceded { get; set; }
+
+        /// <summary>
+        /// Gets or sets an event callback that will be invoked with the stored authentication state when a log out operation succeeds.
+        /// </summary>
+        [Parameter] public EventCallback<TAuthenticationState> OnLogOutSucceded { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="IJSRuntime"/> to use for performin JavaScript interop.
         /// </summary>
         [Inject] public IJSRuntime JS { get; set; }
@@ -242,6 +252,10 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                     // is when we are doing a redirect sign in flow.
                     throw new InvalidOperationException("Should not redirect.");
                 case RemoteAuthenticationStatus.Success:
+                    if (OnLogInSucceded.HasDelegate)
+                    {
+                        await OnLogInSucceded.InvokeAsync(result.State);
+                    }
                     await NavigateToReturnUrl(GetReturnUrl(result.State));
                     break;
                 case RemoteAuthenticationStatus.OperationCompleted:
@@ -305,6 +319,10 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                     // is when we are doing a redirect sign in flow.
                     throw new InvalidOperationException("Should not redirect.");
                 case RemoteAuthenticationStatus.Success:
+                    if (OnLogOutSucceded.HasDelegate)
+                    {
+                        await OnLogOutSucceded.InvokeAsync(result.State);
+                    }
                     await NavigateToReturnUrl(GetReturnUrl(result.State, Navigation.ToAbsoluteUri(ApplicationPaths.LogOutSucceededPath).ToString()));
                     break;
                 case RemoteAuthenticationStatus.OperationCompleted:

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
@@ -77,12 +77,12 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         /// <summary>
         /// Gets or sets an event callback that will be invoked with the stored authentication state when a log in operation succeeds.
         /// </summary>
-        [Parameter] public EventCallback<TAuthenticationState> OnLogInSucceded { get; set; }
+        [Parameter] public EventCallback<TAuthenticationState> OnLogInSucceeded { get; set; }
 
         /// <summary>
         /// Gets or sets an event callback that will be invoked with the stored authentication state when a log out operation succeeds.
         /// </summary>
-        [Parameter] public EventCallback<TAuthenticationState> OnLogOutSucceded { get; set; }
+        [Parameter] public EventCallback<TAuthenticationState> OnLogOutSucceeded { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IJSRuntime"/> to use for performin JavaScript interop.
@@ -252,9 +252,9 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                     // is when we are doing a redirect sign in flow.
                     throw new InvalidOperationException("Should not redirect.");
                 case RemoteAuthenticationStatus.Success:
-                    if (OnLogInSucceded.HasDelegate)
+                    if (OnLogInSucceeded.HasDelegate)
                     {
-                        await OnLogInSucceded.InvokeAsync(result.State);
+                        await OnLogInSucceeded.InvokeAsync(result.State);
                     }
                     await NavigateToReturnUrl(GetReturnUrl(result.State));
                     break;
@@ -319,9 +319,9 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                     // is when we are doing a redirect sign in flow.
                     throw new InvalidOperationException("Should not redirect.");
                 case RemoteAuthenticationStatus.Success:
-                    if (OnLogOutSucceded.HasDelegate)
+                    if (OnLogOutSucceeded.HasDelegate)
                     {
-                        await OnLogOutSucceded.InvokeAsync(result.State);
+                        await OnLogOutSucceeded.InvokeAsync(result.State);
                     }
                     await NavigateToReturnUrl(GetReturnUrl(result.State, Navigation.ToAbsoluteUri(ApplicationPaths.LogOutSucceededPath).ToString()));
                     break;

--- a/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticatorCoreTests.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticatorCoreTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
     public class RemoteAuthenticatorCoreTests
     {
         private const string _action = nameof(RemoteAuthenticatorViewCore<RemoteAuthenticationState>.Action);
+        private const string _onLogInSucceded = nameof(RemoteAuthenticatorViewCore<RemoteAuthenticationState>.OnLogInSucceeded);        
+        private const string _onLogOutSucceeded = nameof(RemoteAuthenticatorViewCore<RemoteAuthenticationState>.OnLogOutSucceeded);        
 
         [Fact]
         public async Task AuthenticationManager_Throws_ForInvalidAction()
@@ -183,9 +185,14 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                 State = remoteAuthenticator.AuthenticationState
             });
 
+            var loggingSucceededCalled = false;
+
             var parameters = ParameterView.FromDictionary(new Dictionary<string, object>
             {
-                [_action] = RemoteAuthenticationActions.LogInCallback
+                [_action] = RemoteAuthenticationActions.LogInCallback,
+                [_onLogInSucceded] = new EventCallbackFactory().Create< RemoteAuthenticationState>(
+                    remoteAuthenticator,
+                    (state) => loggingSucceededCalled = true),
             });
 
             // Act
@@ -193,6 +200,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             // Assert
             Assert.Equal(fetchDataUrl, jsRuntime.LastInvocation.args[0]);
+            Assert.True(loggingSucceededCalled);
 
         }
 
@@ -431,9 +439,14 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                 State = remoteAuthenticator.AuthenticationState
             });
 
+            var loggingOutSucceededCalled = false;
             var parameters = ParameterView.FromDictionary(new Dictionary<string, object>
             {
-                [_action] = RemoteAuthenticationActions.LogOutCallback
+                [_action] = RemoteAuthenticationActions.LogOutCallback,
+                [_onLogOutSucceeded] = new EventCallbackFactory().Create<RemoteAuthenticationState>(
+                    remoteAuthenticator,
+                    (state) => loggingOutSucceededCalled = true),
+
             });
 
             // Act
@@ -441,6 +454,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             // Assert
             Assert.Equal(fetchDataUrl, jsRuntime.LastInvocation.args[0]);
+            Assert.True(loggingOutSucceededCalled);
 
         }
 


### PR DESCRIPTION
### Saving application state before an authentication operation
During an authentication operation there are cases where you want to save the application state before the browser gets redirected to the Identity provider. This can be the case when you are using something like a state container and you want to restore the state after the authentication succeeds. In those scenarios, you can use a custom authentication state object to preserve your app specific state or a reference to it and restore that state once the authentication operation completes successfully:

```razor
@page "/authentication/{action}"
@inject JSRuntime JS
@inject StateContainer State
@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
<RemoteAuthenticatorViewCore Action="@Action" AuthenticationState="AuthenticationState" OnLoginSucceded="RestoreState" OnLogoutSucceded="RestoreState" />

@code{

    public class ApplicationAuthenticationState : RemoteAuthenticationState
    {
        public string Id { get; set; }
    }

    protected async override Task OnInitializedAsync()
    {
        if (RemoteAuthenticationActions.IsAction(RemoteAuthenticationActions.LogIn, Action))
        {
            AuthenticationState.Id = Guid.NewGuid().ToString();
            await JS.InvokeVoidAsync("sessionStorage.setKey", AuthenticationState.Id, State.Store());
        }
    }

    public async Task RestoreState(ApplicationAuthenticationState state)
    {
        var stored = await JS.InvokeAsync<string>("sessionStorage.getKey", state.Id);
        State.FromStore(stored);
    }

    public ApplicationAuthenticationState AuthenticationState { get; set; } = new ApplicationAuthenticationState();

    [Parameter] public string Action { get; set; }
}
```