### PR TITLE
Tweaks for WASM stress runs

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
@@ -163,9 +164,12 @@ namespace Wasm.Performance.Driver
                 });
             }
 
-            Console.WriteLine("#StartJobStatistics");
-            Console.WriteLine(JsonSerializer.Serialize(output));
-            Console.WriteLine("#EndJobStatistics");
+            var builder = new StringBuilder();
+            builder.AppendLine("#StartJobStatistics");
+            builder.AppendLine(JsonSerializer.Serialize(output));
+            builder.AppendLine("#EndJobStatistics");
+
+            Console.WriteLine(builder);
         }
 
         static IHost StartTestApp()

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Selenium.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Selenium.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +15,7 @@ namespace Wasm.Performance.Driver
     {
         const int SeleniumPort = 4444;
         static bool RunHeadlessBrowser = true;
-        static bool PoolForBrowserLogs = true;
+        static bool PoolForBrowserLogs = false;
 
         private static async ValueTask<Uri> WaitForServerAsync(int port, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Prevent interleaved console writes when reporting stats
Do not print browser logs by defualt

