### PR TITLE
Always generate checksums as last part of publish job

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -67,6 +67,7 @@ variables:
     # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
     - name: _PublishArgs
       value: /p:Publish=true
+             /p:GenerateChecksums=true
              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
              /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -170,7 +170,6 @@
 
     <ArchiveExtension>.tar.gz</ArchiveExtension>
     <ArchiveExtension Condition="'$(TargetOsName)' == 'win'">.zip</ArchiveExtension>
-    <ChecksumExtension>.sha512</ChecksumExtension>
   </PropertyGroup>
 
   <Import Project="eng\Workarounds.props" />

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,14 +1,12 @@
 <Project>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(GenerateChecksums)' == 'true'" />
   <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
 
   <PropertyGroup>
     <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
     <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
     <InstallersOutputPath>$(ArtifactsDir)\installers\</InstallersOutputPath>
-    <!-- Suppress warnings about importing certain Arcade projects twice -->
-    <NoWarn>$(NoWarn);MSB4011</NoWarn>
   </PropertyGroup>
 
   <Target Name="PopulateGenerateChecksumItems"
@@ -25,6 +23,6 @@
 
   </Target>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(GenerateChecksums)' == 'true'" />
 
 </Project>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -7,6 +7,8 @@
     <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
     <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
     <InstallersOutputPath>$(ArtifactsDir)\installers\</InstallersOutputPath>
+    <!-- Suppress warnings about importing certain Arcade projects twice -->
+    <NoWarn>$(NoWarn);MSB4011</NoWarn>
   </PropertyGroup>
 
   <Target Name="PopulateGenerateChecksumItems"

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,5 +1,13 @@
 <Project>
 
+  <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
+
+  <PropertyGroup>
+    <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
+    <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
+    <InstallersOutputPath>$(ArtifactsDir)\installers\</InstallersOutputPath>
+  </PropertyGroup>
+
   <Target Name="PopulateGenerateChecksumItems"
           Condition="'$(GenerateChecksums)' == 'true'"
           AfterTargets="Build"
@@ -8,7 +16,7 @@
     <ItemGroup>
       <InstallerFiles Include="$(InstallersOutputPath)**" />
       <GenerateChecksumItems Include="%(InstallerFiles.Identity)" >
-        <DestinationPath>%(FullPath)$(ChecksumExtension)</DestinationPath>
+        <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>
     </ItemGroup>
 

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -15,7 +15,10 @@
           BeforeTargets="GenerateChecksums" >
 
     <ItemGroup>
-      <InstallerFiles Include="$(InstallersOutputPath)**\*" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*.msi" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*.exe" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*.zip" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*.tar.gz" />
       <GenerateChecksumItems Include="%(InstallerFiles.Identity)" >
         <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,0 +1,17 @@
+<Project>
+
+  <Target Name="PopulateGenerateChecksumItems"
+          Condition="'$(GenerateChecksums)' == 'true'"
+          AfterTargets="Build"
+          BeforeTargets="GenerateChecksums" >
+
+    <ItemGroup>
+      <InstallerFiles Include="$(InstallersOutputPath)**" />
+      <GenerateChecksumItems Include="%(InstallerFiles.Identity)" >
+        <DestinationPath>%(FullPath)$(ChecksumExtension)</DestinationPath>
+      </GenerateChecksumItems>
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,5 +1,6 @@
 <Project>
 
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
 
   <PropertyGroup>
@@ -21,5 +22,7 @@
     </ItemGroup>
 
   </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
 </Project>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,11 +1,11 @@
 <Project>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(GenerateChecksums)' == 'true'" />
-  <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(GenerateChecksums)' == 'true'">
     <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
     <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
+    <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
     <InstallersOutputPath>$(ArtifactsDir)\installers\</InstallersOutputPath>
   </PropertyGroup>
 
@@ -19,6 +19,8 @@
       <InstallerFiles Include="$(InstallersOutputPath)**\*.exe" />
       <InstallerFiles Include="$(InstallersOutputPath)**\*.zip" />
       <InstallerFiles Include="$(InstallersOutputPath)**\*.tar.gz" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*.wixlib" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*.rpm" />
       <GenerateChecksumItems Include="%(InstallerFiles.Identity)" >
         <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -14,7 +14,7 @@
           BeforeTargets="GenerateChecksums" >
 
     <ItemGroup>
