### PR TITLE
Ignore implicity-passed directory name for WebItem templates

### DIFF
--- a/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
@@ -16,7 +16,7 @@
   "precedence": "100",
   "identity": "Microsoft.Web.Grpc.Protobuf",
   "shortname": "proto",
-  "sourceName": "protobuf",
+  "sourceName": "ignoreme",
   "primaryOutputs": [
     {
       "path": "protobuf.proto"

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
@@ -16,7 +16,7 @@
   "precedence": "100",
   "identity": "Microsoft.AspNetCore.Components.RazorComponent",
   "shortname": "razorcomponent",
-  "sourceName": "Component1",
+  "sourceName": "ignoreme",
   "primaryOutputs": [
     {
       "path": "Component1.razor"

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
@@ -13,7 +13,7 @@
   "precedence": "100",
   "identity": "Microsoft.AspNetCore.Mvc.RazorPage",
   "shortName": "page",
-  "sourceName": "Index",
+  "sourceName": "ignoreme",
   "primaryOutputs": [
     { "path": "Index.cshtml" },
     {


### PR DESCRIPTION
**Changes in the PR**
- Ignores implicitly-passed directory name for file name overrides in razorcomponent, protobuf, and razorpage templates

Addresses #11824

cc: @danroth27 I saw that your issue was only related to the razorcomponent template, but I noticed the protobuf and razor page template suffers from the same thing so I updated them to be consistent with the other WebItem templates.
