### PR TITLE
Unquarantine H2Spec tests

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -21,7 +21,6 @@ namespace Interop.FunctionalTests
     {
         [ConditionalTheory]
         [MemberData(nameof(H2SpecTestCases))]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore-internal/issues/2225")]
         public async Task RunIndividualTestCase(H2SpecTestCase testCase)
         {
             var hostBuilder = new WebHostBuilder()


### PR DESCRIPTION
These were quarantined before I enabled them in Helix and seem to be running fine now. We can always throw it back in the box later.