### PR TITLE
Diagnose more gRPC template hangs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -533,7 +533,7 @@ stages:
   # Test jobs
   - template: jobs/default-build.yml
     parameters:
-      condition: ne(variables['SkipTests'], 'true')
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Windows_Test
       jobDisplayName: "Test: Windows Server 2016 x64"
       agentOs: Windows
@@ -568,7 +568,7 @@ stages:
 
   - template: jobs/default-build.yml
     parameters:
-      condition: ne(variables['SkipTests'], 'true')
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Windows_Templates_Test
       jobDisplayName: "Test: Templates - Windows Server 2016 x64"
       agentOs: Windows
@@ -639,7 +639,7 @@ stages:
 
   - template: jobs/default-build.yml
     parameters:
-      condition: ne(variables['SkipTests'], 'true')
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Linux_Test
       jobDisplayName: "Test: Ubuntu 16.04 x64"
       agentOs: Linux

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -19,6 +19,10 @@ pr:
     - '*'
 
 variables:
+- name: SkipBuilds
+  value: true
+- name: SkipTests
+  value: true
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: _TeamName
@@ -94,6 +98,7 @@ stages:
   # Code check
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Code_check
       jobDisplayName: Code check
       agentOs: Windows
@@ -117,6 +122,7 @@ stages:
   # Build Windows (x64/x86)
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       codeSign: true
       jobName: Windows_build
       jobDisplayName: "Build: Windows x64/x86"
@@ -227,6 +233,7 @@ stages:
   # Build Windows ARM
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       codeSign: true
       jobName: Windows_arm_build
       jobDisplayName: "Build: Windows ARM"
@@ -257,6 +264,7 @@ stages:
   # Build Windows ARM64
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       codeSign: true
       jobName: Windows_64_build
       jobDisplayName: "Build: Windows ARM64"
@@ -289,6 +297,7 @@ stages:
   # Build MacOS
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: MacOs_x64_build
       jobDisplayName: "Build: macOS"
       agentOs: macOs
@@ -319,6 +328,7 @@ stages:
   # Build Linux x64
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Linux_x64_build
       jobDisplayName: "Build: Linux x64"
       agentOs: Linux
@@ -391,6 +401,7 @@ stages:
   # Build Linux ARM
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Linux_arm_build
       jobDisplayName: "Build: Linux ARM"
       agentOs: Linux
@@ -422,6 +433,7 @@ stages:
   # Build Linux ARM64
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Linux_arm64_build
       jobDisplayName: "Build: Linux ARM64"
       agentOs: Linux
@@ -453,6 +465,7 @@ stages:
   # Build Linux Musl x64
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Linux_musl_x64_build
       jobDisplayName: "Build: Linux Musl x64"
       agentOs: Linux
@@ -487,6 +500,7 @@ stages:
   # Build Linux Musl ARM64
   - template: jobs/default-build.yml
     parameters:
+      condition: ne(variables['SkipBuilds'], 'true')
       jobName: Linux_musl_arm64_build
       jobDisplayName: "Build: Linux Musl ARM64"
       agentOs: Linux
@@ -592,7 +606,6 @@ stages:
 
   - template: jobs/default-build.yml
     parameters:
-      condition: ne(variables['SkipTests'], 'true')
       jobName: MacOS_Test
       jobDisplayName: "Test: macOS 10.13"
       agentOs: macOS
@@ -666,7 +679,7 @@ stages:
   # Helix x64
   - template: jobs/default-build.yml
     parameters:
-      condition: in(variables['Build.Reason'], 'PullRequest')
+      condition: and(in(variables['Build.Reason'], 'PullRequest'), ne(variables['SkipTests'], 'true'))
       jobName: Helix_x64
       jobDisplayName: 'Tests: Helix x64'
       agentOs: Windows

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -615,6 +615,7 @@ stages:
           testResultsFormat: 'xUnit'
           testResultsFiles: '*.xml'
           searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+        condition: always()
       artifacts:
       - name: MacOS_Test_Logs
         path: artifacts/log/

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -21,8 +21,6 @@ pr:
 variables:
 - name: SkipBuilds
   value: true
-- name: SkipTests
-  value: true
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: _TeamName
@@ -679,7 +677,7 @@ stages:
   # Helix x64
   - template: jobs/default-build.yml
     parameters:
-      condition: and(in(variables['Build.Reason'], 'PullRequest'), ne(variables['SkipTests'], 'true'))
+      condition: and(in(variables['Build.Reason'], 'PullRequest'), ne(variables['SkipBuilds'], 'true'))
       jobName: Helix_x64
       jobDisplayName: 'Tests: Helix x64'
       agentOs: Windows

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging;
 using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -57,6 +57,7 @@ namespace Templates.Test
             var isWindowsOld = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version < new Version(6, 2);
             var unsupported = isOsx || isWindowsOld;
 
