### PR TITLE
[Blazor] Auth improvements

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/Models/MsalProviderOptions.cs
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Models/MsalProviderOptions.cs
@@ -24,7 +24,12 @@ namespace Microsoft.Authentication.WebAssembly.Msal.Models
         /// <summary>
         /// Gets or sets the msal.js cache options.
         /// </summary>
-        public MsalCacheOptions Cache { get; set; }
+        public MsalCacheOptions Cache { get; set; } = new MsalCacheOptions
+        {
+            // This matches the defaults in msal.js
+            CacheLocation = "sessionStorage",
+            StoreAuthStateInCookie = false
+        };
 
         /// <summary>
         /// Gets or set the list of default access tokens scopes to provision during the sign-in flow.

--- a/src/Components/WebAssembly/Authentication.Msal/src/MsalDefaultOptionsConfiguration.cs
+++ b/src/Components/WebAssembly/Authentication.Msal/src/MsalDefaultOptionsConfiguration.cs
@@ -40,11 +40,6 @@ namespace Microsoft.Authentication.WebAssembly.Msal
             }
 
             options.ProviderOptions.Authentication.NavigateToLoginRequestUrl = false;
-            options.ProviderOptions.Cache = new MsalCacheOptions
-            {
-                CacheLocation = "localStorage",
-                StoreAuthStateInCookie = true
-            };
         }
 
         public void PostConfigure(string name, RemoteAuthenticationOptions<MsalProviderOptions> options)

--- a/src/Components/WebAssembly/Authentication.Msal/src/MsalWebAssemblyServiceCollectionExtensions.cs
+++ b/src/Components/WebAssembly/Authentication.Msal/src/MsalWebAssemblyServiceCollectionExtensions.cs
@@ -24,13 +24,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection AddMsalAuthentication(this IServiceCollection services, Action<RemoteAuthenticationOptions<MsalProviderOptions>> configure)
         {
+            return AddMsalAuthentication<RemoteAuthenticationState>(services, configure);
+        }
+
+        /// <summary>
+        /// Adds authentication using msal.js to Blazor applications.
+        /// </summary>
+        /// <typeparam name="TRemoteAuthenticationState">The type of the remote authentication state.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configure">The <see cref="Action{RemoteAuthenticationOptions{MsalProviderOptions}}"/> to configure the <see cref="RemoteAuthenticationOptions{MsalProviderOptions}"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddMsalAuthentication<TRemoteAuthenticationState>(this IServiceCollection services, Action<RemoteAuthenticationOptions<MsalProviderOptions>> configure)
+            where TRemoteAuthenticationState : RemoteAuthenticationState, new()
+        {
             services.AddRemoteAuthentication<RemoteAuthenticationState, MsalProviderOptions>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<MsalProviderOptions>>, MsalDefaultOptionsConfiguration>());
-
-            if (configure != null)
-            {
-                services.Configure(configure);
-            }
 
             return services;
         }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/package.json
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "build": "npm run build:release",
     "build:release": "webpack --mode production --env.production --env.configuration=Release",

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/OidcProviderOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/OidcProviderOptions.cs
@@ -17,6 +17,11 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         public string Authority { get; set; }
 
         /// <summary>
+        /// Gets or sets the metadata url of the oidc provider.
+        /// </summary>
+        public string MetadataUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the client of the application.
         /// </summary>
         [JsonPropertyName("client_id")]

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/WebAssemblyAuthenticationServiceCollectionExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/WebAssemblyAuthenticationServiceCollectionExtensions.cs
@@ -78,50 +78,83 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> where the services were registered.</returns>
         public static IServiceCollection AddOidcAuthentication(this IServiceCollection services, Action<RemoteAuthenticationOptions<OidcProviderOptions>> configure)
         {
-            AddRemoteAuthentication<RemoteAuthenticationState, OidcProviderOptions>(services, configure);
+            return AddOidcAuthentication<RemoteAuthenticationState>(services, configure);
+        }
 
+        /// <summary>
+        /// Adds support for authentication for SPA applications using <see cref="OidcProviderOptions"/> and the <see cref="RemoteAuthenticationState"/>.
+        /// </summary>
+        /// <typeparam name="TRemoteAuthenticationState">The type of the remote authentication state.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="configure">An action that will configure the <see cref="RemoteAuthenticationOptions{TProviderOptions}"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> where the services were registered.</returns>
+        public static IServiceCollection AddOidcAuthentication<TRemoteAuthenticationState>(this IServiceCollection services, Action<RemoteAuthenticationOptions<OidcProviderOptions>> configure)
+            where TRemoteAuthenticationState : RemoteAuthenticationState, new()
+        {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<OidcProviderOptions>>, DefaultOidcOptionsConfiguration>());
 
-            if (configure != null)
-            {
-                services.Configure(configure);
-            }
-
-            return services;
+            return AddRemoteAuthentication<TRemoteAuthenticationState, OidcProviderOptions>(services, configure);
         }
 
         /// <summary>
         /// Adds support for authentication for SPA applications using <see cref="ApiAuthorizationProviderOptions"/> and the <see cref="RemoteAuthenticationState"/>.
         /// </summary>
