### PR TITLE
Bugfix: Form validation uses DisplayAttribute.Name

### DIFF
--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Components.Forms
@@ -54,6 +56,18 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// Gets the <see cref="FieldIdentifier"/> for the bound value.
         /// </summary>
         protected FieldIdentifier FieldIdentifier { get; set; }
+
+        /// <summary>
+        /// Gets the Name specified via <see cref="DisplayAttribute"/> for the field set in the <see cref="FieldIdentifier"/>
+        /// </summary>
+        protected string FieldDisplayName
+        {
+            get
+            {
+                MemberInfo fieldProperty = FieldIdentifier.Model.GetType().GetProperty(FieldIdentifier.FieldName);
+                return fieldProperty.GetCustomAttribute<DisplayAttribute>()?.Name;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the current value of the input.

--- a/src/Components/Web/src/Forms/InputDate.cs
+++ b/src/Components/Web/src/Forms/InputDate.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
             else
             {
-                validationErrorMessage = string.Format(ParsingErrorMessage, FieldIdentifier.FieldName);
+                validationErrorMessage = string.Format(ParsingErrorMessage, FieldDisplayName ?? FieldIdentifier.FieldName);
                 return false;
             }
         }

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
             else
             {
-                validationErrorMessage = string.Format(ParsingErrorMessage, FieldIdentifier.FieldName);
+                validationErrorMessage = string.Format(ParsingErrorMessage, FieldDisplayName ?? FieldIdentifier.FieldName);
                 return false;
             }
         }

--- a/src/Components/Web/test/Forms/InputBaseTest.cs
+++ b/src/Components/Web/test/Forms/InputBaseTest.cs
@@ -4,10 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Test.Helpers;
 using Xunit;
 
@@ -35,7 +32,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             // Arrange
             var model = new TestModel();
             var rootComponent = new TestInputHostComponent<string, TestInputComponent<string>> { EditContext = new EditContext(model), ValueExpression = () => model.StringProperty };
-            await RenderAndGetTestInputComponentAsync(rootComponent);
+            await Render.RenderAndGetTestInputComponentAsync(rootComponent);
 
             // Act/Assert
             rootComponent.EditContext = new EditContext(model);
@@ -51,7 +48,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             var rootComponent = new TestInputHostComponent<string, TestInputComponent<string>> { EditContext = new EditContext(model) };
 
             // Act/Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => RenderAndGetTestInputComponentAsync(rootComponent));
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => Render.RenderAndGetTestInputComponentAsync(rootComponent));
             Assert.Contains($"{typeof(TestInputComponent<string>)} requires a value for the 'ValueExpression' parameter. Normally this is provided automatically when using 'bind-Value'.", ex.Message);
         }
 
@@ -68,7 +65,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             };
 
             // Act
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
 
             // Assert
             Assert.Equal("some value", inputComponent.CurrentValue);
@@ -87,7 +84,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             };
 
             // Act
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
 
             // Assert
             Assert.Same(rootComponent.EditContext, inputComponent.EditContext);
@@ -106,7 +103,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             };
 
             // Act
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
 
             // Assert
             Assert.Equal(FieldIdentifier.Create(() => model.StringProperty), inputComponent.FieldIdentifier);
@@ -123,7 +120,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 Value = "initial value",
                 ValueExpression = () => model.StringProperty
             };
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             Assert.Equal("initial value", inputComponent.CurrentValue);
 
             // Act
@@ -146,7 +143,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 ValueChanged = val => valueChangedCallLog.Add(val),
                 ValueExpression = () => model.StringProperty
             };
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             Assert.Empty(valueChangedCallLog);
 
             // Act
@@ -169,7 +166,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 ValueChanged = val => valueChangedCallLog.Add(val),
                 ValueExpression = () => model.StringProperty
             };
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             Assert.Empty(valueChangedCallLog);
 
             // Act
@@ -190,7 +187,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 Value = "initial value",
                 ValueExpression = () => model.StringProperty
             };
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             Assert.False(rootComponent.EditContext.IsModified(() => model.StringProperty));
 
             // Act
@@ -213,7 +210,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             var fieldIdentifier = FieldIdentifier.Create(() => model.StringProperty);
 
             // Act/Assert: Initially, it's valid and unmodified
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             Assert.Equal("valid", inputComponent.CssClass); //  no Class was specified
 
             // Act/Assert: Modify the field
@@ -251,7 +248,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             var fieldIdentifier = FieldIdentifier.Create(() => model.StringProperty);
 
             // Act/Assert
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             Assert.Equal("my-class other-class valid", inputComponent.CssClass);
 
             // Act/Assert: Retains custom class when changing field class
