### PR TITLE
[Blazor] Fix default value for response type

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
@@ -310,7 +310,7 @@ export class AuthenticationService {
             }
 
             if (settings.response_type === null) {
-                // If the response type is not set, it gets serialized as null,. OIDC-client behaves differently than when the value is undefined, so we explicitly check for a null value and remove the property instead.
+                // If the response type is not set, it gets serialized as null. OIDC-client behaves differently than when the value is undefined, so we explicitly check for a null value and remove the property instead.
                 delete settings.response_type;
             }
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
@@ -310,6 +310,7 @@ export class AuthenticationService {
             }
 
             if (settings.response_type === null) {
+                // If the response type is not set, it gets serialized as null,. OIDC-client behaves differently than when the value is undefined, so we explicitly check for a null value and remove the property instead.
                 delete settings.response_type;
             }
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
@@ -309,6 +309,10 @@ export class AuthenticationService {
                 settings.scope = settings.defaultScopes.join(' ');
             }
 
+            if (settings.response_type === null) {
+                delete settings.response_type;
+            }
+
             finalSettings = settings;
         }
 


### PR DESCRIPTION
If the response type is not set, it gets serialized as null, and oidc-client behaves differently than when the value is undefined, so we explicitly check for a null value and remove the property instead.

The choice to do it this way instead of providing a default value is that this way we let the library choose what to do.