### PR TITLE
Only reset Http2Stream on stream completion

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Http1Connection(HttpConnectionContext context)
         {
-            Initialize(context);
+            Initialize(context, reset: true);
 
             _context = context;
             _parser = ServiceContext.HttpParser;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -76,13 +76,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private Stream _requestStreamInternal;
         private Stream _responseStreamInternal;
 
-        public void Initialize(HttpConnectionContext context)
+        public void Initialize(HttpConnectionContext context, bool reset)
         {
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
 
-            Reset();
+            if (reset)
+            {
+                Reset();
+            }
 
             HttpResponseControl = this;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context) 
         {
-            Initialize(context);
+            InitializePooled(context, reset: true);
             _application = application;
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public Http3Stream(Http3Connection http3Connection, Http3StreamContext context) 
         {
-            Initialize(context);
+            Initialize(context, reset: true);
 
             InputRemaining = null;
 

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             public TestHttp2Stream(Http2StreamContext context) 
             {
-                Initialize(context);
+                InitializePooled(context, reset: true);
             }
 
             public override void Execute()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/19428

Known headers are now reused. It currently isn't super useful because most HTTP/2 headers are pseudo headers and aren't known or reused - https://github.com/dotnet/aspnetcore/issues/4761