### PR TITLE
Skip Interop.FunctionalTests on arm

### DIFF
--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -25,6 +25,7 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Project,
     [string]$HelixQueues = "Windows.10.Amd64.Open",
+    [string]$TargetArchitecture = "",
     [bool]$RunQuarantinedTests = $false
 )
 $ErrorActionPreference = 'Stop'
@@ -38,4 +39,4 @@ $env:BUILD_REPOSITORY_NAME="aspnetcore"
 $env:SYSTEM_TEAMPROJECT="aspnetcore"
 
 $HelixQueues = $HelixQueues -replace ";", "%3B"
-dotnet msbuild $Project /t:Helix /p:IsRequiredCheck=true /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests /p:_UseHelixOpenQueues=true
+dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" /p:IsRequiredCheck=true /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests /p:_UseHelixOpenQueues=true

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -6,6 +6,7 @@
     <TestGroupName>Interop.FunctionalTests</TestGroupName>
     <!-- WebDriver is not strong named, so this test assembly cannot be strong-named either. -->
     <SignAssembly>false</SignAssembly>
+    <BuildHelixPayload Condition="'$(TargetArchitecture)' == 'arm64'">false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There's no h2spec build for it, so it fails.

We don't run arm64 builds in our PRs which is a) why the original PR to enable these tests didn't catch this and b) why this PR's checks are mostly moot.

If I get a successful build leg (to make sure I didn't mess that up), I may just force-merge this to unblock builds. Does that sound reasonable @dotnet/aspnet-build ?