### PR TITLE
Reset Http2Stream when it starts

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Http1Connection(HttpConnectionContext context)
         {
-            Initialize(context, reset: true);
+            Initialize(context);
 
             _context = context;
             _parser = ServiceContext.HttpParser;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -76,16 +76,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private Stream _requestStreamInternal;
         private Stream _responseStreamInternal;
 
-        public void Initialize(HttpConnectionContext context, bool reset)
+        public void Initialize(HttpConnectionContext context)
         {
             _context = context;
 
             ServerOptions = ServiceContext.ServerOptions;
 
-            if (reset)
-            {
-                Reset();
-            }
+            Reset();
 
             HttpResponseControl = this;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -33,18 +33,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private StreamCompletionFlags _completionState;
         private readonly object _completionLock = new object();
 
-        /// <summary>
-        /// Initialize the stream with the specified context.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="reset">
-        /// A value indicating whether to reset the protocol instance.
-        /// We want to reset when the stream is created, and when the stream is returned to the pool.
-        /// The stream shouldn't be reset when fetched from the pool.
-        /// </param>
-        public void InitializePooled(Http2StreamContext context, bool reset)
+        public void Initialize(Http2StreamContext context)
         {
-            base.Initialize(context, reset);
+            base.Initialize(context);
 
             _decrementCalled = false;
             _completionState = StreamCompletionFlags.None;
@@ -81,9 +72,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             _context.StreamId = streamId;
 
-            // The stream was reset when it was completed.
-            // We don't want to reset it twice because reused headers will be discarded.
-            InitializePooled(_context, reset: false);
+            Initialize(_context);
         }
 
         public int StreamId => _context.StreamId;
@@ -155,8 +144,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 // The app can no longer read any more of the request body, so return any bytes that weren't read to the
                 // connection's flow-control window.
                 _inputFlowControl.Abort();
-
-                Reset();
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context) 
         {
-            InitializePooled(context, reset: true);
+            Initialize(context);
             _application = application;
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public Http3Stream(Http3Connection http3Connection, Http3StreamContext context) 
         {
-            Initialize(context, reset: true);
+            Initialize(context);
 
             InputRemaining = null;
 

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             public TestHttp2Stream(Http2StreamContext context) 
             {
-                InitializePooled(context, reset: true);
+                Initialize(context);
             }
 
             public override void Execute()

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -234,11 +234,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             // Stream returned to the pool
             Assert.Equal(1, _connection.StreamPool.Count);
 
-            Assert.True(_connection.StreamPool.TryPop(out var stream));
-
-            // Stream has been completed and reset before being returned
-            Assert.Empty(stream.RequestHeaders);
-
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 


### PR DESCRIPTION
Changes https://github.com/dotnet/aspnetcore/pull/19431 to reset at the start of the stream rather than at the end.

Reasons:
1. Resetting at the end introduced flakyness to tests
2. Consistent with Http1Connection which resets at the start of a request, not the end.