### PR TITLE
fix #13651 by logging serialization failures as error

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1352,21 +1352,24 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             var protocol = HubProtocols[protocolName];
             using (var server = await StartServer<Startup>(write => write.EventId.Name == "FailedWritingMessage"))
             {
-                var connection = CreateHubConnection(server.Url, "/default", HttpTransportType.LongPolling, protocol, LoggerFactory);
-                var closedTcs = new TaskCompletionSource<Exception>();
+                var connection = CreateHubConnection(server.Url, "/default", HttpTransportType.WebSockets, protocol, LoggerFactory);
+                var closedTcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection.Closed += (ex) => { closedTcs.TrySetResult(ex); return Task.CompletedTask; };
                 try
                 {
                     await connection.StartAsync().OrTimeout();
 
-                    var result = connection.InvokeAsync<string>(nameof(TestHub.CallWithUnserializableObject)).OrTimeout();
+                    var result = connection.InvokeAsync<string>(nameof(TestHub.CallWithUnserializableObject));
 
                     // The connection should close.
-                    await closedTcs.Task.OrTimeout();
+                    Assert.Null(await closedTcs.Task.OrTimeout());
+
+                    await Assert.ThrowsAsync<TaskCanceledException>(() => result).OrTimeout();
                 }
                 catch (Exception ex)
                 {
                     LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                    throw;
                 }
                 finally
                 {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -95,6 +95,33 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             return Context.Features.Get<IHttpTransportFeature>().TransportType.ToString();
         }
+
+        public async Task CallWithUnserializableObject()
+        {
+            await Clients.All.SendAsync("Foo", Unserializable.Create());
+        }
+
+        public Unserializable GetUnserializableObject()
+        {
+            return Unserializable.Create();
+        }
+
+        public class Unserializable
+        {
+            public Unserializable Child { get; private set; }
+
+            private Unserializable()
+            {
+            }
+
+            internal static Unserializable Create()
+            {
+                // Loops throw off every serializer ;).
+                var o = new Unserializable();
+                o.Child = o;
+                return o;
+            }
+        }
     }
 
     public class DynamicTestHub : DynamicHub

--- a/src/SignalR/common/testassets/Tests.Utils/InProcessTestServer.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/InProcessTestServer.cs
@@ -84,6 +84,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             _logger = _loggerFactory.CreateLogger<InProcessTestServer<TStartup>>();
         }
 
+        public IList<LogRecord> GetLogs() => _logSinkProvider.GetLogs();
+
         private async Task StartServerInner()
         {
             // We're using 127.0.0.1 instead of localhost to ensure that we use IPV4 across different OSes

--- a/src/SignalR/common/testassets/Tests.Utils/LogRecord.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/LogRecord.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging.Testing;
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
     // WriteContext, but with a timestamp...
-    internal class LogRecord
+    public class LogRecord
     {
         public DateTime Timestamp { get; }
         public WriteContext Write { get; }

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -689,7 +689,7 @@ namespace Microsoft.AspNetCore.SignalR
                 LoggerMessage.Define(LogLevel.Debug, new EventId(5, "HandshakeFailed"), "Failed connection handshake.");
 
             private static readonly Action<ILogger, Exception> _failedWritingMessage =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(6, "FailedWritingMessage"), "Failed writing message. Aborting connection.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(6, "FailedWritingMessage"), "Failed writing message. Aborting connection.");
 
             private static readonly Action<ILogger, string, int, Exception> _protocolVersionFailed =
                 LoggerMessage.Define<string, int>(LogLevel.Debug, new EventId(7, "ProtocolVersionFailed"), "Server does not support version {Version} of the {Protocol} protocol.");

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -3298,7 +3298,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Fact]
         public async Task ConnectionAbortedIfSendFailsWithProtocolError()
         {
-            using (StartVerifiableLog())
+            using (StartVerifiableLog(write => write.EventId.Name == "FailedWritingMessage"))
             {
                 var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                 {


### PR DESCRIPTION
Fixes #13651 

All I did was bump the log from debug to error and update tests. That's what we came up with in the thread. It's the *server* the logs the error, not the *client* (because that would disclose possibly-confidential information).