### PR TITLE
Quarantining some tests

### DIFF
--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/EventTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/EventTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
@@ -20,6 +21,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication.Negotiate
 {
+    [QuarantinedTest]
     public class EventTests
     {
         [Fact]

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/Microsoft.AspNetCore.Authentication.Negotiate.Test.csproj
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/Microsoft.AspNetCore.Authentication.Negotiate.Test.csproj
@@ -12,6 +12,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.Negotiate" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
@@ -21,6 +22,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Authentication.Negotiate
 {
+    [QuarantinedTest]
     public class NegotiateHandlerTests
     {
         [Fact]

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/ServerDeferralTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/ServerDeferralTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication.Negotiate
 {
+    [QuarantinedTest]
     public class ServerDeferralTests
     {
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -153,6 +153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task StreamPool_MultipleStreamsInSequence_PooledStreamReused()
         {
             TaskCompletionSource<object> appDelegateTcs = null;
@@ -1175,7 +1176,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task Frame_MultipleStreams_CanBeCreatedIfClientCountIsLessThanActualMaxStreamCount()
         {
-            _serviceContext.ServerOptions.Limits.Http2.MaxStreamsPerConnection = 1; 
+            _serviceContext.ServerOptions.Limits.Http2.MaxStreamsPerConnection = 1;
             var firstRequestBlock = new TaskCompletionSource<object>();
             var firstRequestReceived = new TaskCompletionSource<object>();
             var makeFirstRequestWait = false;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -790,6 +790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task ContentLengthReadAsyncSingleBytesAtATime()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -2541,6 +2541,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task AppAbortViaIConnectionLifetimeFeatureIsLogged()
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1189,6 +1189,7 @@ namespace Interop.FunctionalTests
         // Nor does Kestrel yet support sending dynamic table updates, so there's nothing to test here. https://github.com/dotnet/aspnetcore/issues/4715
 
         [Theory]
+        [QuarantinedTest]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxConcurrentStreamsGet_Server(string scheme)
         {

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2769,6 +2769,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task ReceivingMessagesPreventsConnectionTimeoutFromOccuring()
         {
             using (StartVerifiableLog())


### PR DESCRIPTION
A few HTTP2 tests have been flaking out. Also, all of the Negotiate tests went haywire with a DI failure. Seems to have been a one-off, but quarantining them while we investigate.