### PR TITLE
Build aspnetcore for win-arm64 (#19317)

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -254,6 +254,38 @@ stages:
       - name: Windows_arm_Packages
         path: artifacts/packages/
 
+  # Build Windows ARM64
+  - template: jobs/default-build.yml
+    parameters:
+      codeSign: true
+      jobName: Windows_64_build
+      jobDisplayName: "Build: Windows ARM64"
+      agentOs: Windows
+      buildArgs:
+        -arch arm64
+        -sign
+        -pack
+        -noBuildNodeJS
+        -noBuildJava
+        /bl:artifacts/log/build.win-arm64.binlog
+        /p:DotNetSignType=$(_SignType)
+        /p:OnlyPackPlatformSpecificPackages=true
+        /p:AssetManifestFileName=aspnetcore-win-arm64.xml
+        $(_BuildArgs)
+        $(_PublishArgs)
+        $(_InternalRuntimeDownloadArgs)
+      installNodeJs: false
+      installJdk: false
+      artifacts:
+      - name: Windows_arm64_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: Windows_arm64_Packages
+        path: artifacts/packages/
+      - name: Windows_arm64_Installers
+        path: artifacts/installers/
+
   # Build MacOS
   - template: jobs/default-build.yml
     parameters:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -123,6 +123,7 @@
       win-x64;
       win-x86;
       win-arm;
+      win-arm64;
       osx-x64;
       linux-musl-x64;
       linux-musl-arm64;

--- a/build.ps1
+++ b/build.ps1
@@ -118,7 +118,7 @@ param(
     [ValidateSet('Debug', 'Release')]
     $Configuration,
 
-    [ValidateSet('x64', 'x86', 'arm')]
+    [ValidateSet('x64', 'x86', 'arm', 'arm64')]
     $Architecture = 'x64',
 
     # A list of projects which should be built.
@@ -157,7 +157,7 @@ param(
 
     # Other lifecycle targets
     [switch]$Help, # Show help
-    
+
     # Optional arguments that enable downloading an internal
     # runtime or runtime from a non-default location
     [string]$DotNetRuntimeSourceFeed,

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -94,6 +94,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="microsoft.netcore.app.runtime.win-x64" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
     <LatestPackageReference Include="microsoft.netcore.app.runtime.win-x86" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
     <LatestPackageReference Include="microsoft.netcore.app.runtime.win-arm" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
+    <LatestPackageReference Include="microsoft.netcore.app.runtime.win-arm64" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
     <LatestPackageReference Include="microsoft.netcore.app.runtime.osx-x64" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
     <LatestPackageReference Include="microsoft.netcore.app.runtime.linux-x64" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
     <LatestPackageReference Include="microsoft.netcore.app.runtime.linux-arm" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -93,9 +93,11 @@
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-x64\shared\Microsoft.NETCore.App\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-x86\shared\Microsoft.NETCore.App\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-arm\shared\Microsoft.NETCore.App\**\*.dll" CertificateName="None" />
+    <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-arm64\shared\Microsoft.NETCore.App\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-x64\host\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-x86\host\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-arm\host\**\*.dll" CertificateName="None" />
+    <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-arm64\host\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(RedistNetCorePath)dotnet.exe" CertificateName="None" />
     <FileSignInfo Include="@(_DotNetFilesToExclude->'%(FileName)%(Extension)'->Distinct())" CertificateName="None" />
 

--- a/src/Shared/E2ETesting/E2ETesting.props
+++ b/src/Shared/E2ETesting/E2ETesting.props
@@ -4,7 +4,7 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);node_modules\**</DefaultItemExcludes>
     <SeleniumScreenShotsFolderPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)','$(MSBuildProjectName)'))</SeleniumScreenShotsFolderPath>
     <SeleniumProcessTrackingFolder Condition="'$(SeleniumProcessTrackingFolder)' == ''">$([MSBuild]::EnsureTrailingSlash('$(RepoRoot)'))artifacts\tmp\selenium\</SeleniumProcessTrackingFolder>
-    <SeleniumE2ETestsSupported Condition="'$(SeleniumE2ETestsSupported)' == '' and '$(TargetArchitecture)' != 'arm' and '$(OS)' == 'Windows_NT'">true</SeleniumE2ETestsSupported>
+    <SeleniumE2ETestsSupported Condition="'$(SeleniumE2ETestsSupported)' == '' and '$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'arm64' and '$(OS)' == 'Windows_NT'">true</SeleniumE2ETestsSupported>
 
     <!-- Config that limits driver to chrome-->
     <SeleniumConfigPath>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)selenium-config.json))</SeleniumConfigPath>


### PR DESCRIPTION
Porting change in https://github.com/dotnet/aspnetcore/pull/19317 to preview2

#### Description

This change adds win-arm64 support for AspNetCore.

#### Customer Impact

The change addressed https://github.com/dotnet/aspnetcore/issues/17057. This change is required for win-arm64 SDK in preview2

#### Regression?

No

#### Risk

Low. The change has been made and verified in master so this direct port should be safe.