### PR TITLE
Fix flaky stream pool test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -129,15 +129,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             // Stream has been returned to the pool
             Assert.Equal(1, _connection.StreamPool.Count);
 
-            await StartStreamAsync(3, _browserRequestHeaders, endStream: true);
-
-            await ExpectAsync(Http2FrameType.HEADERS,
-                withLength: 55,
-                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
-                withStreamId: 3);
+            await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
 
             // New stream has been taken from the pool
             Assert.Equal(0, _connection.StreamPool.Count);
+
+            await SendDataAsync(3, _helloBytes, endStream: true);
+            await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+                withStreamId: 3);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 5,
+                withFlags: (byte)Http2DataFrameFlags.NONE,
+                withStreamId: 3);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+                withStreamId: 3);
+
+            // Yield to let Kestrel finish moving the stream to the completed queue
+            await Task.Yield();
 
             // Ping will trigger the stream to be returned to the pool so we can assert it
             await SendPingAsync(Http2PingFrameFlags.NONE);


### PR DESCRIPTION
Start a stream and leave it open to test the stream has been taken from the pool.