### PR TITLE
Obsolete ReceiveBufferSize in WebSocketOptions #20084

### DIFF
--- a/src/Middleware/WebSockets/ref/Microsoft.AspNetCore.WebSockets.netcoreapp.cs
+++ b/src/Middleware/WebSockets/ref/Microsoft.AspNetCore.WebSockets.netcoreapp.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Builder
         public WebSocketOptions() { }
         public System.Collections.Generic.IList<string> AllowedOrigins { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public System.TimeSpan KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        [System.ObsoleteAttribute("This is obsolete and will be removed in a future version")]
+        [System.ObsoleteAttribute("Setting this property has no effect. It will be removed in a future version.")]
         public int ReceiveBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
 }
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.WebSockets
     {
         public ExtendedWebSocketAcceptContext() { }
         public System.TimeSpan? KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        [System.ObsoleteAttribute("This is obsolete and will be removed in a future version")]
+        [System.ObsoleteAttribute("Setting this property has no effect. It will be removed in a future version.")]
         public int? ReceiveBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public override string SubProtocol { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }

--- a/src/Middleware/WebSockets/ref/Microsoft.AspNetCore.WebSockets.netcoreapp.cs
+++ b/src/Middleware/WebSockets/ref/Microsoft.AspNetCore.WebSockets.netcoreapp.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Builder
         public WebSocketOptions() { }
         public System.Collections.Generic.IList<string> AllowedOrigins { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public System.TimeSpan KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.ObsoleteAttribute("This is obsolete and will be removed in a future version")]
         public int ReceiveBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
 }
@@ -22,6 +23,7 @@ namespace Microsoft.AspNetCore.WebSockets
     {
         public ExtendedWebSocketAcceptContext() { }
         public System.TimeSpan? KeepAliveInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.ObsoleteAttribute("This is obsolete and will be removed in a future version")]
         public int? ReceiveBufferSize { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public override string SubProtocol { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }

--- a/src/Middleware/WebSockets/src/ExtendedWebSocketAcceptContext.cs
+++ b/src/Middleware/WebSockets/src/ExtendedWebSocketAcceptContext.cs
@@ -9,7 +9,10 @@ namespace Microsoft.AspNetCore.WebSockets
     public class ExtendedWebSocketAcceptContext : WebSocketAcceptContext
     {
         public override string SubProtocol { get; set; }
+                
+        [Obsolete("This is obsolete and will be removed in a future version")]
         public int? ReceiveBufferSize { get; set; }
+
         public TimeSpan? KeepAliveInterval { get; set; }
     }
 }

--- a/src/Middleware/WebSockets/src/ExtendedWebSocketAcceptContext.cs
+++ b/src/Middleware/WebSockets/src/ExtendedWebSocketAcceptContext.cs
@@ -9,8 +9,8 @@ namespace Microsoft.AspNetCore.WebSockets
     public class ExtendedWebSocketAcceptContext : WebSocketAcceptContext
     {
         public override string SubProtocol { get; set; }
-                
-        [Obsolete("This is obsolete and will be removed in a future version")]
+
+        [Obsolete("Setting this property has no effect. It will be removed in a future version.")]
         public int? ReceiveBufferSize { get; set; }
 
         public TimeSpan? KeepAliveInterval { get; set; }

--- a/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
+++ b/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
@@ -131,14 +131,9 @@ namespace Microsoft.AspNetCore.WebSockets
                 }
 
                 TimeSpan keepAliveInterval = _options.KeepAliveInterval;
-                int receiveBufferSize = _options.ReceiveBufferSize;
                 var advancedAcceptContext = acceptContext as ExtendedWebSocketAcceptContext;
                 if (advancedAcceptContext != null)
                 {
-                    if (advancedAcceptContext.ReceiveBufferSize.HasValue)
-                    {
-                        receiveBufferSize = advancedAcceptContext.ReceiveBufferSize.Value;
-                    }
                     if (advancedAcceptContext.KeepAliveInterval.HasValue)
                     {
                         keepAliveInterval = advancedAcceptContext.KeepAliveInterval.Value;

--- a/src/Middleware/WebSockets/src/WebSocketOptions.cs
+++ b/src/Middleware/WebSockets/src/WebSocketOptions.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNetCore.Builder
         public WebSocketOptions()
         {
             KeepAliveInterval = TimeSpan.FromMinutes(2);
-            ReceiveBufferSize = 4 * 1024;
             AllowedOrigins = new List<string>();
         }
 
@@ -28,6 +27,7 @@ namespace Microsoft.AspNetCore.Builder
         /// Gets or sets the size of the protocol buffer used to receive and parse frames.
         /// The default is 4kb.
         /// </summary>
+        [Obsolete("This is obsolete and will be removed in a future version")]
         public int ReceiveBufferSize { get; set; }
 
         /// <summary>

--- a/src/Middleware/WebSockets/src/WebSocketOptions.cs
+++ b/src/Middleware/WebSockets/src/WebSocketOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Builder
         /// Gets or sets the size of the protocol buffer used to receive and parse frames.
         /// The default is 4kb.
         /// </summary>
-        [Obsolete("This is obsolete and will be removed in a future version")]
+        [Obsolete("Setting this property has no effect. It will be removed in a future version.")]
         public int ReceiveBufferSize { get; set; }
 
         /// <summary>


### PR DESCRIPTION
ReceiveBufferSize property in WebSocketOptions and ExtendedWebSocketAcceptContext is no longer being used.

Addresses #20084

