### PR TITLE
Use browser APIs to calculate Blazor's download size

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkResult.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkResult.cs
@@ -1,24 +1,13 @@
+using System.Collections.Generic;
+
 namespace Wasm.Performance.Driver
 {
     class BenchmarkResult
     {
-        public string Name { get; set; }
+        /// <summary>The result of executing scenario benchmarks</summary>
+        public List<BenchmarkScenarioResult> ScenarioResults { get; set; }
 
-        public BenchmarkDescriptor Descriptor { get; set; }
-
-        public string ShortDescription { get; set; }
-
-        public bool Success { get; set; }
-
-        public int NumExecutions { get; set; }
-
-        public double Duration { get; set; }
-
-        public class BenchmarkDescriptor
-        {
-            public string Name { get; set; }
-
-            public string Description { get; set; }
-        }
+        /// <summary>Downloaded application size in bytes</summary>
+        public long DownloadSize { get; set; }
     }
 }

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkResultsStartup.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkResultsStartup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -25,7 +24,7 @@ namespace Wasm.Performance.Driver
 
             app.Run(async context =>
             {
-                var result = await JsonSerializer.DeserializeAsync<List<BenchmarkResult>>(context.Request.Body, new JsonSerializerOptions
+                var result = await JsonSerializer.DeserializeAsync<BenchmarkResult>(context.Request.Body, new JsonSerializerOptions
                 {
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 });

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkScenarioResult.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/BenchmarkScenarioResult.cs
@@ -1,0 +1,24 @@
+namespace Wasm.Performance.Driver
+{
+    class BenchmarkScenarioResult
+    {
+        public string Name { get; set; }
+
+        public BenchmarkDescriptor Descriptor { get; set; }
+
+        public string ShortDescription { get; set; }
+
+        public bool Success { get; set; }
+
+        public int NumExecutions { get; set; }
+
+        public double Duration { get; set; }
+
+        public class BenchmarkDescriptor
+        {
+            public string Name { get; set; }
+
+            public string Description { get; set; }
+        }
+    }
+}

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -16,5 +16,15 @@
     <ProjectReference Include="..\..\..\WebAssembly\DevServer\src\Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj" />
     <ProjectReference Include="..\TestApp\Wasm.Performance.TestApp.csproj" />
   </ItemGroup>
+
+  <Target Name="_AddTestProjectMetadataAttributes" BeforeTargets="BeforeCompile">
+    <ItemGroup>
+      <AssemblyAttribute
+        Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>TestAppLocatiion</_Parameter1>
+        <_Parameter2>$(MSBuildThisFileDirectory)..\TestApp\</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Pages/Index.razor
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Pages/Index.razor
@@ -6,6 +6,6 @@ Hello, world!
 @code {
     protected override void OnAfterRender(bool firstRender)
     {
-        BenchmarkEvent.Send(JSRuntime, "Rendered index.cshtml");
+        BenchmarkEvent.Send(JSRuntime, "Rendered Index.razor");
     }
 }

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/wwwroot/benchmarks/blazorDownloadSize.js
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/wwwroot/benchmarks/blazorDownloadSize.js
@@ -1,0 +1,17 @@
+import { BlazorApp } from './util/BlazorApp.js';
+
+export async function getBlazorDownloadSize() {
+  // Clear caches
+  for (var key of await caches.keys()) {
+    await caches.delete(key);
+  }
+
+  const app = new BlazorApp();
+  try {
+    await app.start();
+    const downloadSize = app.window.performance.getEntries().reduce((prev, next) => (next.encodedBodySize || 0) + prev, 0);
+    return downloadSize;
+  } finally {
+    app.dispose();
+  }
+}

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/wwwroot/benchmarks/index.js
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/wwwroot/benchmarks/index.js
@@ -4,37 +4,47 @@ import './appStartup.js';
 import './renderList.js';
 import './jsonHandling.js';
 import './orgChart.js';
+import { getBlazorDownloadSize } from './blazorDownloadSize.js';
 
 new HtmlUI('E2E Performance', '#display');
 
 if (location.href.indexOf('#automated') !== -1) {
-  const query = new URLSearchParams(window.location.search);
-  const group = query.get('group');
-  const resultsUrl = query.get('resultsUrl');
+  (async function() {
+    const query = new URLSearchParams(window.location.search);
+    const group = query.get('group');
+    const resultsUrl = query.get('resultsUrl');
 
-  groups.filter(g => !group || g.name === group).forEach(g => g.runAll());
+    console.log('Calculating download size...');
+    const downloadSize = await getBlazorDownloadSize();
+    console.log('Download size: ', downloadSize);
 
-  const benchmarksResults = [];
-  onBenchmarkEvent(async (status, args) => {
-    switch (status) {
+    const scenarioResults = [];
+    groups.filter(g => !group || g.name === group).forEach(g => g.runAll());
+
+    onBenchmarkEvent(async (status, args) => {
+      switch (status) {
         case BenchmarkEvent.runStarted:
-          benchmarksResults.length = 0;
+          scenarioResults.length = 0;
           break;
         case BenchmarkEvent.benchmarkCompleted:
         case BenchmarkEvent.benchmarkError:
           console.log(`Completed benchmark ${args.name}`);
-          benchmarksResults.push(args);
+          scenarioResults.push(args);
           break;
         case BenchmarkEvent.runCompleted:
-            if (resultsUrl) {
-              await fetch(resultsUrl, {
-                method: 'post',
-                body: JSON.stringify(benchmarksResults)
-              });
-            }
-            break;
+          if (resultsUrl) {
+            await fetch(resultsUrl, {
+              method: 'post',
+              body: JSON.stringify({
+                downloadSize: downloadSize,
+                scenarioResults: scenarioResults
+              })
+            });
+          }
+          break;
         default:
           throw new Error(`Unknown status: ${status}`);
       }
-  })
+    });
+  })();
 }

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/wwwroot/benchmarks/util/BlazorApp.js
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/wwwroot/benchmarks/util/BlazorApp.js
@@ -12,7 +12,7 @@ export class BlazorApp {
 
   async start() {
     this._frame.src = 'blazor-frame.html';
-    await receiveEvent('Rendered index.cshtml');
+    await receiveEvent('Rendered Index.razor');
   }
 
   navigateTo(url) {


### PR DESCRIPTION
The publish sizes in our Benchmarks have been broken since the change to the output structure. Looking at the size on disk is also a little cumbersome, since we have to not double count. It seems like it's much more useful to measure the network download size instead. 