### PR TITLE
#18555 - Added condition to Tokenizer 

### DIFF
--- a/src/Middleware/Rewrite/src/ApacheModRewrite/Tokenizer.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/Tokenizer.cs
@@ -108,24 +108,19 @@ namespace Microsoft.AspNetCore.Rewrite.ApacheModRewrite
             {
                 var token = tokens[i];
                 var trimmed = token.Trim('\"');
-                switch (trimmed)
+
+                if (trimmed.Contains("\\d") || trimmed.Contains("\\w") || trimmed.Contains("\\s"))
                 {
-                    case "^/(\\d)$":
-                        tokens[i] = trimmed;
-                        break;
-
-                    case "^/(\\w)$":
-                        tokens[i] = trimmed;
-                        break;
-
-                    case "^/(\\s)$":
-                        tokens[i] = trimmed;
-                        break;
-
-                    default:
-                        tokens[i] = Regex.Unescape(trimmed);
-                        break;
+                    tokens[i] = trimmed;
                 }
+                else
+                {
+                    tokens[i] = Regex.Unescape(trimmed);
+                }
+                
+
+                    
+                
             }
         }
     }

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/Tokenizer.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/Tokenizer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -108,7 +108,24 @@ namespace Microsoft.AspNetCore.Rewrite.ApacheModRewrite
             {
                 var token = tokens[i];
                 var trimmed = token.Trim('\"');
-                tokens[i] = Regex.Unescape(trimmed);
+                switch (trimmed)
+                {
+                    case "^/(\\d)$":
+                        tokens[i] = trimmed;
+                        break;
+
+                    case "^/(\\w)$":
+                        tokens[i] = trimmed;
+                        break;
+
+                    case "^/(\\s)$":
+                        tokens[i] = trimmed;
+                        break;
+
+                    default:
+                        tokens[i] = Regex.Unescape(trimmed);
+                        break;
+                }
             }
         }
     }

--- a/src/Middleware/Rewrite/test/ApacheModRewrite/RewriteTokenizerTest.cs
+++ b/src/Middleware/Rewrite/test/ApacheModRewrite/RewriteTokenizerTest.cs
@@ -92,47 +92,22 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
             Assert.Equal("Mismatched number of quotes: \"", ex.Message);
         }
 
-        [Fact]
-        public void Tokenize_CheckRegexDigitDoesNotHitUnescape()
+        [Theory]
+        [InlineData("^/(\\d)$", "^/(\\d)$" )]
+        [InlineData("^/(\\w)$", "^/(\\w)$")]
+        [InlineData("^/(\\s)$", "^/(\\s)$")]
+        [InlineData("^/foo/(\\d)$", "^/foo/(\\d)$")]
+        [InlineData("^/foo/(\\w)$", "^/foo/(\\w)$")]
+        [InlineData("^/foo/(\\s)$", "^/foo/(\\s)$")]
+        public void Tokenize_CheckRegexUnescapableTypesDoNotHitUnescape(string testString, string expected)
         {
-            var testString = "RewriteRule ^/(\\d)$ /?num=$1";
+           // var testString = "RewriteRule ^/(\\d)$ /?num=$1";
             var tokens = new Tokenizer().Tokenize(testString);
 
-            var expected = new List<string>();
-            expected.Add(@"RewriteRule");
-            expected.Add(@"^/(\d)$");
-            expected.Add(@"/?num=$1");
-
-            Assert.Equal(expected, tokens);
+            Assert.Equal(expected, tokens[0]);
         }
 
-        [Fact]
-        public void Tokenize_CheckRegexWordDoesNotHitUnescape()
-        {
-            var testString = "RewriteRule ^/(\\w)$ /?num=$1";
-            var tokens = new Tokenizer().Tokenize(testString);
-
-            var expected = new List<string>();
-            expected.Add(@"RewriteRule");
-            expected.Add(@"^/(\w)$");
-            expected.Add(@"/?num=$1");
-
-            Assert.Equal(expected, tokens);
-        }
-
-        [Fact]
-        public void Tokenize_CheckRegexShorthandDoesNotHitUnescape()
-        {
-            var testString = "RewriteRule ^/(\\s)$ /?num=$1";
-            var tokens = new Tokenizer().Tokenize(testString);
-
-            var expected = new List<string>();
-            expected.Add(@"RewriteRule");
-            expected.Add(@"^/(\s)$");
-            expected.Add(@"/?num=$1");
-
-            Assert.Equal(expected, tokens);
-        }
+       
 
 
     }

--- a/src/Middleware/Rewrite/test/ApacheModRewrite/RewriteTokenizerTest.cs
+++ b/src/Middleware/Rewrite/test/ApacheModRewrite/RewriteTokenizerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -91,5 +91,49 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
             var ex = Assert.Throws<FormatException>(() => new Tokenizer().Tokenize("\""));
             Assert.Equal("Mismatched number of quotes: \"", ex.Message);
         }
+
+        [Fact]
+        public void Tokenize_CheckRegexDigitDoesNotHitUnescape()
+        {
+            var testString = "RewriteRule ^/(\\d)$ /?num=$1";
+            var tokens = new Tokenizer().Tokenize(testString);
+
+            var expected = new List<string>();
+            expected.Add(@"RewriteRule");
+            expected.Add(@"^/(\d)$");
+            expected.Add(@"/?num=$1");
+
+            Assert.Equal(expected, tokens);
+        }
+
+        [Fact]
+        public void Tokenize_CheckRegexWordDoesNotHitUnescape()
+        {
+            var testString = "RewriteRule ^/(\\w)$ /?num=$1";
+            var tokens = new Tokenizer().Tokenize(testString);
+
+            var expected = new List<string>();
+            expected.Add(@"RewriteRule");
+            expected.Add(@"^/(\w)$");
+            expected.Add(@"/?num=$1");
+
+            Assert.Equal(expected, tokens);
+        }
+
+        [Fact]
+        public void Tokenize_CheckRegexShorthandDoesNotHitUnescape()
+        {
+            var testString = "RewriteRule ^/(\\s)$ /?num=$1";
+            var tokens = new Tokenizer().Tokenize(testString);
+
+            var expected = new List<string>();
+            expected.Add(@"RewriteRule");
+            expected.Add(@"^/(\s)$");
+            expected.Add(@"/?num=$1");
+
+            Assert.Equal(expected, tokens);
+        }
+
+
     }
 }


### PR DESCRIPTION
Added a switch to the RemoveQuotesAndEscapeCharacters function so that \d, \w and \s doesn't get passed into Regex.Unescape causing an argument exception.

There might be a better way to do this but I'm relatively new to this :-)

Fixes #18555
