### PR TITLE
Ingest Primitives from dotnet/runtime

### DIFF
--- a/eng/SharedFramework.External.props
+++ b/eng/SharedFramework.External.props
@@ -53,9 +53,9 @@
     <ExternalAspNetCoreAppReference Include="Microsoft.Extensions.Options.ConfigurationExtensions"         Version="$(MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion)" />
     <ExternalAspNetCoreAppReference Include="Microsoft.Extensions.Options.DataAnnotations"                 Version="$(MicrosoftExtensionsOptionsDataAnnotationsPackageVersion)" />
     <ExternalAspNetCoreAppReference Include="Microsoft.Extensions.Options"                                 Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
-    <ExternalAspNetCoreAppReference Include="Microsoft.Extensions.Primitives"                              Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
 
-    <!-- Dependencies from dotnet/corefx -->
+    <!-- Dependencies from dotnet/runtime -->
+    <ExternalAspNetCoreAppReference Include="Microsoft.Extensions.Primitives"                              Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
     <ExternalAspNetCoreAppReference Include="System.IO.Pipelines"                                          Version="$(SystemIOPipelinesPackageVersion)" />
     <ExternalAspNetCoreAppReference Include="System.Security.Cryptography.Xml"                             Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -213,9 +213,9 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>540b4e8f129a132749a60174464b8c8274bfed7d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="5.0.0-preview.3.20156.3" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
-      <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>540b4e8f129a132749a60174464b8c8274bfed7d</Sha>
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="5.0.0-preview.3-runtime.20160.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>fd1480ec75c7b783264b0526e38fbbf2e62a3b6e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Internal.Extensions.Refs" Version="5.0.0-preview.3.20156.3" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -138,7 +138,6 @@
     <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftInternalExtensionsRefsPackageVersion>5.0.0-preview.3.20156.3</MicrosoftInternalExtensionsRefsPackageVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefPackageVersion>5.0.0-preview.3.20159.5</dotnetefPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,8 @@
     <MicrosoftNETCoreAppRefPackageVersion>5.0.0-preview.2.20155.3</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.2.20155.3</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0-preview.2.20155.3</NETStandardLibraryRefPackageVersion>
-    <!-- Packages from dotnet/corefx -->
+    <!-- Packages from dotnet/runtime -->
+    <MicrosoftExtensionsPrimitivesPackageVersion>5.0.0-preview.3-runtime.20160.1</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.2.20155.3</MicrosoftWin32RegistryPackageVersion>
     <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.2.20155.3</MicrosoftWin32SystemEventsPackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>5.0.0-preview.2.20155.3</SystemComponentModelAnnotationsPackageVersion>


### PR DESCRIPTION
Jumping the gun (on dependency updates) a little but I believe we can start ingesting Primitives from dotnet/runtime now.
