### PR TITLE
Add comments cautioning against changing DeveloperCertificates.XPlat

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -34,6 +34,7 @@
     <!-- 
       This target is defined in eng/targets/Packaging.targets and included in every C# and F# project.
       We use Microsoft.AspNetCore.DeveloperCertificates.XPlat because it is a nonshipping package, and we need a non-stable version string to use as our publish location.
+      If Microsoft.AspNetCore.DeveloperCertificates.XPlat ever becomes a shipping package, this logic will break, so be careful -->
     -->
     <MSBuild Projects="$(RepoRoot)src\Tools\FirstRunCertGenerator\src\Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj"
         Targets="_GetPackageVersionInfo"

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -34,7 +34,7 @@
     <!-- 
       This target is defined in eng/targets/Packaging.targets and included in every C# and F# project.
       We use Microsoft.AspNetCore.DeveloperCertificates.XPlat because it is a nonshipping package, and we need a non-stable version string to use as our publish location.
-      If Microsoft.AspNetCore.DeveloperCertificates.XPlat ever becomes a shipping package, this logic will break, so be careful -->
+      If Microsoft.AspNetCore.DeveloperCertificates.XPlat ever becomes a shipping package, this logic will break, so be careful
     -->
     <MSBuild Projects="$(RepoRoot)src\Tools\FirstRunCertGenerator\src\Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj"
         Targets="_GetPackageVersionInfo"

--- a/src/Tools/FirstRunCertGenerator/src/Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj
+++ b/src/Tools/FirstRunCertGenerator/src/Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj
@@ -7,6 +7,10 @@
     <PackageTags>aspnet;cli</PackageTags>
 
     <!-- This package contains API for the .NET CLI to generate the aspnet HTTPs dev cert during CLI first-run initialization. -->
+    
+    <!-- Our publishing logic depends on this particular package being NonShipping - if this ever becomes a Shipping project, we will incorrectly calculate the repo's version string,
+         which will cause us to publish installers & checksums to the wrong place. If this ever becomes a Shipping project, we also need to update the following line to reference a different NonShipping project:
+         https://github.com/dotnet/aspnetcore/blob/99c9b8ace1d1d916109882d3f983a26ea4e9b66a/eng/Publishing.props#L38 -->
     <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/19068

We rely on `DeveloperCertificates.XPlat` to calculate the non-stable version we use for publishing installers/checksums. As such, we should make sure devs know to be careful if/when that project needs to be changed to a `shipping` project.

CC @dougbu @Pilchie 