### PR TITLE
Add functional test for header string reuse in HTTP/1.1

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -1685,7 +1685,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task ReuseRequestString()
+        public async Task ReuseRequestHeaderStrings()
         {
             var testContext = new TestServiceContext(LoggerFactory);
             string customHeaderValue = null;


### PR DESCRIPTION
There are unit tests around this feature but nothing verifying that it works end-to-end.