### PR TITLE
Load satellite resources before rendering root components

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
@@ -120,8 +120,10 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
 
             _started = true;
 
-            // Users may want to configure the culture based on some ambient state such as local storage, url etc.
-            // If they have changed the culture since the initial load, fetch satellite assemblies for this selection.
+            // EntryPointInvoker loads satellite assemblies for the application default culture.
+            // Application developers might have configured the culture based on some ambient state
+            // such as local storage, url etc as part of their Program.Main(Async).
+            // This is the earliest opportunity to fetch satellite assemblies for this selection.
             await SatelliteResourcesLoader.LoadCurrentCultureResourcesAsync();
 
             var tcs = new TaskCompletionSource<object>();

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
@@ -120,6 +120,10 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
 
             _started = true;
 
+            // Users may want to configure the culture based on some ambient state such as local storage, url etc.
+            // If they have changed the culture since the initial load, fetch satellite assemblies for this selection.
+            await SatelliteResourcesLoader.LoadCurrentCultureResourcesAsync();
+
             var tcs = new TaskCompletionSource<object>();
 
             using (cancellationToken.Register(() => { tcs.TrySetResult(null); }))
@@ -133,10 +137,6 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
                     var rootComponent = rootComponents[i];
                     await _renderer.AddComponentAsync(rootComponent.ComponentType, rootComponent.Selector);
                 }
-
-                // Users may want to configure the culture based on some ambient state such as local storage, url etc.
-                // If they have changed the culture since the initial load, fetch satellite assemblies for this selection.
-                await SatelliteResourcesLoader.LoadCurrentCultureResourcesAsync();
 
                 await tcs.Task;
             }


### PR DESCRIPTION
We need to ensure satellite assemblies are loaded by the time root components are rendered so they can use the right culture strings on the first render.