### PR TITLE
Use TargetPath in blazor dev server

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/build/Microsoft.AspNetCore.Components.WebAssembly.DevServer.targets
+++ b/src/Components/WebAssembly/DevServer/src/build/Microsoft.AspNetCore.Components.WebAssembly.DevServer.targets
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <_BlazorDevServerDll>$(MSBuildThisFileDirectory)../tools/blazor-devserver.dll</_BlazorDevServerDll>
     <RunCommand>dotnet</RunCommand>
-    <RunArguments>&quot;$(_BlazorDevServerDll)&quot; serve --applicationpath &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(TargetFileName)&quot;</RunArguments>
+    <RunArguments>&quot;$(_BlazorDevServerDll)&quot; serve --applicationpath &quot;$(TargetPath)&quot;</RunArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The linker's changed since the issue report and correctly resolves paths.
However the dev-server was doing weird things to calculate the path to the output.

Fixes https://github.com/dotnet/aspnetcore/issues/18288

