### PR TITLE
Improve support to the dictionary returned by ParseQuery

### DIFF
--- a/src/Http/Http.Extensions/ref/Microsoft.AspNetCore.Http.Extensions.netcoreapp.cs
+++ b/src/Http/Http.Extensions/ref/Microsoft.AspNetCore.Http.Extensions.netcoreapp.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
     public partial class QueryBuilder : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
     {
         public QueryBuilder() { }
+        public QueryBuilder(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> parameters) { }
         public QueryBuilder(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> parameters) { }
         public void Add(string key, System.Collections.Generic.IEnumerable<string> values) { }
         public void Add(string key, string value) { }

--- a/src/Http/Http.Extensions/src/QueryBuilder.cs
+++ b/src/Http/Http.Extensions/src/QueryBuilder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
         }
 
         public QueryBuilder(IEnumerable<KeyValuePair<string, StringValues>> parameters)
-            : this(parameters.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v.ToString())))
+            : this(parameters.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v)))
         {
 
         }

--- a/src/Http/Http.Extensions/src/QueryBuilder.cs
+++ b/src/Http/Http.Extensions/src/QueryBuilder.cs
@@ -3,8 +3,10 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http.Extensions
 {
@@ -21,6 +23,12 @@ namespace Microsoft.AspNetCore.Http.Extensions
         public QueryBuilder(IEnumerable<KeyValuePair<string, string>> parameters)
         {
             _params = new List<KeyValuePair<string, string>>(parameters);
+        }
+
+        public QueryBuilder(IEnumerable<KeyValuePair<string, StringValues>> parameters)
+            : this(parameters.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v.ToString())))
+        {
+
         }
 
         public void Add(string key, IEnumerable<string> values)

--- a/src/Http/Http.Extensions/test/QueryBuilderTests.cs
+++ b/src/Http/Http.Extensions/test/QueryBuilderTests.cs
@@ -77,7 +77,8 @@ namespace Microsoft.AspNetCore.Http.Extensions
             var builder = new QueryBuilder(new[]
             {
                 new KeyValuePair<string, StringValues>("key1", new StringValues(new [] { "value1", string.Empty, "value3" })),
-                new KeyValuePair<string, StringValues>("key2", StringValues.Empty)
+                new KeyValuePair<string, StringValues>("key2", string.Empty),
+                new KeyValuePair<string, StringValues>("key3", StringValues.Empty)
             });
             Assert.Equal("?key1=value1&key1=&key1=value3&key2=", builder.ToString());
         }

--- a/src/Http/Http.Extensions/test/QueryBuilderTests.cs
+++ b/src/Http/Http.Extensions/test/QueryBuilderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Http.Extensions
@@ -68,6 +69,17 @@ namespace Microsoft.AspNetCore.Http.Extensions
                 new KeyValuePair<string, string>("key3", "value3"),
             });
             Assert.Equal("?key1=value1&key2=value2&key3=value3", builder.ToString());
+        }
+
+        [Fact]
+        public void AddMultipleValuesViaConstructor_WithStringValues()
+        {
+            var builder = new QueryBuilder(new[]
+            {
+                new KeyValuePair<string, StringValues>("key1", new StringValues(new [] { "value1", string.Empty, "value3" })),
+                new KeyValuePair<string, StringValues>("key2", StringValues.Empty)
+            });
+            Assert.Equal("?key1=value1&key1=&key1=value3&key2=", builder.ToString());
         }
 
         [Fact]

--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
@@ -216,6 +216,8 @@ namespace Microsoft.AspNetCore.WebUtilities
     public static partial class QueryHelpers
     {
         public static string AddQueryString(string uri, System.Collections.Generic.IDictionary<string, string> queryString) { throw null; }
+        public static string AddQueryString(string uri, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> queryString) { throw null; }
+        public static string AddQueryString(string uri, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> queryString) { throw null; }
         public static string AddQueryString(string uri, string name, string value) { throw null; }
         public static System.Collections.Generic.Dictionary<string, Microsoft.Extensions.Primitives.StringValues> ParseNullableQuery(string queryString) { throw null; }
         public static System.Collections.Generic.Dictionary<string, Microsoft.Extensions.Primitives.StringValues> ParseQuery(string queryString) { throw null; }

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 throw new ArgumentNullException(nameof(queryString));
             }
 
