### PR TITLE
Spruce up WebAssemblyHostEnvironment interface and use

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -58,10 +58,11 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
             InitializeDefaultServices();
 
             var hostEnvironment = InitializeEnvironment(jsRuntimeInvoker);
+            HostEnvironment = hostEnvironment;
 
             _createServiceProvider = () =>
             {
-                return Services.BuildServiceProvider(validateScopes: hostEnvironment.Environment == "Development");
+                return Services.BuildServiceProvider(validateScopes: WebAssemblyHostEnvironmentExtensions.IsDevelopment(hostEnvironment));
             };
         }
 
@@ -110,6 +111,11 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
         /// Gets the service collection.
         /// </summary>
         public IServiceCollection Services { get; }
+
+        /// <summary>
+        /// Gets information about the app's host environment.
+        /// </summary>
+        public IWebAssemblyHostEnvironment HostEnvironment { get; }
 
         /// <summary>
         /// Registers a <see cref="IServiceProviderFactory{TBuilder}" /> instance to be used to create the <see cref="IServiceProvider" />.

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostEnvironmentExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostEnvironmentExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
+{
+    public static class WebAssemblyHostEnvironmentExtensions
+    {
+        /// <summary>
+        /// Checks if the current hosting environment name is <see cref="EnvironmentName.Development"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">An instance of <see cref="IWebAssemblyHostEnvironment"/>.</param>
+        /// <returns>True if the environment name is <see cref="EnvironmentName.Development"/>, otherwise false.</returns>
+        public static bool IsDevelopment(this IWebAssemblyHostEnvironment hostingEnvironment)
+        {
+            if (hostingEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostingEnvironment));
+            }
+
+            return hostingEnvironment.IsEnvironment("Development");
+        }
+
+        /// <summary>
+        /// Checks if the current hosting environment name is <see cref="EnvironmentName.Staging"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">An instance of <see cref="IWebAssemblyHostEnvironment"/>.</param>
+        /// <returns>True if the environment name is <see cref="EnvironmentName.Staging"/>, otherwise false.</returns>
+        public static bool IsStaging(this IWebAssemblyHostEnvironment hostingEnvironment)
+        {
+            if (hostingEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostingEnvironment));
+            }
+
+            return hostingEnvironment.IsEnvironment("Staging");
+        }
+
+        /// <summary>
+        /// Checks if the current hosting environment name is <see cref="EnvironmentName.Production"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">An instance of <see cref="IWebAssemblyHostEnvironment"/>.</param>
+        /// <returns>True if the environment name is <see cref="EnvironmentName.Production"/>, otherwise false.</returns>
+        public static bool IsProduction(this IWebAssemblyHostEnvironment hostingEnvironment)
+        {
+            if (hostingEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostingEnvironment));
+            }
+
+            return hostingEnvironment.IsEnvironment("Production");
+        }
+
+        /// <summary>
+        /// Compares the current hosting environment name against the specified value.
+        /// </summary>
+        /// <param name="hostingEnvironment">An instance of <see cref="IWebAssemblyHostEnvironment"/>.</param>
+        /// <param name="environmentName">Environment name to validate against.</param>
+        /// <returns>True if the specified name is the same as the current environment, otherwise false.</returns>
+        public static bool IsEnvironment(
+            this IWebAssemblyHostEnvironment hostingEnvironment,
+            string environmentName)
+        {
+            if (hostingEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostingEnvironment));
+            }
+
+            return string.Equals(
+                hostingEnvironment.Environment,
+                environmentName,
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostBuilderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostBuilderTest.cs
@@ -126,6 +126,20 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
             Assert.NotNull(host.Services.GetRequiredService<TestServiceThatTakesStringBuilder>());
         }
 
+        [Fact]
+        public void Builder_InDevelopment_SetsHostEnvironmentProperty()
+        {
+            // Arrange
+            var builder = new WebAssemblyHostBuilder(new TestWebAssemblyJSRuntimeInvoker(environment: "Development"));
+
+            builder.Services.AddScoped<StringBuilder>();
+            builder.Services.AddSingleton<TestServiceThatTakesStringBuilder>();
+
+            // Assert
+            Assert.NotNull(builder.HostEnvironment);
+            Assert.True(WebAssemblyHostEnvironmentExtensions.IsDevelopment(builder.HostEnvironment));
+        }
+
         private class TestServiceThatTakesStringBuilder
         {
             public TestServiceThatTakesStringBuilder(StringBuilder builder) { }


### PR DESCRIPTION
**Changes in this PR**
- Adds `HostEnvironment` property for accessing `WebAssemblyHostEnvironment` in `WebAssemblyHostBuilder`
- Adds convenience methods for checking currently set environment in `WebAssemblyHostEnvironment`

Addresses #19900
