### PR TITLE
Fix flaky StreamPool_MultipleStreamsInSequence_PooledStreamReused

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamStack.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamStack.cs
@@ -37,6 +37,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             return true;
         }
 
+        public bool TryPeek(out Http2Stream result)
+        {
+            int size = _size - 1;
+            Http2StreamAsValueType[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
+            {
+                result = default;
+                return false;
+            }
+
+            result = array[size];
+            return true;
+        }
+
         // Pushes an item to the top of the stack.
         public void Push(Http2Stream item)
         {


### PR DESCRIPTION
Ensures stream is moved out of completed streams and is returned to pool.