-            return AddQueryString(uri, queryString.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v.ToString())));
+            return AddQueryString(uri, queryString.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v)));
         }
 
         /// <summary>

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -77,10 +77,20 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// <returns>The combined result.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
-        public static string AddQueryString(
-            string uri,
-            IEnumerable<KeyValuePair<string, StringValues>> queryString)
-            => AddQueryString(uri, queryString.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v.ToString())));
+        public static string AddQueryString(string uri, IEnumerable<KeyValuePair<string, StringValues>> queryString)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (queryString == null)
+            {
+                throw new ArgumentNullException(nameof(queryString));
+            }
+
+            return AddQueryString(uri, queryString.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v.ToString())));
+        }
 
         /// <summary>
         /// Append the given query keys and values to the URI.

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -46,10 +46,10 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         /// <summary>
-        /// Append the given query keys and values to the uri.
+        /// Append the given query keys and values to the URI.
         /// </summary>
-        /// <param name="uri">The base uri.</param>
-        /// <param name="queryString">A collection of name value query pairs to append.</param>
+        /// <param name="uri">The base URI.</param>
+        /// <param name="queryString">A dictionary of query keys and values to append.</param>
         /// <returns>The combined result.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
@@ -68,7 +68,15 @@ namespace Microsoft.AspNetCore.WebUtilities
             return AddQueryString(uri, (IEnumerable<KeyValuePair<string, string>>)queryString);
         }
 
