### PR TITLE
Harden template tests for invalid cert state

### DIFF
--- a/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
+++ b/src/ProjectTemplates/test/Helpers/AspNetProcess.cs
@@ -80,7 +80,8 @@ namespace Templates.Test.Helpers
             var now = DateTimeOffset.Now;
             var manager = new CertificateManager();
             var result = manager.EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1));
-            if (result.ResultCode == EnsureCertificateResult.Succeeded)
+            if (result.ResultCode == EnsureCertificateResult.Succeeded || 
+                result.ResultCode == EnsureCertificateResult.ValidCertificatePresent)
             {
                 return;
             }


### PR DESCRIPTION
This code runs before every template test to try and put the development
certificates in a good state. There's one problem though! It returns a
result object rather than throwing, but this code doesn't look at the
result.

With this change we should get some insight into the cause when
certificate issue crop up.

