### PR TITLE
Adding reference to MessagePackAnalyzer to check for MsgPack001 / MsgPack002 (Banned API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ BenchmarkDotNet.Artifacts/
 .gradle/
 src/SignalR/clients/**/dist/
 modules/
+.ionide/
 
 # File extensions
 *.aps

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -162,6 +162,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="IdentityServer4.Storage" Version="$(IdentityServer4StoragePackageVersion)" />
     <LatestPackageReference Include="Libuv" Version="$(LibuvPackageVersion)" />
     <LatestPackageReference Include="MessagePack" Version="$(MessagePackPackageVersion)" />
+    <LatestPackageReference Include="MessagePackAnalyzer" Version="$(MessagePackAnalyzerPackageVersion)" />
     <LatestPackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
     <LatestPackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <LatestPackageReference Include="Newtonsoft.Json.Bson" Version="$(NewtonsoftJsonBsonPackageVersion)" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -162,7 +162,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="IdentityServer4.Storage" Version="$(IdentityServer4StoragePackageVersion)" />
     <LatestPackageReference Include="Libuv" Version="$(LibuvPackageVersion)" />
     <LatestPackageReference Include="MessagePack" Version="$(MessagePackPackageVersion)" />
-    <LatestPackageReference Include="MessagePackAnalyzer" Version="$(MessagePackAnalyzerPackageVersion)" />
+    <LatestPackageReference Include="MessagePackAnalyzer" Version="$(MessagePackPackageVersion)" />
     <LatestPackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
     <LatestPackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <LatestPackageReference Include="Newtonsoft.Json.Bson" Version="$(NewtonsoftJsonBsonPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -225,6 +225,7 @@
     <IdentityServer4StoragePackageVersion>3.0.0</IdentityServer4StoragePackageVersion>
     <IdentityServer4EntityFrameworkStoragePackageVersion>3.0.0</IdentityServer4EntityFrameworkStoragePackageVersion>
     <MessagePackPackageVersion>2.1.80</MessagePackPackageVersion>
+    <MessagePackAnalyzerPackageVersion>2.1.80</MessagePackAnalyzerPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <MonoCecilPackageVersion>0.10.1</MonoCecilPackageVersion>
     <NewtonsoftJsonBsonPackageVersion>1.0.2</NewtonsoftJsonBsonPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -225,7 +225,6 @@
     <IdentityServer4StoragePackageVersion>3.0.0</IdentityServer4StoragePackageVersion>
     <IdentityServer4EntityFrameworkStoragePackageVersion>3.0.0</IdentityServer4EntityFrameworkStoragePackageVersion>
     <MessagePackPackageVersion>2.1.90</MessagePackPackageVersion>
-    <MessagePackAnalyzerPackageVersion>2.1.90</MessagePackAnalyzerPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <MonoCecilPackageVersion>0.10.1</MonoCecilPackageVersion>
     <NewtonsoftJsonBsonPackageVersion>1.0.2</NewtonsoftJsonBsonPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -224,8 +224,8 @@
     <IdentityServer4PackageVersion>3.0.0</IdentityServer4PackageVersion>
     <IdentityServer4StoragePackageVersion>3.0.0</IdentityServer4StoragePackageVersion>
     <IdentityServer4EntityFrameworkStoragePackageVersion>3.0.0</IdentityServer4EntityFrameworkStoragePackageVersion>
-    <MessagePackPackageVersion>2.1.80</MessagePackPackageVersion>
-    <MessagePackAnalyzerPackageVersion>2.1.80</MessagePackAnalyzerPackageVersion>
+    <MessagePackPackageVersion>2.1.90</MessagePackPackageVersion>
+    <MessagePackAnalyzerPackageVersion>2.1.90</MessagePackAnalyzerPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <MonoCecilPackageVersion>0.10.1</MonoCecilPackageVersion>
     <NewtonsoftJsonBsonPackageVersion>1.0.2</NewtonsoftJsonBsonPackageVersion>

--- a/src/SignalR/common/Protocols.MessagePack/src/.editorconfig
+++ b/src/SignalR/common/Protocols.MessagePack/src/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome:http://EditorConfig.org
+# NOTE: Requires **VS2019 16.3** or later
+
+# New Rule Set
+# Description:
+# MsgPack001 : MsgPack001 Avoid static default for MessagePackSerializerOptions
+# MsgPack002 : MsgPack002 Avoid using a mutable static value for MessagePackSerializerOptions
+
+# Code files
+[*.{cs,vb}]
+dotnet_diagnostic.MsgPack001.severity = error
+dotnet_diagnostic.MsgPack002.severity = error

--- a/src/SignalR/common/Protocols.MessagePack/src/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.csproj
+++ b/src/SignalR/common/Protocols.MessagePack/src/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.SignalR.Common" />
     <Reference Include="MessagePack" />
+    <Reference Include="MessagePackAnalyzer" />
   </ItemGroup>
 
 </Project>

--- a/src/SignalR/common/Protocols.MessagePack/src/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.csproj
+++ b/src/SignalR/common/Protocols.MessagePack/src/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Implements the SignalR Hub Protocol over MsgPack.</Description>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.SignalR.Common" />
     <Reference Include="MessagePack" />
-    <Reference Include="MessagePackAnalyzer" />
+    <Reference Include="MessagePackAnalyzer" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -54,12 +54,12 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         {
             var msgPackOptions = options.Value;
             var resolver = SignalRResolver.Instance;
-            var hasCustomFormatterResovler = false;
+            var hasCustomFormatterResolver = false;
 
             // if counts don't match then we know users customized resolvers so we set up the options with the provided resolvers
             if (msgPackOptions.FormatterResolvers.Count != SignalRResolver.Resolvers.Count)
             {
-                hasCustomFormatterResovler = true;
+                hasCustomFormatterResolver = true;
             }
             else
             {
@@ -69,13 +69,13 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                     // check if the user customized the resolvers
                     if (msgPackOptions.FormatterResolvers[i] != SignalRResolver.Resolvers[i])
                     {
-                        hasCustomFormatterResovler = true;
+                        hasCustomFormatterResolver = true;
                         break;
                     }
                 }
             }
 
-            if (hasCustomFormatterResovler)
+            if (hasCustomFormatterResolver)
             {
                 resolver = CompositeResolver.Create(Array.Empty<IMessagePackFormatter>(), (IReadOnlyList<IFormatterResolver>)msgPackOptions.FormatterResolvers);
             }

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             }
             else
             {
-                //Compare each "reference" in the FormatterResolvers IList<> against the default "SignalRResolver.Resolvers" IList<>
+                // Compare each "reference" in the FormatterResolvers IList<> against the default "SignalRResolver.Resolvers" IList<>
                 for (var i = 0; i < msgPackOptions.FormatterResolvers.Count; i++)
                 {
                     // check if the user customized the resolvers


### PR DESCRIPTION
## Description
Make sure `MessagePack` built in analyzers run to be sure the `MessagePackSerializerOptions` are not using `BannedApi`

Addresses #18290

## Details :
 - [x] Add dependency on package `MessagePackAnalyzer`
 - [x] Update to `2.1.90`
 - [x] Added `.editorconfig` for analyzers
 - [x] Use the same variable for both package
 - [x] `MessagePackAnalyzer` should not be "leaked as a transitive" to consumer as it wont be possible to enforce the same severity as this repo set in `.editorconfig`
 - [x] Make `MessagePackSerializerOptions` readonly

## Results
![image](https://user-images.githubusercontent.com/2266487/77074773-9a996380-69f1-11ea-97ce-766ab75addc7.png)

Generated nuget / nuspec :
![image](https://user-images.githubusercontent.com/2266487/77097228-bf510380-6a10-11ea-841c-eec0fe26c89a.png)
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Microsoft.AspNetCore.SignalR.Protocols.MessagePack</id>
    <version>5.0.0-dev</version>
    <authors>Microsoft</authors>
    <owners>Microsoft</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <license type="expression">Apache-2.0</license>
    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
    <icon>Icon.png</icon>
    <projectUrl>https://asp.net/</projectUrl>
    <description>Implements the SignalR Hub Protocol over MsgPack.

This package was built from the source code at https://github.com/dotnet/aspnetcore/tree/19c629ffd143a6a666c6a8912889156a595185de</description>
    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
    <tags>aspnetcore signalr</tags>
    <serviceable>true</serviceable>
    <repository type="git" url="https://github.com/dotnet/aspnetcore" commit="19c629ffd143a6a666c6a8912889156a595185de" />
    <dependencies>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Microsoft.AspNetCore.SignalR.Common" version="5.0.0-dev" exclude="Build,Analyzers" />
        <dependency id="MessagePack" version="2.1.90" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```