### PR TITLE
Re-enable SignalR HTTP/2 test

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -79,8 +79,7 @@ describe("hubConnection", () => {
             });
 
             if (shouldRunHttpsTests) {
-                // xit will skip the test
-                xit("using https, can invoke server method and receive result", (done) => {
+                it("using https, can invoke server method and receive result", (done) => {
                     const message = "你好，世界！";
 
                     const hubConnection = getConnectionBuilder(transportType, TESTHUBENDPOINT_HTTPS_URL, { httpClient })


### PR DESCRIPTION
Was likely fixed by https://github.com/dotnet/aspnetcore/pull/20121
Ran the test suite 4 times to verify that it doesn't fail.

Closes https://github.com/dotnet/aspnetcore/issues/20009