### PR TITLE
Unquarantine but skip on OSX all template tests

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -691,7 +691,7 @@ stages:
 
   - template: jobs/default-build.yml
     parameters:
-      condition: notin(variables['Build.Reason'], 'PullRequest')
+      #condition: notin(variables['Build.Reason'], 'PullRequest')
       jobName: Helix_x64_daily
       jobDisplayName: 'Tests: Helix x64 Daily'
       agentOs: Windows

--- a/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
@@ -10,5 +10,3 @@ using Xunit;
 
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(ProjectFactoryFixture))]
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(SeleniumStandaloneServer))]
-
-[assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/20479")]

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -24,9 +24,9 @@ namespace Templates.Test
 
         public Project Project { get; private set; }
 
-        [ConditionalFact(Skip = "This test ran for over an hour")]
+        [ConditionalFact]
         [SkipOnHelix("selenium")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/20172")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task BlazorServerTemplateWorks_NoAuth()
         {
             Project = await ProjectFactory.GetOrCreateProject("blazorservernoauth", Output);
@@ -85,7 +85,7 @@ namespace Templates.Test
         [InlineData(true)]
         [InlineData(false)]
         [SkipOnHelix("ef restore no worky")]
-        [QuarantinedTest]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task BlazorServerTemplateWorks_IndividualAuth(bool useLocalDB)
         {
             Project = await ProjectFactory.GetOrCreateProject("blazorserverindividual" + (useLocalDB ? "uld" : ""), Output);

--- a/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
@@ -23,9 +23,9 @@ namespace Templates.Test
 
         public ITestOutputHelper Output { get; }
 
-        [ConditionalFact(Skip = "This test ran for over an hour")]
+        [ConditionalFact]
         [SkipOnHelix("Cert failures", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/20162")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task EmptyWebTemplateCSharp()
         {
             await EmtpyTemplateCore(languageOverride: null);

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -27,7 +27,7 @@ namespace Templates.Test
 
         [ConditionalFact]
         [SkipOnHelix("Not supported queues", Queues = "Windows.7.Amd64;Windows.7.Amd64.Open;OSX.1014.Amd64;OSX.1014.Amd64.Open")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task GrpcTemplate()
         {
             // Setup AssemblyTestLog

--- a/src/ProjectTemplates/test/IdentityUIPackageTest.cs
+++ b/src/ProjectTemplates/test/IdentityUIPackageTest.cs
@@ -121,7 +121,7 @@ namespace Templates.Test
         [ConditionalTheory]
         [MemberData(nameof(MSBuildIdentityUIPackageOptions))]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task IdentityUIPackage_WorksWithDifferentOptions(IDictionary<string, string> packageOptions, string versionValidator, string[] expectedFiles)
         {
             Project = await ProjectFactory.GetOrCreateProject("identityuipackage" + string.Concat(packageOptions.Values), Output);

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -30,6 +30,7 @@ namespace Templates.Test
 
         [ConditionalFact]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task MvcTemplate_NoAuthCSharp() => await MvcTemplateCore(languageOverride: null);
 
         private async Task MvcTemplateCore(string languageOverride)
@@ -108,7 +109,7 @@ namespace Templates.Test
         [InlineData(true)]
         [InlineData(false)]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task MvcTemplate_IndividualAuth(bool useLocalDB)
         {
             Project = await ProjectFactory.GetOrCreateProject("mvcindividual" + (useLocalDB ? "uld" : ""), Output);
@@ -223,8 +224,8 @@ namespace Templates.Test
             }
         }
 
-        [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task MvcTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
         {
             Project = await ProjectFactory.GetOrCreateProject("mvc_rc", Output);

--- a/src/ProjectTemplates/test/RazorClassLibraryTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorClassLibraryTemplateTest.cs
@@ -41,8 +41,8 @@ namespace Templates.Test
             Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", Project, buildResult));
         }
 
-        [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task RazorClassLibraryTemplateAsync()
         {
             Project = await ProjectFactory.GetOrCreateProject("razorclasslib", Output);

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -27,6 +27,7 @@ namespace Templates.Test
 
         [ConditionalFact]
         [SkipOnHelix("Cert failures", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task RazorPagesTemplate_NoAuth()
         {
             Project = await ProjectFactory.GetOrCreateProject("razorpagesnoauth", Output);
@@ -98,7 +99,7 @@ namespace Templates.Test
         [InlineData(false)]
         [InlineData(true)]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task RazorPagesTemplate_IndividualAuth(bool useLocalDB)
         {
             Project = await ProjectFactory.GetOrCreateProject("razorpagesindividual" + (useLocalDB ? "uld" : ""), Output);
@@ -213,8 +214,8 @@ namespace Templates.Test
             }
         }
 
-        [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task RazorPagesTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
         {
             Project = await ProjectFactory.GetOrCreateProject("razorpages_rc", Output);
@@ -235,8 +236,7 @@ namespace Templates.Test
             // Verify ref assemblies isn't published
             var refsDirectory = Path.Combine(Project.TemplatePublishDir, "refs");
             Assert.False(Directory.Exists(refsDirectory), $"{refsDirectory} should not be in the publish output.");
-       }
-
+        }
 
         private string ReadFile(string basePath, string path)
         {

--- a/src/ProjectTemplates/test/SpaTemplateTest/AngularTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/AngularTemplateTest.cs
@@ -17,16 +17,19 @@ namespace Templates.Test.SpaTemplateTest
 
         [ConditionalFact]
         [SkipOnHelix("selenium")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task AngularTemplate_Works()
             => SpaTemplateImplAsync("angularnoauth", "angular", useLocalDb: false, usesAuth: false);
 
         [ConditionalFact]
         [SkipOnHelix("selenium")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task AngularTemplate_IndividualAuth_Works()
             => SpaTemplateImplAsync("angularindividual", "angular", useLocalDb: false, usesAuth: true);
 
         [ConditionalFact]
         [SkipOnHelix("selenium")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task AngularTemplate_IndividualAuth_Works_LocalDb()
             => SpaTemplateImplAsync("angularindividualuld", "angular", useLocalDb: true, usesAuth: true);
     }

--- a/src/ProjectTemplates/test/SpaTemplateTest/ReactTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/ReactTemplateTest.cs
@@ -19,17 +19,19 @@ namespace Templates.Test.SpaTemplateTest
 
         [ConditionalFact]
         [SkipOnHelix("selenium")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task ReactTemplate_Works_NetCore()
             => SpaTemplateImplAsync("reactnoauth", "react", useLocalDb: false, usesAuth: false);
 
-        [QuarantinedTest]
         [ConditionalFact]
         [SkipOnHelix("selenium")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task ReactTemplate_IndividualAuth_NetCore()
             => SpaTemplateImplAsync("reactindividual", "react", useLocalDb: false, usesAuth: true);
 
         [ConditionalFact]
         [SkipOnHelix("selenium")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task ReactTemplate_IndividualAuth_NetCore_LocalDb()
             => SpaTemplateImplAsync("reactindividualuld", "react", useLocalDb: true, usesAuth: true);
     }

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -28,6 +28,7 @@ namespace Templates.Test
 
         [ConditionalFact]
         [SkipOnHelix("Cert failures", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task WebApiTemplateCSharp() => await WebApiTemplateCore(languageOverride: null);
 
         private async Task WebApiTemplateCore(string languageOverride)

--- a/src/ProjectTemplates/test/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/WorkerTemplateTest.cs
@@ -21,8 +21,8 @@ namespace Templates.Test
         public ProjectFactoryFixture ProjectFactory { get; }
         public ITestOutputHelper Output { get; }
 
-        [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task WorkerTemplateAsync()
         {
             Project = await ProjectFactory.GetOrCreateProject("worker", Output);


### PR DESCRIPTION
We think the template tests are ok everywhere but OSX where there's a cert issue going on, so switch to targeted isolation instead of social distancing