### PR TITLE
Add HeaderNames.XRequestedWith = "X-Requested-With"

### DIFF
--- a/src/Http/Headers/ref/Microsoft.Net.Http.Headers.netcoreapp.cs
+++ b/src/Http/Headers/ref/Microsoft.Net.Http.Headers.netcoreapp.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Net.Http.Headers
         public static readonly string WebSocketSubProtocols;
         public static readonly string WWWAuthenticate;
         public static readonly string XFrameOptions;
+        public static readonly string XRequestedWith;
     }
     public static partial class HeaderQuality
     {

--- a/src/Http/Headers/src/HeaderNames.cs
+++ b/src/Http/Headers/src/HeaderNames.cs
@@ -88,5 +88,6 @@ namespace Microsoft.Net.Http.Headers
         public static readonly string WebSocketSubProtocols = "Sec-WebSocket-Protocol";
         public static readonly string WWWAuthenticate = "WWW-Authenticate";
         public static readonly string XFrameOptions = "X-Frame-Options";
+        public static readonly string XRequestedWith = "X-Requested-With";
     }
 }

--- a/src/Identity/test/InMemory.Test/FunctionalTest.cs
+++ b/src/Identity/test/InMemory.Test/FunctionalTest.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Net.Http.Headers;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -425,7 +426,7 @@ namespace Microsoft.AspNetCore.Identity.InMemory
             }
             if (ajaxRequest)
             {
-                request.Headers.Add("X-Requested-With", "XMLHttpRequest");
+                request.Headers.Add(HeaderNames.XRequestedWith, "XMLHttpRequest");
             }
             var transaction = new Transaction
             {

--- a/src/Identity/test/InMemory.Test/FunctionalTest.cs
+++ b/src/Identity/test/InMemory.Test/FunctionalTest.cs
@@ -17,8 +17,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Net.Http.Headers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Identity.InMemory

--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
@@ -9,7 +9,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Authentication.Cookies
 {
     /// <summary>
-    /// This default implementation of the ICookieAuthenticationEvents may be used if the 
+    /// This default implementation of the ICookieAuthenticationEvents may be used if the
     /// application only needs to override a few of the interface methods. This may be used as a base class
     /// or may be instantiated directly.
     /// </summary>
@@ -103,9 +103,9 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
 
         private static bool IsAjaxRequest(HttpRequest request)
         {
-            return string.Equals(request.Query["X-Requested-With"], "XMLHttpRequest", StringComparison.Ordinal) ||
-                string.Equals(request.Headers["X-Requested-With"], "XMLHttpRequest", StringComparison.Ordinal);
-        }		
+            return string.Equals(request.Query[HeaderNames.XRequestedWith], "XMLHttpRequest", StringComparison.Ordinal) ||
+                string.Equals(request.Headers[HeaderNames.XRequestedWith], "XMLHttpRequest", StringComparison.Ordinal);
+        }
 
         /// <summary>
         /// Implements the interface method by invoking the related delegate method.

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Transport.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Transport.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.AspNetCore.Http.Connections.Client.Internal;
 using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
@@ -162,7 +163,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                 testHttpHandler.OnRequest(async (request, next, token) =>
                 {
-                    var requestedWithHeader = request.Headers.GetValues("X-Requested-With");
+                    var requestedWithHeader = request.Headers.GetValues(HeaderNames.XRequestedWith);
                     var requestedWithValue = Assert.Single(requestedWithHeader);
                     Assert.Equal("XMLHttpRequest", requestedWithValue);
 

--- a/src/SignalR/server/SignalR/test/WebSocketsTransportTests.cs
+++ b/src/SignalR/server/SignalR/test/WebSocketsTransportTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.AspNetCore.Http.Connections.Client.Internal;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -103,7 +104,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await webSocketsTransport.StartAsync(new Uri(server.WebSocketsUrl + "/httpheader"),
                     TransferFormat.Binary).OrTimeout();
 
-                await webSocketsTransport.Output.WriteAsync(Encoding.UTF8.GetBytes("X-Requested-With"));
+                await webSocketsTransport.Output.WriteAsync(Encoding.UTF8.GetBytes(HeaderNames.XRequestedWith));
 
                 // The HTTP header endpoint closes the connection immediately after sending response which should stop the transport
                 await webSocketsTransport.Running.OrTimeout();


### PR DESCRIPTION
X-Requested-With is the standard for differentiating AJAX requests and is commonly used. Having this in HeaderNames would prevent typos related to typing this header name. I couldn't find any rationale about excluding this but there might be legitimate reasons like discouraging the use of HTTP headers or differentiating AJAX requests, etc. Please reject this if that's the case.

https://github.com/dotnet/aspnetcore/issues/19478