### PR TITLE
try re-enabling http2 interop tests on helix

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -6,8 +6,6 @@
     <TestGroupName>Interop.FunctionalTests</TestGroupName>
     <!-- WebDriver is not strong named, so this test assembly cannot be strong-named either. -->
     <SignAssembly>false</SignAssembly>
-    <!-- See: https://github.com/dotnet/aspnetcore/issues/7299 -->
-    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The referenced issue is closed and even if it's still there we should try to resolve this and get the test in Helix. Opening a PR to try.

TODO:
* [x] Check for these results in Kusto