### PR TITLE
Add tags to HealthReportEntry if an exception occurs

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
+++ b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         description: "A timeout occurred while running check.",
                         duration: duration,
                         exception: ex,
-                        data: null);
+                        data: null,
+                        tags: registration.Tags);
 
                     Log.HealthCheckError(_logger, registration, ex, duration);
                 }
@@ -139,7 +140,8 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         description: ex.Message,
                         duration: duration,
                         exception: ex,
-                        data: null);
+                        data: null,
+                        tags: registration.Tags);
 
                     Log.HealthCheckError(_logger, registration, ex, duration);
                 }


### PR DESCRIPTION
 - Added tags parameter to constructor of `HealthReportEntry` in `catch` blocks

Addresses #20216 
