### PR TITLE
Fix #2442 by adding webmanifest extension to content-type map

### DIFF
--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -343,6 +343,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".wcm", "application/vnd.ms-works" },
                 { ".wdb", "application/vnd.ms-works" },
                 { ".webm", "video/webm" },
+                { ".webmanifest", "application/manifest+json" }, // https://w3c.github.io/manifest/#media-type-registration
                 { ".webp", "image/webp" },
                 { ".wks", "application/vnd.ms-works" },
                 { ".wm", "video/x-ms-wm" },


### PR DESCRIPTION
Fixes #2442 

We're very conservative about what we add to this list, restricting it only to high-value items that are backed by a clear RFC, well-adopted spec or IANA registration. WebManifest had a spec but now is getting enough hits (as PWAs become more common) and Blazor seems to be interfering with adding this manually (though I'm not sure I understand that and I think it needs further investigation).