@@ -270,7 +267,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 Value = new DateTime(1915, 3, 2),
                 ValueExpression = () => model.DateProperty
             };
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
 
             // Act/Assert
             Assert.Equal("1915/03/02", inputComponent.CurrentValueAsString);
@@ -289,7 +286,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 ValueExpression = () => model.DateProperty
             };
             var fieldIdentifier = FieldIdentifier.Create(() => model.DateProperty);
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             var numValidationStateChanges = 0;
             rootComponent.EditContext.OnValidationStateChanged += (sender, eventArgs) => { numValidationStateChanges++; };
 
@@ -319,7 +316,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 ValueExpression = () => model.DateProperty
             };
             var fieldIdentifier = FieldIdentifier.Create(() => model.DateProperty);
-            var inputComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
             var numValidationStateChanges = 0;
             rootComponent.EditContext.OnValidationStateChanged += (sender, eventArgs) => { numValidationStateChanges++; };
 
@@ -400,21 +397,6 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.Empty(renderer.Batches.Skip(1));
         }
 
-        private static TComponent FindComponent<TComponent>(CapturedBatch batch)
-            => batch.ReferenceFrames
-                    .Where(f => f.FrameType == RenderTreeFrameType.Component)
-                    .Select(f => f.Component)
-                    .OfType<TComponent>()
-                    .Single();
-
-        private static async Task<TComponent> RenderAndGetTestInputComponentAsync<TValue, TComponent>(TestInputHostComponent<TValue, TComponent> hostComponent) where TComponent : TestInputComponent<TValue>
-        {
-            var testRenderer = new TestRenderer();
-            var componentId = testRenderer.AssignRootComponentId(hostComponent);
-            await testRenderer.RenderRootComponentAsync(componentId);
-            return FindComponent<TComponent>(testRenderer.Batches.Single());
-        }
-
         class TestModel
         {
             public string StringProperty { get; set; }
@@ -477,36 +459,6 @@ namespace Microsoft.AspNetCore.Components.Forms
                     validationErrorMessage = "Bad date value";
                     return false;
                 }
-            }
-        }
-
-        class TestInputHostComponent<TValue, TComponent> : AutoRenderComponent where TComponent : TestInputComponent<TValue>
-        {
-            public Dictionary<string, object> AdditionalAttributes { get; set; }
-
-            public EditContext EditContext { get; set; }
-
-            public TValue Value { get; set; }
-
-            public Action<TValue> ValueChanged { get; set; }
-
-            public Expression<Func<TValue>> ValueExpression { get; set; }
-
-            protected override void BuildRenderTree(RenderTreeBuilder builder)
-            {
-                builder.OpenComponent<CascadingValue<EditContext>>(0);
-                builder.AddAttribute(1, "Value", EditContext);
-                builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
-                {
-                    childBuilder.OpenComponent<TComponent>(0);
-                    childBuilder.AddAttribute(0, "Value", Value);
-                    childBuilder.AddAttribute(1, "ValueChanged",
-                        EventCallback.Factory.Create(this, ValueChanged));
-                    childBuilder.AddAttribute(2, "ValueExpression", ValueExpression);
-                    childBuilder.AddMultipleAttributes(3, AdditionalAttributes);
-                    childBuilder.CloseComponent();
-                }));
-                builder.CloseComponent();
             }
         }
     }

