### PR TITLE
Quarantine a hosting test that failed

### DIFF
--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
             await ExecuteShutdownTest(nameof(ShutdownTestRun), "Run");
         }
 
+        [QuarantinedTest]
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Windows)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -133,7 +134,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
 
         private static void WaitForExitOrKill(Process process)
         {
-            process.WaitForExit(1000);
+            process.WaitForExit(5 * 1000);
             if (!process.HasExited)
             {
                 process.Kill();


### PR DESCRIPTION
This test failed overnight on linux. The part that failed was checking the exit code
of `kill` which is a little surprising. This implies that `kill` itself was also
forcibly killed - so we're increasing the timeout before we kill `kill`. :+1:

