### PR TITLE
Re-enable signing validation again

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -813,7 +813,6 @@ stages:
     parameters:
       # See https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
-      enableSigningValidation: false
       publishInstallersAndChecksums: true
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:


### PR DESCRIPTION
- part of 4ba64f54705e was either merged incorrectly from 'release/3.1' or overridden later
