### PR TITLE
Fix SWAM hash

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -23,7 +23,7 @@
           Inputs="@(ServiceWorkerAssetsManifestItem)"
           Outputs="$(_ServiceWorkerAssetsManifestIntermediateOutputPath)"
           BeforeTargets="_BlazorStaticWebAssetsCopyGeneratedFilesToOutputDirectory"
-          DependsOnTargets="_ComputeServiceWorkerAssetsManifestFileHashes; _ComputeDefaultServiceWorkerAssetsManifestVersion">
+          DependsOnTargets="_ComputeServiceWorkerAssetsManifestFileHashes; _ComputeDefaultServiceWorkerAssetsManifestVersion; _GenerateServiceWorkerIntermediateFiles">
 
     <GenerateServiceWorkerAssetsManifest
       Version="$(ServiceWorkerAssetsManifestVersion)"
@@ -61,7 +61,9 @@
     Compute a default ServiceWorkerAssetsManifestVersion value by combining all the asset hashes.
     This is useful because then clients will only have to repopulate caches if the contents have changed.
   -->
-  <Target Name="_ComputeDefaultServiceWorkerAssetsManifestVersion" Condition="'$(ServiceWorkerAssetsManifest)' != ''">
+  <Target Name="_ComputeDefaultServiceWorkerAssetsManifestVersion"
+          DependsOnTargets="_ComputeServiceWorkerAssetsManifestFileHashes"
+          Condition="'$(ServiceWorkerAssetsManifest)' != ''">
     <PropertyGroup>
       <_CombinedHashIntermediatePath>$(_BlazorIntermediateOutputPath)serviceworkerhashes.txt</_CombinedHashIntermediatePath>
     </PropertyGroup>
@@ -97,7 +99,7 @@
 
   <Target Name="_ResolveServiceWorkerOutputs"
           BeforeTargets="_ResolveBlazorOutputs"
-          DependsOnTargets="_ComputeServiceWorkerOutputs; _GenerateServiceWorkerIntermediateFiles">
+          DependsOnTargets="_ComputeServiceWorkerOutputs">
     <ItemGroup>
       <_BlazorOutputWithTargetPath Include="@(_ServiceWorkerIntermediateFile)" />
     </ItemGroup>

--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -66,6 +66,12 @@
       <_CombinedHashIntermediatePath>$(_BlazorIntermediateOutputPath)serviceworkerhashes.txt</_CombinedHashIntermediatePath>
     </PropertyGroup>
 
+    <!-- Neither of these should ever happen, but if we do we want to know about it. -->
+    <Error Text="Cannot compute service worker assets manifest version, because no service worker manifest items were defined."
+           Condition="'@(_ServiceWorkerAssetsManifestItemWithHash)' == ''" />
+    <Error Text="While computing service worker assets manifest version, did not find any dll entries in service worker assets manifest."
+           Condition="'@(_ServiceWorkerAssetsManifestItemWithHash->WithMetadataValue('Extension', '.dll'))' == ''" />
+
     <WriteLinesToFile
       File="$(_CombinedHashIntermediatePath)"
       Lines="@(_ServiceWorkerAssetsManifestItemWithHash->'%(FileHash)')"

--- a/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
@@ -191,10 +191,11 @@ namespace Templates.Test
             var serviceWorkerContents = ReadFile(publishDir, "service-worker.js");
 
             // Parse the "version": "..." value from the SWAM, and check it's in the service worker
-            var serviceWorkerAssetsManifestVersionMatch = new Regex(@"^\s*\""version\"":\s*\""([^\""]+)\""", RegexOptions.Multiline)
+            var serviceWorkerAssetsManifestVersionMatch = new Regex(@"^\s*\""version\"":\s*(\""[^\""]+\"")", RegexOptions.Multiline)
                 .Match(serviceWorkerAssetsManifestContents);
             Assert.True(serviceWorkerAssetsManifestVersionMatch.Success);
-            var serviceWorkerAssetsManifestVersion = serviceWorkerAssetsManifestVersionMatch.Groups[1].Captures[0];
+            var serviceWorkerAssetsManifestVersionJson = serviceWorkerAssetsManifestVersionMatch.Groups[1].Captures[0].Value;
+            var serviceWorkerAssetsManifestVersion = JsonSerializer.Deserialize<string>(serviceWorkerAssetsManifestVersionJson);
             Assert.True(serviceWorkerContents.Contains($"/* Manifest version: {serviceWorkerAssetsManifestVersion} */", StringComparison.Ordinal));
         }
 


### PR DESCRIPTION
I noticed that the service worker assets manifest (SWAM) version hash was always coming up as the same value. On investigation, it seems that the MSBuild targets can run in a different order than anticipated because the dependencies between targets were not specified with the right constraints. This caused the list of service worker assets to be empty at the time we computed its hash, hence always getting the same result.

This PR makes them run in the right order so the list is correctly populated, plus adds an assertion so that if this sort of situation happens again we'd fail builds and hence our build would fail.