### PR TITLE
Fix content showing on top of sticky header

### DIFF
--- a/src/ProjectTemplates/BlazorWasm.ProjectTemplates/content/BlazorWasm-CSharp/Client/wwwroot/css/site.css
+++ b/src/ProjectTemplates/BlazorWasm.ProjectTemplates/content/BlazorWasm-CSharp/Client/wwwroot/css/site.css
@@ -165,6 +165,7 @@ app {
     .main .top-row {
         position: sticky;
         top: 0;
+        z-index: 1;
     }
 
     .main > div {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -165,7 +165,7 @@ app {
     .main .top-row {
         position: sticky;
         top: 0;
-        z-index: 9999;
+        z-index: 1;
     }
 
     .main > div {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -165,6 +165,7 @@ app {
     .main .top-row {
         position: sticky;
         top: 0;
+        z-index: 9999;
     }
 
     .main > div {


### PR DESCRIPTION
Explicitly set z-index on top row so that it displays above other content.
When I had the following in a razor component it was showing on top of the sticky bar.

```html
<div class="row">
  <div class="col-md-12">
    Test
  </div>
</div>
```
