### PR TITLE
Remove global xunit max thread setting

### DIFF
--- a/eng/helix/content/default.runner.json
+++ b/eng/helix/content/default.runner.json
@@ -1,5 +1,4 @@
 {
   "longRunningTestSeconds": 60,
-  "diagnosticMessages": true,
-  "maxParallelThreads": -1
+  "diagnosticMessages": true
 }


### PR DESCRIPTION
We have some sketchy tests that behave better under default xunit settings. The [original change](https://github.com/dotnet/aspnetcore/pull/19922) was about hanging test detection so lets remove the thread setting and let individual areas have their own settings if they want.
