### PR TITLE
Skipping a Blazor template test

### DIFF
--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -81,7 +81,7 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "See: https://github.com/dotnet/aspnetcore/issues/20520")]
         [InlineData(true)]
         [InlineData(false)]
         [SkipOnHelix("ef restore no worky")]


### PR DESCRIPTION
This test is causing hangs in quarantine. Adding an explicit skip.

See: https://github.com/dotnet/aspnetcore/issues/20520
