### PR TITLE
Convert InvalidOperationException to InvalidDataException for form reader

### DIFF
--- a/src/Http/WebUtilities/src/FormPipeReader.cs
+++ b/src/Http/WebUtilities/src/FormPipeReader.cs
@@ -97,17 +97,10 @@ namespace Microsoft.AspNetCore.WebUtilities
                     {
                         ParseFormValues(ref buffer, ref accumulator, readResult.IsCompleted);
                     }
-                    catch (InvalidOperationException ex)
-                    {
-                        throw new InvalidDataException("The path contains null characters.", ex);
-                    }
-                    catch (Exception)
-                    {
-                        throw;
-                    }
-                    finally
+                    catch
                     {
                         _pipeReader.AdvanceTo(buffer.Start);
+                        throw;
                     }
                 }
 
@@ -393,7 +386,7 @@ namespace Microsoft.AspNetCore.WebUtilities
                 }
                 catch (InvalidOperationException ex)
                 {
-                    throw new InvalidDataException("The path contains null characters.", ex);
+                    throw new InvalidDataException("The form value contains invalid characters.", ex);
                 }
             }
             else

--- a/src/Http/WebUtilities/test/FormPipeReaderTests.cs
+++ b/src/Http/WebUtilities/test/FormPipeReaderTests.cs
@@ -79,6 +79,18 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
+        public async Task ReadFormAsync_ValueContainsInvalidCharacters_Throw()
+        {
+            var bodyPipe = await MakePipeReader("%00");
+
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                () => ReadFormAsync(new FormPipeReader(bodyPipe)));
+
+            Assert.Equal("The form value contains invalid characters.", exception.Message);
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Fact]
         public async Task ReadFormAsync_ValueCountLimitMet_Success()
         {
             var bodyPipe = await MakePipeReader("foo=1&bar=2&baz=3");

--- a/src/Shared/UrlDecoder/UrlDecoder.cs
+++ b/src/Shared/UrlDecoder/UrlDecoder.cs
@@ -294,7 +294,7 @@ namespace Microsoft.AspNetCore.Internal
         /// Read the next char and convert it into hexadecimal value.
         ///
         /// The <paramref name="scan"/> index will be moved to the next
-        /// byte no matter no matter whether the operation successes.
+        /// byte no matter whether the operation successes.
         /// </summary>
         /// <param name="scan">The index of the byte in the buffer to read</param>
         /// <param name="buffer">The byte span from which the hex to be read</param>


### PR DESCRIPTION
For now, I wrapped the `InvalidOperationException` in an `InvalidDataException` in 2 places for review.
Please clarify which one should be removed, from `GetDecodedString` or `ReadFormAsync`? 

One more possible solution is adding try/catch to the `ParseValuesSlow` method. 👎 

Addresses #19962

Please review,
Thank you in advance