### PR TITLE
List dotnet processes about to be killed

### DIFF
--- a/eng/scripts/KillProcesses.ps1
+++ b/eng/scripts/KillProcesses.ps1
@@ -38,6 +38,15 @@ function _killSeleniumTrackedProcesses() {
     }
 }
 
+function _listProcesses($processName) {
+    $processes = Get-WmiObject win32_process -Filter "name like '%$processName'" -ErrorAction SilentlyContinue;
+    if ($processes) {
+        Write-Host "These processes will be killed..."
+        $processes | select commandline
+    }
+}
+
+_listProcesses dotnet
 _kill dotnet.exe
 _kill testhost.exe
 _kill iisexpress.exe

--- a/eng/scripts/KillProcesses.ps1
+++ b/eng/scripts/KillProcesses.ps1
@@ -42,7 +42,7 @@ function _listProcesses($processName) {
     $processes = Get-WmiObject win32_process -Filter "name like '%$processName'" -ErrorAction SilentlyContinue;
     if ($processes) {
         Write-Host "These processes will be killed..."
-        $processes | select commandline
+        $processes | select commandline | Out-String -Width 800
     }
 }
 

--- a/eng/scripts/KillProcesses.sh
+++ b/eng/scripts/KillProcesses.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
 
+# list processes that would be killed so they appear in the log
+p=$(pgrep dotnet)
+if [ $? -eq 0 ]
+then
+  echo "These processes will be killed..."
+  ps -p $p
+fi
+
 pkill dotnet || true
 exit 0


### PR DESCRIPTION
This should make it easier to see which test projects are failing to
terminate when troubleshooting test hangs.

