### PR TITLE
Use custom DebugProxyHost to initialize DebugProxy config

### DIFF
--- a/src/Components/WebAssembly/DebugProxy/src/Hosting/DebugProxyHost.cs
+++ b/src/Components/WebAssembly/DebugProxy/src/Hosting/DebugProxyHost.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.Hosting
+{
+    public static class DebugProxyHost
+    {
+        /// <summary>
+        /// Creates a custom HostBuilder for the DebugProxyLauncher so that we can inject
+        /// only the needed configurations.
+        /// </summary>
+        /// <param name="args">Command line arguments passed in</param>
+        /// <param name="browserHost">Host where browser is listening for debug connections</param>
+        /// <returns><see cref="IHostBuilder"></returns>
+        public static IHostBuilder CreateDefaultBuilder(string[] args, string browserHost)
+        {
+            var builder = new HostBuilder();
+
+            builder.ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                if (args != null)
+                {
+                    config.AddCommandLine(args);
+                }
+                config.AddJsonFile("blazor-debugproxysettings.json", optional: true, reloadOnChange: true);
+            })
+            .ConfigureLogging((hostingContext, logging) =>
+            {
+                logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                logging.AddConsole();
+                logging.AddDebug();
+                logging.AddEventSourceLogger();
+            })
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+
+                // By default we bind to a dyamic port
+                // This can be overridden using an option like "--urls http://localhost:9500"
+                webBuilder.UseUrls("http://127.0.0.1:0");
+            })
+            .UseDefaultServiceProvider((context, options) =>
+            {
+                options.ValidateScopes = context.HostingEnvironment.IsDevelopment();
+            })
+            .ConfigureServices(serviceCollection =>
+            {
+                serviceCollection.AddSingleton(new DebugProxyOptions
+                {
+                    BrowserHost = browserHost
+                });
+            });
+
+            return builder;
+
+        }
+    }
+}

--- a/src/Components/WebAssembly/DebugProxy/src/Hosting/DebugProxyHost.cs
+++ b/src/Components/WebAssembly/DebugProxy/src/Hosting/DebugProxyHost.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -44,10 +47,6 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.Hosting
                 // By default we bind to a dyamic port
                 // This can be overridden using an option like "--urls http://localhost:9500"
                 webBuilder.UseUrls("http://127.0.0.1:0");
-            })
-            .UseDefaultServiceProvider((context, options) =>
-            {
-                options.ValidateScopes = context.HostingEnvironment.IsDevelopment();
             })
             .ConfigureServices(serviceCollection =>
             {

--- a/src/Components/WebAssembly/DebugProxy/src/Program.cs
+++ b/src/Components/WebAssembly/DebugProxy/src/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.Hosting;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
@@ -36,29 +37,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.DebugProxy
 
             app.OnExecute(() =>
             {
-                var host = Host.CreateDefaultBuilder(args)
-                    .ConfigureAppConfiguration((hostingContext, config) =>
-                    {
-                        config.AddCommandLine(args);
-                    })
-                    .ConfigureWebHostDefaults(webBuilder =>
-                    {
-                        webBuilder.UseStartup<Startup>();
-
-                        // By default we bind to a dyamic port
-                        // This can be overridden using an option like "--urls http://localhost:9500"
-                        webBuilder.UseUrls("http://127.0.0.1:0");
-                    })
-                    .ConfigureServices(serviceCollection =>
-                    {
-                        serviceCollection.AddSingleton(new DebugProxyOptions
-                        {
-                            BrowserHost = browserHostOption.HasValue()
-                                ? browserHostOption.Value()
-                                : "http://127.0.0.1:9222",
-                        });
-                    })
-                    .Build();
+                var browserHost = browserHostOption.HasValue() ? browserHostOption.Value(): "http://127.0.0.1:9222";
+                var host = DebugProxyHost.CreateDefaultBuilder(args, browserHost).Build();
 
                 if (ownerPidOption.HasValue())
                 {

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -52,7 +52,6 @@ namespace Microsoft.AspNetCore.Builder
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
             };
-            RemoveUnwantedEnvironmentVariables(processStartInfo.Environment);
 
             var debugProxyProcess = Process.Start(processStartInfo);
             CompleteTaskWhenServerIsReady(debugProxyProcess, tcs);
@@ -63,20 +62,6 @@ namespace Microsoft.AspNetCore.Builder
             });
 
             return await tcs.Task;
-        }
-
-        private static void RemoveUnwantedEnvironmentVariables(IDictionary<string, string> environment)
-        {
-            // Generally we expect to pass through most environment variables, since dotnet might
-            // need them for arbitrary reasons to function correctly. However, we specifically don't
-            // want to pass through any ASP.NET Core hosting related ones, since the child process
-            // shouldn't be trying to use the same port numbers, etc. In particular we need to break
-            // the association with IISExpress and the MS-ASPNETCORE-TOKEN check.
-            var keysToRemove = environment.Keys.Where(key => key.StartsWith("ASPNETCORE_")).ToList();
-            foreach (var key in keysToRemove)
-            {
-                environment.Remove(key);
-            }
         }
 
         private static string LocateDebugProxyExecutable(IWebHostEnvironment environment)


### PR DESCRIPTION
This PR creates a new DebugProxyHost that is used to configure and initialize the debugging proxy.

I migrated some of the applicable configs from the WebHostBuilder and migrated our configs that were in Program.cs to this class.

Following @pranavkm I also added support for loading configurations from a JSON file should we need this in the future.

Addresses #19909
