### PR TITLE
Add objects result for a better restful webapi response treatment.

### DIFF
--- a/src/Mvc/Mvc.Core/src/PartialContentObjectResult.cs
+++ b/src/Mvc/Mvc.Core/src/PartialContentObjectResult.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// An <see cref="ObjectResult"/> that when executed will produce a <see cref="StatusCodes.Status206PartialContent"/> response.
+    /// </summary>
+    [DefaultStatusCode(DefaultStatusCode)]
+    public class PartialContentObjectResult : ObjectResult
+    {
+        private const int DefaultStatusCode = StatusCodes.Status206PartialContent;
+
+        /// <summary>
+        /// Creates a new <see cref="PartialContentObjectResult"/> instance.
+        /// </summary>
+        /// <param name="value">The value to format in the entity body.</param>
+        public PartialContentObjectResult([ActionResultObjectValue]object value)
+            : base(value)
+        {
+            StatusCode = DefaultStatusCode;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/PreconditionFailedObjectResult.cs
+++ b/src/Mvc/Mvc.Core/src/PreconditionFailedObjectResult.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// An <see cref="ObjectResult"/> that when executed will produce a <see cref="StatusCodes.Status422UnprocessableEntity"/> response.
+    /// </summary>
+    [DefaultStatusCode(DefaultStatusCode)]
+    public class PreconditionFailedObjectResult : ObjectResult
+    {
+        private const int DefaultStatusCode = StatusCodes.Status412PreconditionFailed;
+
+        /// <summary>
+        /// Creates a new <see cref="PreconditionFailedObjectResult"/> instance.
+        /// </summary>
+        /// <param name="value">The value to format in the entity body.</param>
+        public PreconditionFailedObjectResult(object value)
+            : base(value)
+        {
+            StatusCode = DefaultStatusCode;
+        }
+    }
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Adds new `PartialContentObjectResult` class in order to allow web api return 206 response like others status code that already exists in solution;
 - Adds new `PreconditionFailedObjectResult` class in order to allow web api return 412 response like others status code that already exists in solution;

Following Clean Architecture in web api constrution, for example, we can now create a output data presenter that set directly the response according the result the application produced.