### PR TITLE
Enable detailed msbuild verbosity for user secrets

### DIFF
--- a/src/Tools/Shared/TestHelpers/TestConsole.cs
+++ b/src/Tools/Shared/TestHelpers/TestConsole.cs
@@ -91,6 +91,8 @@ namespace Microsoft.Extensions.Tools.Internal
                         _output.WriteLine(_sb.ToString());
                         _sb.Clear();
                     }
+
+                    _currentOutput.Append(value);
                 }
                 else
                 {

--- a/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
+using System.Text;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Tools.Internal;
 
@@ -53,26 +53,51 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
                     "/p:Configuration=" + configuration,
                     "/p:CustomAfterMicrosoftCommonTargets=" + _targetsFile,
                     "/p:CustomAfterMicrosoftCommonCrossTargetingTargets=" + _targetsFile,
+                    "-verbosity:detailed",
                 };
                 var psi = new ProcessStartInfo
                 {
                     FileName = DotNetMuxer.MuxerPathOrDefault(),
                     Arguments = ArgumentEscaper.EscapeAndConcatenate(args),
                     RedirectStandardOutput = true,
-                    RedirectStandardError = true
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
                 };
 
 #if DEBUG
                 _reporter.Verbose($"Invoking '{psi.FileName} {psi.Arguments}'");
 #endif
 
-                using var process = Process.Start(psi);
+                using var process = new Process()
+                {
+                    StartInfo = psi,
+                };
+
+                var outputBuilder = new StringBuilder();
+                var errorBuilder = new StringBuilder();
+                process.OutputDataReceived += (_, d) =>
+                {
+                    if (!string.IsNullOrEmpty(d.Data))
+                    {
+                        outputBuilder.AppendLine(d.Data);
+                    }
+                };
+                process.ErrorDataReceived += (_, d) =>
+                {
+                    if (!string.IsNullOrEmpty(d.Data))
+                    {
+                        errorBuilder.AppendLine(d.Data);
+                    }
+                };
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
                 process.WaitForExit();
 
                 if (process.ExitCode != 0)
                 {
-                    _reporter.Verbose(process.StandardOutput.ReadToEnd());
-                    _reporter.Verbose(process.StandardError.ReadToEnd());
+                    _reporter.Verbose(outputBuilder.ToString());
+                    _reporter.Verbose(errorBuilder.ToString());
                     throw new InvalidOperationException(Resources.FormatError_ProjectFailedToLoad(projectFile));
                 }
 


### PR DESCRIPTION
This will make the verbose output for errors a lot bigger, but that should be rare?