### PR TITLE
Increase logging in TS functional tests

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/Program.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Program.cs
@@ -30,9 +30,14 @@ namespace FunctionalTests
             var hostBuilder = new WebHostBuilder()
                 .ConfigureLogging(factory =>
                 {
-                    factory.AddConsole(options => options.IncludeScopes = true);
+                    factory.AddConsole(options =>
+                    {
+                        options.IncludeScopes = true;
+                        options.TimestampFormat = "[HH:mm:ss] ";
+                        options.UseUtcTimestamp = true;
+                    });
                     factory.AddDebug();
-                    factory.SetMinimumLevel(LogLevel.Information);
+                    factory.SetMinimumLevel(LogLevel.Debug);
                 })
                 .UseKestrel((builderContext, options) =>
                 {

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
@@ -104,7 +105,7 @@ namespace FunctionalTests
                 });
         }
 
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
         {
             if (env.IsDevelopment())
             {
@@ -120,6 +121,7 @@ namespace FunctionalTests
                 var originHeader = context.Request.Headers[HeaderNames.Origin];
                 if (!StringValues.IsNullOrEmpty(originHeader))
                 {
+                    logger.LogInformation("Setting CORS headers.");
                     context.Response.Headers[HeaderNames.AccessControlAllowOrigin] = originHeader;
                     context.Response.Headers[HeaderNames.AccessControlAllowCredentials] = "true";
 
@@ -138,6 +140,7 @@ namespace FunctionalTests
 
                 if (HttpMethods.IsOptions(context.Request.Method))
                 {
+                    logger.LogInformation("Setting '204' CORS response.");
                     context.Response.StatusCode = StatusCodes.Status204NoContent;
                     return Task.CompletedTask;
                 }


### PR DESCRIPTION
Somehow OPTIONS requests with https are sometimes getting a 0 status code in the server logs.

Chris suggested increasing logging to Debug to see if there were any connection abort errors.