### PR TITLE
Include third-party-notices.txt in all packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -104,6 +104,14 @@
     <BuildHelixPayload Condition="'$(BuildHelixPayload)' == '' AND '$(IsTestProject)' == 'true'">true</BuildHelixPayload>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageThirdPartyNoticesFile Condition="'$(PackageThirdPartyNoticesFile)' == ''">$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(PackageThirdPartyNoticesFile)" Pack="true" PackagePath="." />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(Language)' == 'C#' AND '$(IsReferenceAssemblyProject)' == 'true'">
     <Compile Include="$(SharedSourceRoot)ReferenceAssemblyInfo.cs" LinkBase="Properties" />
   </ItemGroup>

--- a/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -23,6 +23,7 @@
     <NuspecProperty Include="componentsversion=$(ComponentsPackageVersion)" />
     <NuspecProperty Include="razorversion=$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
     <NuspecProperty Include="blazormonoversion=$(MicrosoftAspNetCoreBlazorMonoPackageVersion)" />
+    <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.nuspec
+++ b/src/Components/Blazor/Build/src/Microsoft.AspNetCore.Blazor.Build.nuspec
@@ -8,7 +8,7 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="..\..\..\THIRD-PARTY-NOTICES.txt" />
+    <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
     <file src="build\**" target="build" />
     <file src="targets\**" target="targets" />
     <file src="$publishdir$**\*" target="tools/" />

--- a/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
+++ b/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.csproj
@@ -33,6 +33,7 @@
     <NuspecProperty Include="publishDir=$(PublishDir)" />
     <NuspecProperty Include="componentsrootdir=..\..\..\" />
     <NuspecProperty Include="blazorversion=$(PackageVersion)" />
+    <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.nuspec
+++ b/src/Components/Blazor/DevServer/src/Microsoft.AspNetCore.Blazor.DevServer.nuspec
@@ -7,6 +7,6 @@
     $CommonFileElements$
     <file src="build\**" target="build" />
     <file src="$publishDir$**\*" target="tools" />
-    <file src="$componentsrootdir$THIRD-PARTY-NOTICES.txt" target=".\THIRD-PARTY-NOTICES.txt" />
+    <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
   </files>
 </package>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -54,6 +54,7 @@
     <NuspecProperty Condition="'$(DotNetBuildFromSource)' != 'true'" Include="systemComponentModelAnnotationsPackageVersion=$(SystemComponentModelAnnotationsPackageVersion)" />
     <NuspecProperty Include="AssemblyName=$(AssemblyName)" />
     <NuspecProperty Include="OutputPath=$(OutputPath)" />
+    <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.multitarget.nuspec
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.multitarget.nuspec
@@ -21,6 +21,6 @@
     <file src="$OutputPath$**\$AssemblyName$.dll" target="lib\" />
     <file src="$OutputPath$**\$AssemblyName$.pdb" target="lib\" />
     <file src="$OutputPath$**\$AssemblyName$.xml" target="lib\" />
-    <file src="..\..\THIRD-PARTY-NOTICES.txt" target=".\THIRD-PARTY-NOTICES.txt" />
+    <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
   </files>
 </package>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.netcoreapp.nuspec
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.netcoreapp.nuspec
@@ -15,6 +15,6 @@
     <file src="$OutputPath$**\$AssemblyName$.dll" target="lib\" />
     <file src="$OutputPath$**\$AssemblyName$.pdb" target="lib\" />
     <file src="$OutputPath$**\$AssemblyName$.xml" target="lib\" />
-    <file src="..\..\THIRD-PARTY-NOTICES.txt" target=".\THIRD-PARTY-NOTICES.txt" />
+    <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
   </files>
 </package>

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -16,6 +16,8 @@
 
     <!-- So we can use the tool from source within the repo without having to pack -->
     <BlazorToolsDir>$(MSBuildThisFileDirectory)Blazor\Build\src\bin\$(Configuration)\$(DefaultNetCoreTargetFramework)\</BlazorToolsDir>
+
+    <PackageThirdPartyNoticesFile>$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.txt</PackageThirdPartyNoticesFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -4,8 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.txt" Pack="true" PackagePath="." />
-
     <!-- Add a project dependency without reference output assemblies to enforce build order -->
     <!-- Applying workaround for https://github.com/microsoft/msbuild/issues/2661 and https://github.com/dotnet/sdk/issues/952 -->
     <ProjectReference

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -67,7 +67,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- There is no way to suppress the .dev.runtimeconfig.json generation. -->
     <ProjectRuntimeConfigDevFilePath>$(IntermediateOutputPath)ignoreme.dev.runtimeconfig.json</ProjectRuntimeConfigDevFilePath>
 
-    <VersionFileIntermediateOutputPath>$(IntermediateOutputPath).version</VersionFileIntermediateOutputPath>
+    <VersionFileIntermediateOutputPath>$(IntermediateOutputPath)$(SharedFxName).versions.txt</VersionFileIntermediateOutputPath>
 
     <!-- The project representing the shared framework doesn't produce a .NET assembly or symbols. -->
     <DebugType>none</DebugType>
@@ -494,6 +494,15 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <ItemGroup>
       <RuntimePackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
       <_PackageFiles Include="@(RuntimePackContent)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeVersionFile"
+          DependsOnTargets="GenerateSharedFxVersionsFiles" 
+          BeforeTargets="_GetPackageFiles">
+
+    <ItemGroup>
+      <None Include="$(VersionFileIntermediateOutputPath)" Pack="true" PackagePath="." />
     </ItemGroup>
   </Target>
 

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void ItContainsVersionFile()
         {
-            var versionFile = Path.Combine(_sharedFxRoot, ".version");
+            var versionFile = Path.Combine(_sharedFxRoot, "Microsoft.AspNetCore.App.versions.txt");
             AssertEx.FileExists(versionFile);
             var lines = File.ReadAllLines(versionFile);
             Assert.Equal(2, lines.Length);

--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -23,6 +23,7 @@
     </GetCurrentProjectStaticWebAssetsDependsOn>
 
     <IdentityUIFrameworkVersion Condition="'$(IdentityUIFrameworkVersion)' == ''">Bootstrap4</IdentityUIFrameworkVersion>
+    <PackageThirdPartyNoticesFile>$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
 
   </PropertyGroup>
 
@@ -32,7 +33,6 @@
     <None Include="build\*" Pack="true" PackagePath="build\" />
     <None Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting\" />
     <None Include="buildTransitive\*" Pack="true" PackagePath="buildTransitive\" />
-    <None Include="THIRD-PARTY-NOTICES.txt" Pack="true" PackagePath="/THIRD-PARTY-NOTICES.txt" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/20086

Explicitly includes `Third-Party-Notices.txt` in all packages, and allows packages to use a custom `third-party-notices.txt` file if they so choose (Identity.UI and the Components packages currently do so). Also includes the `version.txt` file that was missing from the shared framework

