### PR TITLE
Quarantine identity test

### DIFF
--- a/src/Identity/test/Identity.Test/IdentityUIScriptsTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityUIScriptsTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.AspNetCore.Identity.Test
 
         [Theory]
         [MemberData(nameof(ScriptWithIntegrityData))]
+        [QuarantinedTest]
         public async Task IdentityUI_ScriptTags_SubresourceIntegrityCheck(ScriptTag scriptTag)
         {
             var integrity = await GetShaIntegrity(scriptTag);


### PR DESCRIPTION
I don't feel great about quarantining this because the failure is odd and doesn't seem related to identity per se. https://dev.azure.com/dnceng/public/_build/results?buildId=580722&view=ms.vss-test-web.build-test-results-tab&runId=18259416&resultId=108224&paneView=debug

It says that HttpClient is timing out after 100 seconds, however I don't see the RetryHandler (which would retry the request) at all.

@javiercn do you have any more context on this failure?
