### PR TITLE
Fix #19792 copy paste err in EventData

### DIFF
--- a/src/Mvc/Mvc.Core/src/Diagnostics/MvcDiagnostics.cs
+++ b/src/Mvc/Mvc.Core/src/Diagnostics/MvcDiagnostics.cs
@@ -525,7 +525,7 @@ namespace Microsoft.AspNetCore.Mvc.Diagnostics
         protected override KeyValuePair<string, object> this[int index] => index switch
         {
             0 => new KeyValuePair<string, object>(nameof(ActionContext), ActionContext),
-            1 => new KeyValuePair<string, object>(nameof(Controller), Controller),
+            1 => new KeyValuePair<string, object>(nameof(Arguments), Arguments),
             2 => new KeyValuePair<string, object>(nameof(Controller), Controller),
             3 => new KeyValuePair<string, object>(nameof(Result), Result),
             _ => throw new IndexOutOfRangeException(nameof(index))


### PR DESCRIPTION
 Copy-paste error: AfterControllerActionMethodEventData indexes Controller twice, but misses Arguments (#19792)

Addresses #19792
