### PR TITLE
Update StackExchange.Redis from 2.0.x to 2.1.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -237,7 +237,7 @@
     <SeleniumWebDriverPackageVersion>3.12.1</SeleniumWebDriverPackageVersion>
     <SerilogExtensionsLoggingPackageVersion>1.4.0</SerilogExtensionsLoggingPackageVersion>
     <SerilogSinksFilePackageVersion>4.0.0</SerilogSinksFilePackageVersion>
-    <StackExchangeRedisPackageVersion>2.0.593</StackExchangeRedisPackageVersion>
+    <StackExchangeRedisPackageVersion>2.1.0</StackExchangeRedisPackageVersion>
     <SystemReactiveLinqPackageVersion>3.1.1</SystemReactiveLinqPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>


### PR DESCRIPTION
Summary of the changes :
 - Just update `StackExchange.Redis` to `2.1.0`
Release note : https://stackexchange.github.io/StackExchange.Redis/ReleaseNotes

Related to #20040 but does not seems to address it ...


### Details
After trying to work on #20040 i saw multiple post from @NickCraver and @mgravell pointing out that `2.1.0` was just released

As i understood from existing issues, one of the changes is "better error msg" <==== i though it would have helped me understanding #20040


Given the fact that it seems to be related to a massive list of potential issues, is it worth updating it ?
eg:
* https://github.com/StackExchange/StackExchange.Redis/pull/1374
* It also enables supports for `IAsyncEnumerable` which might be useful somedays (or not) in `Microsoft.AspNetCore.SignalR.StackExchangeRedis`