### PR TITLE
Cleanup resources in Java client

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -29,6 +29,13 @@ final class DefaultHttpClient extends HttpClient {
         return new DefaultHttpClient(timeoutInMilliseconds, newClient);
     }
 
+    @Override
+    public void close() {
+        if (this.client != null) {
+            this.client.dispatcher().executorService().shutdown();
+        }
+    }
+
     public DefaultHttpClient(int timeoutInMilliseconds, OkHttpClient client) {
         if (client != null) {
             this.client = client;

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -40,7 +40,6 @@ final class DefaultHttpClient extends HttpClient {
         if (client != null) {
             this.client = client;
         } else {
-
             OkHttpClient.Builder builder = new OkHttpClient.Builder().cookieJar(new CookieJar() {
                 private List<Cookie> cookieList = new ArrayList<>();
                 private Lock cookieLock = new ReentrantLock();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpClient.java
@@ -74,7 +74,7 @@ class HttpResponse {
     }
 }
 
-abstract class HttpClient {
+abstract class HttpClient implements AutoCloseable {
     public Single<HttpResponse> get(String url) {
         HttpRequest request = new HttpRequest();
         request.setUrl(url);

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpClient.java
@@ -127,4 +127,6 @@ abstract class HttpClient {
     public abstract WebSocketWrapper createWebSocket(String url, Map<String, String> headers);
 
     public abstract HttpClient cloneWithTimeOut(int timeoutInMilliseconds);
+
+    public abstract void close();
 }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -31,6 +31,7 @@ public class HubConnection {
 
     private String baseUrl;
     private Transport transport;
+    private boolean customTransport = false;
     private OnReceiveCallBack callback;
     private final CallbackMap handlers = new CallbackMap();
     private HubProtocol protocol;
@@ -112,7 +113,7 @@ public class HubConnection {
     }
 
     // For testing purposes
-    Map<String,Observable> getStreamMap() {
+    Map<String, Observable> getStreamMap() {
         return this.streamMap;
     }
 
@@ -147,6 +148,7 @@ public class HubConnection {
 
         if (transport != null) {
             this.transport = transport;
+            this.customTransport = true;
         } else if (transportEnum != null) {
             this.transportEnum = transportEnum;
         }
@@ -548,7 +550,10 @@ public class HubConnection {
             if (this.httpClient instanceof DefaultHttpClient) {
                 this.httpClient = null;
             }
-            this.transport = null;
+
+            if (this.customTransport == false) {
+                this.transport = null;
+            }
         } finally {
             hubConnectionStateLock.unlock();
         }

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -1111,10 +1111,10 @@ public class HubConnection implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         try {
             stop().blockingAwait();
-        } catch (Exception ex) {
+        } finally {
             // Don't close HttpClient if it's passed in by the user
             if (this.httpClient != null && this.httpClient instanceof DefaultHttpClient) {
                 this.httpClient.close();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/LongPollingTransport.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/LongPollingTransport.java
@@ -160,6 +160,8 @@ class LongPollingTransport implements Transport {
                 CompletableSubject stopCompletableSubject = CompletableSubject.create();
                 return this.receiveLoop.andThen(Completable.defer(() -> {
                     logger.info("LongPolling transport stopped.");
+                    this.onReceiveThread.shutdown();
+                    this.threadPool.shutdown();
                     this.onClose.invoke(this.closeError);
                     return Completable.complete();
                 })).subscribeWith(stopCompletableSubject);

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2479,7 +2479,7 @@ class HubConnectionTest {
     }
 
     @Test
-    public void hubConnectionCanBeStartedAfterBeingStoppedAndRedirected()  {
+    public void hubConnectionCanBeStartedAfterBeingStoppedAndRedirected() {
         MockTransport mockTransport = new MockTransport();
         TestHttpClient client = new TestHttpClient()
                 .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
@@ -2518,5 +2518,32 @@ class HubConnectionTest {
         RuntimeException exception = assertThrows(RuntimeException.class,
             () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Unexpected status code returned from negotiate: 500 Internal server error.", exception.getMessage());
+    }
+
+    public void hubConnectionClosesHttpClientOnClose() throws Exception {
+        MockTransport mockTransport = new MockTransport();
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"url\":\"http://testexample.com/\"}")))
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", "{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                        + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+
+        try (HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(mockTransport)
+                .withHttpClient(client)
+                .build()) {
+            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+            hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+            hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+            assertEquals(false, client.getCloseCalled());
+        }
+
+        assertEquals(true, client.getCloseCalled());
     }
 }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
@@ -76,6 +76,10 @@ class TestHttpClient extends HttpClient {
         return this;
     }
 
+    @Override
+    public void close() {
+    }
+
     interface TestHttpRequestHandler {
         Single<HttpResponse> invoke(HttpRequest request);
     }

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
@@ -12,6 +12,7 @@ import io.reactivex.Single;
 class TestHttpClient extends HttpClient {
     private TestHttpRequestHandler handler;
     private List<HttpRequest> sentRequests;
+    private boolean closeCalled;
 
     public TestHttpClient() {
         this.sentRequests = new ArrayList<>();
@@ -78,6 +79,11 @@ class TestHttpClient extends HttpClient {
 
     @Override
     public void close() {
+        this.closeCalled = true;
+    }
+
+    public boolean getCloseCalled() {
+        return this.closeCalled;
     }
 
     interface TestHttpRequestHandler {

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
@@ -55,6 +55,10 @@ class WebSocketTransportTest {
         public HttpClient cloneWithTimeOut(int timeoutInMilliseconds) {
             return null;
         }
+
+        @Override
+        public void close() {
+        }
     }
 
     class TestWrapper extends WebSocketWrapper {

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
@@ -10,33 +10,33 @@ import com.microsoft.signalr.HubConnectionBuilder;
 
 
 public class Chat {
-    public static void main(String[] args) {
+    public static void main(final String[] args) throws Exception {
         System.out.println("Enter the URL of the SignalR Chat you want to join");
-        Scanner reader = new Scanner(System.in);  // Reading from System.in
-        String input = reader.nextLine();
+        final Scanner reader = new Scanner(System.in); // Reading from System.in
+        final String input = reader.nextLine();
 
-        HubConnection hubConnection = HubConnectionBuilder.create(input).build();
+        try (HubConnection hubConnection = HubConnectionBuilder.create(input).build()) {
+            hubConnection.on("Send", (message) -> {
+                System.out.println(message);
+            }, String.class);
 
-        hubConnection.on("Send", (message) -> {
-            System.out.println(message);
-        }, String.class);
+            hubConnection.onClosed((ex) -> {
+                if (ex != null) {
+                    System.out.printf("There was an error: %s", ex.getMessage());
+                }
+            });
 
-        hubConnection.onClosed((ex) -> {
-            if (ex != null) {
-                System.out.printf("There was an error: %s", ex.getMessage());
+            //This is a blocking call
+            hubConnection.start().blockingAwait();
+
+            String message = "";
+            while (!message.equals("leave")) {
+                // Scans the next token of the input as an int.
+                message = reader.nextLine();
+                hubConnection.send("Send", message);
             }
-        });
 
-        //This is a blocking call
-        hubConnection.start().blockingAwait();
-
-        String message = "";
-        while (!message.equals("leave")) {
-            // Scans the next token of the input as an int.
-            message = reader.nextLine();
-            hubConnection.send("Send", message);
+            hubConnection.stop().blockingAwait();
         }
-
-        hubConnection.stop().blockingAwait();
     }
 }


### PR DESCRIPTION
Before, the chat sample would just hang when main exited. This is because Java is waiting for threads to close before exiting the program. Now at least if main exits (without the [try resource](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html)) the program will close after ~1 minute which is how long OkHttp will keep its internal threads open. Otherwise, using the try resource pattern, the program will close immediately.

We'll need to discuss the API additions.