### PR TITLE
Skip grpc template test

### DIFF
--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -25,7 +25,7 @@ namespace Templates.Test
         public ProjectFactoryFixture ProjectFactory { get; }
         public ITestOutputHelper Output { get; }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "This test run for over an hour")]
         [SkipOnHelix("Not supported queues", Queues = "Windows.7.Amd64;Windows.7.Amd64.Open;OSX.1014.Amd64;OSX.1014.Amd64.Open")]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
         public async Task GrpcTemplate()


### PR DESCRIPTION
Turns out there are additional test hang conditions:

```
[0.028s] [TestLifetime] [Information] Starting test GrpcTemplate at 2020-03-26T04:44:10
[9,535.658s] [TestLogger] [Information] AspNetProcess - process: /Users/runner/runners/2.165.2/work/1/s/.dotnet/dotnet arguments: exec /Users/runner/runners/2.165.2/work/1/s/src/ProjectTemplates/test/bin/Release/netcoreapp5.0/TestTemplates/AspNet.grpc.mnuhnsvae3x/bin/Debug/netcoreapp5.0/AspNet.grpc.mnuhnsvae3x.dll
[9,535.669s] [TestLogger] [Information] AspNetProcess - process started
```

Looks like it took >150 mins for the process to start.