### PR TITLE
Remove dependency on netstandard.library.ref

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -134,10 +134,6 @@
       <TargetingPackVersion Condition="'$(IsServicingBuild)' != 'true'">$(SharedFxVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
 
-    <KnownFrameworkReference Update="NETStandard.Library">
-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1' and '$(IsServicingBuild)' != 'true'">$(NETStandardLibraryRefPackageVersion)</TargetingPackVersion>
-    </KnownFrameworkReference>
-
     <!-- Track compiler separately from Arcade.-->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset"
         Version="$(MicrosoftNetCompilersToolsetPackageVersion)"

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -317,10 +317,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>35df31cc5564964617669cb0d6bcce48b90998b4</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview.3.20160.8" CoherentParentDependency="Microsoft.Extensions.Logging">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>73268c790b7ff31c98a292efbc583e25562074d7</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,6 @@
     <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-preview.3.20169.13</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>5.0.0-preview.3.20169.13</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.3.20169.13</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview.3.20160.8</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->
     <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.3.20169.13</MicrosoftWin32RegistryPackageVersion>
     <MicrosoftWin32SystemEventsPackageVersion>5.0.0-preview.3.20169.13</MicrosoftWin32SystemEventsPackageVersion>


### PR DESCRIPTION
This package isn't being produced out of dotnet/runtime anymore - we should just use the default version that is bundled with the SDK rather than listing a dependency on it.

CC @dagood @Pilchie @ericstj