### PR TITLE
Fix Helix log upload

### DIFF
--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -157,6 +157,6 @@ fi
 echo "Copying TestResults/TestResults to ."
 cp TestResults/TestResults.xml testResults.xml
 echo "Copying artifacts/logs to $HELIX_WORKITEM_UPLOAD_ROOT/"
-cp -R artifacts/log/ $HELIX_WORKITEM_UPLOAD_ROOT/../
-cp -R artifacts/log/ $HELIX_WORKITEM_UPLOAD_ROOT/
+cp `find . -name \*.log` $HELIX_WORKITEM_UPLOAD_ROOT/../
+cp `find . -name \*.log` $HELIX_WORKITEM_UPLOAD_ROOT/
 exit $exit_code

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -156,8 +156,7 @@ fi
 
 echo "Copying TestResults/TestResults to ."
 cp TestResults/TestResults.xml testResults.xml
-echo "Copying artifacts/logs to $HELIX_WORKITEM_UPLOAD_ROOT/../"
-shopt -s globstar
-cp artifacts/log/**/*.log $HELIX_WORKITEM_UPLOAD_ROOT/../
-cp artifacts/log/**/*.log $HELIX_WORKITEM_UPLOAD_ROOT/
+echo "Copying artifacts/logs to $HELIX_WORKITEM_UPLOAD_ROOT/"
+cp -R artifacts/log/ $HELIX_WORKITEM_UPLOAD_ROOT/../
+cp -R artifacts/log/ $HELIX_WORKITEM_UPLOAD_ROOT/
 exit $exit_code

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -25,7 +25,7 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Project,
     [string]$HelixQueues = "Windows.10.Amd64.Open",
-    [string]$TargetArchitecture = "",
+    [string]$TargetArchitecture = "x64",
     [bool]$RunQuarantinedTests = $false
 )
 $ErrorActionPreference = 'Stop'
@@ -39,4 +39,4 @@ $env:BUILD_REPOSITORY_NAME="aspnetcore"
 $env:SYSTEM_TEAMPROJECT="aspnetcore"
 
 $HelixQueues = $HelixQueues -replace ";", "%3B"
-dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" /p:IsRequiredCheck=true /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests /p:_UseHelixOpenQueues=true
+dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" /p:IsRequiredCheck=true /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests /p:_UseHelixOpenQueues=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log


### PR DESCRIPTION
No clue what `shopt -s globstar` is but it wasn't working in some environments.