### PR TITLE
Normalize all file headers to the expected Apache 2.0 license

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 [*.cs]
 indent_size = 4

--- a/eng/tools/RepoTasks/DownloadFile.cs
+++ b/eng/tools/RepoTasks/DownloadFile.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;

--- a/eng/tools/RepoTasks/GetMsiProperty.cs
+++ b/eng/tools/RepoTasks/GetMsiProperty.cs
@@ -1,7 +1,7 @@
-#if BUILD_MSI_TASKS
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if BUILD_MSI_TASKS
 using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Antiforgery/src/Internal/IAntiforgeryFeature.cs
+++ b/src/Antiforgery/src/Internal/IAntiforgeryFeature.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Antiforgery
 {
     internal interface IAntiforgeryFeature

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Controllers/AccountController.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Controllers/AccountController.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/AccessDenied.cshtml.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/AccessDenied.cshtml.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/Error.cshtml.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/Error.cshtml.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/SignedOut.cshtml.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Areas/AzureAD/Pages/Account/SignedOut.cshtml.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAccountControllerFeatureProvider.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAccountControllerFeatureProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAuthenticationBuilderExtensions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADAuthenticationBuilderExtensions.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADCookieOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADDefaults.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADDefaults.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
 namespace Microsoft.AspNetCore.Authentication.AzureAD.UI

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADJwtBearerOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADJwtBearerOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Authentication.AzureAD.UI;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOpenIdConnectOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOpenIdConnectOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptionsValidation.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOptionsValidation.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADSchemeOptions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADSchemeOptions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Properties/AssemblyInfo.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Authentication.AzureAD.UI;

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/test/Controllers/AccountControllerTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/test/Controllers/AccountControllerTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Claims;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Controllers/AccountController.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Controllers/AccountController.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/AccessDenied.cshtml.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/AccessDenied.cshtml.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/Error.cshtml.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/Error.cshtml.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/SignedOut.cshtml.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Areas/AzureADB2C/Pages/Account/SignedOut.cshtml.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CAccountControllerFeatureProvider.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CAccountControllerFeatureProvider.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CCookieOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CCookieOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CJwtBearerOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2CJwtBearerOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2COpenIdConnectOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureADB2COpenIdConnectOptionsConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CAuthenticationBuilderExtensions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CAuthenticationBuilderExtensions.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CDefaults.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CDefaults.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
 using Microsoft.AspNetCore.Authentication;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COpenIDConnectEventHandlers.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COpenIDConnectEventHandlers.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2COptionsConfiguration.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CSchemeOptions.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/AzureAdB2CSchemeOptions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Properties/AssemblyInfo.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/AzureAdB2CAuthenticationBuilderExtensionsTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/AzureAdB2CAuthenticationBuilderExtensionsTests.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/AzureAdB2COpenIDConnectEventHandlersTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/AzureAdB2COpenIDConnectEventHandlersTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/Controllers/AccountControllerTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/test/Controllers/AccountControllerTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Claims;

--- a/src/Azure/AzureAD/samples/AzureADB2CSample/Pages/About.cshtml.cs
+++ b/src/Azure/AzureAD/samples/AzureADB2CSample/Pages/About.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Azure/AzureAD/samples/AzureADB2CSample/Pages/Index.cshtml.cs
+++ b/src/Azure/AzureAD/samples/AzureADB2CSample/Pages/Index.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace AzureADB2CSample.Pages
 {

--- a/src/Azure/AzureAD/samples/AzureADSample/Pages/About.cshtml.cs
+++ b/src/Azure/AzureAD/samples/AzureADSample/Pages/About.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Azure/AzureAD/samples/AzureADSample/Pages/Index.cshtml.cs
+++ b/src/Azure/AzureAD/samples/AzureADSample/Pages/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace AzureADSample.Pages

--- a/src/Azure/AzureAD/test/FunctionalTests/ApiAuthenticationTests.cs
+++ b/src/Azure/AzureAD/test/FunctionalTests/ApiAuthenticationTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
 using System.Threading.Tasks;

--- a/src/Azure/AzureAD/test/FunctionalTests/WebAuthenticationTests.cs
+++ b/src/Azure/AzureAD/test/FunctionalTests/WebAuthenticationTests.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
 using System.Threading.Tasks;

--- a/src/Azure/AzureAD/test/testassets/AzureAD.WebSite/Controllers/TestController.cs
+++ b/src/Azure/AzureAD/test/testassets/AzureAD.WebSite/Controllers/TestController.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using Microsoft.AspNetCore.Authorization;
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Azure/samples/AzureAppServicesHostingStartupSample/Startup.cs
+++ b/src/Azure/samples/AzureAppServicesHostingStartupSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;

--- a/src/Azure/samples/AzureAppServicesSample/Startup.cs
+++ b/src/Azure/samples/AzureAppServicesSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;

--- a/src/Components/Analyzers/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Analyzers/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Components.Analyzers.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsersRendererTypesInMethodBody.cs
+++ b/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsersRendererTypesInMethodBody.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Components.RenderTree;
 

--- a/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererAsBaseClass.cs
+++ b/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererAsBaseClass.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.RenderTree;

--- a/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererTypesInDeclarations.cs
+++ b/src/Components/Analyzers/test/TestFiles/ComponentInternalUsageDiagnosticsAnalyzerTest/UsesRendererTypesInDeclarations.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.RenderTree;

--- a/src/Components/Blazor/Blazor/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Blazor/Blazor/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Blazor.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/Blazor/Build/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Blazor/Build/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Blazor.Build.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/DebugStore.cs
+++ b/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/DebugStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Collections.Generic;

--- a/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/MonoProxy.cs
+++ b/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/MonoProxy.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/WsProxy.cs
+++ b/src/Components/Blazor/Server/src/MonoDebugProxy/ws-proxy/WsProxy.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Components/Components/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Components/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Blazor.Build.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/Ignitor/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Ignitor/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Ignitor.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/Samples/BlazorServerApp/Data/WeatherForecast.cs
+++ b/src/Components/Samples/BlazorServerApp/Data/WeatherForecast.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace BlazorServerApp.Data

--- a/src/Components/Samples/BlazorServerApp/Data/WeatherForecastService.cs
+++ b/src/Components/Samples/BlazorServerApp/Data/WeatherForecastService.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Components/Samples/BlazorServerApp/Program.cs
+++ b/src/Components/Samples/BlazorServerApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Components/Samples/BlazorServerApp/Startup.cs
+++ b/src/Components/Samples/BlazorServerApp/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Components/Server/src/BlazorPack/Requires.cs
+++ b/src/Components/Server/src/BlazorPack/Requires.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Andrew Arnott. All rights reserved.
-// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Buffers;

--- a/src/Components/Server/src/BlazorPack/SequenceOfT.cs
+++ b/src/Components/Server/src/BlazorPack/SequenceOfT.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Andrew Arnott. All rights reserved.
-// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Nerdbank.Streams
 {

--- a/src/Components/Server/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Server/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Blazor.DevServer, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/Web/src/Properties/AssemblyInfo.cs
+++ b/src/Components/Web/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Components.Server.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkResult.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkResult.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Wasm.Performance.Driver
 {
     class BenchmarkResult

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.E2ETesting;

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppWebDriverExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using OpenQA.Selenium;

--- a/src/Components/test/testassets/BasicTestApp/BindMethods.cs
+++ b/src/Components/test/testassets/BasicTestApp/BindMethods.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Components
 {
     // This is a temporary workaround for the fact that public previews of VS look for

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/SimpleValidationComponentUsingExperimentalValidator.cs
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/SimpleValidationComponentUsingExperimentalValidator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace BasicTestApp.FormsTest
 {
     public class TypicalValidationComponentUsingExperimentalValidator : TypicalValidationComponent

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponentUsingExperimentalValidator.cs
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponentUsingExperimentalValidator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace BasicTestApp.FormsTest
 {
     public class SimpleValidationComponentUsingExperimentalValidator : SimpleValidationComponent

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/JSInterop.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/JSInterop.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.JSInterop;
 

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingAttachComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingAttachComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingConstructorComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingConstructorComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingDisposeComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingDisposeComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderAsyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderAsyncComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderSyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingOnAfterRenderSyncComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingRenderComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingRenderComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersAsyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersAsyncComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersSyncComponent.cs
+++ b/src/Components/test/testassets/BasicTestApp/ServerReliability/ThrowingSetParametersSyncComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/src/Components/test/testassets/TestContentPackage/MyPrompt.cs
+++ b/src/Components/test/testassets/TestContentPackage/MyPrompt.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.JSInterop;
 using System.Threading.Tasks;
 

--- a/src/Components/test/testassets/TestServer/AuthenticationStartup.cs
+++ b/src/Components/test/testassets/TestServer/AuthenticationStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;

--- a/src/Components/test/testassets/TestServer/ClientStartup.cs
+++ b/src/Components/test/testassets/TestServer/ClientStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/Components/test/testassets/TestServer/Controllers/CookieController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/CookieController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Cors;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 
 namespace TestServer.Controllers

--- a/src/Components/test/testassets/TestServer/Controllers/CultureController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/CultureController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Components/test/testassets/TestServer/Controllers/DataController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/DataController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Cors;

--- a/src/Components/test/testassets/TestServer/Controllers/GreetingController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/GreetingController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 namespace TestServer.Controllers
 {

--- a/src/Components/test/testassets/TestServer/Controllers/PersonController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/PersonController.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Text;

--- a/src/Components/test/testassets/TestServer/Controllers/UserController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/UserController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Components/test/testassets/TestServer/CorsStartup.cs
+++ b/src/Components/test/testassets/TestServer/CorsStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/Components/test/testassets/TestServer/InternationalizationStartup.cs
+++ b/src/Components/test/testassets/TestServer/InternationalizationStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;

--- a/src/Components/test/testassets/TestServer/MultipleComponents.cs
+++ b/src/Components/test/testassets/TestServer/MultipleComponents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Components/test/testassets/TestServer/PrerenderedStartup.cs
+++ b/src/Components/test/testassets/TestServer/PrerenderedStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Components/test/testassets/TestServer/Program.cs
+++ b/src/Components/test/testassets/TestServer/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/Components/test/testassets/TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/TestServer/ServerStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/Components/test/testassets/TestServer/Startup.cs
+++ b/src/Components/test/testassets/TestServer/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Components/test/testassets/TestServer/TestAppInfo.cs
+++ b/src/Components/test/testassets/TestServer/TestAppInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 
 namespace TestServer

--- a/src/DataProtection/samples/EntityFrameworkCoreSample/Migrations/20181219214311_AddDataProtectionKeys.cs
+++ b/src/DataProtection/samples/EntityFrameworkCoreSample/Migrations/20181219214311_AddDataProtectionKeys.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace EntityFrameworkCoreSample.Migrations

--- a/src/DefaultBuilder/src/GenericHostBuilderExtensions.cs
+++ b/src/DefaultBuilder/src/GenericHostBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore;

--- a/src/Features/JsonPatch/src/Adapters/AdapterFactory.cs
+++ b/src/Features/JsonPatch/src/Adapters/AdapterFactory.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.JsonPatch.Internal;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.JsonPatch.Internal;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System;

--- a/src/Features/JsonPatch/src/Adapters/IAdapterFactory.cs
+++ b/src/Features/JsonPatch/src/Adapters/IAdapterFactory.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.JsonPatch.Internal;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.JsonPatch.Internal;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;

--- a/src/Features/JsonPatch/src/Internal/JObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/JObjectAdapter.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.JsonPatch.Internal;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.JsonPatch.Internal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/Features/JsonPatch/test/Adapters/AdapterFactoryTests.cs
+++ b/src/Features/JsonPatch/test/Adapters/AdapterFactoryTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.JsonPatch.Adapters;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.JsonPatch.Adapters;
 using Microsoft.AspNetCore.JsonPatch.Internal;
 using Moq;
 using Newtonsoft.Json.Serialization;

--- a/src/Features/JsonPatch/test/Adapters/TestDynamicObject.cs
+++ b/src/Features/JsonPatch/test/Adapters/TestDynamicObject.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Text;

--- a/src/Features/JsonPatch/test/TestObjectModels/ObjectWithJObject.cs
+++ b/src/Features/JsonPatch/test/TestObjectModels/ObjectWithJObject.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.JsonPatch

--- a/src/Hosting/Hosting/src/GenericHostWebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/GenericHostWebHostBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/test/Fakes/StartupCaseInsensitive.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupCaseInsensitive.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Builder;

--- a/src/Hosting/Hosting/test/Fakes/StartupNoServicesNoInterface.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupNoServicesNoInterface.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Builder;

--- a/src/Hosting/Hosting/test/Fakes/StartupWithBuiltConfigureServices.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupWithBuiltConfigureServices.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/test/Fakes/StartupWithConfigureServices.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupWithConfigureServices.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/test/Fakes/StartupWithHostingEnvironment.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupWithHostingEnvironment.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
 

--- a/src/Hosting/Hosting/test/Fakes/StartupWithScopedServices.cs
+++ b/src/Hosting/Hosting/test/Fakes/StartupWithScopedServices.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Builder;

--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Text;
 using System.Threading;

--- a/src/Hosting/Hosting/test/Internal/MyBadContainerFactory.cs
+++ b/src/Hosting/Hosting/test/Internal/MyBadContainerFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Hosting/Hosting/test/Internal/MyContainer.cs
+++ b/src/Hosting/Hosting/test/Internal/MyContainer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Hosting/Hosting/test/Internal/MyContainerFactory.cs
+++ b/src/Hosting/Hosting/test/Internal/MyContainerFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Hosting/Server.IntegrationTesting/src/Common/LoggingHandler.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/LoggingHandler.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/Server.IntegrationTesting/src/Common/TestUrlHelper.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/TestUrlHelper.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
 {
     // Public for use in other test projects
     public static class TestUrlHelper

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemoteWindowsDeploymentParameters.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemoteWindowsDeploymentParameters.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting
 {

--- a/src/Hosting/samples/GenericWebHost/Program.cs
+++ b/src/Hosting/samples/GenericWebHost/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;

--- a/src/Hosting/samples/SampleStartups/StartupBlockingOnStart.cs
+++ b/src/Hosting/samples/SampleStartups/StartupBlockingOnStart.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Hosting/samples/SampleStartups/StartupConfigureAddresses.cs
+++ b/src/Hosting/samples/SampleStartups/StartupConfigureAddresses.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/Hosting/samples/SampleStartups/StartupExternallyControlled.cs
+++ b/src/Hosting/samples/SampleStartups/StartupExternallyControlled.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Hosting/samples/SampleStartups/StartupFullControl.cs
+++ b/src/Hosting/samples/SampleStartups/StartupFullControl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Builder;

--- a/src/Hosting/samples/SampleStartups/StartupHelloWorld.cs
+++ b/src/Hosting/samples/SampleStartups/StartupHelloWorld.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/Hosting/samples/SampleStartups/StartupInjection.cs
+++ b/src/Hosting/samples/SampleStartups/StartupInjection.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Hosting/test/testassets/IStartupInjectionAssemblyName/Startup.cs
+++ b/src/Hosting/test/testassets/IStartupInjectionAssemblyName/Startup.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
+++ b/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Http/Http.Extensions/test/SendFileResponseExtensionsTests.cs
+++ b/src/Http/Http.Extensions/test/SendFileResponseExtensionsTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
 using System.IO.Pipelines;

--- a/src/Http/Http/perf/Properties/AssemblyInfo.cs
+++ b/src/Http/Http/perf/Properties/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Http/Http/src/Properties/AssemblyInfo.cs
+++ b/src/Http/Http/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Http.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Http/Http/test/HttpContextFactoryTests.cs
+++ b/src/Http/Http/test/HttpContextFactoryTests.cs
@@ -1,7 +1,7 @@
-#pragma warning disable CS0618 // Type or member is obsolete
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#pragma warning disable CS0618 // Type or member is obsolete
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Http.Features;

--- a/src/Http/Routing/perf/Properties/AssemblyInfo.cs
+++ b/src/Http/Routing/perf/Properties/AssemblyInfo.cs
@@ -1,1 +1,4 @@
-﻿[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Http/Routing/src/ArrayBuilder.cs
+++ b/src/Http/Routing/src/ArrayBuilder.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // LICENSING NOTE: This file is from the dotnet corefx repository.
 // 

--- a/src/Http/Routing/src/HostAttribute.cs
+++ b/src/Http/Routing/src/HostAttribute.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Http/Routing/src/IHostMetadata.cs
+++ b/src/Http/Routing/src/IHostMetadata.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 

--- a/src/Http/Routing/src/IHttpMethodMetadata.cs
+++ b/src/Http/Routing/src/IHttpMethodMetadata.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 

--- a/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/AssemblyInfo.cs
+++ b/src/Http/WebUtilities/perf/Microsoft.AspNetCore.WebUtilities.Performance/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Http/samples/SampleApp/Program.cs
+++ b/src/Http/samples/SampleApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Controllers/ConfigurationController.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Controllers/ConfigurationController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Controllers/ValuesController.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Controllers/ValuesController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Data/ApplicationDbContext.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Data/ApplicationDbContext.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.EntityFramework.Options;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using IdentityServer4.EntityFramework.Options;
 using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Data/Migrations/20180919224505_InitialMigration.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Data/Migrations/20180919224505_InitialMigration.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace ApiAuthSample.Data.Migrations

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Models/ApplicationUser.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Models/ApplicationUser.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Identity;
 
 namespace ApiAuthSample.Models
 {

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Pages/Index.cshtml.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Pages/Index.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Program.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;

--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Startup.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Identity/Extensions.Core/src/EmailTokenProvider.cs
+++ b/src/Identity/Extensions.Core/src/EmailTokenProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Identity

--- a/src/Identity/Extensions.Core/src/PhoneNumberTokenProvider.cs
+++ b/src/Identity/Extensions.Core/src/PhoneNumberTokenProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 

--- a/src/Identity/Extensions.Core/src/TotpSecurityStampBasedTokenProvider.cs
+++ b/src/Identity/Extensions.Core/src/TotpSecurityStampBasedTokenProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.DefaultUI/Controllers/HomeController.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Controllers/HomeController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace IdentitySample.DefaultUI.Controllers

--- a/src/Identity/samples/IdentitySample.DefaultUI/Data/ApplicationDbContext.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Data/ApplicationDbContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.DefaultUI/Data/ApplicationUser.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Data/ApplicationUser.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Identity;
 
 namespace IdentitySample.DefaultUI.Data
 {

--- a/src/Identity/samples/IdentitySample.DefaultUI/Data/Migrations/20190411154115_CreateIdentitySchema.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Data/Migrations/20190411154115_CreateIdentitySchema.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 

--- a/src/Identity/samples/IdentitySample.DefaultUI/Program.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;

--- a/src/Identity/samples/IdentitySample.DefaultUI/Startup.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using IdentitySample.DefaultUI.Data;
 using Microsoft.AspNetCore.Builder;

--- a/src/Identity/samples/IdentitySample.Mvc/Controllers/AccountController.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Controllers/AccountController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/Controllers/HomeController.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Controllers/HomeController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace IdentitySample.Controllers

--- a/src/Identity/samples/IdentitySample.Mvc/Controllers/ManageController.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Controllers/ManageController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading.Tasks;
 using IdentitySample.Models;

--- a/src/Identity/samples/IdentitySample.Mvc/Data/Migrations/00000000000000_CreateIdentitySchema.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Data/Migrations/00000000000000_CreateIdentitySchema.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/MessageServices.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/MessageServices.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 
 namespace IdentitySamples

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/ExternalLoginConfirmationViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/ExternalLoginConfirmationViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/ForgotPasswordViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/ForgotPasswordViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/LoginViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/LoginViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/RegisterViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/RegisterViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/ResetPasswordViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/ResetPasswordViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/SendCodeViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/SendCodeViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/UseRecoveryCodeViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/UseRecoveryCodeViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace IdentitySample.Models.AccountViewModels
 {

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/VerifyAuthenticatorCodeViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/VerifyAuthenticatorCodeViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace IdentitySample.Models.AccountViewModels
 {

--- a/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/VerifyCodeViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/AccountViewModels/VerifyCodeViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace IdentitySample.Models.AccountViewModels
 {

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ApplicationDbContext.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ApplicationDbContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ApplicationUser.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ApplicationUser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/AddPhoneNumberViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/AddPhoneNumberViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/ChangePasswordViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/ChangePasswordViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/ConfigureTwoFactorViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/ConfigureTwoFactorViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/DisplayRecoveryCodesViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/DisplayRecoveryCodesViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace IdentitySample.Models.ManageViewModels

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/FactorViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/FactorViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/IndexViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/IndexViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Identity;
 

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/ManageLoginsViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/ManageLoginsViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/RemoveLoginViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/RemoveLoginViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/SetPasswordViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/SetPasswordViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/VerifyPhoneNumberViewModel.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Models/ManageViewModels/VerifyPhoneNumberViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/src/Identity/samples/IdentitySample.Mvc/Program.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 

--- a/src/Identity/samples/IdentitySample.Mvc/Services/IEmailSender.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Services/IEmailSender.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/Services/ISmsSender.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Services/ISmsSender.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/Services/MessageServices.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Services/MessageServices.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Identity/samples/IdentitySample.Mvc/Startup.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using IdentitySample.Models;
 using IdentitySample.Services;
 using Microsoft.AspNetCore.Builder;

--- a/src/Identity/test/Identity.FunctionalTests/Pages/Account/Manage/ExternalLogins.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Pages/Account/Manage/ExternalLogins.cs
@@ -1,4 +1,7 @@
-﻿using System.Net.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
 using AngleSharp.Dom.Html;
 
 namespace Microsoft.AspNetCore.Identity.FunctionalTests.Account.Manage

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetInvocationResult.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetInvocationResult.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.JSInterop.Infrastructure

--- a/src/Localization/Localization/test/Microsoft.Extensions.Localization.RootNamespace.Tests/AssemblyInfo.cs
+++ b/src/Localization/Localization/test/Microsoft.Extensions.Localization.RootNamespace.Tests/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Reflection;
 using Microsoft.Extensions.Localization;
 

--- a/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/Model.cs
+++ b/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/Model.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // This namespace for test resources with alternative RootNamespace
 namespace MyNamespace
 {

--- a/src/Middleware/ConcurrencyLimiter/perf/Microbenchmarks/AssemblyInfo.cs
+++ b/src/Middleware/ConcurrencyLimiter/perf/Microbenchmarks/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEventSource.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEventSource.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics.Tracing;

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/IQueuePolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/IQueuePolicy.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEventSourceTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEventSourceTests.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Middleware/ConcurrencyLimiter/test/MiddlewareTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/MiddlewareTests.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/src/MigrationsEndPointExtensions.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/src/MigrationsEndPointExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/src/MigrationsEndPointMiddleware.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/src/MigrationsEndPointMiddleware.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/src/MigrationsEndPointOptions.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/src/MigrationsEndPointOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore;

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Middleware/Diagnostics/test/testassets/DatabaseErrorPageSample/Startup.cs
+++ b/src/Middleware/Diagnostics/test/testassets/DatabaseErrorPageSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;

--- a/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/Startup.cs
+++ b/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Builder;

--- a/src/Middleware/Diagnostics/test/testassets/WelcomePageSample/Startup.cs
+++ b/src/Middleware/Diagnostics/test/testassets/WelcomePageSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Program.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/src/Middleware/HealthChecks.EntityFrameworkCore/src/Properties/AssemblyInfo.cs
+++ b/src/Middleware/HealthChecks.EntityFrameworkCore/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/BasicStartup.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/BasicStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/CustomWriterStartup.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/CustomWriterStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/DBHealthStartup.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/DBHealthStartup.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/DbContextHealthStartup.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/DbContextHealthStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/GCInfoHealthCheck.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/GCInfoHealthCheck.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/LivenessProbeStartup.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/LivenessProbeStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/ManagementPortStartup.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/ManagementPortStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/MyContext.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/MyContext.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
 
 namespace HealthChecksSample
 {

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/Program.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/SlowDependencyHealthCheck.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/SlowDependencyHealthCheck.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 

--- a/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/SqlConnectionHealthCheck.cs
+++ b/src/Middleware/HealthChecks/test/testassets/HealthChecksSample/SqlConnectionHealthCheck.cs
@@ -1,4 +1,7 @@
-﻿using System.Data.Common;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 
 namespace HealthChecksSample

--- a/src/Middleware/HttpOverrides/sample/Startup.cs
+++ b/src/Middleware/HttpOverrides/sample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/Middleware/HttpsPolicy/sample/Startup.cs
+++ b/src/Middleware/HttpsPolicy/sample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Middleware/MiddlewareAnalysis/samples/MiddlewareAnalysisSample/Startup.cs
+++ b/src/Middleware/MiddlewareAnalysis/samples/MiddlewareAnalysisSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Builder;

--- a/src/Middleware/ResponseCompression/sample/CustomCompressionProvider.cs
+++ b/src/Middleware/ResponseCompression/sample/CustomCompressionProvider.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using Microsoft.AspNetCore.ResponseCompression;
 
 namespace ResponseCompressionSample

--- a/src/Middleware/Rewrite/test/UrlMatches/StringMatchTests.cs
+++ b/src/Middleware/Rewrite/test/UrlMatches/StringMatchTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Middleware/SpaServices.Extensions/test/ListLoggerFactory.cs
+++ b/src/Middleware/SpaServices.Extensions/test/ListLoggerFactory.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;

--- a/src/Middleware/StaticFiles/samples/StaticFileSample/Startup.cs
+++ b/src/Middleware/StaticFiles/samples/StaticFileSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Builder;

--- a/src/Middleware/WebSockets/samples/EchoApp/Program.cs
+++ b/src/Middleware/WebSockets/samples/EchoApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Middleware/WebSockets/samples/EchoApp/Startup.cs
+++ b/src/Middleware/WebSockets/samples/EchoApp/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Middleware/WebSockets/samples/TestServer/Program.cs
+++ b/src/Middleware/WebSockets/samples/TestServer/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnCaseResult.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnCaseResult.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnExpectations.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnExpectations.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Server.IntegrationTesting;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnResult.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnResult.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnServerResult.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnServerResult.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Server.IntegrationTesting;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnSpec.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnSpec.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnTester.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnTester.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/Executable.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/Executable.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/Expectation.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/Expectation.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 {
     public enum Expectation
     {

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/ServerSpec.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/ServerSpec.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json.Linq;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 {

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/Wstest.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/Wstest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 

--- a/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/Program.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Net;

--- a/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/Startup.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net.WebSockets;
 using System.Threading;

--- a/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTests.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Middleware/WebSockets/test/ConformanceTests/Helpers.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Helpers.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 

--- a/src/Middleware/WebSockets/test/ConformanceTests/SkipIfWsTestNotPresentAttribute.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/SkipIfWsTestNotPresentAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn;

--- a/src/Middleware/WebSockets/test/UnitTests/BufferStream.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/BufferStream.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Middleware/WebSockets/test/UnitTests/DuplexStream.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/DuplexStream.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;

--- a/src/Middleware/WebSockets/test/UnitTests/SendReceiveTests.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/SendReceiveTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Text;

--- a/src/Middleware/WebSockets/test/UnitTests/WebSocketPair.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/WebSocketPair.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net.WebSockets;
 

--- a/src/Middleware/perf/Microbenchmarks/AssemblyInfo.cs
+++ b/src/Middleware/perf/Microbenchmarks/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Middleware/perf/ResponseCaching.Microbenchmarks/AssemblyInfo.cs
+++ b/src/Middleware/perf/ResponseCaching.Microbenchmarks/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/MusicStore/samples/MusicStore/Areas/Admin/Controllers/StoreManagerController.cs
+++ b/src/MusicStore/samples/MusicStore/Areas/Admin/Controllers/StoreManagerController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/MusicStore/samples/MusicStore/Components/CartSummaryComponent.cs
+++ b/src/MusicStore/samples/MusicStore/Components/CartSummaryComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/Components/GenreMenuComponent.cs
+++ b/src/MusicStore/samples/MusicStore/Components/GenreMenuComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/Components/ISystemClock.cs
+++ b/src/MusicStore/samples/MusicStore/Components/ISystemClock.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace MusicStore.Components
 {

--- a/src/MusicStore/samples/MusicStore/Components/SystemClock.cs
+++ b/src/MusicStore/samples/MusicStore/Components/SystemClock.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace MusicStore.Components
 {

--- a/src/MusicStore/samples/MusicStore/Controllers/AccountController.cs
+++ b/src/MusicStore/samples/MusicStore/Controllers/AccountController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/Controllers/CheckoutController.cs
+++ b/src/MusicStore/samples/MusicStore/Controllers/CheckoutController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/MusicStore/samples/MusicStore/Controllers/HomeController.cs
+++ b/src/MusicStore/samples/MusicStore/Controllers/HomeController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/samples/MusicStore/Controllers/ManageController.cs
+++ b/src/MusicStore/samples/MusicStore/Controllers/ManageController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/Controllers/ShoppingCartController.cs
+++ b/src/MusicStore/samples/MusicStore/Controllers/ShoppingCartController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/Controllers/StoreController.cs
+++ b/src/MusicStore/samples/MusicStore/Controllers/StoreController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Common/CustomStateDataFormat.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Common/CustomStateDataFormat.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication;
 using Newtonsoft.Json;
 

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Common/Helpers.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Common/Helpers.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace MusicStore.Mocks.Common
 {

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Facebook/FacebookMockBackChannelHttpHandler.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Facebook/FacebookMockBackChannelHttpHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Facebook/TestFacebookEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Facebook/TestFacebookEvents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Google/GoogleMockBackChannelHttpHandler.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Google/GoogleMockBackChannelHttpHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Google/TestGoogleEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Google/TestGoogleEvents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/MicrosoftAccountMockBackChannelHandler.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/MicrosoftAccountMockBackChannelHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/TestMicrosoftAccountEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/TestMicrosoftAccountEvents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/OpenIdConnect/CustomStringDataFormat.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/OpenIdConnect/CustomStringDataFormat.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication;
 
 namespace MusicStore.Mocks.OpenIdConnect

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/OpenIdConnect/OpenIdConnectBackChannelHttpHandler.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/OpenIdConnect/OpenIdConnectBackChannelHttpHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Net.Http;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/OpenIdConnect/TestOpenIdConnectEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/OpenIdConnect/TestOpenIdConnectEvents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupOpenIdConnectTesting.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupOpenIdConnectTesting.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupSocialTesting.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupSocialTesting.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Globalization;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.Twitter;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Twitter/CustomTwitterStateDataFormat.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Twitter/CustomTwitterStateDataFormat.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Twitter;
 using Newtonsoft.Json;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Twitter/TestTwitterEvents.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Twitter/TestTwitterEvents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Twitter/TwitterMockBackChannelHttpHandler.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/Twitter/TwitterMockBackChannelHttpHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/MusicStore/samples/MusicStore/ForTesting/MusicStoreConfig.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/MusicStoreConfig.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace MusicStore
 {
     public class StoreConfig

--- a/src/MusicStore/samples/MusicStore/MessageServices.cs
+++ b/src/MusicStore/samples/MusicStore/MessageServices.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 
 namespace MusicStore

--- a/src/MusicStore/samples/MusicStore/Models/AccountViewModels.cs
+++ b/src/MusicStore/samples/MusicStore/Models/AccountViewModels.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/src/MusicStore/samples/MusicStore/Models/Album.cs
+++ b/src/MusicStore/samples/MusicStore/Models/Album.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/MusicStore/samples/MusicStore/Models/Artist.cs
+++ b/src/MusicStore/samples/MusicStore/Models/Artist.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace MusicStore.Models
 {

--- a/src/MusicStore/samples/MusicStore/Models/CartItem.cs
+++ b/src/MusicStore/samples/MusicStore/Models/CartItem.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace MusicStore.Models

--- a/src/MusicStore/samples/MusicStore/Models/Genre.cs
+++ b/src/MusicStore/samples/MusicStore/Models/Genre.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace MusicStore.Models

--- a/src/MusicStore/samples/MusicStore/Models/ManageViewModels.cs
+++ b/src/MusicStore/samples/MusicStore/Models/ManageViewModels.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authentication;

--- a/src/MusicStore/samples/MusicStore/Models/MusicStoreContext.cs
+++ b/src/MusicStore/samples/MusicStore/Models/MusicStoreContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;

--- a/src/MusicStore/samples/MusicStore/Models/Order.cs
+++ b/src/MusicStore/samples/MusicStore/Models/Order.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;

--- a/src/MusicStore/samples/MusicStore/Models/OrderDetail.cs
+++ b/src/MusicStore/samples/MusicStore/Models/OrderDetail.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MusicStore.Models
 {

--- a/src/MusicStore/samples/MusicStore/Models/SampleData.cs
+++ b/src/MusicStore/samples/MusicStore/Models/SampleData.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/samples/MusicStore/Models/ShoppingCart.cs
+++ b/src/MusicStore/samples/MusicStore/Models/ShoppingCart.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/samples/MusicStore/Platform.cs
+++ b/src/MusicStore/samples/MusicStore/Platform.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Runtime.InteropServices;
 
 namespace MusicStore

--- a/src/MusicStore/samples/MusicStore/Program.cs
+++ b/src/MusicStore/samples/MusicStore/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Hosting;

--- a/src/MusicStore/samples/MusicStore/Properties/AppSettings.cs
+++ b/src/MusicStore/samples/MusicStore/Properties/AppSettings.cs
@@ -1,4 +1,7 @@
-﻿namespace MusicStore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace MusicStore
 {
     public class AppSettings
     {

--- a/src/MusicStore/samples/MusicStore/Startup.cs
+++ b/src/MusicStore/samples/MusicStore/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Globalization;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Builder;

--- a/src/MusicStore/samples/MusicStore/StartupNtlmAuthentication.cs
+++ b/src/MusicStore/samples/MusicStore/StartupNtlmAuthentication.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;

--- a/src/MusicStore/samples/MusicStore/StartupOpenIdConnect.cs
+++ b/src/MusicStore/samples/MusicStore/StartupOpenIdConnect.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Globalization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/MusicStore/samples/MusicStore/ViewModels/AlbumData.cs
+++ b/src/MusicStore/samples/MusicStore/ViewModels/AlbumData.cs
@@ -1,4 +1,7 @@
-﻿namespace MusicStore.ViewModels
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace MusicStore.ViewModels
 {
     public class AlbumData
     {

--- a/src/MusicStore/samples/MusicStore/ViewModels/ShoppingCartRemoveViewModel.cs
+++ b/src/MusicStore/samples/MusicStore/ViewModels/ShoppingCartRemoveViewModel.cs
@@ -1,4 +1,7 @@
-﻿namespace MusicStore.ViewModels
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace MusicStore.ViewModels
 {
     public class ShoppingCartRemoveViewModel
     {

--- a/src/MusicStore/samples/MusicStore/ViewModels/ShoppingCartViewModel.cs
+++ b/src/MusicStore/samples/MusicStore/ViewModels/ShoppingCartViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using MusicStore.Models;
 
 namespace MusicStore.ViewModels

--- a/src/MusicStore/test/MusicStore.E2ETests/Common/DbUtils.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Common/DbUtils.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Data.SqlClient;

--- a/src/MusicStore/test/MusicStore.E2ETests/Common/Helpers.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Common/Helpers.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Server.IntegrationTesting;

--- a/src/MusicStore/test/MusicStore.E2ETests/Common/HtmlDOMHelper.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Common/HtmlDOMHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Xml;
 
 namespace E2ETests

--- a/src/MusicStore/test/MusicStore.E2ETests/Common/XunitLogger.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Common/XunitLogger.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/MusicStore/test/MusicStore.E2ETests/Implementation/FacebookLoginScenarios.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Implementation/FacebookLoginScenarios.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.E2ETests/Implementation/GoogleLoginScenarios.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Implementation/GoogleLoginScenarios.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.E2ETests/Implementation/MicrosoftAccountAuthenticationScenarios.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Implementation/MicrosoftAccountAuthenticationScenarios.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.E2ETests/Implementation/OpenIdConnectLoginScenarios.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Implementation/OpenIdConnectLoginScenarios.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.E2ETests/Implementation/TwitterLoginScenarios.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Implementation/TwitterLoginScenarios.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/MusicStore/test/MusicStore.E2ETests/Implementation/Validator.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Implementation/Validator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.E2ETests/MusicStoreConfig.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/MusicStoreConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace E2ETests
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace E2ETests
 {
     public class MusicStoreConfig
     {

--- a/src/MusicStore/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/MusicStore/test/MusicStore.E2ETests/OpenIdConnectTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/OpenIdConnectTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/src/MusicStore/test/MusicStore.E2ETests/Properties/AssemblyInfo.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/MusicStore/test/MusicStore.E2ETests/PublishAndRunTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/PublishAndRunTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/MusicStore/test/MusicStore.E2ETests/RemoteDeploymentConfig.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/RemoteDeploymentConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace E2ETests
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace E2ETests
 {
     public class RemoteDeploymentConfig
     {

--- a/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/MusicStore/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/MusicStore/test/MusicStore.Test/CartSummaryComponentTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/CartSummaryComponentTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/src/MusicStore/test/MusicStore.Test/CheckoutControllerTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/CheckoutControllerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.Test/GenreMenuComponentTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/GenreMenuComponentTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/MusicStore/test/MusicStore.Test/HomeControllerTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/HomeControllerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.Test/ManageControllerTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/ManageControllerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/src/MusicStore/test/MusicStore.Test/Models/ShoppingCartTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/Models/ShoppingCartTest.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// See License.txt in the project root for license information
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/MusicStore/test/MusicStore.Test/ShoppingCartControllerTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/ShoppingCartControllerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.Test/SqliteInMemoryFixture.cs
+++ b/src/MusicStore/test/MusicStore.Test/SqliteInMemoryFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;

--- a/src/MusicStore/test/MusicStore.Test/StoreControllerTest.cs
+++ b/src/MusicStore/test/MusicStore.Test/StoreControllerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MusicStore/test/MusicStore.Test/TestAppSettings.cs
+++ b/src/MusicStore/test/MusicStore.Test/TestAppSettings.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Options;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Options;
 
 namespace MusicStore.Test
 {

--- a/src/MusicStore/test/MusicStore.Test/TestSession.cs
+++ b/src/MusicStore/test/MusicStore.Test/TestSession.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Mvc/.editorconfig
+++ b/src/Mvc/.editorconfig
@@ -8,6 +8,8 @@ root = true
 indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
+file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfAllowAnonymousIsAppliedToPageHandlerMethod.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfAllowAnonymousIsAppliedToPageHandlerMethod.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfAttributeIsAppliedToBaseType.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfAttributeIsAppliedToBaseType.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfAuthorizeAttributeIsAppliedToPageHandlerMethod.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfAuthorizeAttributeIsAppliedToPageHandlerMethod.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfFiltersAreAppliedToPageHandlerMethod.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfFiltersAreAppliedToPageHandlerMethod.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfFiltersAreAppliedToPageHandlerMethodDerivingFromCustomModel.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfFiltersAreAppliedToPageHandlerMethodDerivingFromCustomModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfFiltersAreAppliedToPageHandlerMethodForTypeWithPageModelAttribute.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfFiltersAreAppliedToPageHandlerMethodForTypeWithPageModelAttribute.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfRouteAttribute_IsAppliedToPageModel.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfRouteAttribute_IsAppliedToPageModel.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfRouteAttributesAreAppliedToPageHandlerMethod.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/DiagnosticsAreReturned_IfRouteAttributesAreAppliedToPageHandlerMethod.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForControllerActions.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForControllerActions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForControllerBaseActions.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForControllerBaseActions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForNonHandlerMethodsWithAttributes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForNonHandlerMethodsWithAttributes.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForPageHandlersWithNonFilterAttributes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_ForPageHandlersWithNonFilterAttributes.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_IfAllowAnonymousIsAppliedToPageModel.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_IfAllowAnonymousIsAppliedToPageModel.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_IfAuthorizeAttributeIsAppliedToPageModel.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_IfAuthorizeAttributeIsAppliedToPageModel.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_IfFiltersAreAppliedToPageModel.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AttributesShouldNotBeAppliedToPageModelAnalyzerTest/NoDiagnosticsAreReturned_IfFiltersAreAppliedToPageModel.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.Test

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfHtmlPartial.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfHtmlPartial.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfHtmlPartial_InSections.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfHtmlPartial_InSections.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfHtmlPartial_WithAdditionalParameters.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfHtmlPartial_WithAdditionalParameters.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfRenderPartial.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfRenderPartial.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfRenderPartial_InSections.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfRenderPartial_InSections.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfRenderPartial_WithAdditionalParameters.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/DiagnosticsAreReturned_ForUseOfRenderPartial_WithAdditionalParameters.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/NoDiagnosticsAreReturned_ForNonUseOfHtmlPartial.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/NoDiagnosticsAreReturned_ForNonUseOfHtmlPartial.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/NoDiagnosticsAreReturned_ForUseOfHtmlPartialAsync.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/NoDiagnosticsAreReturned_ForUseOfHtmlPartialAsync.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/NoDiagnosticsAreReturned_ForUseOfRenderPartialAsync.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/AvoidHtmlPartialAnalyzerTest/NoDiagnosticsAreReturned_ForUseOfRenderPartialAsync.cs
@@ -1,4 +1,7 @@
-﻿namespace AspNetCore
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AspNetCore
 {
     using System;
     using System.Collections.Generic;

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_BaseTypeWithAttributes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_BaseTypeWithAttributes.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     [ApiConventionType(typeof(object))]
     [ApiController]

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_OnMethodWithoutAttributes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_OnMethodWithoutAttributes.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class GetAttributes_OnMethodWithoutAttributesClass
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_OnTypeWithAttributes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_OnTypeWithAttributes.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     [ApiConventionType(typeof(object))]
     [ApiController]

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_OnTypeWithoutAttributes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_OnTypeWithoutAttributes.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_WithMethodOverridding.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_WithMethodOverridding.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class GetAttributes_WithInheritFalse_ReturnsAllAttributesOnCurrentActionBase
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_WithNewMethod.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_WithNewMethod.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class GetAttributes_WithNewMethodBase
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_WithoutMethodOverriding.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/GetAttributes_WithoutMethodOverriding.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class GetAttributes_WithoutMethodOverriding
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsFalseIfSymbolDoesNotHaveAttribute.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsFalseIfSymbolDoesNotHaveAttribute.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnMethods.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnMethods.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnOverriddenMethods.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnOverriddenMethods.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnOverridenProperties.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnOverridenProperties.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnProperties.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForAttributesOnProperties.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForInterfaceContractOnAttribute.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueForInterfaceContractOnAttribute.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueIfBaseTypeHasAttribute.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueIfBaseTypeHasAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     [Controller]
     public class HasAttribute_ReturnsTrueIfBaseTypeHasAttributeBase { }

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueIfTypeHasAttribute.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/HasAttribute_ReturnsTrueIfTypeHasAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     [Controller]
     public class HasAttribute_ReturnsTrueIfTypeHasAttribute { }

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsFalseForDifferentTypes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsFalseForDifferentTypes.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class IsAssignable_ReturnsFalseForDifferentTypesA
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfAncestorTypeImplementsInterface.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfAncestorTypeImplementsInterface.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public interface IsAssignable_ReturnsTrueIfAncestorTypeImplementsInterface
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfTypeImplementsInterface.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfTypeImplementsInterface.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public interface IsAssignable_ReturnsTrueIfTypeImplementsInterface
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfTypeIsBaseClass.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfTypeIsBaseClass.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class IsAssignable_ReturnsTrueIfTypeIsBaseClassBase
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfTypesAreExact.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/CodeAnalysisExtensionsTest/IsAssignable_ReturnsTrueIfTypesAreExact.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     public class IsAssignable_ReturnsTrueIfTypesAreExact
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties : Controller
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForModelBoundParameters.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForModelBoundParameters.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class DiagnosticsAreReturned_ForModelBoundParameters : Controller
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName : Controller
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/GetNameTests.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/GetNameTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class GetNameTests
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresFields.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresFields.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_IgnoresFields
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresMethods.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresMethods.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_IgnoresMethods
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresNonPublicProperties.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresNonPublicProperties.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_IgnoresNonPublicProperties
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresStaticProperties.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresStaticProperties.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_IgnoresStaticProperties
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForFromBodyParameter.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForFromBodyParameter.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_ReturnsFalse_ForFromBodyParameter
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForParametersWithCustomModelBinder.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForParametersWithCustomModelBinder.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForSimpleTypes.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForSimpleTypes.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfBindingSourceAttributeIsUsedToRenameParameter.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfBindingSourceAttributeIsUsedToRenameParameter.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_ReturnsFalse_IfBindingSourceAttributeIsUsedToRenameParameter
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfBindingSourceAttributeIsUsedToRenameProperty.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfBindingSourceAttributeIsUsedToRenameProperty.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_ReturnsFalse_IfBindingSourceAttributeIsUsedToRenameProperty
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfModelBinderAttributeIsUsedToRenameParameter.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfModelBinderAttributeIsUsedToRenameParameter.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_ReturnsTrue_IfModelBinderAttributeIsUsedToRenameParameter
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForApiControllers.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForApiControllers.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     [ApiController]
     public class NoDiagnosticsAreReturnedForApiControllers : Controller

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForNonActions.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForNonActions.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class NoDiagnosticsAreReturnedForNonActions : Controller
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {
     public class NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute : Controller
     {

--- a/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/SpecifiesModelTypeTests.cs
+++ b/src/Mvc/Mvc.Analyzers/test/TestFiles/TopLevelParameterNameAnalyzerTest/SpecifiesModelTypeTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/GetDefaultStatusCodeTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/GetDefaultStatusCodeTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/InspectReturnExpressionTests.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/InspectReturnExpressionTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.InspectReturnExpressionTests
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/TryGetActualResponseMetadataTests.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/TryGetActualResponseMetadataTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ActualApiResponseMetadataFactoryTest

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Input.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: Microsoft.AspNetCore.Mvc.ApiConventionType(typeof(Microsoft.AspNetCore.Mvc.DefaultApiConventions))]
 
 namespace TestApp._INPUT_

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 [assembly: Microsoft.AspNetCore.Mvc.ApiConventionType(typeof(Microsoft.AspNetCore.Mvc.DefaultApiConventions))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodesAndTypes.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodesAndTypes.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodesAndTypes.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodesAndTypes.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsResponseTypeWhenDifferentFromErrorType.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsResponseTypeWhenDifferentFromErrorType.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {
     [ProducesErrorResponseType(typeof(CodeFixAddsResponseTypeWhenDifferentErrorModel))]
     [ApiController]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsResponseTypeWhenDifferentFromErrorType.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsResponseTypeWhenDifferentFromErrorType.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Input.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Output.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Input.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError.Output.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/DiagnosticsAreReturned_ForApiActionsWithModelStateChecks.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/DiagnosticsAreReturned_ForApiActionsWithModelStateChecks.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/DiagnosticsAreReturned_ForApiActionsWithModelStateChecksUsingEquality.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/DiagnosticsAreReturned_ForApiActionsWithModelStateChecksUsingEquality.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/DiagnosticsAreReturned_ForApiActionsWithModelStateChecksWithoutBracing.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/DiagnosticsAreReturned_ForApiActionsWithModelStateChecksWithoutBracing.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsCheckingAdditionalConditions.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsCheckingAdditionalConditions.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsReturning400FromNonModelStateIsValidBlocks.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsReturning400FromNonModelStateIsValidBlocks.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsReturningNot400FromNonModelStateIsValidBlock.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsReturningNot400FromNonModelStateIsValidBlock.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsWithoutModelStateChecks.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiActionsWithoutModelStateChecks.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     [ApiController]
     public class NoDiagnosticsAreReturned_ForApiActionsWithoutModelStateChecks : ControllerBase

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForNonApiController.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForNonApiController.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {
     public class NoDiagnosticsAreReturned_ForNonApiController : ControllerBase
     {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForRazorPageModels.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForRazorPageModels.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzerIntegrationTest
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesIfBlockWithoutBraces.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesIfBlockWithoutBraces.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._INPUT_
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesIfBlockWithoutBraces.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesIfBlockWithoutBraces.Output.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._OUTPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._OUTPUT_
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithEqualityCheck.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithEqualityCheck.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._INPUT_
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithEqualityCheck.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithEqualityCheck.Output.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._OUTPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._OUTPUT_
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithIfNotCheck.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithIfNotCheck.Input.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._INPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._INPUT_
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithIfNotCheck.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest/CodeFixRemovesModelStateIsInvalidBlockWithIfNotCheck.Output.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._OUTPUT_
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProviderTest._OUTPUT_
 {
     [ApiController]
     [Route("/api/[controller]")]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiControllerFactsTest/IsApiControllerAction_ReturnsTrue_IfAttributeIsDeclaredOnAssembly.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiControllerFactsTest/IsApiControllerAction_ReturnsTrue_IfAttributeIsDeclaredOnAssembly.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiController]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiControllerFactsTest/TestFile.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiControllerFactsTest/TestFile.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutAnyAttributes.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutAnyAttributes.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutSomeAttributes.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutSomeAttributes.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForControllerWithCustomConvention.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForControllerWithCustomConvention.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Api.Analyzers;

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodReturningValueTaskWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodReturningValueTaskWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithApiConventionMethod_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithApiConventionMethod_ReturnsUndocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeAsynchronouslyReturnsValue_WithoutDocumentation.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeAsynchronouslyReturnsValue_WithoutDocumentation.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentation.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentation.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
     [ApiController]
     public class DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentation : ControllerBase

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttribute_ReturnsDerivedType.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttribute_ReturnsDerivedType.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithConvention_DoesNotReturnDocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithConvention_DoesNotReturnDocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithConvention_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithConvention_ReturnsUndocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Api.Analyzers;
 
 [assembly: ApiConventionType(typeof(DiagnosticsAreReturned_IfMethodWithConvention_ReturnsUndocumentedStatusCodeConvention))]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_DoesNotDocumentSuccessStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_DoesNotDocumentSuccessStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_DoesNotReturnDocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_DoesNotReturnDocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
     [ApiController]
     public class DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode : ControllerBase

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiController_IfStatusCodesCannotBeInferred.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiController_IfStatusCodesCannotBeInferred.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
     [ApiController]
     public class NoDiagnosticsAreReturned_ForApiController_IfStatusCodesCannotBeInferred : ControllerBase

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiController_WithAllDocumentedStatusCodes.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiController_WithAllDocumentedStatusCodes.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForNonApiController.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForNonApiController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForOkResultReturningAction.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForOkResultReturningAction.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForRazorPageModels.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForRazorPageModels.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForReturnStatementsInLambdas.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForReturnStatementsInLambdas.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNetCore.Mvc;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForReturnStatementsInLocalFunctions.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForReturnStatementsInLocalFunctions.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
     [ApiController]
     public class NoDiagnosticsAreReturned_ForReturnStatementsInLocalFunctions : ControllerBase

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/MvcFactsTest/IsControllerActionTests.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/MvcFactsTest/IsControllerActionTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/MvcFactsTest/IsControllerTests.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/MvcFactsTest/IsControllerTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
     public interface ITestController { }
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiConventionMatcherTest/SymbolApiConventionMatcherTestFile.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiConventionMatcherTest/SymbolApiConventionMatcherTestFile.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsProblemDetails_IfNoAttributeIsDiscovered.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsProblemDetails_IfNoAttributeIsDiscovered.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.SymbolApiResponseMetadataProviderTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.SymbolApiResponseMetadataProviderTest
 {
     public class GetErrorResponseType_ReturnsProblemDetails_IfNoAttributeIsDiscoveredController
     {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsTypeDefinedAtAction.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsTypeDefinedAtAction.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.SymbolApiResponseMetadataProviderTest
 {

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsTypeDefinedAtAssembly.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsTypeDefinedAtAssembly.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 [assembly: ProducesErrorResponseType(typeof(Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.SymbolApiResponseMetadataProviderTest.GetErrorResponseType_ReturnsTypeDefinedAtAssemblyModel))]
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsTypeDefinedAtController.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/SymbolApiResponseMetadataProviderTest/GetErrorResponseType_ReturnsTypeDefinedAtController.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.SymbolApiResponseMetadataProviderTest
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.SymbolApiResponseMetadataProviderTest
 {
     [ProducesErrorResponseType(typeof(GetErrorResponseType_ReturnsTypeDefinedAtControllerModel))]
     public class GetErrorResponseType_ReturnsTypeDefinedAtControllerController

--- a/src/Mvc/Mvc.DataAnnotations/test/MvcDataAnnotationsMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.DataAnnotations/test/MvcDataAnnotationsMvcOptionsSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) .NET Foundation.All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;

--- a/src/Mvc/Mvc.ViewFeatures/test/Rendering/JsonHelperTestBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Rendering/JsonHelperTestBase.cs
@@ -1,4 +1,5 @@
-﻿// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Html;
 using Xunit;

--- a/src/Mvc/Mvc.ViewFeatures/test/Rendering/SystemTextJsonHelperTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Rendering/SystemTextJsonHelperTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Text.Encodings.Web;

--- a/src/Mvc/benchmarkapps/BasicApi/Migrations/20180609000420_InitialCreate.cs
+++ b/src/Mvc/benchmarkapps/BasicApi/Migrations/20180609000420_InitialCreate.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 

--- a/src/Mvc/benchmarkapps/BasicViews/Migrations/20180609000611_InitialCreate.cs
+++ b/src/Mvc/benchmarkapps/BasicViews/Migrations/20180609000611_InitialCreate.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;

--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance.Views/HelperExtensions.cs
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance.Views/HelperExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Razor;

--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance.Views/ViewAssemblyMarker.cs
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance.Views/ViewAssemblyMarker.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Mvc.Performance
 {
     public class ViewAssemblyMarker

--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/AssemblyInfo.cs
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Mvc/test/Mvc.FunctionalTests/AsyncActionsTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/AsyncActionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/Mvc/test/Mvc.FunctionalTests/DataAnnotationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/DataAnnotationTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
 using System.Threading.Tasks;
 using RazorWebSite;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET  Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/Mvc/test/Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Mvc/test/Mvc.IntegrationTests/CompanyNameAttribute.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/CompanyNameAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;

--- a/src/Mvc/test/Mvc.IntegrationTests/Models/Product.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/Models/Product.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;

--- a/src/Mvc/test/Mvc.IntegrationTests/Models/ProductDetails.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/Models/ProductDetails.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;

--- a/src/Mvc/test/Mvc.IntegrationTests/Models/ProductViewModel.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/Models/ProductViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;

--- a/src/Mvc/test/Mvc.IntegrationTests/Models/Software.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/Models/Software.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Mvc/test/Mvc.IntegrationTests/Models/SoftwareViewModel.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/Models/SoftwareViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Mvc/test/Mvc.IntegrationTests/Models/SuccessfulModel.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/Models/SuccessfulModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNetCore.Mvc.IntegrationTests

--- a/src/Mvc/test/Mvc.IntegrationTests/ProductValidatorAttribute.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ProductValidatorAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;

--- a/src/Mvc/test/Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Mvc/test/WebSites/ApiExplorerWebSite/ReloadAttribute.cs
+++ b/src/Mvc/test/WebSites/ApiExplorerWebSite/ReloadAttribute.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace ApiExplorerWebSite
 {

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/InvalidContentTypeController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/InvalidContentTypeController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace BasicWebSite.Controllers.ContentNegotiation

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/TestingController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/TestingController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/Mvc/test/WebSites/BasicWebSite/Filters/RedirectAntiforgeryValidationFailedResultFilter.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Filters/RedirectAntiforgeryValidationFailedResultFilter.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Core.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Filters;
 

--- a/src/Mvc/test/WebSites/FormatterWebSite/Models/InvalidModel.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Models/InvalidModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace FormatterWebSite.Models

--- a/src/Mvc/test/WebSites/FormatterWebSite/Models/Project.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Models/Project.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/Mvc/test/WebSites/FormatterWebSite/Models/SimpleTypePropertiesModel.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Models/SimpleTypePropertiesModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace FormatterWebSite

--- a/src/Mvc/test/WebSites/GenericHostWebSite/Controllers/TestingController.cs
+++ b/src/Mvc/test/WebSites/GenericHostWebSite/Controllers/TestingController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/Mvc/test/WebSites/RazorBuildWebSite.Views/Pages/Rzc/Page_Model.cs
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite.Views/Pages/Rzc/Page_Model.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace RazorBuildWebSite.Pages.Rzc

--- a/src/Mvc/test/WebSites/RazorBuildWebSite/Controllers/CommonController.cs
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite/Controllers/CommonController.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Mvc/test/WebSites/RazorBuildWebSite/Controllers/PrecompilationController.cs
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite/Controllers/PrecompilationController.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace RazorBuildWebSite.Controllers

--- a/src/Mvc/test/WebSites/RazorBuildWebSite/Controllers/RzcController.cs
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite/Controllers/RzcController.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace RazorBuildWebSite.Controllers

--- a/src/Mvc/test/WebSites/RazorPagesClassLibrary/ClassLibraryStartup.cs
+++ b/src/Mvc/test/WebSites/RazorPagesClassLibrary/ClassLibraryStartup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace RazorPagesClassLibrary

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Antiforgery/AntiforgeryDefault.cshtml.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Antiforgery/AntiforgeryDefault.cshtml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Antiforgery/IgnoreAntiforgery.cshtml.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Antiforgery/IgnoreAntiforgery.cshtml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Conventions/AuthFolder/AnonymousModel.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Conventions/AuthFolder/AnonymousModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/CustomModelTypeModel.cshtml.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/CustomModelTypeModel.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Localized/PageWithModel.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Localized/PageWithModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Redirects/RedirectFromModel.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Redirects/RedirectFromModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/TryUpdateModelPageModel.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/TryUpdateModelPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/TryValidateModelPageModel.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/TryValidateModelPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Validation/PageWithValidation.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/Validation/PageWithValidation.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/ViewData/ViewDataInPage.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/ViewData/ViewDataInPage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/ViewData/ViewDataSetInViewStart/Index.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/ViewData/ViewDataSetInViewStart/Index.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/ViewData/ViewDataToViewComponentPage.cs
+++ b/src/Mvc/test/WebSites/RazorPagesWebSite/Pages/ViewData/ViewDataToViewComponentPage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/src/Mvc/test/WebSites/RoutingWebSite/Pages/DynamicPage.cshtml.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Pages/DynamicPage.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Mvc/test/WebSites/RoutingWebSite/Pages/FallbackPage.cshtml.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Pages/FallbackPage.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Razor/.editorconfig
+++ b/src/Razor/.editorconfig
@@ -8,6 +8,8 @@ root = true
 indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
+file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4

--- a/src/Security/Authentication/Certificate/samples/Certificate.Sample/Program.cs
+++ b/src/Security/Authentication/Certificate/samples/Certificate.Sample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Https;

--- a/src/Security/Authentication/Certificate/samples/Certificate.Sample/Startup.cs
+++ b/src/Security/Authentication/Certificate/samples/Certificate.Sample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Certificate;

--- a/src/Security/Authentication/Cookies/samples/CookieSample/Program.cs
+++ b/src/Security/Authentication/Cookies/samples/CookieSample/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/src/Security/Authentication/Cookies/samples/CookieSample/Startup.cs
+++ b/src/Security/Authentication/Cookies/samples/CookieSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/Authentication/Cookies/samples/CookieSessionSample/MemoryCacheTicketStore.cs
+++ b/src/Security/Authentication/Cookies/samples/CookieSessionSample/MemoryCacheTicketStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/Authentication/Cookies/samples/CookieSessionSample/Program.cs
+++ b/src/Security/Authentication/Cookies/samples/CookieSessionSample/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/src/Security/Authentication/Cookies/samples/CookieSessionSample/Startup.cs
+++ b/src/Security/Authentication/Cookies/samples/CookieSessionSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Security/Authentication/Cookies/src/ITicketStore.cs
+++ b/src/Security/Authentication/Cookies/src/ITicketStore.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 

--- a/src/Security/Authentication/Google/src/GoogleChallengeProperties.cs
+++ b/src/Security/Authentication/Google/src/GoogleChallengeProperties.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OAuth;
 
 namespace Microsoft.AspNetCore.Authentication.Google

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Program.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Todo.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Todo.cs
@@ -1,4 +1,7 @@
-﻿namespace JwtBearerSample
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace JwtBearerSample
 {
     public class Todo
     {

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftChallengeProperties.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftChallengeProperties.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OAuth;
 

--- a/src/Security/Authentication/OAuth/src/OAuthChallengeProperties.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthChallengeProperties.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth
 {

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/AuthPropertiesTokenCache.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/AuthPropertiesTokenCache.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/Program.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnect.AzureAdSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Program.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Program.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectChallengeProperties.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectChallengeProperties.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectRedirectBehavior.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectRedirectBehavior.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 {
     /// <summary>

--- a/src/Security/Authentication/WsFederation/samples/WsFedSample/Program.cs
+++ b/src/Security/Authentication/WsFederation/samples/WsFedSample/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/Authentication/WsFederation/samples/WsFedSample/Startup.cs
+++ b/src/Security/Authentication/WsFederation/samples/WsFedSample/Startup.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;

--- a/src/Security/Authentication/samples/SocialSample/Program.cs
+++ b/src/Security/Authentication/samples/SocialSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 

--- a/src/Security/Authentication/samples/SocialSample/Startup.cs
+++ b/src/Security/Authentication/samples/SocialSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
+++ b/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Claims;

--- a/src/Security/Authentication/test/CertificateTests.cs
+++ b/src/Security/Authentication/test/CertificateTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Barry Dorrans. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Security/Authentication/test/DynamicSchemeTests.cs
+++ b/src/Security/Authentication/test/DynamicSchemeTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Net;

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Builder;

--- a/src/Security/Authentication/test/MicrosoftAccountTests.cs
+++ b/src/Security/Authentication/test/MicrosoftAccountTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
 using Microsoft.AspNetCore.Authentication.OAuth;

--- a/src/Security/Authentication/test/OAuthChallengePropertiesTest.cs
+++ b/src/Security/Authentication/test/OAuthChallengePropertiesTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/src/Security/Authentication/test/OpenIdConnect/MockOpenIdConnectMessage.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/MockOpenIdConnectMessage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect

--- a/src/Security/Authentication/test/PolicyTests.cs
+++ b/src/Security/Authentication/test/PolicyTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Claims;

--- a/src/Security/Authentication/test/TestHandlers.cs
+++ b/src/Security/Authentication/test/TestHandlers.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
 using System.Text.Encodings.Web;

--- a/src/Security/Authentication/test/TwitterTests.cs
+++ b/src/Security/Authentication/test/TwitterTests.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Security/CookiePolicy/samples/CookiePolicySample/Program.cs
+++ b/src/Security/CookiePolicy/samples/CookiePolicySample/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/src/Security/CookiePolicy/samples/CookiePolicySample/Startup.cs
+++ b/src/Security/CookiePolicy/samples/CookiePolicySample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Security/benchmarks/Microsoft.AspNetCore.Security.Performance/Properties/AssemblyInfo.cs
+++ b/src/Security/benchmarks/Microsoft.AspNetCore.Security.Performance/Properties/AssemblyInfo.cs
@@ -1,1 +1,4 @@
-﻿[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Security/samples/ClaimsTransformation/ClaimsTransformer.cs
+++ b/src/Security/samples/ClaimsTransformation/ClaimsTransformer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/samples/ClaimsTransformation/Controllers/AccountController.cs
+++ b/src/Security/samples/ClaimsTransformation/Controllers/AccountController.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/samples/ClaimsTransformation/Controllers/HomeController.cs
+++ b/src/Security/samples/ClaimsTransformation/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
 using AuthSamples.ClaimsTransformer.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Security/samples/ClaimsTransformation/Models/ErrorViewModel.cs
+++ b/src/Security/samples/ClaimsTransformation/Models/ErrorViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace AuthSamples.ClaimsTransformer.Models

--- a/src/Security/samples/ClaimsTransformation/Program.cs
+++ b/src/Security/samples/ClaimsTransformation/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/samples/ClaimsTransformation/Startup.cs
+++ b/src/Security/samples/ClaimsTransformation/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Cookies/ConfigureMyCookie.cs
+++ b/src/Security/samples/Cookies/ConfigureMyCookie.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authentication.Cookies;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Options;
 
 namespace AuthSamples.Cookies

--- a/src/Security/samples/Cookies/Controllers/AccountController.cs
+++ b/src/Security/samples/Cookies/Controllers/AccountController.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/samples/Cookies/Controllers/HomeController.cs
+++ b/src/Security/samples/Cookies/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
 using AuthSamples.Cookies.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Security/samples/Cookies/Models/ErrorViewModel.cs
+++ b/src/Security/samples/Cookies/Models/ErrorViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace AuthSamples.Cookies.Models

--- a/src/Security/samples/Cookies/Program.cs
+++ b/src/Security/samples/Cookies/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/samples/Cookies/Startup.cs
+++ b/src/Security/samples/Cookies/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgeAuthorizationHandler.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgeAuthorizationHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgeAuthorizeAttribute.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgeAuthorizeAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authorization;
 
 namespace CustomPolicyProvider

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgePolicyProvider.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgePolicyProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgeRequirement.cs
+++ b/src/Security/samples/CustomPolicyProvider/Authorization/MinimumAgeRequirement.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authorization;
 
 namespace CustomPolicyProvider

--- a/src/Security/samples/CustomPolicyProvider/Controllers/AccountController.cs
+++ b/src/Security/samples/CustomPolicyProvider/Controllers/AccountController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authentication;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;

--- a/src/Security/samples/CustomPolicyProvider/Controllers/HomeController.cs
+++ b/src/Security/samples/CustomPolicyProvider/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
 
 namespace CustomPolicyProvider.Controllers
 {

--- a/src/Security/samples/CustomPolicyProvider/Program.cs
+++ b/src/Security/samples/CustomPolicyProvider/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
 namespace CustomPolicyProvider

--- a/src/Security/samples/CustomPolicyProvider/Startup.cs
+++ b/src/Security/samples/CustomPolicyProvider/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;

--- a/src/Security/samples/DynamicSchemes/Controllers/AuthController.cs
+++ b/src/Security/samples/DynamicSchemes/Controllers/AuthController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Security/samples/DynamicSchemes/Pages/About.cshtml.cs
+++ b/src/Security/samples/DynamicSchemes/Pages/About.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/DynamicSchemes/Pages/Contact.cshtml.cs
+++ b/src/Security/samples/DynamicSchemes/Pages/Contact.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/DynamicSchemes/Pages/Error.cshtml.cs
+++ b/src/Security/samples/DynamicSchemes/Pages/Error.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Security/samples/DynamicSchemes/Pages/Index.cshtml.cs
+++ b/src/Security/samples/DynamicSchemes/Pages/Index.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/DynamicSchemes/Program.cs
+++ b/src/Security/samples/DynamicSchemes/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/samples/DynamicSchemes/SimpleAuthHandler.cs
+++ b/src/Security/samples/DynamicSchemes/SimpleAuthHandler.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/samples/DynamicSchemes/Startup.cs
+++ b/src/Security/samples/DynamicSchemes/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Controllers/AccountController.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Controllers/AccountController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Data/ApplicationDbContext.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Data/ApplicationDbContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Data/ApplicationUser.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Data/ApplicationUser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Data/Migrations/00000000000000_CreateIdentitySchema.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Data/Migrations/00000000000000_CreateIdentitySchema.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Extensions/EmailSenderExtensions.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Extensions/EmailSenderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Extensions/UrlHelperExtensions.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Extensions/UrlHelperExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/AccessDenied.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/AccessDenied.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/ConfirmEmail.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/ExternalLogin.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/ForgotPassword.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Lockout.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Lockout.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Login.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Login.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/LoginWith2fa.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/LoginWith2fa.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/Disable2fa.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/Disable2fa.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ExternalLogins.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ExternalLogins.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/GenerateRecoveryCodes.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/GenerateRecoveryCodes.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/Index.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ManageNavPages.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ManageNavPages.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ResetAuthenticator.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/ResetAuthenticator.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/SetPassword.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/SetPassword.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/TwoFactorAuthentication.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/TwoFactorAuthentication.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Register.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Register.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/ResetPassword.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/ResetPassword.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/ResetPasswordConfirmation.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/ResetPasswordConfirmation.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/SignedOut.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/SignedOut.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Contact.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Contact.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Error.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Error.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/Index.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Index.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Pages/MyClaims.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/MyClaims.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Program.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Services/EmailSender.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Services/EmailSender.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/Identity.ExternalClaims/Services/IEmailSender.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Services/IEmailSender.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Security/samples/Identity.ExternalClaims/Startup.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/PathSchemeSelection/Controllers/AccountController.cs
+++ b/src/Security/samples/PathSchemeSelection/Controllers/AccountController.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/samples/PathSchemeSelection/Controllers/HomeController.cs
+++ b/src/Security/samples/PathSchemeSelection/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
 using AuthSamples.PathSchemeSelection.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Security/samples/PathSchemeSelection/Models/ErrorViewModel.cs
+++ b/src/Security/samples/PathSchemeSelection/Models/ErrorViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace AuthSamples.PathSchemeSelection.Models

--- a/src/Security/samples/PathSchemeSelection/Program.cs
+++ b/src/Security/samples/PathSchemeSelection/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/samples/PathSchemeSelection/Startup.cs
+++ b/src/Security/samples/PathSchemeSelection/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Security/samples/StaticFilesAuth/Controllers/AccountController.cs
+++ b/src/Security/samples/StaticFilesAuth/Controllers/AccountController.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;

--- a/src/Security/samples/StaticFilesAuth/Controllers/HomeController.cs
+++ b/src/Security/samples/StaticFilesAuth/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Security/samples/StaticFilesAuth/Models/ErrorViewModel.cs
+++ b/src/Security/samples/StaticFilesAuth/Models/ErrorViewModel.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace StaticFilesAuth.Models

--- a/src/Security/samples/StaticFilesAuth/Program.cs
+++ b/src/Security/samples/StaticFilesAuth/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Security/samples/StaticFilesAuth/Startup.cs
+++ b/src/Security/samples/StaticFilesAuth/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Servers/Connections.Abstractions/src/Exceptions/ConnectionAbortedException.cs
+++ b/src/Servers/Connections.Abstractions/src/Exceptions/ConnectionAbortedException.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Connections
 {

--- a/src/Servers/HttpSys/samples/HotAddSample/Startup.cs
+++ b/src/Servers/HttpSys/samples/HotAddSample/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Servers/HttpSys/samples/QueueSharing/Program.cs
+++ b/src/Servers/HttpSys/samples/QueueSharing/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Xml.Schema;
 using Microsoft.AspNetCore.Builder;

--- a/src/Servers/HttpSys/samples/TestClient/Program.cs
+++ b/src/Servers/HttpSys/samples/TestClient/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/Servers/HttpSys/src/LoggerEventIds.cs
+++ b/src/Servers/HttpSys/src/LoggerEventIds.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.HttpSys

--- a/src/Servers/IIS/IIS/src/StartupHook.cs
+++ b/src/Servers/IIS/IIS/src/StartupHook.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/StartupHook.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/StartupHook.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using TestSite;
 
 internal class StartupHook

--- a/src/Servers/IIS/IIS/test/testassets/shared/WebSockets/TestStartup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/shared/WebSockets/TestStartup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StackTraceHiddenAttribute.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StackTraceHiddenAttribute.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Diagnostics
 {

--- a/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Servers/Kestrel/Core/src/Internal/ThrowHelper.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ThrowHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/Servers/Kestrel/Core/test/DiagnosticMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/DiagnosticMemoryPoolTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Buffers;

--- a/src/Servers/Kestrel/Core/test/MemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/MemoryPoolTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Buffers;

--- a/src/Servers/Kestrel/Core/test/SlabMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/SlabMemoryPoolTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using Xunit;

--- a/src/Servers/Kestrel/Core/test/VariableIntHelperTests.cs
+++ b/src/Servers/Kestrel/Core/test/VariableIntHelperTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Net.Http;

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvAwaitable.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics;

--- a/src/Servers/Kestrel/Transport.Quic/src/Libraries.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Libraries.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 internal static partial class Interop
 {

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/AssemblyInfo.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Net;

--- a/src/Servers/Kestrel/samples/Http2SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/Http2SampleApp/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Servers/Kestrel/samples/Http2SampleApp/TimingMiddleware.cs
+++ b/src/Servers/Kestrel/samples/Http2SampleApp/TimingMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Servers/Kestrel/samples/QuicSampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/QuicSampleApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Net;

--- a/src/Servers/Kestrel/samples/QuicSampleClient/Program.cs
+++ b/src/Servers/Kestrel/samples/QuicSampleClient/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Net;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/PipeReaderFactory.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/PipeReaderFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportFactoryTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Servers/test/FunctionalTests/Properties/AssemblyInfo.cs
+++ b/src/Servers/test/FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/Shared/Buffers.MemoryPool/DiagnosticMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/DiagnosticMemoryPool.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Shared/Buffers.MemoryPool/DiagnosticPoolBlock.cs
+++ b/src/Shared/Buffers.MemoryPool/DiagnosticPoolBlock.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
 using System.Diagnostics;

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolBlock.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolBlock.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.InteropServices;
 

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolSlab.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolSlab.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.InteropServices;
 

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolThrowHelper.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolThrowHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/Shared/Buffers.MemoryPool/SlabMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/SlabMemoryPool.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
 using System.Diagnostics;

--- a/src/Shared/Buffers.Testing/BufferSegment.cs
+++ b/src/Shared/Buffers.Testing/BufferSegment.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Buffers
 {

--- a/src/Shared/Buffers.Testing/CustomMemoryForTest.cs
+++ b/src/Shared/Buffers.Testing/CustomMemoryForTest.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Buffers
 {

--- a/src/Shared/Buffers.Testing/ReadOnlySequenceFactory.cs
+++ b/src/Shared/Buffers.Testing/ReadOnlySequenceFactory.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Text;

--- a/src/Shared/ServerInfrastructure/DuplexPipe.cs
+++ b/src/Shared/ServerInfrastructure/DuplexPipe.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.IO.Pipelines
 {

--- a/src/Shared/ServerInfrastructure/MemoryPoolExtensions.cs
+++ b/src/Shared/ServerInfrastructure/MemoryPoolExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/Shared/TaskToApm.cs
+++ b/src/Shared/TaskToApm.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // Helper methods for using Tasks to implement the APM pattern.
 //

--- a/src/Shared/UrlDecoder/UrlDecoder.cs
+++ b/src/Shared/UrlDecoder/UrlDecoder.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 

--- a/src/Shared/runtime/Http2/Hpack/DynamicTable.cs
+++ b/src/Shared/runtime/Http2/Hpack/DynamicTable.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http.HPack
 {

--- a/src/Shared/runtime/Http2/Hpack/H2StaticTable.cs
+++ b/src/Shared/runtime/Http2/Hpack/H2StaticTable.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Text;

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Diagnostics;

--- a/src/Shared/runtime/Http2/Hpack/HPackDecodingException.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecodingException.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
 

--- a/src/Shared/runtime/Http2/Hpack/HPackEncoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackEncoder.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Shared/runtime/Http2/Hpack/HPackEncodingException.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackEncodingException.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http.HPack
 {

--- a/src/Shared/runtime/Http2/Hpack/HeaderField.cs
+++ b/src/Shared/runtime/Http2/Hpack/HeaderField.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 using System.Text;

--- a/src/Shared/runtime/Http2/Hpack/Huffman.cs
+++ b/src/Shared/runtime/Http2/Hpack/Huffman.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 

--- a/src/Shared/runtime/Http2/Hpack/HuffmanDecodingException.cs
+++ b/src/Shared/runtime/Http2/Hpack/HuffmanDecodingException.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
 

--- a/src/Shared/runtime/Http2/Hpack/IntegerDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/IntegerDecoder.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 using System.Numerics;

--- a/src/Shared/runtime/Http2/Hpack/IntegerEncoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/IntegerEncoder.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 

--- a/src/Shared/runtime/Http2/Hpack/StatusCodes.cs
+++ b/src/Shared/runtime/Http2/Hpack/StatusCodes.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
 using System.Text;

--- a/src/Shared/runtime/Http3/Frames/Http3ErrorCode.cs
+++ b/src/Shared/runtime/Http3/Frames/Http3ErrorCode.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http
 {

--- a/src/Shared/runtime/Http3/Frames/Http3Frame.cs
+++ b/src/Shared/runtime/Http3/Frames/Http3Frame.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
 

--- a/src/Shared/runtime/Http3/Frames/Http3FrameType.cs
+++ b/src/Shared/runtime/Http3/Frames/Http3FrameType.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http
 {

--- a/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Buffers.Binary;

--- a/src/Shared/runtime/Http3/Http3SettingType.cs
+++ b/src/Shared/runtime/Http3/Http3SettingType.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http
 {

--- a/src/Shared/runtime/Http3/Http3StreamType.cs
+++ b/src/Shared/runtime/Http3/Http3StreamType.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http
 {

--- a/src/Shared/runtime/Http3/QPack/H3StaticTable.cs
+++ b/src/Shared/runtime/Http3/QPack/H3StaticTable.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Text;

--- a/src/Shared/runtime/Http3/QPack/HeaderField.cs
+++ b/src/Shared/runtime/Http3/QPack/HeaderField.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Http.QPack
 {

--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Diagnostics;

--- a/src/Shared/runtime/Http3/QPack/QPackDecodingException.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecodingException.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
 

--- a/src/Shared/runtime/Http3/QPack/QPackEncoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackEncoder.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Shared/runtime/Http3/QPack/QPackEncodingException.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackEncodingException.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
 

--- a/src/Shared/runtime/IHttpHeadersHandler.cs
+++ b/src/Shared/runtime/IHttpHeadersHandler.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // Don't ever change this unless we are explicitly trying to remove IHttpHeadersHandler as public API.
 #if KESTREL

--- a/src/Shared/runtime/NetEventSource.Common.cs
+++ b/src/Shared/runtime/NetEventSource.Common.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if DEBUG
 // Uncomment to enable runtime checks to help validate that NetEventSource isn't being misused

--- a/src/Shared/runtime/Quic/Implementations/Mock/MockConnection.cs
+++ b/src/Shared/runtime/Quic/Implementations/Mock/MockConnection.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers.Binary;
 using System.Net.Security;

--- a/src/Shared/runtime/Quic/Implementations/Mock/MockImplementationProvider.cs
+++ b/src/Shared/runtime/Quic/Implementations/Mock/MockImplementationProvider.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Security;
 

--- a/src/Shared/runtime/Quic/Implementations/Mock/MockListener.cs
+++ b/src/Shared/runtime/Quic/Implementations/Mock/MockListener.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Sockets;
 using System.Net.Security;

--- a/src/Shared/runtime/Quic/Implementations/Mock/MockStream.cs
+++ b/src/Shared/runtime/Quic/Implementations/Mock/MockStream.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Diagnostics;

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Sockets;
 using static System.Net.Quic.Implementations.MsQuic.Internal.MsQuicNativeMethods;

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
 using System.Net.Security;

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicParameterHelpers.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicParameterHelpers.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using static System.Net.Quic.Implementations.MsQuic.Internal.MsQuicNativeMethods;
 

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicSecurityConfig.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicSecurityConfig.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicSession.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/MsQuicSession.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/QuicExceptionHelpers.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/QuicExceptionHelpers.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/ResettableCompletionSource.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/Internal/ResettableCompletionSource.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
 using System.Net.Quic.Implementations.MsQuic.Internal;

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicImplementationProvider.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicImplementationProvider.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Quic.Implementations.MsQuic.Internal;
 using System.Net.Security;

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Quic.Implementations.MsQuic.Internal;
 using System.Net.Security;

--- a/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/Shared/runtime/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/Shared/runtime/Quic/Implementations/QuicConnectionProvider.cs
+++ b/src/Shared/runtime/Quic/Implementations/QuicConnectionProvider.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Shared/runtime/Quic/Implementations/QuicImplementationProvider.cs
+++ b/src/Shared/runtime/Quic/Implementations/QuicImplementationProvider.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Security;
 

--- a/src/Shared/runtime/Quic/Implementations/QuicListenerProvider.cs
+++ b/src/Shared/runtime/Quic/Implementations/QuicListenerProvider.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Shared/runtime/Quic/Implementations/QuicStreamProvider.cs
+++ b/src/Shared/runtime/Quic/Implementations/QuicStreamProvider.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Threading;

--- a/src/Shared/runtime/Quic/Interop/Interop.MsQuic.cs
+++ b/src/Shared/runtime/Quic/Interop/Interop.MsQuic.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Net.Quic.Implementations.MsQuic.Internal;

--- a/src/Shared/runtime/Quic/Interop/MsQuicEnums.cs
+++ b/src/Shared/runtime/Quic/Interop/MsQuicEnums.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {

--- a/src/Shared/runtime/Quic/Interop/MsQuicNativeMethods.cs
+++ b/src/Shared/runtime/Quic/Interop/MsQuicNativeMethods.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Sockets;
 using System.Runtime.InteropServices;

--- a/src/Shared/runtime/Quic/Interop/MsQuicStatusCodes.cs
+++ b/src/Shared/runtime/Quic/Interop/MsQuicStatusCodes.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.InteropServices;
 

--- a/src/Shared/runtime/Quic/Interop/MsQuicStatusHelper.cs
+++ b/src/Shared/runtime/Quic/Interop/MsQuicStatusHelper.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.InteropServices;
 

--- a/src/Shared/runtime/Quic/NetEventSource.Quic.cs
+++ b/src/Shared/runtime/Quic/NetEventSource.Quic.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics.Tracing;
 

--- a/src/Shared/runtime/Quic/QuicClientConnectionOptions.cs
+++ b/src/Shared/runtime/Quic/QuicClientConnectionOptions.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Security;
 

--- a/src/Shared/runtime/Quic/QuicConnection.cs
+++ b/src/Shared/runtime/Quic/QuicConnection.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Quic.Implementations;
 using System.Net.Quic.Implementations.MsQuic.Internal;

--- a/src/Shared/runtime/Quic/QuicConnectionAbortedException.cs
+++ b/src/Shared/runtime/Quic/QuicConnectionAbortedException.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic
 {

--- a/src/Shared/runtime/Quic/QuicException.cs
+++ b/src/Shared/runtime/Quic/QuicException.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic
 {

--- a/src/Shared/runtime/Quic/QuicImplementationProviders.cs
+++ b/src/Shared/runtime/Quic/QuicImplementationProviders.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic
 {

--- a/src/Shared/runtime/Quic/QuicListener.cs
+++ b/src/Shared/runtime/Quic/QuicListener.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Quic.Implementations;
 using System.Net.Security;

--- a/src/Shared/runtime/Quic/QuicListenerOptions.cs
+++ b/src/Shared/runtime/Quic/QuicListenerOptions.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net.Security;
 

--- a/src/Shared/runtime/Quic/QuicOperationAbortedException.cs
+++ b/src/Shared/runtime/Quic/QuicOperationAbortedException.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic
 {

--- a/src/Shared/runtime/Quic/QuicStream.cs
+++ b/src/Shared/runtime/Quic/QuicStream.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.IO;

--- a/src/Shared/runtime/Quic/QuicStreamAbortedException.cs
+++ b/src/Shared/runtime/Quic/QuicStreamAbortedException.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace System.Net.Quic
 {

--- a/src/Shared/test/Shared.Tests/runtime/Http2/DynamicTableTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/DynamicTableTest.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Linq;

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackIntegerTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackIntegerTest.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Net.Http.HPack;

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HuffmanDecodingTests.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HuffmanDecodingTests.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestTransport.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestTransport.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO.Pipelines;
 using System.Threading;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/PipeReaderFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/PipeReaderFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/SignalR/common/Http.Connections/src/LongPollingOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/LongPollingOptions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNetCore.Http.Connections

--- a/src/SignalR/common/Http.Connections/test/TestWebSocketConnectionFeature.cs
+++ b/src/SignalR/common/Http.Connections/test/TestWebSocketConnectionFeature.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;

--- a/src/SignalR/common/Shared/DuplexPipe.cs
+++ b/src/SignalR/common/Shared/DuplexPipe.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Buffers;
 
 namespace System.IO.Pipelines

--- a/src/SignalR/common/SignalR.Common/src/Protocol/InvocationBindingFailureMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/InvocationBindingFailureMessage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.ExceptionServices;
 
 namespace Microsoft.AspNetCore.SignalR.Protocol

--- a/src/SignalR/common/SignalR.Common/src/Protocol/StreamBindingFailureMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/StreamBindingFailureMessage.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Text;

--- a/src/SignalR/common/testassets/Tests.Utils/DummyHubProtocol.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/DummyHubProtocol.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/SignalR/common/testassets/Tests.Utils/PipeReaderExtensions.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/PipeReaderExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Text;

--- a/src/SignalR/perf/Microbenchmarks/AssemblyInfo.cs
+++ b/src/SignalR/perf/Microbenchmarks/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/SignalR/perf/Microbenchmarks/ServerSentEventsBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/ServerSentEventsBenchmark.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.IO;

--- a/src/SignalR/samples/ClientSample/Tcp/BufferExtensions.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/BufferExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/SignalR/samples/ClientSample/Tcp/SocketAwaitable.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/SocketAwaitable.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Pipelines;

--- a/src/SignalR/samples/ClientSample/Tcp/SocketReceiver.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/SocketReceiver.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Net.Sockets;

--- a/src/SignalR/samples/ClientSample/Tcp/SocketSender.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/SocketSender.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/SignalR/samples/ClientSample/Tcp/TcpConnection.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/TcpConnection.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SignalR/samples/ClientSample/Tcp/TcpHubConnectionBuilderExtensions.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/TcpHubConnectionBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using System.Net;

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/SignalR/server/SignalR/test/MapSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/MapSignalRTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;

--- a/src/SignalR/server/SignalR/test/SerializedHubMessageTests.cs
+++ b/src/SignalR/server/SignalR/test/SerializedHubMessageTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Internal;

--- a/src/Testing/src/FlakyOn.cs
+++ b/src/Testing/src/FlakyOn.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Testing/src/HelixQueues.cs
+++ b/src/Testing/src/HelixQueues.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Testing
 {
     public static class HelixQueues

--- a/src/Testing/src/ShortClassNameAttribute.cs
+++ b/src/Testing/src/ShortClassNameAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Testing/src/Tracing/CollectingEventListener.cs
+++ b/src/Testing/src/Tracing/CollectingEventListener.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Testing/src/Tracing/EventAssert.cs
+++ b/src/Testing/src/Tracing/EventAssert.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/Testing/src/Tracing/EventSourceTestBase.cs
+++ b/src/Testing/src/Tracing/EventSourceTestBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/Testing/src/contentFiles/cs/netstandard2.0/EventSourceTestCollection.cs
+++ b/src/Testing/src/contentFiles/cs/netstandard2.0/EventSourceTestCollection.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Testing.Tracing
 {
     // This file comes from Microsoft.AspNetCore.Testing and has to be defined in the test assembly.

--- a/src/Testing/src/xunit/FlakyAttribute.cs
+++ b/src/Testing/src/xunit/FlakyAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Xunit.Sdk;

--- a/src/Testing/src/xunit/FlakyTraitDiscoverer.cs
+++ b/src/Testing/src/xunit/FlakyTraitDiscoverer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Xunit.Abstractions;

--- a/src/Testing/src/xunit/WORKAROUND_SkippedDataRowTestCase.cs
+++ b/src/Testing/src/xunit/WORKAROUND_SkippedDataRowTestCase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel;
 using Xunit.Abstractions;

--- a/src/Testing/test/CollectingEventListenerTest.cs
+++ b/src/Testing/test/CollectingEventListenerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing.Tracing;

--- a/src/Testing/test/Properties/AssemblyInfo.cs
+++ b/src/Testing/test/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 

--- a/src/Tools/Extensions.ApiDescription.Client/test/MockBuildEngine.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/test/MockBuildEngine.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Tools/FirstRunCertGenerator/src/CertificateGenerator.cs
+++ b/src/Tools/FirstRunCertGenerator/src/CertificateGenerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNetCore.Certificates.Generation;
 


### PR DESCRIPTION
This change makes the conversion to MIT simpler by ensuring the repository starts with all headers in a known state. This change should be reviewed to make sure we aren't adding a header to a file where it would change meaning, and we aren't changing the header in a file that should keep its original header.

Edit: Only C# files are updated in this pull request. Other content types will be updated in a separate pull request.