### PR TITLE
OpenAPI Flaky fix

### DIFF
--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -424,7 +424,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         {
             var project = CreateBasicProject(withOpenApi: false);
 
-            var app = GetApplication(realHttp: true);
+            var app = GetApplication();
             var url = BrokenUrl;
             var run = app.Execute(new[] { "add", "url", url });
 

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.OpenApi.Tests
                 { NoDispositionUrl, Tuple.Create<string, ContentDispositionHeaderValue>(Content, null) },
                 { NoExtensionUrl, Tuple.Create(Content, noExtension) },
                 { NoSegmentUrl, Tuple.Create(Content, justAttachments) },
-                { BrokenUrl, Tuple.Create<string, ContentDispositionHeaderValue>(Content, null) }
+                { BrokenUrl, null }
             };
         }
 
@@ -140,10 +140,14 @@ namespace Microsoft.DotNet.OpenApi.Tests
         public Task<IHttpResponseMessageWrapper> GetResponseAsync(string url)
         {
             var result = _results[url];
-            byte[] byteArray = Encoding.ASCII.GetBytes(result.Item1);
-            var stream = new MemoryStream(byteArray);
+            MemoryStream stream = null;
+            if(result != null)
+            {
+                byte[] byteArray = Encoding.ASCII.GetBytes(result.Item1);
+                stream = new MemoryStream(byteArray);
+            }
 
-            return Task.FromResult<IHttpResponseMessageWrapper>(new TestHttpResponseMessageWrapper(stream, result.Item2));
+            return Task.FromResult<IHttpResponseMessageWrapper>(new TestHttpResponseMessageWrapper(stream, result?.Item2));
         }
     }
 
@@ -175,7 +179,7 @@ namespace Microsoft.DotNet.OpenApi.Tests
             ContentDispositionHeaderValue header)
         {
             Stream = Task.FromResult<Stream>(stream);
-            if (header is null)
+            if (header is null && stream is null)
             {
                 StatusCode = HttpStatusCode.NotFound;
             }

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
@@ -106,7 +106,8 @@ namespace Microsoft.DotNet.OpenApi.Tests
                 { PackageUrl, Tuple.Create<string, ContentDispositionHeaderValue>(PackageUrlContent, null) },
                 { NoDispositionUrl, Tuple.Create<string, ContentDispositionHeaderValue>(Content, null) },
                 { NoExtensionUrl, Tuple.Create(Content, noExtension) },
-                { NoSegmentUrl, Tuple.Create(Content, justAttachments) }
+                { NoSegmentUrl, Tuple.Create(Content, justAttachments) },
+                { BrokenUrl, Tuple.Create<string, ContentDispositionHeaderValue>(Content, null) }
             };
         }
 
@@ -154,7 +155,17 @@ namespace Microsoft.DotNet.OpenApi.Tests
 
         public bool IsSuccessCode()
         {
-            return true;
+            switch(StatusCode)
+            {
+                case HttpStatusCode.OK:
+                case HttpStatusCode.Created:
+                case HttpStatusCode.NoContent:
+                case HttpStatusCode.Accepted:
+                    return true;
+                case HttpStatusCode.NotFound:
+                default:
+                    return false;
+            }
         }
 
         private readonly ContentDispositionHeaderValue _contentDisposition;
@@ -164,6 +175,10 @@ namespace Microsoft.DotNet.OpenApi.Tests
             ContentDispositionHeaderValue header)
         {
             Stream = Task.FromResult<Stream>(stream);
+            if (header is null)
+            {
+                StatusCode = HttpStatusCode.NotFound;
+            }
             _contentDisposition = header;
         }
 


### PR DESCRIPTION
This test flaked on what was probably a networking/server problem. Considering that it is not specifically a test of the network section of code (we have one of those) I figured we might as well mock out the request as we have for other scenarios.

@mkArtakMSFT