### PR TITLE
Added null check to CorsPolicyBuilder

### DIFF
--- a/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
@@ -65,6 +65,11 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
         internal static string GetNormalizedOrigin(string origin)
         {
+            if (string.IsNullOrEmpty(origin))
+            {
+                throw new ArgumentNullException(nameof(origin));
+            }
+
             if (Uri.TryCreate(origin, UriKind.Absolute, out var uri) &&
                 (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps) &&
                 !string.Equals(uri.IdnHost, uri.Host, StringComparison.Ordinal))
@@ -73,9 +78,9 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 if (!uri.IsDefaultPort)
                 {
                     // Uri does not have a way to differentiate between a port value inferred by default (e.g. Port = 80 for http://www.example.com) and
-                    // a default port value that is specified (e.g. Port = 80 for http://www.example.com:80). Although the HTTP or FETCH spec does not say 
+                    // a default port value that is specified (e.g. Port = 80 for http://www.example.com:80). Although the HTTP or FETCH spec does not say
                     // anything about including the default port as part of the Origin header, at the time of writing, browsers drop "default" port when navigating
-                    // and when sending the Origin header. All this goes to say, it appears OK to drop an explicitly specified port, 
+                    // and when sending the Origin header. All this goes to say, it appears OK to drop an explicitly specified port,
                     // if it is the default port when working with an IDN host.
                     builder.Port = uri.Port;
                 }
@@ -208,7 +213,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
         /// <summary>
         /// Sets the <see cref="CorsPolicy.IsOriginAllowed"/> property of the policy to be a function
-        /// that allows origins to match a configured wildcarded domain when evaluating if the 
+        /// that allows origins to match a configured wildcarded domain when evaluating if the
         /// origin is allowed.
         /// </summary>
         /// <returns>The current policy builder.</returns>

--- a/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
@@ -54,6 +54,11 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// </remarks>
         public CorsPolicyBuilder WithOrigins(params string[] origins)
         {
+            if (origins is null)
+            {
+                throw new ArgumentNullException(nameof(origins));
+            }
+
             foreach (var origin in origins)
             {
                 var normalizedOrigin = GetNormalizedOrigin(origin);

--- a/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
         internal static string GetNormalizedOrigin(string origin)
         {
-            if (string.IsNullOrEmpty(origin))
+            if (origin is null)
             {
                 throw new ArgumentNullException(nameof(origin));
             }

--- a/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
@@ -139,13 +139,23 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.Equal(new List<string>() { "http://www.example.com", "https://example2.com" }, corsPolicy.Origins);
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData(new string[] { null })]
-        public void WithOrigins_ThrowsIfArgumentNull(string[] args)
+        [Fact]
+        public void WithOrigins_ThrowsIfArgumentNull()
         {
             // Arrange
             var builder = new CorsPolicyBuilder();
+            var args = null;
+
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(args));
+        }
+
+        [Fact]
+        public void WithOrigins_ThrowsIfArgumentArrayContainsNull()
+        {
+            // Arrange
+            var builder = new CorsPolicyBuilder();
+            var args = new string[] { null };
 
             // Act / Assert
             Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(args));

--- a/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
@@ -140,6 +140,16 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         }
 
         [Fact]
+        public void WithOrigins_ThrowsIfArgumentNull()
+        {
+            // Arrange
+            var builder = new CorsPolicyBuilder();
+
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(null));
+        }
+
+        [Fact]
         public void AllowAnyOrigin_AllowsAny()
         {
             // Arrange

--- a/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
@@ -139,14 +139,16 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.Equal(new List<string>() { "http://www.example.com", "https://example2.com" }, corsPolicy.Origins);
         }
 
-        [Fact]
-        public void WithOrigins_ThrowsIfArgumentNull()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new string[] { null })]
+        public void WithOrigins_ThrowsIfArgumentNull(string[] args)
         {
             // Arrange
             var builder = new CorsPolicyBuilder();
 
             // Act / Assert
-            Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(null));
+            Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(args));
         }
 
         [Fact]

--- a/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         {
             // Arrange
             var builder = new CorsPolicyBuilder();
-            var args = null;
+            string[] args = null;
 
             // Act / Assert
             Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(args));
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         {
             // Arrange
             var builder = new CorsPolicyBuilder();
-            var args = new string[] { null };
+            string[] args = new string[] { null };
 
             // Act / Assert
             Assert.Throws<ArgumentNullException>(() => builder.WithOrigins(args));


### PR DESCRIPTION
It was noticed that there is no null checking in the `CorsPolicyBuilder.GetNormalizedOrigin` method after a `NullReferenceException` was picked up. In the case that a null string is passed to the method via `WithOrigins` (in our case it was because a configuration file read failed) this change throws an `ArgumentNullException` which gives a clearer indication of what has failed.

Addresses #19830
