### PR TITLE
Skip stream pool test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -428,8 +428,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
-        [QuarantinedTest]
+        [Fact(Skip = "Causes tests to not finish. See https://dev.azure.com/dnceng/internal/_build/results?buildId=580307&view=logs")]
         public async Task StreamPool_StreamIsInvalidState_DontReturnedToPool()
         {
             var serverTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -428,14 +428,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact(Skip = "Causes tests to not finish. See https://dev.azure.com/dnceng/internal/_build/results?buildId=580307&view=logs")]
+        [Fact]
+        [QuarantinedTest]
         public async Task StreamPool_StreamIsInvalidState_DontReturnedToPool()
         {
             var serverTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await InitializeConnectionAsync(async context =>
             {
-                await serverTcs.Task;
+                await serverTcs.Task.DefaultTimeout();
 
                 await context.Response.WriteAsync("Content");
                 throw new InvalidOperationException("Put the stream into an invalid state by throwing after writing to response.");
@@ -467,9 +468,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(0, _connection.StreamPool.Count);
 
             var output = (Http2OutputProducer)stream.Output;
-            await output._dataWriteProcessingTask;
+            await output._dataWriteProcessingTask.DefaultTimeout();
 
-            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false).DefaultTimeout();
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -470,7 +470,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var output = (Http2OutputProducer)stream.Output;
             await output._dataWriteProcessingTask.DefaultTimeout();
 
-            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false).DefaultTimeout();
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
         [Fact]


### PR DESCRIPTION
@JamesNK there seems to be some build hangs.
https://dev.azure.com/dnceng/internal/_build/results?buildId=580307&view=logs

https://dev.azure.com/dnceng/_apis/resources/Containers/3761800?itemPath=MacOS_Test_Logs%2FRelease%2FQuarantined%2FInMemory.FunctionalTests_netcoreapp5.0_x64.log