### PR TITLE
Fix flaky StreamPool_StreamIsInvalidState_DontReturnedToPool

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -41,10 +41,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private bool _suffixSent;
         private bool _streamEnded;
         private bool _writerComplete;
-        private bool _disposed;
 
         // Internal for testing
         internal ValueTask _dataWriteProcessingTask;
+        internal bool _disposed;
 
         /// <summary>The core logic for the IValueTaskSource implementation.</summary>
         private ManualResetValueTaskSourceCore<FlushResult> _responseCompleteTaskSource = new ManualResetValueTaskSourceCore<FlushResult> { RunContinuationsAsynchronously = true }; // mutable struct, do not make this readonly

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -484,12 +484,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
             await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, null);
 
-            // Ping will trigger the stream to be returned to the pool so we can assert it
-            await SendPingAsync(Http2PingFrameFlags.NONE);
-            await ExpectAsync(Http2FrameType.PING,
-                withLength: 8,
-                withFlags: (byte)Http2PingFrameFlags.ACK,
-                withStreamId: 0);
+            await PingUntilStreamDisposed(stream).DefaultTimeout();
 
             // Stream is not returned to the pool
             Assert.Equal(0, _connection.StreamPool.Count);
@@ -498,6 +493,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await output._dataWriteProcessingTask.DefaultTimeout();
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            async Task PingUntilStreamDisposed(Http2Stream stream)
+            {
+                var output = (Http2OutputProducer)stream.Output;
+
+                do
+                {
+                    // Ping will trigger the stream to be returned to the pool so we can assert it
+                    await SendPingAsync(Http2PingFrameFlags.NONE);
+                    await ExpectAsync(Http2FrameType.PING,
+                        withLength: 8,
+                        withFlags: (byte)Http2PingFrameFlags.ACK,
+                        withStreamId: 0);
+                } while (!output._disposed);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Ensures stream is moved out of completed streams and is disposed before awaiting