### PR TITLE
Write hash to service worker on publish

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -44,7 +44,12 @@
         Condition="'%(RelativePath)' != '$(ServiceWorkerAssetsManifest)'">
         <AssetUrl>$([System.String]::Copy('$([System.String]::Copy('%(StaticWebAsset.BasePath)').TrimEnd('/'))/%(StaticWebAsset.RelativePath)').Replace('\','/').TrimStart('/'))</AssetUrl>
       </ServiceWorkerAssetsManifestItem>
+
+      <!-- Don't include compressed files in the manifest, since their existence is transparent to the client -->
       <ServiceWorkerAssetsManifestItem Remove="@(_CompressedStaticWebAsset->'%(FullPath)')" />
+
+      <!-- Don't include the service worker files in the manifest, as the service worker doesn't need to fetch itself -->
+      <ServiceWorkerAssetsManifestItem Remove="@(_ServiceWorkerIntermediateFile->'%(FullPath)')" />
     </ItemGroup>
 
     <GetFileHash Files="@(ServiceWorkerAssetsManifestItem)" Algorithm="SHA256" HashEncoding="base64">
@@ -53,11 +58,10 @@
   </Target>
 
   <!--
-    If no ServiceWorkerAssetsManifestVersion was specified, we compute a default value by combining all the asset hashes.
+    Compute a default ServiceWorkerAssetsManifestVersion value by combining all the asset hashes.
     This is useful because then clients will only have to repopulate caches if the contents have changed.
   -->
-  <Target Name="_ComputeDefaultServiceWorkerAssetsManifestVersion"
-          Condition="'$(ServiceWorkerAssetsManifestVersion)' == ''">
+  <Target Name="_ComputeDefaultServiceWorkerAssetsManifestVersion" Condition="'$(ServiceWorkerAssetsManifest)' != ''">
     <PropertyGroup>
       <_CombinedHashIntermediatePath>$(_BlazorIntermediateOutputPath)serviceworkerhashes.txt</_CombinedHashIntermediatePath>
     </PropertyGroup>
@@ -65,6 +69,7 @@
     <WriteLinesToFile
       File="$(_CombinedHashIntermediatePath)"
       Lines="@(_ServiceWorkerAssetsManifestItemWithHash->'%(FileHash)')"
+      WriteOnlyWhenDifferent="true"
       Overwrite="true" />
 
     <GetFileHash Files="$(_CombinedHashIntermediatePath)" Algorithm="SHA256" HashEncoding="base64">
@@ -72,8 +77,50 @@
     </GetFileHash>
 
     <PropertyGroup>
-      <ServiceWorkerAssetsManifestVersion>$([System.String]::Copy('%(_ServiceWorkerAssetsManifestCombinedHash.FileHash)').Substring(0, 8))</ServiceWorkerAssetsManifestVersion>
+      <ServiceWorkerAssetsManifestVersion Condition="'$(ServiceWorkerAssetsManifestVersion)' == ''">$([System.String]::Copy('%(_ServiceWorkerAssetsManifestCombinedHash.FileHash)').Substring(0, 8))</ServiceWorkerAssetsManifestVersion>
     </PropertyGroup>
+  </Target>
+
+  <Target Name="_OmitServiceWorkerContent" BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <!-- Don't emit the service worker source files to the output -->
+      <Content Remove="@(ServiceWorker)" />
+      <Content Remove="@(ServiceWorker->'%(PublishedContent)')" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ResolveServiceWorkerOutputs"
+          BeforeTargets="_ResolveBlazorOutputs"
+          DependsOnTargets="_ComputeServiceWorkerOutputs; _GenerateServiceWorkerIntermediateFiles">
+    <ItemGroup>
+      <_BlazorOutputWithTargetPath Include="@(_ServiceWorkerIntermediateFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ComputeServiceWorkerOutputs">
+    <ItemGroup>
+      <!-- Figure out where we're getting the content for each @(ServiceWorker) entry, depending on whether there's a PublishedContent value -->
+      <_ServiceWorkerIntermediateFile Include="@(ServiceWorker->'$(IntermediateOutputPath)blazor\serviceworkers\%(Identity)')">
+        <ContentSourcePath Condition="'%(ServiceWorker.PublishedContent)' != ''">%(ServiceWorker.PublishedContent)</ContentSourcePath>
+        <ContentSourcePath Condition="'%(ServiceWorker.PublishedContent)' == ''">%(ServiceWorker.Identity)</ContentSourcePath>
+        <TargetOutputPath>%(ServiceWorker.Identity)</TargetOutputPath>
+        <TargetOutputPath Condition="$([System.String]::Copy('%(ServiceWorker.Identity)').StartsWith('wwwroot\'))">$([System.String]::Copy('%(ServiceWorker.Identity)').Substring(8))</TargetOutputPath>
+      </_ServiceWorkerIntermediateFile>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateServiceWorkerIntermediateFiles"
+          Inputs="@(_ServiceWorkerIntermediateFile->'%(ContentSourcePath)'); $(_CombinedHashIntermediatePath)"
+          Outputs="@(_ServiceWorkerIntermediateFile)"
+          DependsOnTargets="_ComputeDefaultServiceWorkerAssetsManifestVersion">
+    <Copy SourceFiles="%(_ServiceWorkerIntermediateFile.ContentSourcePath)" DestinationFiles="%(_ServiceWorkerIntermediateFile.Identity)" />
+    <WriteLinesToFile
+      File="%(_ServiceWorkerIntermediateFile.Identity)"
+      Lines="/* Manifest version: $(ServiceWorkerAssetsManifestVersion) */"
+      Condition="'$(ServiceWorkerAssetsManifestVersion)' != ''" />
+    <ItemGroup>
+      <FileWrites Include="%(_ServiceWorkerIntermediateFile.Identity)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -49,7 +49,7 @@
       <ServiceWorkerAssetsManifestItem Remove="@(_CompressedStaticWebAsset->'%(FullPath)')" />
 
       <!-- Don't include the service worker files in the manifest, as the service worker doesn't need to fetch itself -->
-      <ServiceWorkerAssetsManifestItem Remove="@(_ServiceWorkerIntermediateFile->'%(FullPath)')" />
+      <ServiceWorkerAssetsManifestItem Remove="%(_ServiceWorkerIntermediateFile.FullPath)" />
     </ItemGroup>
 
     <GetFileHash Files="@(ServiceWorkerAssetsManifestItem)" Algorithm="SHA256" HashEncoding="base64">

--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/ComponentsWebAssembly-CSharp.Client.csproj.in
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/ComponentsWebAssembly-CSharp.Client.csproj.in
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="${MicrosoftAspNetCoreComponentsWebAssemblyAuthenticationPackageVersion}" Condition="'$(IndividualLocalAuth)' == 'true'" />
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="${MicrosoftAuthenticationWebAssemblyMsalPackageVersion}" Condition="'$(OrganizationalAuth)' == 'true' OR '$(IndividualB2CAuth)' == 'true'" />
   </ItemGroup>
+
   <!--#if Hosted -->
   <ItemGroup>
     <ProjectReference Include="..\Shared\ComponentsWebAssembly-CSharp.Shared.csproj" />
@@ -23,10 +24,8 @@
 
   <!--#endif -->
   <!--#if PWA -->
-  <!-- When publishing, swap service-worker.published.js in place of service-worker.js -->
-  <ItemGroup Condition="'$(DesignTimeBuild)' != 'true'">
-    <Content Remove="wwwroot\service-worker.js" />
-    <Content Update="wwwroot\service-worker.published.js" Link="wwwroot\service-worker.js" />
+  <ItemGroup>
+    <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
   </ItemGroup>
 
   <!--#endif -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/19882

This changes the recommended way of setting up service workers from this:

```xml
<ItemGroup Condition="'$(DesignTimeBuild)' != 'true'">
    <Content Remove="wwwroot\service-worker.js" />
    <Content Update="wwwroot\service-worker.published.js" Link="wwwroot\service-worker.js" />
</ItemGroup>
```

... to this:

```xml
<ItemGroup>
    <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
</ItemGroup>
```

The behavior for `<ServiceWorker>` items is:

 * Corresponding items (and their `PublishedContent` items, if specified) are *not* written to the output/publish in their original forms
 * However, during publishing we we emit a file matching the item name (e.g., `wwwroot\service-worker.js`) where the content is:
    * The content from the `PublishedContent` item (e.g., `wwwroot\service-worker.published.js`), if specified, or the original item if not (e.g., `wwwroot\service-worker.js`)
    * ... plus, if you specify a `<ServiceWorkerAssetsManifest>` path property, then we also append some text like `/* Manifest version: dW38dwk9 */`, where the random-looking string is the "version" value taken from the generated service worker assets manifest.

The point of this is:

1. Ensures that the published service worker file always changes every time your underlying assets change. This is the fix to #19882.
2. Simplifies the method for swapping in the "published" version of your service worker during publish. I didn't really want to do this but it's a side-effect of item (1).

As a side effect, when performing regular builds the service worker file also gets written to `bin\Debug\netstandard2.1\wwwroot`, even though we're not looking for it there at runtime. This is a side effect of generating the content in the form that SWA recognizes, but I don't think it causes any harm and people can just ignore that.

Also note:

 * You can have multiple `<ServiceWorker>` items if you want
 * We don't assume you're specifying a `PublishedContent`
 * We don't assume you're specifying a `ServiceWorkerAssetsManifest`
 * This works for both standalone and hosting publishing mechanisms
