### PR TITLE
Re-enable project template tests

### DIFF
--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -25,7 +25,7 @@ namespace Templates.Test
         public ProjectFactoryFixture ProjectFactory { get; }
         public ITestOutputHelper Output { get; }
 
-        [ConditionalFact(Skip = "This test run for over an hour")]
+        [ConditionalFact]
         [SkipOnHelix("Not supported queues", Queues = "Windows.7.Amd64;Windows.7.Amd64.Open;OSX.1014.Amd64;OSX.1014.Amd64.Open")]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
         public async Task GrpcTemplate()

--- a/src/ProjectTemplates/test/IdentityUIPackageTest.cs
+++ b/src/ProjectTemplates/test/IdentityUIPackageTest.cs
@@ -118,7 +118,7 @@ namespace Templates.Test
             "Identity/lib/jquery-validation-unobtrusive/LICENSE.txt",
         };
 
-        [ConditionalTheory(Skip = "This test run for over an hour")]
+        [ConditionalTheory]
         [MemberData(nameof(MSBuildIdentityUIPackageOptions))]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -104,7 +104,7 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalTheory(Skip = "This test run for over an hour")]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -94,7 +94,7 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalTheory(Skip = "This test run for over an hour")]
+        [ConditionalTheory]
         [InlineData(false)]
         [InlineData(true)]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]

--- a/src/ProjectTemplates/test/SpaTemplateTest/ReactTemplateTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplateTest/ReactTemplateTest.cs
@@ -23,7 +23,7 @@ namespace Templates.Test.SpaTemplateTest
             => SpaTemplateImplAsync("reactnoauth", "react", useLocalDb: false, usesAuth: false);
 
         [QuarantinedTest]
-        [ConditionalFact(Skip="This test run for over an hour")]
+        [ConditionalFact]
         [SkipOnHelix("selenium")]
         public Task ReactTemplate_IndividualAuth_NetCore()
             => SpaTemplateImplAsync("reactindividual", "react", useLocalDb: false, usesAuth: true);

--- a/src/ProjectTemplates/test/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/WorkerTemplateTest.cs
@@ -21,7 +21,7 @@ namespace Templates.Test
         public ProjectFactoryFixture ProjectFactory { get; }
         public ITestOutputHelper Output { get; }
 
-        [Fact(Skip = "This test run for over an hour")]
+        [Fact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19716")]
         public async Task WorkerTemplateAsync()
         {


### PR DESCRIPTION
@javiercn claims that he has fixed the underlying issues with https://github.com/dotnet/aspnetcore/pull/20494 so it's time to turn these tests back on.