### PR TITLE
Update AzDO pipeline display name for macOS

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -594,7 +594,7 @@ stages:
     parameters:
       condition: ne(variables['SkipTests'], 'true')
       jobName: MacOS_Test
-      jobDisplayName: "Test: macOS 10.13"
+      jobDisplayName: "Test: macOS 10.14"
       agentOs: macOS
       isTestingJob: true
       buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)


### PR DESCRIPTION
We updated the agents to macOS 10.14 recently but the display name wasn't updated.