### PR TITLE
Quarantine flaky tests

### DIFF
--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Templates.Test.Helpers;

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -70,6 +70,7 @@ namespace Templates.Test
 
         [Theory]
         [MemberData(nameof(TemplateBaselines))]
+        [QuarantinedTest]
         public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)
         {
             Project = await ProjectFactory.GetOrCreateProject("baseline" + SanitizeArgs(arguments), Output);

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -24,7 +24,7 @@ namespace Templates.Test
 
         public Project Project { get; private set; }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "This test ran for over an hour")]
         [SkipOnHelix("selenium")]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/20172")]
         public async Task BlazorServerTemplateWorks_NoAuth()

--- a/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
@@ -23,7 +23,7 @@ namespace Templates.Test
 
         public ITestOutputHelper Output { get; }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "This test ran for over an hour")]
         [SkipOnHelix("Cert failures", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/20162")]
         public async Task EmptyWebTemplateCSharp()


### PR DESCRIPTION
Template_Produces_The_Right_Set_Of_FilesAsync: https://dev.azure.com/dnceng/public/_build/results?buildId=577215&view=ms.vss-test-web.build-test-results-tab&runId=18127966&paneView=debug&resultId=120453
Related issue: https://github.com/dotnet/aspnetcore/issues/20219

BlazorServerTemplateWorks_NoAuth and EmptyWebTemplateCSharp: https://dev.azure.com/dnceng/internal/_build/results?buildId=574867
Related issue: https://github.com/dotnet/aspnetcore/issues/19979