### PR TITLE
Make src/Analyzers tests pass successfully locally in Vs2019

### DIFF
--- a/src/Analyzers/Analyzers/test/AnalyzerTestBase.cs
+++ b/src/Analyzers/Analyzers/test/AnalyzerTestBase.cs
@@ -5,15 +5,12 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Analyzers
 {
     public abstract class AnalyzerTestBase
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
-
         public TestSource Read(string source)
         {
             if (!source.EndsWith(".cs"))
@@ -21,7 +18,7 @@ namespace Microsoft.AspNetCore.Analyzers
                 source = source + ".cs";
             }
 
-            var filePath = Path.Combine(ProjectDirectory, "TestFiles", GetType().Name, source);
+            var filePath = Path.Combine(AppContext.BaseDirectory, "TestFiles", GetType().Name, source);
             if (!File.Exists(filePath))
             {
                 throw new FileNotFoundException($"TestFile {source} could not be found at {filePath}.", filePath);
@@ -45,23 +42,6 @@ namespace Microsoft.AspNetCore.Analyzers
         public Task<Compilation> CreateCompilationAsync(string source)
         {
             return CreateProject(source).GetCompilationAsync();
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-// This test code needs to be updated to support distributed testing.
-// See https://github.com/dotnet/aspnetcore/issues/10422
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Analyzers");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Analyzers", "test");
-            return projectDirectory;
         }
     }
 }

--- a/src/Analyzers/Analyzers/test/Microsoft.AspNetCore.Analyzers.Test.csproj
+++ b/src/Analyzers/Analyzers/test/Microsoft.AspNetCore.Analyzers.Test.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)test\SkipOnHelixAttribute.cs" />
-    <Content Include="TestFiles\**\*.*" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="TestFiles\**\*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Applying suggesting fix from https://github.com/dotnet/aspnetcore/isses/10422
 - use "CopyToOutputDirectory" rather than "CopyToPublishDirectory"

Addresses #bugnumber (not created yet)

As i have no idea if it will break the CI or not, i did not created an issue yet
