### PR TITLE
[release/3.1] Update hosted (AzDO) and BYOC (dnceng) agents used in our builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -52,7 +52,7 @@ variables:
   - name: _InternalRuntimeDownloadCodeSignArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     - group: DotNet-Blob-Feed
@@ -72,7 +72,7 @@ variables:
              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _BuildArgs
       value: ''
     - name: _SignType
@@ -82,7 +82,7 @@ variables:
   # used for post-build phases, internal builds only
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-AspNet-SDLValidation-Params
-    
+
 stages:
 - stage: build
   displayName: Build
@@ -119,10 +119,10 @@ stages:
       agentOs: Windows
       steps:
       - script: "echo ##vso[build.addbuildtag]daily-build"
-        condition: and(ne(variables['Build.Reason'], 'PullRequest'), notin(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+        condition: and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
         displayName: 'Set CI tags'
       - script: "echo ##vso[build.addbuildtag]release-candidate"
-        condition: and(ne(variables['Build.Reason'], 'PullRequest'), in(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+        condition: and(notin(variables['Build.Reason'], 'PullRequest'), in(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
         displayName: 'Set CI tags'
 
       # !!! NOTE !!! Some of these steps have disabled code signing.
@@ -676,7 +676,7 @@ stages:
       displayName: Upload package artifacts
       # Only capture source build artifacts in PRs for the sake of inspecting
       # changes that impact source-build. The artifacts from this build pipeline are never actually used.
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'))
       inputs:
         pathtoPublish: artifacts/packages/
         artifactName: Source_Build_Packages

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -89,7 +89,7 @@ jobs:
     # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
     pool:
       ${{ if eq(parameters.agentOs, 'macOS') }}:
-        vmImage: macOS-10.13
+        vmImage: macOS-10.14
       ${{ if eq(parameters.agentOs, 'Linux') }}:
         vmImage: ubuntu-16.04
       ${{ if eq(parameters.agentOs, 'Windows') }}:
@@ -97,14 +97,14 @@ jobs:
           name: NetCorePublic-Pool
           ${{ if ne(parameters.isTestingJob, true) }}:
             # Visual Studio Build Tools
-            queue: BuildPool.Windows.10.Amd64.VS2019.BT.Open
+            queue: BuildPool.Server.Amd64.VS2019.BT.Open
           ${{ if eq(parameters.isTestingJob, true) }}:
             # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-            queue: BuildPool.Windows.10.Amd64.VS2019.Open
+            queue: BuildPool.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Windows.10.Amd64.VS2019
+          queue: BuildPool.Server.Amd64.VS2019
     variables:
     - AgentOsName: ${{ parameters.agentOs }}
     - ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping
@@ -120,9 +120,9 @@ jobs:
     - ${{ if or(ne(parameters.codeSign, true), ne(variables['System.TeamProject'], 'internal')) }}:
       - _SignType: ''
     - ${{ if and(eq(parameters.codeSign, true), eq(variables['System.TeamProject'], 'internal')) }}:
-      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
         - _SignType: real
-      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
         - _SignType: test
     steps:
     - checkout: self


### PR DESCRIPTION
- dotnet/aspnetcore-internal#3540
- nit: Consistently use in / notin with Build.Reason
  - YAML was inconsistent and this aligns w/ the Arcade code