### PR TITLE
[release/3.1] Pass access token as query string when running SignalR in the browser

### DIFF
--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Log.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Log.cs
@@ -66,6 +66,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             private static readonly Action<ILogger, HttpTransportType, Exception> _transportStarted =
                 LoggerMessage.Define<HttpTransportType>(LogLevel.Debug, new EventId(18, "TransportStarted"), "Transport '{Transport}' started.");
 
+            private static readonly Action<ILogger, Exception> _serverSentEventsNotSupportedByBrowser =
+                LoggerMessage.Define(LogLevel.Debug, new EventId(19, "ServerSentEventsNotSupportedByBrowser"), "Skipping ServerSentEvents because they are not supported by the browser.");
+
             public static void Starting(ILogger logger)
             {
                 _starting(logger, null);
@@ -166,6 +169,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             public static void TransportStarted(ILogger logger, HttpTransportType transportType)
             {
                 _transportStarted(logger, transportType, null);
+            }
+
+            public static void ServerSentEventsNotSupportedByBrowser(ILogger logger)
+            {
+                _serverSentEventsNotSupportedByBrowser(logger, null);
             }
         }
     }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private bool _started;
         private bool _disposed;
         private bool _hasInherentKeepAlive;
+        private bool _isRunningInBrowser;
 
         private readonly HttpClient _httpClient;
         private readonly HttpConnectionOptions _httpConnectionOptions;
@@ -148,6 +149,14 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             if (!httpConnectionOptions.SkipNegotiation || httpConnectionOptions.Transports != HttpTransportType.WebSockets)
             {
                 _httpClient = CreateHttpClient();
+            }
+
+            _isRunningInBrowser = Utils.IsRunningInBrowser();
+
+
+            if (httpConnectionOptions.Transports == HttpTransportType.ServerSentEvents && _isRunningInBrowser)
+            {
+                throw new ArgumentException("ServerSentEvents can not be the only transport specified when running in the browser.", nameof(httpConnectionOptions));
             }
 
             _transportFactory = new DefaultTransportFactory(httpConnectionOptions.Transports, _loggerFactory, _httpClient, httpConnectionOptions, GetAccessTokenAsync);
@@ -362,6 +371,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                     {
                         Log.WebSocketsNotSupportedByOperatingSystem(_logger);
                         transportExceptions.Add(new TransportFailedException("WebSockets", "The transport is not supported on this operating system."));
+                        continue;
+                    }
+
+                    if (transportType == HttpTransportType.ServerSentEvents && _isRunningInBrowser)
+                    {
+                        Log.ServerSentEventsNotSupportedByBrowser(_logger);
+                        transportExceptions.Add(new TransportFailedException("ServerSentEvents", "The transport is not supported in the browser."));
                         continue;
                     }
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Utils.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Utils.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
         internal static bool IsRunningInBrowser()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
         }
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Utils.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Utils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 {
@@ -40,6 +41,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
             builder.Query = newQueryString;
             return builder.Uri;
+        }
+
+        internal static bool IsRunningInBrowser()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
         }
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
+using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
         private readonly ILogger _logger;
         private readonly TimeSpan _closeTimeout;
         private volatile bool _aborted;
+        private bool _isRunningInBrowser;
 
         private IDuplexPipe _transport;
 
@@ -87,6 +89,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
             // Ignore the HttpConnectionOptions access token provider. We were given an updated delegate from the HttpConnection.
             _accessTokenProvider = accessTokenProvider;
+
+            _isRunningInBrowser = Utils.IsRunningInBrowser();
         }
 
         public async Task StartAsync(Uri url, TransferFormat transferFormat, CancellationToken cancellationToken = default)
@@ -113,7 +117,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 var accessToken = await _accessTokenProvider();
                 if (!string.IsNullOrEmpty(accessToken))
                 {
-                    _webSocket.Options.SetRequestHeader("Authorization", $"Bearer {accessToken}");
+                    // We can't use request headers in the browser, so instead append the token as a query string in that case
+                    if (_isRunningInBrowser)
+                    {
+                        var accessTokenEncoded = UrlEncoder.Default.Encode(accessToken);
+                        accessTokenEncoded = "access_token=" + accessTokenEncoded;
+                        resolvedUrl = Utils.AppendQueryString(resolvedUrl, accessTokenEncoded);
+                    }
+                    else
+                    {
+                        _webSocket.Options.SetRequestHeader("Authorization", $"Bearer {accessToken}");
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/18697

#### Description

When running in the browser, we can't use request headers. The SignalR client tries to do so anyways, which causes issues w/ Blazor Wasm. This PR detects if we're running in the browser, and sends the access token as a query string instead.

#### Customer Impact

Customers writing Blazor Wasm apps w/ SignalR will not see issues when adding Auth to their apps

#### Regression?

No

#### Risk

Behavior has been tested locally, but there could be obscure scenarios we've missed.

I used https://github.com/wtgodbe/scratch/tree/master/SigRBlazor/BlazorSignalRApp to validate that the token gets passed as a query string & can be pulled out and referenced by the server.