### PR TITLE
Remove dependency on Microsoft.Extensions.Configuration.AzureKeyVault

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -81,10 +81,6 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>540b4e8f129a132749a60174464b8c8274bfed7d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.AzureKeyVault" Version="5.0.0-preview.3.20156.3" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
-      <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>540b4e8f129a132749a60174464b8c8274bfed7d</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="5.0.0-preview.3.20156.3" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>540b4e8f129a132749a60174464b8c8274bfed7d</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -104,7 +104,6 @@
     <MicrosoftExtensionsCachingSqlServerPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsCachingSqlServerPackageVersion>
     <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>5.0.0-preview.3.20156.3</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>


### PR DESCRIPTION
This package was recently removed from dotnet/extensions - https://github.com/dotnet/aspnetcore/pull/19572 removed it from our version files, but through some git weirdness, it found its way back in. Deleting it again should unblock us from ingesting aspnetcore-tooling & extensions (I've validated this locally).

CC @JunTaoLuo @BrennanConroy @anurse 