### PR TITLE
Added new extension method IServiceCollection for setting up HttpClient.BaseAddress with baseAddress parameter.

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/HttpClientServiceCollectionExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/HttpClientServiceCollectionExtensions.cs
@@ -27,5 +27,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 };
             });
         }
+        /// <summary>
+        /// Adds a <see cref="HttpClient" /> instance to the <paramref name="serviceCollection" /> that is
+        /// configured to set the application's <see cref="HttpClient.BaseAddress" />.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection" />.</param>
+        /// <param name="baseAddress">The <see cref="HttpClient.BaseAddress" /></param>
+        /// <returns>The configured <see cref="IServiceCollection" />.</returns>
+        public static IServiceCollection AddBaseAddressHttpClient(this IServiceCollection serviceCollection, string baseAddress)
+        {
+            return serviceCollection.AddSingleton(s =>
+            {
+                // Creating the URI helper needs to wait until the JS Runtime is initialized, so defer it.
+                return new HttpClient
+                {
+                    BaseAddress = new Uri(baseAddress)
+                };
+            });
+        }
     }
 }


### PR DESCRIPTION
It's more practical to set the BaseAddress of the http client when setting up the service cause most of the time we may communicate with an api so there is were the idea of this extension method comes in.

Summary of the changes (Less than 80 chars)
 - Added new extension method to IServiceCollection when setting up the HttpClient as Singleton use a baseAddress parameter instead of just read the NavigationManager.BaseUri