--- a/src/Components/Web/test/Forms/InputDateTest.cs
+++ b/src/Components/Web/test/Forms/InputDateTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    public class InputDateTest
+    {
+        [Fact]
+        public async Task ValidationErrorUsesDisplayAttributeName()
+        {
+            // Arrange
+            var model = new TestModelWithDisplayProperty();
+            var rootComponent = new TestInputHostComponent<DateTime, TestInputDateComponent>
+            {
+                EditContext = new EditContext(model),
+                ValueExpression = () => model.DateProperty
+            };
+            var fieldIdentifier = FieldIdentifier.Create(() => model.DateProperty);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
+
+            // Act
+            await inputComponent.SetCurrentValueAsStringAsync("InvalidDateValue");
+
+            // Assert
+            var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+            Assert.NotEmpty(validationMessages);
+            Assert.Contains("The Birthday field must be a date.", validationMessages);
+        }
+
+        class TestModelWithDisplayProperty
+        {
+            [Display(Name = "Birthday")]
+            public DateTime DateProperty { get; set; }
+        }
+
+        class TestInputDateComponent : InputDate<DateTime>
+        {
+            // Expose protected members publicly for tests
+
+            public new EditContext EditContext
+            {
+                get => base.EditContext;
+                set { base.EditContext = value; }
+            }
+
+            public async Task SetCurrentValueAsStringAsync(string value)
+            {
+                // This is equivalent to the subclass writing to CurrentValueAsString
+                // (e.g., from @bind), except to simplify the test code there's an InvokeAsync
+                // here. In production code it wouldn't normally be required because @bind
+                // calls run on the sync context anyway.
+                await InvokeAsync(() => { base.CurrentValueAsString = value; });
+            }
+        }
+    }
+}

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    public class InputNumberTest
+    {
+        [Fact]
+        public async Task ValidationErrorUsesDisplayAttributeName()
+        {
+            // Arrange
+            var model = new TestModelWithDisplayProperty();
+            var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent>
+            {
+                EditContext = new EditContext(model),
+                ValueExpression = () => model.NumberProperty
+            };
+            var fieldIdentifier = FieldIdentifier.Create(() => model.NumberProperty);
+            var inputComponent = await Render.RenderAndGetTestInputComponentAsync(rootComponent);
+
+            // Act
+            await inputComponent.SetCurrentValueAsStringAsync("InvalidNumberValue");
+
+            // Assert
+            var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+            Assert.NotEmpty(validationMessages);
+            Assert.Contains("The Height field must be a number.", validationMessages);
+        }
+
+        class TestModelWithDisplayProperty
+        {
+            [Display(Name = "Height")]
+            public int NumberProperty { get; set; }
+        }
+
+        class TestInputNumberComponent : InputNumber<int>
+        {
+            // Expose protected members publicly for tests
+
+            public new EditContext EditContext
+            {
+                get => base.EditContext;
+                set { base.EditContext = value; }
+            }
+
+            public async Task SetCurrentValueAsStringAsync(string value)
+            {
+                // This is equivalent to the subclass writing to CurrentValueAsString
+                // (e.g., from @bind), except to simplify the test code there's an InvokeAsync
+                // here. In production code it wouldn't normally be required because @bind
+                // calls run on the sync context anyway.
+                await InvokeAsync(() => { base.CurrentValueAsString = value; });
+            }
+        }
+    }
+}

--- a/src/Components/Web/test/Forms/Render.cs
+++ b/src/Components/Web/test/Forms/Render.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    internal static class Render
+    {
+        public static async Task<TComponent> RenderAndGetTestInputComponentAsync<TValue, TComponent>(TestInputHostComponent<TValue, TComponent> hostComponent) where TComponent : InputBase<TValue>
+        {
+            var testRenderer = new TestRenderer();
+            var componentId = testRenderer.AssignRootComponentId(hostComponent);
+            await testRenderer.RenderRootComponentAsync(componentId);
+            return FindComponent<TComponent>(testRenderer.Batches.Single());
+        }
+
+        private static TComponent FindComponent<TComponent>(CapturedBatch batch)
+            => batch.ReferenceFrames
+                    .Where(f => f.FrameType == RenderTreeFrameType.Component)
+                    .Select(f => f.Component)
+                    .OfType<TComponent>()
+                    .Single();
+    }
+}

--- a/src/Components/Web/test/Forms/TestInputHostComponent.cs
+++ b/src/Components/Web/test/Forms/TestInputHostComponent.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    internal class TestInputHostComponent<TValue, TComponent> : AutoRenderComponent where TComponent : InputBase<TValue>
+    {
+        public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+        public EditContext EditContext { get; set; }
+
+        public TValue Value { get; set; }
+
+        public Action<TValue> ValueChanged { get; set; }
+
+        public Expression<Func<TValue>> ValueExpression { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<CascadingValue<EditContext>>(0);
+            builder.AddAttribute(1, "Value", EditContext);
+            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            {
+                childBuilder.OpenComponent<TComponent>(0);
+                childBuilder.AddAttribute(0, "Value", Value);
+                childBuilder.AddAttribute(1, "ValueChanged",
+                    EventCallback.Factory.Create(this, ValueChanged));
+                childBuilder.AddAttribute(2, "ValueExpression", ValueExpression);
+                childBuilder.AddMultipleAttributes(3, AdditionalAttributes);
+                childBuilder.CloseComponent();
+            }));
+            builder.CloseComponent();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #11414

Blazor Form Validation ignores the DisplayAttribute applied to the model. The issue is reported only for InputDate but also affects InputNumber so the fix is applied there as well.

Created a new protected property in InputBase.cs that retrieves the DisplayAttribute.Name via reflection.

Had to refactor the tests in InputBaseTest to avoid code-duplication.

Side note:
I'm based in Europe and my development machine uses different settings for the date formats. So many (about 40) tests fail for me like so:

 Microsoft.AspNetCore.Components.E2ETest.Tests.BindTest.CanBindTextboxDateTime
   Source: BindTest.cs line 718
   Duration: 92 ms

  Message: 
    Assert.Equal() Failure
    Expected: 1985-03-04T00:00:00.0000000
    Actual:   1985-04-03T00:00:00.0000000
  Stack Trace: 
    BindTest.CanBindTextboxDateTime() line 724

Is this expected?