### PR TITLE
Preserve new lines and whitespace when adding secret

### DIFF
--- a/src/Tools/dotnet-user-secrets/src/Internal/InitCommand.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/InitCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
             var projectPath = ResolveProjectPath(ProjectPath, WorkingDirectory);
 
             // Load the project file as XML
-            var projectDocument = XDocument.Load(projectPath);
+            var projectDocument = XDocument.Load(projectPath, LoadOptions.PreserveWhitespace);
 
             // Accept the `--id` CLI option to the main app
             string newSecretsId = string.IsNullOrWhiteSpace(OverrideId)
@@ -120,19 +120,18 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
                 }
 
                 // Add UserSecretsId element
+                propertyGroup.Add("  ");
                 propertyGroup.Add(new XElement("UserSecretsId", newSecretsId));
+                propertyGroup.Add($"{Environment.NewLine}  ");
             }
 
             var settings = new XmlWriterSettings
             {
-                Indent = true,
                 OmitXmlDeclaration = true,
             };
 
-            using (var xw = XmlWriter.Create(projectPath, settings))
-            {
-                projectDocument.Save(xw);
-            }
+            using var xw = XmlWriter.Create(projectPath, settings);
+            projectDocument.Save(xw);
 
             context.Reporter.Output(Resources.FormatMessage_SetUserSecretsIdForProject(newSecretsId, projectPath));
         }

--- a/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Testing;
@@ -94,6 +95,22 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
 
             var projectDocument = XDocument.Load(projectFile);
             Assert.Null(projectDocument.Declaration);
+        }
+
+        [Fact]
+        public void DoesNotRemoveBlankLines()
+        {
+            var projectDir = _fixture.CreateProject(null);
+            var projectFile = Path.Combine(projectDir, "TestProject.csproj");
+            var projectDocumentWithoutSecret = XDocument.Load(projectFile, LoadOptions.PreserveWhitespace);
+            var lineCountWithoutSecret = projectDocumentWithoutSecret.ToString().Split(Environment.NewLine).Length;
+
+            new InitCommand(null, null).Execute(MakeCommandContext(), projectDir);
+
+            var projectDocumentWithSecret = XDocument.Load(projectFile, LoadOptions.PreserveWhitespace);
+            var lineCountWithSecret = projectDocumentWithSecret.ToString().Split(Environment.NewLine).Length;
+
+            Assert.True(lineCountWithSecret == lineCountWithoutSecret + 1);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/19298

Summary of the changes
- Preserve existing formatting of project file when loading
- Manually insert spacing and new line when adding `UserSecretsId` element to project file (necessary because we've indicated that whitespace should be preserved)
- Replace existing `using` statement with C# 8 using declaration
- Add a unit test to confirm that the modified project file (with the `UserSecretsId` element) contains exactly 1 more line

Project file before:

```xml
<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
    
    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="**\*.cs" Exclude="Excluded.cs;$(DefaultItemExcludes)" />
  </ItemGroup>
</Project>
```

Project file after:

```xml
<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
    
    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
    <UserSecretsId>06af5cc9-a276-4fbe-b65c-5bbd10f5280c</UserSecretsId>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="**\*.cs" Exclude="Excluded.cs;$(DefaultItemExcludes)" />
  </ItemGroup>
</Project>
```