-        private static string AddQueryString(
+        /// <summary>
+        /// Append the given query keys and values to the URI.
+        /// </summary>
+        /// <param name="uri">The base URI.</param>
+        /// <param name="queryString">A collection of name value query pairs to append.</param>
+        /// <returns>The combined result.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
+        public static string AddQueryString(
             string uri,
             IEnumerable<KeyValuePair<string, string>> queryString)
         {

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.Primitives;

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -72,6 +72,19 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// Append the given query keys and values to the URI.
         /// </summary>
         /// <param name="uri">The base URI.</param>
+        /// <param name="queryString">A collection of query names and values to append.</param>
+        /// <returns>The combined result.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
+        public static string AddQueryString(
+            string uri,
+            IEnumerable<KeyValuePair<string, StringValues>> queryString)
+            => AddQueryString(uri, queryString.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v.ToString())));
+
+        /// <summary>
+        /// Append the given query keys and values to the URI.
+        /// </summary>
+        /// <param name="uri">The base URI.</param>
         /// <param name="queryString">A collection of name value query pairs to append.</param>
         /// <returns>The combined result.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <c>null</c>.</exception>

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.AspNetCore.WebUtilities

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -142,9 +142,9 @@ namespace Microsoft.AspNetCore.WebUtilities
             "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=#name#something")]
         public void AddQueryStringWithEnumerableOfKeysAndStringValues(string uri, string expectedUri)
         {
-            var queryStrings = new Dictionary<string, StringValue>()
+            var queryStrings = new Dictionary<string, StringValues>()
                         {
-                            { "param1[]", new StringValue(new [] { "value1", string.Empty, "value3" }) },
+                            { "param1[]", new StringValues(new [] { "value1", string.Empty, "value3" }) },
                             { "param2[]", StringValues.Empty }
                         };
 

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         {
             var queryStrings = new Dictionary<string, StringValues>()
                         {
-                            { "param1[]", new StringValues(new [] { "value1", string.Empty, "value3" }) },
+                            { "param1", new StringValues(new [] { "value1", string.Empty, "value3" }) },
                             { "param2[]", string.Empty },
                             { "param3[]", StringValues.Empty }
                         };

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -122,30 +122,31 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Theory]
-        [InlineData("http://contoso.com/", "http://contoso.com/?param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
-        [InlineData("http://contoso.com/someaction", "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
-        [InlineData("http://contoso.com/someaction?param2[]=1", "http://contoso.com/someaction?param2[]=1&param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
-        [InlineData("http://contoso.com/some#action", "http://contoso.com/some?param1[]=value1&param1[]=&param1[]=value3&param2[]=#action")]
-        [InlineData("http://contoso.com/some?param2[]=1#action", "http://contoso.com/some?param2[]=1&param1[]=value1&param1[]=&param1[]=value3&param2[]=#action")]
-        [InlineData("http://contoso.com/#action", "http://contoso.com/?param1[]=value1&param1[]=&param1[]=value3&param2[]=#action")]
+        [InlineData("http://contoso.com/", "http://contoso.com/?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
+        [InlineData("http://contoso.com/someaction", "http://contoso.com/someaction?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
+        [InlineData("http://contoso.com/someaction?param2%5B%5D=1", "http://contoso.com/someaction?param2%5B%5D=1&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
+        [InlineData("http://contoso.com/some#action", "http://contoso.com/some?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#action")]
+        [InlineData("http://contoso.com/some?param2%5B%5D=1#action", "http://contoso.com/some?param2%5B%5D=1&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#action")]
+        [InlineData("http://contoso.com/#action", "http://contoso.com/?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#action")]
         [InlineData(
             "http://contoso.com/someaction?q=test#anchor?value",
-            "http://contoso.com/someaction?q=test&param1[]=value1&param1[]=&param1[]=value3&param2[]=#anchor?value")]
+            "http://contoso.com/someaction?q=test&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#anchor?value")]
         [InlineData(
             "http://contoso.com/someaction#anchor?stuff",
-            "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=#anchor?stuff")]
+            "http://contoso.com/someaction?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#anchor?stuff")]
         [InlineData(
             "http://contoso.com/someaction?name?something",
-            "http://contoso.com/someaction?name?something&param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
+            "http://contoso.com/someaction?name?something&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
         [InlineData(
             "http://contoso.com/someaction#name#something",
-            "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=#name#something")]
+            "http://contoso.com/someaction?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#name#something")]
         public void AddQueryStringWithEnumerableOfKeysAndStringValues(string uri, string expectedUri)
         {
             var queryStrings = new Dictionary<string, StringValues>()
                         {
                             { "param1[]", new StringValues(new [] { "value1", string.Empty, "value3" }) },
-                            { "param2[]", StringValues.Empty }
+                            { "param2[]", string.Empty },
+                            { "param3[]", StringValues.Empty }
                         };
 
             var result = QueryHelpers.AddQueryString(uri, queryStrings);

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             "http://contoso.com/someaction?name?something&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
         [InlineData(
             "http://contoso.com/someaction#name#something",
-            "http://contoso.com/someaction?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#name#something")]
+            "http://contoso.com/someaction?param1=value1&param1=&param1=value3&param2=#name#something")]
         public void AddQueryStringWithEnumerableOfKeysAndStringValues(string uri, string expectedUri)
         {
             var queryStrings = new Dictionary<string, StringValues>()

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -122,21 +122,21 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Theory]
-        [InlineData("http://contoso.com/", "http://contoso.com/?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
-        [InlineData("http://contoso.com/someaction", "http://contoso.com/someaction?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
-        [InlineData("http://contoso.com/someaction?param2%5B%5D=1", "http://contoso.com/someaction?param2%5B%5D=1&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
-        [InlineData("http://contoso.com/some#action", "http://contoso.com/some?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#action")]
-        [InlineData("http://contoso.com/some?param2%5B%5D=1#action", "http://contoso.com/some?param2%5B%5D=1&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#action")]
-        [InlineData("http://contoso.com/#action", "http://contoso.com/?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#action")]
+        [InlineData("http://contoso.com/", "http://contoso.com/?param1=value1&param1=&param1=value3&param2=")]
+        [InlineData("http://contoso.com/someaction", "http://contoso.com/someaction?param1=value1&param1=&param1=value3&param2=")]
+        [InlineData("http://contoso.com/someaction?param2=1", "http://contoso.com/someaction?param2=1&param1=value1&param1=&param1=value3&param2=")]
+        [InlineData("http://contoso.com/some#action", "http://contoso.com/some?param1=value1&param1=&param1=value3&param2=#action")]
+        [InlineData("http://contoso.com/some?param2=1#action", "http://contoso.com/some?param2=1&param1=value1&param1=&param1=value3&param2=#action")]
+        [InlineData("http://contoso.com/#action", "http://contoso.com/?param1=value1&param1=&param1=value3&param2=#action")]
         [InlineData(
             "http://contoso.com/someaction?q=test#anchor?value",
-            "http://contoso.com/someaction?q=test&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#anchor?value")]
+            "http://contoso.com/someaction?q=test&param1=value1&param1=&param1=value3&param2=#anchor?value")]
         [InlineData(
             "http://contoso.com/someaction#anchor?stuff",
-            "http://contoso.com/someaction?param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=#anchor?stuff")]
+            "http://contoso.com/someaction?param1=value1&param1=&param1=value3&param2=#anchor?stuff")]
         [InlineData(
             "http://contoso.com/someaction?name?something",
-            "http://contoso.com/someaction?name?something&param1%5B%5D=value1&param1%5B%5D=&param1%5B%5D=value3&param2%5B%5D=")]
+            "http://contoso.com/someaction?name?something&param1=value1&param1=&param1=value3&param2=")]
         [InlineData(
             "http://contoso.com/someaction#name#something",
             "http://contoso.com/someaction?param1=value1&param1=&param1=value3&param2=#name#something")]
@@ -145,8 +145,8 @@ namespace Microsoft.AspNetCore.WebUtilities
             var queryStrings = new Dictionary<string, StringValues>()
                         {
                             { "param1", new StringValues(new [] { "value1", string.Empty, "value3" }) },
-                            { "param2[]", string.Empty },
-                            { "param3[]", StringValues.Empty }
+                            { "param2", string.Empty },
+                            { "param3", StringValues.Empty }
                         };
 
             var result = QueryHelpers.AddQueryString(uri, queryStrings);

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -119,5 +119,36 @@ namespace Microsoft.AspNetCore.WebUtilities
             var result = QueryHelpers.AddQueryString(uri, queryStrings);
             Assert.Equal(expectedUri, result);
         }
+
+        [Theory]
+        [InlineData("http://contoso.com/", "http://contoso.com/?param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
+        [InlineData("http://contoso.com/someaction", "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
+        [InlineData("http://contoso.com/someaction?param2[]=1", "http://contoso.com/someaction?param2[]=1&param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
+        [InlineData("http://contoso.com/some#action", "http://contoso.com/some?param1[]=value1&param1[]=&param1[]=value3&param2[]=#action")]
+        [InlineData("http://contoso.com/some?param2[]=1#action", "http://contoso.com/some?param2[]=1&param1[]=value1&param1[]=&param1[]=value3&param2[]=#action")]
+        [InlineData("http://contoso.com/#action", "http://contoso.com/?param1[]=value1&param1[]=&param1[]=value3&param2[]=#action")]
+        [InlineData(
+            "http://contoso.com/someaction?q=test#anchor?value",
+            "http://contoso.com/someaction?q=test&param1[]=value1&param1[]=&param1[]=value3&param2[]=#anchor?value")]
+        [InlineData(
+            "http://contoso.com/someaction#anchor?stuff",
+            "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=#anchor?stuff")]
+        [InlineData(
+            "http://contoso.com/someaction?name?something",
+            "http://contoso.com/someaction?name?something&param1[]=value1&param1[]=&param1[]=value3&param2[]=")]
+        [InlineData(
+            "http://contoso.com/someaction#name#something",
+            "http://contoso.com/someaction?param1[]=value1&param1[]=&param1[]=value3&param2[]=#name#something")]
+        public void AddQueryStringWithEnumerableOfKeysAndStringValues(string uri, string expectedUri)
+        {
+            var queryStrings = new Dictionary<string, StringValue>()
+                        {
+                            { "param1[]", new StringValue(new [] { "value1", string.Empty, "value3" }) },
+                            { "param2[]", StringValues.Empty }
+                        };
+
+            var result = QueryHelpers.AddQueryString(uri, queryStrings);
+            Assert.Equal(expectedUri, result);
+        }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Make `AddQueryString(string uri, IEnumerable<KeyValuePair<string, string>> queryString)` `public`
 - Add `AddQueryString(string uri, IEnumerable<KeyValuePair<string, StringValues>> queryString)`
 - Update the summary of `AddQueryString(string uri, IDictionary<string, string> queryString)`
 - Add `QueryBuilder(IEnumerable<KeyValuePair<string, StringValues>> parameters)`

Addresses #7945