### PR TITLE
Cleanup Blazor standalone publish output

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/Publish.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Publish.targets
@@ -9,4 +9,31 @@
     <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
   </PropertyGroup>
 
+  <Target
+    Name="_BlazorCleanupPublishOutput"
+    AfterTargets="ComputeResolvedFilesToPublishList"
+    Condition="'$(BlazorPrunePublishOutput)' != 'false'">
+
+    <ItemGroup>
+      <!-- Delete stray contents from the root of the the app. -->
+      <ResolvedFileToPublish
+        Remove="%(ResolvedFileToPublish.Identity)"
+        Condition="!$([System.String]::Copy('%(ResolvedFileToPublish.RelativePath)').Replace('\','/').StartsWith('wwwroot/'))"/>
+    </ItemGroup>
+  </Target>
+
+  <Target
+      Name="_BlazorCopyStandaloneWebConfig"
+      AfterTargets="_BlazorCleanupPublishOutput;ComputeResolvedFilesToPublishList">
+
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(MSBuildThisFileDirectory)Standalone.Web.config">
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <RelativePath>web.config</RelativePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+
+  </Target>
+
 </Project>

--- a/src/Components/WebAssembly/Build/src/targets/StaticWebAssets.targets
+++ b/src/Components/WebAssembly/Build/src/targets/StaticWebAssets.targets
@@ -89,12 +89,6 @@
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </ResolvedFileToPublish>
 
-      <ResolvedFileToPublish Include="$(MSBuildThisFileDirectory)Standalone.Web.config">
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <RelativePath>web.config</RelativePath>
-      </ResolvedFileToPublish>
-
     </ItemGroup>
 
   </Target>

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/Assert.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/Assert.cs
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             return filePath;
         }
 
-        public static void FileCountEquals(MSBuildResult result, int expected, string directoryPath, string searchPattern)
+        public static void FileCountEquals(MSBuildResult result, int expected, string directoryPath, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
         {
             if (result == null)
             {
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
 
             if (Directory.Exists(directoryPath))
             {
-                var files = Directory.GetFiles(directoryPath, searchPattern, SearchOption.AllDirectories);
+                var files = Directory.GetFiles(directoryPath, searchPattern, searchOption);
                 if (files.Length != expected)
                 {
                     throw new FileCountException(result, expected, directoryPath, searchPattern, files);

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/PublishIntegrationTest.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/PublishIntegrationTest.cs
@@ -21,11 +21,13 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
         {
             // Arrange
             using var project = ProjectDirectory.Create("standalone", additionalProjects: new [] { "razorclasslibrary", "LinkBaseToWebRoot" });
+            project.Configuration = "Debug";
             var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish");
 
             Assert.BuildPassed(result);
 
             var publishDirectory = project.PublishOutputDirectory;
+
             var blazorPublishDirectory = Path.Combine(publishDirectory, "wwwroot");
 
             Assert.FileExists(result, blazorPublishDirectory, "_framework", "blazor.boot.json");
@@ -50,12 +52,52 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
 
             // Verify web.config
             Assert.FileExists(result, publishDirectory, "web.config");
+            Assert.FileCountEquals(result, 1, publishDirectory, "*", SearchOption.TopDirectoryOnly);
 
             VerifyBootManifestHashes(result, blazorPublishDirectory);
             VerifyServiceWorkerFiles(result, blazorPublishDirectory,
                 serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
                 serviceWorkerContent: "// This is the production service worker",
                 assetsManifestPath: "custom-service-worker-assets.js");
+        }
+
+        [Fact]
+        public async Task Publish_InRelease_Works()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone", additionalProjects: new [] { "razorclasslibrary", "LinkBaseToWebRoot" });
+            project.Configuration = "Release";
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish");
+
+            Assert.BuildPassed(result);
+
+            var publishDirectory = project.PublishOutputDirectory;
+
+            var blazorPublishDirectory = Path.Combine(publishDirectory, "wwwroot");
+
+            Assert.FileExists(result, blazorPublishDirectory, "_framework", "blazor.boot.json");
+            Assert.FileExists(result, blazorPublishDirectory, "_framework", "blazor.webassembly.js");
+            Assert.FileExists(result, blazorPublishDirectory, "_framework", "wasm", "dotnet.wasm");
+            Assert.FileExists(result, blazorPublishDirectory, "_framework", "wasm", DotNetJsFileName);
+            Assert.FileExists(result, blazorPublishDirectory, "_framework", "_bin", "standalone.dll");
+            Assert.FileExists(result, blazorPublishDirectory, "_framework", "_bin", "Microsoft.Extensions.Logging.Abstractions.dll"); // Verify dependencies are part of the output.
+
+            // Verify referenced static web assets
+            Assert.FileExists(result, blazorPublishDirectory, "_content", "RazorClassLibrary", "wwwroot", "exampleJsInterop.js");
+            Assert.FileExists(result, blazorPublishDirectory, "_content", "RazorClassLibrary", "styles.css");
+
+            // Verify static assets are in the publish directory
+            Assert.FileExists(result, blazorPublishDirectory, "index.html");
+
+            // Verify link item assets are in the publish directory
+            Assert.FileExists(result, blazorPublishDirectory, "js", "LinkedScript.js");
+            var cssFile = Assert.FileExists(result, blazorPublishDirectory, "css", "app.css");
+            Assert.FileContains(result, cssFile, ".publish");
+            Assert.FileDoesNotExist(result, "dist", "Fake-License.txt");
+
+            // Verify web.config
+            Assert.FileExists(result, publishDirectory, "web.config");
+            Assert.FileCountEquals(result, 1, publishDirectory, "*", SearchOption.TopDirectoryOnly);
         }
 
         [Fact]


### PR DESCRIPTION
* Remove stray content from Blazor's publish output.
* Introduce BlazorPrunePublishOutput as a way for users to opt-out of this.

Fixes https://github.com/dotnet/aspnetcore/issues/17018

