### PR TITLE
Changing msgpack options

### DIFF
--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         /// <summary>
         /// <para>Get or Set the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
-        /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:<para>
+        /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
         /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
         /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// <para>Gets or sets the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
         /// <para>If you override the default value, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
-        /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
+        /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>.
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
         /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>
         /// </summary>

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <para>Get or Set the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
         /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:<para>
         /// <code>customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
-        /// If you want to modify to the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
+        /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
         /// <code>SerializerOptions = SerializerOptions.WithResolver(new CustomResolver());</code>
         /// </summary>
         public MessagePackSerializerOptions SerializerOptions

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -11,6 +11,13 @@ namespace Microsoft.AspNetCore.SignalR
     {
         private MessagePackSerializerOptions _messagePackSerializerOptions;
 
+        /// <summary>
+        /// <para>Get or Set the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
+        /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling :<para>
+        /// <code>customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
+        /// If you want to modify to the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
+        /// <code>SerializerOptions = SerializerOptions.WithResolver(new CustomResolver());</code>
+        /// </summary>
         public MessagePackSerializerOptions SerializerOptions
         {
             get

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         /// <summary>
         /// <para>Gets or sets the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
-        /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
+        /// <para>If you override the default value, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
         /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
         /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// <para>Get or Set the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
         /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:<para>
-        /// <code>customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
+        /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
         /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>
         /// </summary>

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.SignalR
         private MessagePackSerializerOptions _messagePackSerializerOptions;
 
         /// <summary>
-        /// <para>Get or Set the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
+        /// <para>Gets or sets the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
         /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
         /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// <para>Gets or sets the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
         /// <para>If you override the default value, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
-        /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>.
+        /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you modify the default options you must also assign the updated options back to the <see cref="SerializerOptions" /> property:
-        /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>.
+        /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>
         /// </summary>
         public MessagePackSerializerOptions SerializerOptions
         {

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -9,24 +9,24 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public class MessagePackHubProtocolOptions
     {
-        private IList<IFormatterResolver> _formatterResolvers;
+        private MessagePackSerializerOptions _messagePackSerializerOptions;
 
-        public IList<IFormatterResolver> FormatterResolvers
+        public MessagePackSerializerOptions SerializerOptions
         {
             get
             {
-                if (_formatterResolvers == null)
+                if (_messagePackSerializerOptions == null)
                 {
                     // The default set of resolvers trigger a static constructor that throws on AOT environments.
                     // This gives users the chance to use an AOT friendly formatter.
-                    _formatterResolvers = MessagePackHubProtocol.CreateDefaultFormatterResolvers();
+                    _messagePackSerializerOptions = MessagePackHubProtocol.CreateDefaultFormatterResolvers();
                 }
 
-                return _formatterResolvers;
+                return _messagePackSerializerOptions;
             }
             set
             {
-                _formatterResolvers = value;
+                _messagePackSerializerOptions = value;
             }
         }
     }

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR
                 {
                     // The default set of resolvers trigger a static constructor that throws on AOT environments.
                     // This gives users the chance to use an AOT friendly formatter.
-                    _messagePackSerializerOptions = MessagePackHubProtocol.CreateDefaultFormatterResolvers();
+                    _messagePackSerializerOptions = MessagePackHubProtocol.CreateDefaultMessagePackSerializerOptions();
                 }
 
                 return _messagePackSerializerOptions;

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <para>If you override the default value, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
         /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>.
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
-        /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>
+        /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>.
         /// </summary>
         public MessagePackSerializerOptions SerializerOptions
         {

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <para>Gets or sets the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
         /// <para>If you override the default value, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:</para>
         /// <code>customMessagePackSerializerOptions = customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>.
-        /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
+        /// If you modify the default options you must also assign the updated options back to the <see cref="SerializerOptions" /> property:
         /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>.
         /// </summary>
         public MessagePackSerializerOptions SerializerOptions

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         /// <summary>
         /// <para>Get or Set the <see cref="MessagePackSerializerOptions"/> used internally by the <see cref="MessagePackSerializer" />.</para>
-        /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling :<para>
+        /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:<para>
         /// <code>customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you want to modify to the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
         /// <code>SerializerOptions = SerializerOptions.WithResolver(new CustomResolver());</code>

--- a/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/MessagePackHubProtocolOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <para>If you override it, we strongly recommend that you set <see cref="MessagePackSecurity" /> to <see cref="MessagePackSecurity.UntrustedData"/> by calling:<para>
         /// <code>customMessagePackSerializerOptions.WithSecurity(MessagePackSecurity.UntrustedData)</code>
         /// If you want to modify the default options you need to assign the options back to the <see cref="SerializerOptions" /> after modifications:
-        /// <code>SerializerOptions = SerializerOptions.WithResolver(new CustomResolver());</code>
+        /// <code>options.SerializerOptions = options.SerializerOptions.WithResolver(new CustomResolver());</code>
         /// </summary>
         public MessagePackSerializerOptions SerializerOptions
         {

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         private const int NonVoidResult = 3;
 
         private readonly MessagePackSerializerOptions _msgPackSerializerOptions;
+
         private static readonly string ProtocolName = "messagepack";
         private static readonly int ProtocolVersion = 1;
 
@@ -52,37 +53,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// <param name="options">The options used to initialize the protocol.</param>
         public MessagePackHubProtocol(IOptions<MessagePackHubProtocolOptions> options)
         {
-            var msgPackOptions = options.Value;
-            var resolver = SignalRResolver.Instance;
-            var hasCustomFormatterResolver = false;
-
-            // if counts don't match then we know users customized resolvers so we set up the options with the provided resolvers
-            if (msgPackOptions.FormatterResolvers.Count != SignalRResolver.Resolvers.Count)
-            {
-                hasCustomFormatterResolver = true;
-            }
-            else
-            {
-                // Compare each "reference" in the FormatterResolvers IList<> against the default "SignalRResolver.Resolvers" IList<>
-                for (var i = 0; i < msgPackOptions.FormatterResolvers.Count; i++)
-                {
-                    // check if the user customized the resolvers
-                    if (msgPackOptions.FormatterResolvers[i] != SignalRResolver.Resolvers[i])
-                    {
-                        hasCustomFormatterResolver = true;
-                        break;
-                    }
-                }
-            }
-
-            if (hasCustomFormatterResolver)
-            {
-                resolver = CompositeResolver.Create(Array.Empty<IMessagePackFormatter>(), (IReadOnlyList<IFormatterResolver>)msgPackOptions.FormatterResolvers);
-            }
-
-            _msgPackSerializerOptions = MessagePackSerializerOptions.Standard
-                                                                    .WithResolver(resolver)
-                                                                    .WithSecurity(MessagePackSecurity.UntrustedData);
+            _msgPackSerializerOptions = options.Value.SerializerOptions;
         }
 
         /// <inheritdoc />
@@ -656,11 +627,11 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             }
         }
 
-        internal static List<IFormatterResolver> CreateDefaultFormatterResolvers()
-        {
-            // Copy to allow users to add/remove resolvers without changing the static SignalRResolver list
-            return new List<IFormatterResolver>(SignalRResolver.Resolvers);
-        }
+        internal static MessagePackSerializerOptions CreateDefaultFormatterResolvers() =>
+            MessagePackSerializerOptions
+                .Standard
+                .WithResolver(SignalRResolver.Instance)
+                .WithSecurity(MessagePackSecurity.UntrustedData);
 
         internal class SignalRResolver : IFormatterResolver
         {

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -627,7 +627,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             }
         }
 
-        internal static MessagePackSerializerOptions CreateDefaultFormatterResolvers() =>
+        internal static MessagePackSerializerOptions CreateDefaultMessagePackSerializerOptions() =>
             MessagePackSerializerOptions
                 .Standard
                 .WithResolver(SignalRResolver.Instance)

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -637,7 +637,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         {
             public static readonly IFormatterResolver Instance = new SignalRResolver();
 
-            public static readonly IList<IFormatterResolver> Resolvers = new IFormatterResolver[]
+            public static readonly IReadOnlyList<IFormatterResolver> Resolvers = new IFormatterResolver[]
             {
                 DynamicEnumAsStringResolver.Instance,
                 ContractlessStandardResolver.Instance,

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MessagePack;
 using MessagePack.Formatters;
+using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
@@ -2370,7 +2371,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     services.AddSignalR()
                         .AddMessagePackProtocol(options =>
                         {
-                            options.FormatterResolvers.Insert(0, new CustomFormatter());
+                            options.SerializerOptions = MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter(), options.SerializerOptions.Resolver));
                         });
                 }, LoggerFactory);
 


