### PR TITLE
Unquarantine a pile of long-passing tests

### DIFF
--- a/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
@@ -106,7 +106,6 @@ namespace Microsoft.AspNetCore.Hosting
 
         [Theory]
         [MemberData(nameof(RequestStartData))]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2230", FlakyOn.All)]
         public void RequestStart(DefaultHttpContext httpContext, string[] expected)
         {
             // Arrange

--- a/src/Hosting/Hosting/test/WebHostTests.cs
+++ b/src/Hosting/Hosting/test/WebHostTests.cs
@@ -238,7 +238,6 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2244", FlakyOn.Helix.All)]
         public async Task WebHostStopAsyncUsesDefaultTimeoutIfNoTokenProvided()
         {
             var data = new Dictionary<string, string>

--- a/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
@@ -550,7 +550,6 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         }
 
         [Fact]
-        [Flaky("https://github.com/dotnet/aspnetcore/issues/8187", FlakyOn.Helix.All)]
         public async Task OriginIsNotValidatedForNonWebSocketRequests()
         {
             using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, context =>

--- a/src/Servers/Kestrel/Kestrel/test/GeneratedCodeTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/GeneratedCodeTests.cs
@@ -13,15 +13,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
     public class GeneratedCodeTests
     {
         [ConditionalFact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2223", FlakyOn.Helix.All)]
         public void GeneratedCodeIsUpToDate()
         {
             var httpHeadersGeneratedPath = Path.Combine(AppContext.BaseDirectory, "shared", "GeneratedContent", "HttpHeaders.Generated.cs");
             var httpProtocolGeneratedPath = Path.Combine(AppContext.BaseDirectory, "shared", "GeneratedContent", "HttpProtocol.Generated.cs");
             var httpUtilitiesGeneratedPath = Path.Combine(AppContext.BaseDirectory, "shared", "GeneratedContent", "HttpUtilities.Generated.cs");
             var http2ConnectionGeneratedPath = Path.Combine(AppContext.BaseDirectory, "shared", "GeneratedContent", "Http2Connection.Generated.cs");
-            var transportMultiplexedConnectionGeneratedPath = Path.Combine(AppContext.BaseDirectory,"shared", "GeneratedContent", "TransportMultiplexedConnection.Generated.cs");
-            var transportConnectionGeneratedPath = Path.Combine(AppContext.BaseDirectory,"shared", "GeneratedContent", "TransportConnection.Generated.cs");
+            var transportMultiplexedConnectionGeneratedPath = Path.Combine(AppContext.BaseDirectory, "shared", "GeneratedContent", "TransportMultiplexedConnection.Generated.cs");
+            var transportConnectionGeneratedPath = Path.Combine(AppContext.BaseDirectory, "shared", "GeneratedContent", "TransportConnection.Generated.cs");
 
             var testHttpHeadersGeneratedPath = Path.GetTempFileName();
             var testHttpProtocolGeneratedPath = Path.GetTempFileName();

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -596,7 +596,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Fact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2178", FlakyOn.All)]
         public async Task DoesNotOverrideDirectConfigurationWithIServerAddressesFeature_IfPreferHostingUrlsFalse()
         {
             var useUrlsAddress = $"http://127.0.0.1:0";
@@ -881,7 +880,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         var exception = Assert.Throws<IOException>(() => host.Start());
 
                         var thisAddressString = $"http://{(addressFamily == AddressFamily.InterNetwork ? "127.0.0.1" : "[::1]")}:{port}";
-                        var otherAddressString = $"http://{(addressFamily == AddressFamily.InterNetworkV6? "127.0.0.1" : "[::1]")}:{port}";
+                        var otherAddressString = $"http://{(addressFamily == AddressFamily.InterNetworkV6 ? "127.0.0.1" : "[::1]")}:{port}";
 
                         if (exception.Message == CoreStrings.FormatEndpointAlreadyInUse(otherAddressString))
                         {

--- a/src/Servers/Kestrel/test/FunctionalTests/ConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ConnectionMiddlewareTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class ConnectionMiddlewareTests : LoggedTest
     {
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         [Fact]
         public async Task ThrowingSynchronousConnectionMiddlewareDoesNotCrashServer()
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -45,7 +45,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
         [CollectDump]
         [ConditionalFact]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/9985", Queues = "Fedora.28.Amd64;Fedora.28.Amd64.Open")]
-        [Flaky("https://github.com/dotnet/aspnetcore/issues/9985", FlakyOn.All)]
         public async Task GracefulShutdownWaitsForRequestsToFinish()
         {
             var requestStarted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -101,7 +100,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2667", FlakyOn.All)]
         public async Task GracefulTurnsAbortiveIfRequestsDoNotFinish()
         {
             var requestStarted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -132,9 +132,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [IPv6SupportedCondition]
-#if LIBUV
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/1977", FlakyOn.Helix.All)] // https://github.com/dotnet/aspnetcore/issues/8109
-#endif
         public Task RemoteIPv6Address()
         {
             return TestRemoteIPAddress("[::1]", "[::1]", "::1");
@@ -538,7 +535,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2181", FlakyOn.Helix.All)]
         [MemberData(nameof(ConnectionMiddlewareData))]
         public async Task ConnectionClosedTokenFiresOnServerFIN(ListenOptions listenOptions)
         {
@@ -791,9 +787,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-#if LIBUV
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/1971", FlakyOn.Helix.All)]
-#endif
         [MemberData(nameof(ConnectionMiddlewareData))]
         public async Task AppCanHandleClientAbortingConnectionMidRequest(ListenOptions listenOptions)
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -339,7 +339,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/1972", FlakyOn.All)]
         [MemberData(nameof(ConnectionMiddlewareData))]
         public async Task AppCanHandleClientAbortingConnectionMidResponse(ListenOptions listenOptions)
         {
@@ -640,7 +639,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Fact]
-        [Flaky("<no longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task ConnectionClosedWhenBothRequestAndResponseExperienceBackPressure()
         {
             const int bufferSize = 65536;
@@ -735,7 +733,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [ConditionalFact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2181", FlakyOn.All)]
         public async Task ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseChunks()
         {
             var chunkSize = 64 * 128 * 1024;
@@ -815,7 +812,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Fact]
         [CollectDump]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseHeaders()
         {
             var headerSize = 1024 * 1024; // 1 MB for each header value
@@ -903,7 +899,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Fact]
-        [Flaky("https://github.com/dotnet/aspnetcore/issues/13219", FlakyOn.AzP.Linux, FlakyOn.Helix.All)]
         public async Task ClientCanReceiveFullConnectionCloseResponseWithoutErrorAtALowDataRate()
         {
             var chunkSize = 64 * 128 * 1024;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -310,7 +310,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Theory]
-        [Flaky("<no longer needed; tracked in Kusto>", FlakyOn.All)]
         [InlineData(HttpProtocols.Http1)]
         [InlineData(HttpProtocols.Http1AndHttp2)] // Make sure Http/1.1 doesn't regress with Http/2 enabled.
         public async Task CertificatePassedToHttpContext(HttpProtocols httpProtocols)
@@ -391,7 +390,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Theory]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/1976", FlakyOn.All)]
         [InlineData(ClientCertificateMode.AllowCertificate)]
         [InlineData(ClientCertificateMode.RequireCertificate)]
         public async Task ClientCertificateValidationGetsCalledWithNotNullParameters(ClientCertificateMode mode)
@@ -426,7 +424,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalTheory]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/1950", FlakyOn.Helix.All)]
         [InlineData(ClientCertificateMode.AllowCertificate)]
         [InlineData(ClientCertificateMode.RequireCertificate)]
         public async Task ValidationFailureRejectsConnection(ClientCertificateMode mode)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/LoggingConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/LoggingConnectionMiddlewareTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
     public class LoggingConnectionMiddlewareTests : LoggedTest
     {
         [Fact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2276", FlakyOn.Helix.All)]
         public async Task LoggingConnectionMiddlewareCanBeAddedBeforeAndAfterHttps()
         {
             await using (var server = new TestServer(context =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -790,7 +790,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/2176", FlakyOn.All)]
         public async Task ContentLengthReadAsyncSingleBytesAtATime()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -2541,7 +2541,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        [Flaky("https://github.com/dotnet/aspnetcore/issues/12401", FlakyOn.All)]
         public async Task AppAbortViaIConnectionLifetimeFeatureIsLogged()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -520,7 +520,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         [LogLevel(LogLevel.Trace)]
-        [Flaky("<No longer used; tracked in Kusto>", FlakyOn.All)]
         public async Task StreamAsyncTest(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubProtocolVersionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubProtocolVersionTests.cs
@@ -65,7 +65,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task ClientUsingOldCallWithNewProtocol(HttpTransportType transportType)
         {
             using (var server = await StartServer<VersionStartup>())
@@ -99,7 +98,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
-        [Flaky("<No longer used; tracked in Kusto>", FlakyOn.All)]
         public async Task ClientUsingNewCallWithNewProtocol(HttpTransportType transportType)
         {
             using (var server = await StartServer<VersionStartup>())

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1295,7 +1295,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task RequestToActiveConnectionIdKillsPreviousConnectionLongPolling()
         {
             using (StartVerifiableLog())

--- a/src/SignalR/server/SignalR/test/EndToEndTests.cs
+++ b/src/SignalR/server/SignalR/test/EndToEndTests.cs
@@ -308,7 +308,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [ConditionalTheory]
-        [Flaky("https://github.com/dotnet/aspnetcore-internal/issues/1383", FlakyOn.All)]
         [WebSocketsSupportedCondition]
         [InlineData(5 * 4096)]
         [InlineData(1000 * 4096 + 32)]

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -1039,7 +1039,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
-        [Flaky("<No longer used; tracked in Kusto>", FlakyOn.All)]
         public async Task HubMethodCanBeRenamedWithAttribute()
         {
             using (StartVerifiableLog())

--- a/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [Flaky("<no longer needed; tracked in Kusto>", FlakyOn.All)]
         public void AddsEscapedSpecificSecretIdToProject()
         {
             const string SecretId = @"<lots of XML invalid values>&";

--- a/src/Tools/dotnet-watch/test/GlobbingAppTests.cs
+++ b/src/Tools/dotnet-watch/test/GlobbingAppTests.cs
@@ -104,11 +104,10 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [Fact]
-        [Flaky("<No longer needed; tracked in Kusto>", FlakyOn.All)]
         public async Task ListsFiles()
         {
             await _app.PrepareAsync();
-            _app.Start(new [] { "--list" });
+            _app.Start(new[] { "--list" });
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(30));
             var lines = await _app.Process.GetAllOutputLinesAsync(cts.Token);

--- a/src/Tools/dotnet-watch/test/ProgramTests.cs
+++ b/src/Tools/dotnet-watch/test/ProgramTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         }
 
         [Fact]
-        [Flaky("<No longer required; Tracked in Kusto>", FlakyOn.All)]
         public async Task ConsoleCancelKey()
         {
             _tempDir


### PR DESCRIPTION
These are all tests that meet the following criteria:

1. Have passed 100% of runs for the past 30 days
1. Have had at least 150 total runs
1. Have been approved for unquarantining by the "owners" (Servers/SignalR team, etc.)

I've closed all the linked issues (for those that have issues). This may cause a little thrashing as some of these may pop back up again, but a reset seems in order here. For some tests, we've taken some specific actions to deflake them. For others, we believe that other infrastructure changes (moving to Helix, etc.) have improved reliability.