### PR TITLE
Disable the sync action in forks

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -1,7 +1,7 @@
 name: AspNetCore-Runtime Code Sync
 on:
   # Test this script using on: push
-  # push:
+  push:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
@@ -10,6 +10,8 @@ on:
 
 jobs:
   compare_repos:
+    # Comment out this line to test the scripts in a fork
+    if: github.repository == 'dotnet/aspnetcore'
     name: Compare the shared code in the AspNetCore and Runtime repos and notify if they're out of sync.
     runs-on: windows-latest
     steps:

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -1,7 +1,7 @@
 name: AspNetCore-Runtime Code Sync
 on:
   # Test this script using on: push
-  push:
+  # push:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -1,7 +1,7 @@
 name: AspNetCore-Runtime Code Sync
 on:
   # Test this script using on: push
-  push:
+  # push:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
@@ -11,7 +11,7 @@ on:
 jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
-    if: github.repository == 'Tratcher/aspnetcore'
+    if: github.repository == 'dotnet/aspnetcore'
     name: Compare the shared code in the AspNetCore and Runtime repos and notify if they're out of sync.
     runs-on: windows-latest
     steps:

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -1,7 +1,7 @@
 name: AspNetCore-Runtime Code Sync
 on:
   # Test this script using on: push
-  # push:
+  push:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
@@ -11,7 +11,7 @@ on:
 jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
-    if: github.repository == 'dotnet/aspnetcore'
+    if: github.repository == 'Tratcher/aspnetcore'
     name: Compare the shared code in the AspNetCore and Runtime repos and notify if they're out of sync.
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/18943#issuecomment-599943299

The sync action runs in all forks of the repo and fails because those repos don't have permissions to open issues in the parent. This adds a check to skip the action in forks.

Thanks @campersau for the hint.