### PR DESCRIPTION
Summary of the changes :
 - In `MessagePack-CSharp v2` there is a `MessagePackSerializerOptions` class passed to the serializer
 - This PR try to see if it's possible to let the consumer seed an instance of `MessagePackSerializerOptions` rather than an `IList<IFormatterResolvers>`

Addresses #18569

## First Approach
Use an `IOptions<MessagePackSerializerOptions>`,
an attempt was done here https://github.com/tebeco/AspNetCore/commit/56c457739c54677626fad11f2821f3c101d8e04c
**BUT** not possible since this type has no `public parameter less ctor` AND it's API if a Fluent/Immutable one making it impossible to do this :
```
builder
    .Services.AddOptions<MessagePackSerializerOptions>()                                       // <=== will crash on first call (no ctor)
    .Configure(options => XXX = options.WithResolver(SignalRResolver.Instance))                // Will have 0 impact since it creates a new instance that wont be tracked by the DI
    .PostConfigure(options => XXX = options.WithSecurity(MessagePackSecurity.UntrustedData));  // same here

```

## Other Approaches
1. Keep the current `IOptions<MessagePackHubProtocolOptions>` and expose directly a property of type `MessagePackSerializerOptions`
2. Remove the `IOptions<>` and create an overload accepting an instance of `MessagePackSerializerOptions`
   * Not DI friendly
   * then i stumbled on lots of issue, [the WIP is here](https://github.com/tebeco/AspNetCore/tree/changing-msgpack-options-2)
   * the 1 test KO is the `CustomFormatter` one, and clearly show DI issue + the use of `TryAddEnumerable` + `captured Closure`
   * if we need something in the DI to avoid that `closure` issue ... then why not an `IOptions<>` ... oO hello proposal 1

Currently looking at `Approach 1`