### PR TITLE
[SignalR] Avoid deadlock with closing and user callbacks (#19612)

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1207,11 +1207,13 @@ namespace Microsoft.AspNetCore.SignalR.Client
             finally
             {
                 invocationMessageChannel.Writer.TryComplete();
-                await invocationMessageReceiveTask;
                 timer.Stop();
                 await timerTask;
                 uploadStreamSource.Cancel();
                 await HandleConnectionClose(connectionState);
+
+                // await after the connection has been closed, otherwise could deadlock on a user's .On callback(s)
+                await invocationMessageReceiveTask;
             }
         }
 

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.cs
@@ -448,22 +448,15 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     return Task.CompletedTask;
                 };
 
-                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.InvocationMessageType, target = "Echo", arguments = new object[] { "42" } });
+                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.InvocationMessageType, target = "Echo", arguments = new object[] { "42" } }).OrTimeout();
 
                 // Read sent message first to make sure invoke has been processed and is waiting for a response
                 await connection.ReadSentJsonAsync().OrTimeout();
-                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.CloseMessageType });
+                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.CloseMessageType }).OrTimeout();
 
                 await closedTcs.Task.OrTimeout();
 
-                try
-                {
-                    await tcs.Task.OrTimeout();
-                    Assert.True(false);
-                }
-                catch (TaskCanceledException)
-                {
-                }
+                await Assert.ThrowsAsync<TaskCanceledException>(() => tcs.Task.OrTimeout());
             }
         }
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/19612

### Description

If the server closed the client's connection while they were waiting on `InvokeAsync` in their `On(...)` handler, the client would deadlock.

#### Customer Impact

Bug was reported by a customer at https://github.com/dotnet/aspnetcore/issues/17584
Can cause deadlocks in seemingly innocent code.

As a workaround, customers can refactor their code a bit to trigger `InvokeAsync` from the `On(...)` method, but not wait for it inside the `On(...)` method.

#### Regression?
No

#### Risk
Very low, moved a wait during close to fix a deadlock scenario.