### PR TITLE
Fix max redirect count

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
+++ b/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing.Handlers
             var originalRequestContent = HasBody(request) ? await DuplicateRequestContent(request) : null;
             CopyRequestHeaders(request.Headers, redirectRequest.Headers);
             var response = await base.SendAsync(request, cancellationToken);
-            while (IsRedirect(response) && remainingRedirects >= 0)
+            while (IsRedirect(response) && remainingRedirects > 0)
             {
                 remainingRedirects--;
                 UpdateRedirectRequest(response, redirectRequest, originalRequestContent);


### PR DESCRIPTION
Without this change, RedirectHandler always follows MaxRedirects + 1. If MaxRedirects was initially set to 1, the body of the while statement is executed twice. This defect expresses itself when calling WebApplicationFactory<Startup>.CreateClient() with WebApplicationFactoryClientOptions.MaxAutomaticRedirections >= 1 and .AllowAutoRedirects = true in integration tests.

Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