+        /// <typeparam name="TRemoteAuthenticationState">The type of the remote authentication state.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
         /// <returns>The <see cref="IServiceCollection"/> where the services were registered.</returns>
         public static IServiceCollection AddApiAuthorization(this IServiceCollection services)
         {
-            var inferredClientId = Assembly.GetCallingAssembly().GetName().Name;
-
-            services.AddRemoteAuthentication<RemoteAuthenticationState, ApiAuthorizationProviderOptions>();
-
-            services.TryAddEnumerable(
-                ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>, DefaultApiAuthorizationOptionsConfiguration>(_ =>
-                new DefaultApiAuthorizationOptionsConfiguration(inferredClientId)));
-
-            return services;
+            return AddApiauthorizationCore<RemoteAuthenticationState>(services, configure: null, Assembly.GetCallingAssembly().GetName().Name);
         }
 
         /// <summary>
         /// Adds support for authentication for SPA applications using <see cref="ApiAuthorizationProviderOptions"/> and the <see cref="RemoteAuthenticationState"/>.
         /// </summary>
+        /// <typeparam name="TRemoteAuthenticationState">The type of the remote authentication state.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <returns>The <see cref="IServiceCollection"/> where the services were registered.</returns>
+        public static IServiceCollection AddApiAuthorization<TRemoteAuthenticationState>(this IServiceCollection services)
+            where TRemoteAuthenticationState : RemoteAuthenticationState, new()
+        {
+            return AddApiauthorizationCore<TRemoteAuthenticationState>(services, configure: null, Assembly.GetCallingAssembly().GetName().Name);
+        }
+
+        /// <summary>
+        /// Adds support for authentication for SPA applications using <see cref="ApiAuthorizationProviderOptions"/> and the <see cref="RemoteAuthenticationState"/>.
+        /// </summary>
+        /// <typeparam name="TRemoteAuthenticationState">The type of the remote authentication state.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
         /// <param name="configure">An action that will configure the <see cref="RemoteAuthenticationOptions{ApiAuthorizationProviderOptions}"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/> where the services were registered.</returns>
         public static IServiceCollection AddApiAuthorization(this IServiceCollection services, Action<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>> configure)
         {
-            services.AddApiAuthorization();
+            return AddApiauthorizationCore<RemoteAuthenticationState>(services, configure, Assembly.GetCallingAssembly().GetName().Name);
+        }
 
-            if (configure != null)
-            {
-                services.Configure(configure);
-            }
+        /// <summary>
+        /// Adds support for authentication for SPA applications using <see cref="ApiAuthorizationProviderOptions"/> and the <see cref="RemoteAuthenticationState"/>.
+        /// </summary>
+        /// <typeparam name="TRemoteAuthenticationState">The type of the remote authentication state.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="configure">An action that will configure the <see cref="RemoteAuthenticationOptions{ApiAuthorizationProviderOptions}"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> where the services were registered.</returns>
+        public static IServiceCollection AddApiAuthorization<TRemoteAuthenticationState>(this IServiceCollection services, Action<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>> configure)
+            where TRemoteAuthenticationState : RemoteAuthenticationState, new()
+        {
+            return AddApiauthorizationCore<TRemoteAuthenticationState>(services, configure, Assembly.GetCallingAssembly().GetName().Name);
+        }
+
+        private static IServiceCollection AddApiauthorizationCore<TRemoteAuthenticationState>(
+            IServiceCollection services,
+            Action<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>> configure,
+            string inferredClientId)
+            where TRemoteAuthenticationState : RemoteAuthenticationState, new()
+        {
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>, DefaultApiAuthorizationOptionsConfiguration>(_ =>
+                new DefaultApiAuthorizationOptionsConfiguration(inferredClientId)));
+
+            services.AddRemoteAuthentication<TRemoteAuthenticationState, ApiAuthorizationProviderOptions>(configure);
 
             return services;
         }

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
@@ -52,8 +52,8 @@ namespace Wasm.Authentication.Server
 
             app.UseRouting();
 
-            app.UseAuthentication();
             app.UseIdentityServer();
+            app.UseAuthentication();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/App.razor
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/App.razor
@@ -15,7 +15,14 @@
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
                 <NotAuthorized>
-                    <RedirectToLogin />
+                    @if(!context.User.Identity.IsAuthenticated)
+                    {
+                        <RedirectToLogin />
+                    }
+                    else
+                    {
+                        <p>You are not authorized to access this resource.</p>
+                    }
                 </NotAuthorized>
             </AuthorizeRouteView>
         </Found>

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/RedirectToLogin.razor
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/RedirectToLogin.razor
@@ -3,6 +3,6 @@
 @code {
     protected override void OnInitialized()
     {
-        Navigation.NavigateTo($"authentication/login?returnUrl={Navigation.Uri}");
+        Navigation.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(Navigation.Uri)}");
     }
 }

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
@@ -107,11 +107,11 @@ namespace ComponentsWebAssembly_CSharp.Server
 
             app.UseRouting();
 
-#if (OrganizationalAuth || IndividualAuth)
-            app.UseAuthentication();
-#endif
 #if (IndividualLocalAuth)
             app.UseIdentityServer();
+#endif
+#if (OrganizationalAuth || IndividualAuth)
+            app.UseAuthentication();
 #endif
 #if (!NoAuth)
             app.UseAuthorization();


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/19966

Multiple fixes for small issues in the auth packages:
* Fixes some issues with the startup APIs.
* Fixes redirect to login on the template to avoid an infinite redirect loop if the user is already authenticated but not authorized.
* Fixes missing escape data string on the return url for redirect to login.
* Fixes an async initialization bug in the oidc-client.js implementation where calls could be made before the service was fully initialized.
* Adds missing metadataUrl parameter to OidcProvider options. This allows dealing with non-compliant providers that host their metadata url in places other than `<<authority>>/.well-known/openid-configuration`
* Updates the Msal cache options to match the defaults provided by MSAL and fixes a bug that prevented overriding them.
* Fixes an issue where authorization didn't work if the app was hosted under a base path. 
  * The fix was to re-order IdentityServer in the middleware pipeline as they have a special middleware that handles the base path.