-      <InstallerFiles Include="$(InstallersOutputPath)**" />
+      <InstallerFiles Include="$(InstallersOutputPath)**\*" />
       <GenerateChecksumItems Include="%(InstallerFiles.Identity)" >
         <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -49,12 +49,10 @@
       <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows. -->
       <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT'" />
 
-      <!-- Skip publishing checksums for now - the checksums for the .zip files don't match (https://github.com/dotnet/aspnetcore/issues/18792)
       <ItemsToPushToBlobFeed Include="@(_ChecksumsToPublish)">
         <PublishFlatContainer>true</PublishFlatContainer>
         <RelativeBlobPath>$(_UploadPathRoot)/Runtime/$(_PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
       </ItemsToPushToBlobFeed>
-      -->
 
       <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
         <IsShipping>true</IsShipping>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,7 +1,7 @@
 <Project>
-  <PropertyGroup Condition=" HasTrailingSlash('$(ArtifactsDir)') ">
+  <PropertyGroup>
     <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
-    <ArtifactsDir>$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
+    <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
 
     <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallersAndChecksums</PublishDependsOnTargets>
 

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -154,12 +154,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <RedistArchiveOutputPath>$(InstallersOutputPath)$(RedistArchiveOutputFileName)</RedistArchiveOutputPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <GenerateChecksumItems Include="$(RedistArchiveOutputPath)">
-      <DestinationPath>$(RedistArchiveOutputPath)$(ChecksumExtension)</DestinationPath>
-    </GenerateChecksumItems>
-  </ItemGroup>
-
   <!-- Target chain -->
   <PropertyGroup>
     <ResolveReferencesDependsOn>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -64,18 +64,12 @@
 
   <Target Name="CopyToArtifactsDirectory"
           Condition=" '$(IsShipping)' == 'true' AND '$(SkipCopyToArtifactsDirectory)' != 'true' "
-          AfterTargets="Build" BeforeTargets="GenerateChecksums">
+          AfterTargets="Build">
     <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(InstallersOutputPath)$(PackageFileName)" />
     <ItemGroup>
       <_cabs Include="$(TargetDir)**/*.cab" />
     </ItemGroup>
     <Copy SourceFiles="@(_cabs)" DestinationFolder="$(InstallersOutputPath)" />
   </Target>
-
-  <ItemGroup Condition=" '$(IsShipping)' == 'true' AND '$(SkipCopyToArtifactsDirectory)' != 'true' ">
-    <GenerateChecksumItems Include="$(InstallersOutputPath)$(PackageFileName)">
-      <DestinationPath>$(InstallersOutputPath)$(PackageFileName)$(ChecksumExtension)</DestinationPath>
-    </GenerateChecksumItems>
-  </ItemGroup>
 
 </Project>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -64,7 +64,7 @@
 
   <Target Name="CopyToArtifactsDirectory"
           Condition=" '$(IsShipping)' == 'true' AND '$(SkipCopyToArtifactsDirectory)' != 'true' "
-          AfterTargets="Build">
+          BeforeTargets="Build">
     <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(InstallersOutputPath)$(PackageFileName)" />
     <ItemGroup>
       <_cabs Include="$(TargetDir)**/*.cab" />


### PR DESCRIPTION
My first iteration of publishing checksums for this repo didn't work, since it generated checksums for some assets, _before_ those assets were signed (specifically the installer zips). Instead, I'm here trying to ensure that checksums are only generated once per build, after all build and signing jobs are done. I'm using the assumption that the step that passes `_PublishArgs` is always the final build step, and therefore we can safely hook the checksum target into `AfterSigning.proj` in that leg (note that only the winx64/x86 job has multiple build steps - all the other jobs just run `build` once & pass `_PublishArgs` to that).

This should generate checksums for the same set of assets as my previous solution.

Internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=581767

Resolves part of https://github.com/dotnet/aspnetcore/issues/18792 (still need to port this to master, and find another solution for 2.1)