### PR TITLE
Added new extension method IServiceCollection for setting up HttpClient with HttpClient parameter.

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/HttpClientServiceCollectionExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/HttpClientServiceCollectionExtensions.cs
@@ -27,5 +27,19 @@ namespace Microsoft.Extensions.DependencyInjection
                 };
             });
         }
+        /// <summary>
+        /// Adds a <see cref="HttpClient" /> instance to the <paramref name="serviceCollection" /> that is
+        /// configured to set the application's <see cref="HttpClient" />.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection" />.</param>
+        /// <param name="HttpClient">The <see cref="HttpClient" /></param>
+        /// <returns>The configured <see cref="IServiceCollection" />.</returns>
+        public static IServiceCollection AddBaseAddressHttpClient(this IServiceCollection serviceCollection, HttpClient httpClient)
+        {
+            return serviceCollection.AddSingleton(s =>
+            {
+                return httpClient;
+            });
+        }
     }
 }


### PR DESCRIPTION
We may need to setup other options like initial authorization token, a custom header I think we should be able to pass an entire HttpClient object to setup properly our singleton HttpClient.

Summary of the changes (Less than 80 chars)
 - Added HttpClient as parameter
