### PR TITLE
Ignore bad restore sources (dotnet-watch tests)

### DIFF
--- a/src/Tools/dotnet-watch/test/Scenario/ProjectToolScenario.cs
+++ b/src/Tools/dotnet-watch/test/Scenario/ProjectToolScenario.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public Task RestoreAsync(string project)
         {
             _logger?.WriteLine($"Restoring msbuild project in {project}");
-            return ExecuteCommandAsync(project, TimeSpan.FromSeconds(120), "restore");
+            return ExecuteCommandAsync(project, TimeSpan.FromSeconds(120), "restore", "--ignore-failed-sources");
         }
 
         public Task BuildAsync(string project)


### PR DESCRIPTION
Only recent failures in a dotnet-watch test were:
`C:\h\w\BB5D0998\p\sdk\x64\sdk\5.0.100-preview.2.20120.3\NuGet.targets(124,5): error : The local source 'C:\h\w\BFF00A2E\w\B1060995\e' doesn't exist. [C:\h\w\BB5D0998\w\A4AE0957\e\tmp\fv4rajpq.50b\AppWithDeps\AppWithDeps.csproj]`

Not sure where that feed is coming from, and not sure we really care either. Hopefully this flag actually works and resolves the issue.