+            logger.LogInformation("GrpcTemplateTest - Starting built project");
             using (var serverProcess = Project.StartBuiltProjectAsync(hasListeningUri: !unsupported, logger: logger))
             {
                 logger.LogInformation("GrpcTemplateTest - Verifing built project results");

--- a/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
+++ b/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
@@ -42,6 +42,8 @@ namespace Templates.Test.Helpers
             bool hasListeningUri = true,
             ILogger logger = null)
         {
+            logger?.LogInformation($"AspNetProcess - initializing");
+
             _output = output;
             _httpClient = new HttpClient(new HttpClientHandler()
             {
@@ -54,7 +56,11 @@ namespace Templates.Test.Helpers
                 Timeout = TimeSpan.FromMinutes(2)
             };
 
-            EnsureDevelopmentCertificates();
+            logger?.LogInformation($"AspNetProcess - http client created");
+
+            EnsureDevelopmentCertificates(logger);
+
+            logger?.LogInformation($"AspNetProcess - development certificates resolved");
 
             output.WriteLine("Running ASP.NET application...");
 
@@ -74,10 +80,12 @@ namespace Templates.Test.Helpers
             }
         }
 
-        internal static void EnsureDevelopmentCertificates()
+        internal static void EnsureDevelopmentCertificates(ILogger logger = null)
         {
+            logger?.LogInformation($"AspNetProcess/EnsureDevelopmentCertificates - start");
             var now = DateTimeOffset.Now;
             new CertificateManager().EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1));
+            logger?.LogInformation($"AspNetProcess/EnsureDevelopmentCertificates - end");
         }
 
         public void VisitInBrowser(IWebDriver driver)

--- a/src/ProjectTemplates/test/Helpers/Project.cs
+++ b/src/ProjectTemplates/test/Helpers/Project.cs
@@ -27,11 +27,11 @@ namespace Templates.Test.Helpers
         public static bool IsCIEnvironment => typeof(Project).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
             .Any(a => a.Key == "ContinuousIntegrationBuild");
 
-        public static string ArtifactsLogDir => (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_DIR"))) 
+        public static string ArtifactsLogDir => (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_DIR")))
             ? GetAssemblyMetadata("ArtifactsLogDir")
             : Path.Combine(Environment.GetEnvironmentVariable("HELIX_DIR"), "logs");
-        
-        public static string DotNetEfFullPath => (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DotNetEfFullPath"))) 
+
+        public static string DotNetEfFullPath => (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DotNetEfFullPath")))
             ? typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
                 .First(attribute => attribute.Key == "DotNetEfFullPath")
                 .Value
@@ -221,6 +221,9 @@ namespace Templates.Test.Helpers
             };
 
             var projectDll = Path.Combine(TemplateBuildDir, $"{ProjectName}.dll");
+
+            logger?.LogInformation("Project - creating AspNetProcess");
+
             return new AspNetProcess(Output, TemplateOutputDir, projectDll, environment, hasListeningUri: hasListeningUri, logger: logger);
         }
 
@@ -309,7 +312,7 @@ namespace Templates.Test.Helpers
         internal async Task<ProcessEx> RunDotNetEfCreateMigrationAsync(string migrationName)
         {
             var args = $"--verbose --no-build migrations add {migrationName}";
-            
+
             // Only run one instance of 'dotnet new' at once, as a workaround for
             // https://github.com/aspnet/templating/issues/63
             await DotNetNewLock.WaitAsync();
@@ -324,7 +327,7 @@ namespace Templates.Test.Helpers
                 {
                     command = "dotnet-ef";
                 }
-                
+
                 var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
                 await result.Exited;
                 return result;
@@ -353,7 +356,7 @@ namespace Templates.Test.Helpers
                 {
                     command = "dotnet-ef";
                 }
-                
+
                 var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
                 await result.Exited;
                 return result;


### PR DESCRIPTION
The symptoms under diagnosis:
```
[0.028s] [TestLifetime] [Information] Starting test GrpcTemplate at 2020-03-26T04:44:10
[9,535.658s] [TestLogger] [Information] AspNetProcess - process: /Users/runner/runners/2.165.2/work/1/s/.dotnet/dotnet arguments: exec /Users/runner/runners/2.165.2/work/1/s/src/ProjectTemplates/test/bin/Release/netcoreapp5.0/TestTemplates/AspNet.grpc.mnuhnsvae3x/bin/Debug/netcoreapp5.0/AspNet.grpc.mnuhnsvae3x.dll
[9,535.669s] [TestLogger] [Information] AspNetProcess - process started
```

This could be an issue in our test setup (creating, publishing and building the SUT) or it could be an issue with the project template infrastructure (uninstalling/installing the project template via dotnet new --install).