### PR TITLE
Read server response in Http2ConnectionBenchmark

### DIFF
--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http2ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http2ConnectionBenchmark.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,11 +33,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private int _currentStreamId;
         private byte[] _headersBuffer;
         private DuplexPipe.DuplexPipePair _connectionPair;
+        private Http2Frame _httpFrame;
+        private string _responseData;
+        private int _dataWritten;
+
+        [Params(0, 10, 1024 * 1024)]
+        public int ResponseDataLength { get; set; }
 
         [GlobalSetup]
         public void GlobalSetup()
         {
             _memoryPool = SlabMemoryPoolFactory.Create();
+            _httpFrame = new Http2Frame();
+            _responseData = new string('!', ResponseDataLength);
 
             var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
 
@@ -71,11 +83,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             _currentStreamId = 1;
 
-            _ = _connection.ProcessRequestsAsync(new DummyApplication(_ => Task.CompletedTask, new MockHttpContextFactory()));
+            _ = _connection.ProcessRequestsAsync(new DummyApplication(c => ResponseDataLength == 0 ? Task.CompletedTask : c.Response.WriteAsync(_responseData), new MockHttpContextFactory()));
 
             _connectionPair.Application.Output.Write(Http2Connection.ClientPreface);
-            _connectionPair.Application.Output.WriteSettings(new Http2PeerSettings());
+            _connectionPair.Application.Output.WriteSettings(new Http2PeerSettings
+            {
+                InitialWindowSize = 2147483647
+            });
             _connectionPair.Application.Output.FlushAsync().GetAwaiter().GetResult();
+
+            // Read past connection setup frames
+            ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame).GetAwaiter().GetResult();
+            Debug.Assert(_httpFrame.Type == Http2FrameType.SETTINGS);
+            ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame).GetAwaiter().GetResult();
+            Debug.Assert(_httpFrame.Type == Http2FrameType.WINDOW_UPDATE);
+            ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame).GetAwaiter().GetResult();
+            Debug.Assert(_httpFrame.Type == Http2FrameType.SETTINGS);
         }
 
         [Benchmark]
@@ -83,12 +106,71 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             _requestHeadersEnumerator.Initialize(_httpRequestHeaders);
             _requestHeadersEnumerator.MoveNext();
-            _connectionPair.Application.Output.WriteStartStream(streamId: _currentStreamId, _requestHeadersEnumerator, _headersBuffer, endStream: true);
-            _currentStreamId += 2;
+            _connectionPair.Application.Output.WriteStartStream(streamId: _currentStreamId, _requestHeadersEnumerator, _headersBuffer, endStream: true, frame: _httpFrame);
             await _connectionPair.Application.Output.FlushAsync();
 
-            var readResult = await _connectionPair.Application.Input.ReadAsync();
-            _connectionPair.Application.Input.AdvanceTo(readResult.Buffer.End);
+            while (true)
+            {
+                await ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame);
+
+                if (_httpFrame.StreamId != _currentStreamId && _httpFrame.StreamId != 0)
+                {
+                    throw new Exception($"Unexpected stream ID: {_httpFrame.StreamId}");
+                }
+
+                if (_httpFrame.Type == Http2FrameType.DATA)
+                {
+                    _dataWritten += _httpFrame.DataPayloadLength;
+                }
+
+                if (_dataWritten > 1024 * 32)
+                {
+                    _connectionPair.Application.Output.WriteWindowUpdateAsync(streamId: 0, _dataWritten, _httpFrame);
+                    await _connectionPair.Application.Output.FlushAsync();
+
+                    _dataWritten = 0;
+                }
+
+                if ((_httpFrame.HeadersFlags & Http2HeadersFrameFlags.END_STREAM) == Http2HeadersFrameFlags.END_STREAM)
+                {
+                    break;
+                }
+            }
+
+            _currentStreamId += 2;
+        }
+
+        internal async ValueTask ReceiveFrameAsync(PipeReader pipeReader, Http2Frame frame, uint maxFrameSize = Http2PeerSettings.DefaultMaxFrameSize)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+                var buffer = result.Buffer;
+                var consumed = buffer.Start;
+                var examined = buffer.Start;
+
+                try
+                {
+                    if (Http2FrameReader.TryReadFrame(ref buffer, frame, maxFrameSize, out var framePayload))
+                    {
+                        consumed = examined = framePayload.End;
+                        return;
+                    }
+                    else
+                    {
+                        examined = buffer.End;
+                    }
+
+                    if (result.IsCompleted)
+                    {
+                        throw new IOException("The reader completed without returning a frame.");
+                    }
+                }
+                finally
+                {
+                    pipeReader.AdvanceTo(consumed, examined);
+                }
+            }
         }
 
         [GlobalCleanup]

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockHttpContextFactory.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockHttpContextFactory.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class MockHttpContextFactory : IHttpContextFactory
+    {
+        private readonly object _lock = new object();
+        private readonly Queue<DefaultHttpContext> _cache = new Queue<DefaultHttpContext>();
+
+        public HttpContext Create(IFeatureCollection featureCollection)
+        {
+            DefaultHttpContext httpContext;
+
+            lock (_lock)
+            {
+                if (!_cache.TryDequeue(out httpContext))
+                {
+                    httpContext = new DefaultHttpContext();
+                }
+            }
+
+            httpContext.Initialize(featureCollection);
+            return httpContext;
+        }
+
+        public void Dispose(HttpContext httpContext)
+        {
+            lock (_lock)
+            {
+                _cache.Enqueue((DefaultHttpContext)httpContext);
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockHttpContextFactory.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockHttpContextFactory.cs
@@ -32,7 +32,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             lock (_lock)
             {
-                _cache.Enqueue((DefaultHttpContext)httpContext);
+                var defaultHttpContext = (DefaultHttpContext)httpContext;
+
+                defaultHttpContext.Uninitialize();
+                _cache.Enqueue(defaultHttpContext);
             }
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
@@ -1051,12 +1052,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected Task SendWindowUpdateAsync(int streamId, int sizeIncrement)
         {
             var outputWriter = _pair.Application.Output;
-            var frame = new Http2Frame();
-            frame.PrepareWindowUpdate(streamId, sizeIncrement);
-            Http2FrameWriter.WriteHeader(frame, outputWriter);
-            var buffer = outputWriter.GetSpan(4);
-            BinaryPrimitives.WriteUInt32BigEndian(buffer, (uint)sizeIncrement);
-            outputWriter.Advance(4);
+            outputWriter.WriteWindowUpdateAsync(streamId, sizeIncrement);
             return FlushAsync(outputWriter);
         }
 

--- a/src/Shared/BenchmarkRunner/Program.cs
+++ b/src/Shared/BenchmarkRunner/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;


### PR DESCRIPTION
Changes the benchmark so the client reads response content. This stops the server starting responses as quickly as possible and exceeding max queue sizes.

Also update the benchmark to reuse `HttpContext` instances between requests.