### PR TITLE
Only reuse HTTP/2 streams when response writer was completed successfully

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     internal class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, IValueTaskSource<FlushResult>, IDisposable
     {
         private int StreamId => _stream.StreamId;
-
         private readonly Http2FrameWriter _frameWriter;
         private readonly TimingPipeFlusher _flusher;
         private readonly IKestrelTrace _log;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -528,8 +528,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
             _disposed = true;
 
-            // Set awaitable after disposed is true to ensure ProcessDataWrites
-            // exits successfully.
+            // Set awaitable after disposed is true to ensure ProcessDataWrites exits successfully.
             _resetAwaitable.SetResult(null);
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 // We only want to reuse a stream that has completely finished writing
                 // and the request wasn't aborted. This is to ensure
                 // Http2OutputProducer.ProcessDataWrites is in the correct state to be reused.
-                CanReuse = !_keepAlive && HasResponseCompleted && !_connectionAborted;
+                CanReuse = !_keepAlive && HasResponseCompleted && _http2Output.HasWriterCompletedSuccessfully;
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -156,9 +156,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 // connection's flow-control window.
                 _inputFlowControl.Abort();
 
-                // We only want to reuse a stream that has completely finished writing
-                // This is to ensure Http2OutputProducer.ProcessDataWrites is in the
-                // correct state to be reused.
+                // We only want to reuse a stream that was not aborted and has completely finished writing.
+                // This ensures Http2OutputProducer.ProcessDataWrites is in the correct state to be reused.
                 CanReuse = !_connectionAborted && HasResponseCompleted;
             }
             finally

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -156,10 +156,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 // connection's flow-control window.
                 _inputFlowControl.Abort();
 
-                // We only want to reuse a stream that has completely finished writing.
-                // This is to prevent the situation where Http2OutputProducer.ProcessDataWrites
-                // is still running in the background.
-                CanReuse = !_keepAlive && HasResponseCompleted;
+                // We only want to reuse a stream that has completely finished writing
+                // and the request wasn't aborted. This is to ensure
+                // Http2OutputProducer.ProcessDataWrites is in the correct state to be reused.
+                CanReuse = !_keepAlive && HasResponseCompleted && !_connectionAborted;
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -157,9 +157,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _inputFlowControl.Abort();
 
                 // We only want to reuse a stream that has completely finished writing
-                // and the request wasn't aborted. This is to ensure
-                // Http2OutputProducer.ProcessDataWrites is in the correct state to be reused.
-                CanReuse = !_keepAlive && HasResponseCompleted && _http2Output.HasWriterCompletedSuccessfully;
+                // This is to ensure Http2OutputProducer.ProcessDataWrites is in the
+                // correct state to be reused.
+                CanReuse = !_connectionAborted && HasResponseCompleted;
             }
             finally
             {


### PR DESCRIPTION
When the HTTP/2 stress suite is run with the latest 5.0 master source code there are some failure results, e.g. 30,000 success, 5 failures. I tracked it down to a race condition between the response being written and the request being aborted.

Currently the stream reuse logic assumes that if the response is successfully written then the stream is safe to reuse. However a race condition occurs if:

1. Server execution ends and HttpProtocol.ProduceEnd is called.
2. Request is aborted after ProduceEnd is called but before the response pipe is completed by ProduceEnd.
3. The abort cancels the response pipe pending read.
4. ReadAsync in `Http2OutputProducer.ProcessDataWrites` gets a canceled result.
5. ProcessDataWrites exits, but because the response is written, the stream is reused.
6. The next request to use the stream will fail

The simple solution is to add an explicit flag at the end of the read loop that checks if the writer completed successfully. That flag is used to decide whether to reuse a stream.