### PR TITLE
Generate Localization's RootNamespaceAttribute on build

### DIFF
--- a/src/Localization/Localization/src/Microsoft.Extensions.Localization.csproj
+++ b/src/Localization/Localization/src/Microsoft.Extensions.Localization.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Product>Microsoft .NET Extensions</Product>
@@ -21,6 +21,11 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Extensions.Localization.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- NuGet Tasks path. -->
+    <Content Include="build\Microsoft.Extensions.Localization.props" PackagePath="build\" />
   </ItemGroup>
 
 </Project>

--- a/src/Localization/Localization/src/build/Microsoft.Extensions.Localization.props
+++ b/src/Localization/Localization/src/build/Microsoft.Extensions.Localization.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.Extensions.Localization.RootNamespaceAttribute">
+      <_Parameter1>$(RootNamespace)</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Based on the work for [MessagePack.MSBuild](https://github.com/aspnet/MessagePack-CSharp/blob/a4a14ce447e4ef694af1a485fb672db35e766111/src/MessagePack.MSBuild.Tasks/MessagePack.MSBuild.Tasks.csproj#L20) and [@natemcmaster comment](https://github.com/dotnet/aspnetcore/issues/2804#issuecomment-363944811)

Addresses #2804 
