### PR TITLE
[HTTPS] Temporarily disable trust on Mac OS

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -222,12 +222,19 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 reporter.Warn("Trusting the HTTPS development certificate was requested. A confirmation prompt will be displayed " +
                     "if the certificate was not previously trusted. Click yes on the prompt to trust the certificate.");
             }
+            
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && trust?.HasValue() == true)
+            {
+                reporter.Warn("Trusting the HTTPS development certificate is currently disabled. To trust the certificate manually " +
+                 "export the certificate with dotnet dev-certs https -ep <<path>> and run the following command "+
+                 "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain'.");
+            }
 
             var result = manager.EnsureAspNetCoreHttpsDevelopmentCertificate(
                 now,
                 now.Add(HttpsCertificateValidity),
                 exportPath.Value(),
-                trust == null ? false : trust.HasValue(),
+                (trust == null || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ? false : trust.HasValue(),
                 password.HasValue(),
                 password.Value());
 

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -218,7 +218,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
             {
                 reporter.Warn("Trusting the HTTPS development certificate is currently disabled. To trust the certificate manually " +
                  "export the certificate with dotnet dev-certs https -ep <<path>> and run the following command "+
-                 "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain'.");
+                 "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<path>>'.");
             }
 
             var result = manager.EnsureAspNetCoreHttpsDevelopmentCertificate(

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -208,15 +208,6 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                     "This command will make the certificate key accessible across security partitions and might prompt you for your password. For more information see: https://aka.ms/aspnetcore/3.1/troubleshootcertissues");
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && trust?.HasValue() == true)
-            {
-                reporter.Warn("Trusting the HTTPS development certificate was requested. If the certificate is not " +
-                    "already trusted we will run the following command:" + Environment.NewLine +
-                    "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<certificate>>'" +
-                    Environment.NewLine + "This command might prompt you for your password to install the certificate " +
-                    "on the system keychain.");
-            }
-
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && trust?.HasValue() == true)
             {
                 reporter.Warn("Trusting the HTTPS development certificate was requested. A confirmation prompt will be displayed " +


### PR DESCRIPTION
Temporarily disable trying to trust the certificate on Mac OS due to an issue in .NET Core that prevents it from working and blocks VS 4 Mac.


Sample output
```console
dotnet run https --trust
Trusting the HTTPS development certificate is currently disabled. To trust the certificate manually export the certificate with dotnet dev-certs https -ep <<path>> and run the following command 'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<path>>'.
A valid HTTPS certificate is already present.

```
