### PR TITLE
Remove workaround in HeaderPropagationMiddleware

### DIFF
--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationMiddleware.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationMiddleware.cs
@@ -33,8 +33,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
             _values = values ?? throw new ArgumentNullException(nameof(values));
         }
 
-        // This needs to be async as otherwise the AsyncLocal could bleed across requests, see https://github.com/aspnet/AspNetCore/issues/13991.
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             // We need to intialize the headers because the message handler will use this to detect misconfiguration.
             var headers = _values.Headers ??= new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
@@ -57,7 +56,7 @@ namespace Microsoft.AspNetCore.HeaderPropagation
                 }
             }
 
-            await _next.Invoke(context);
+            return _next.Invoke(context);
         }
 
         private static StringValues GetValue(HttpContext context, HeaderPropagationEntry entry)

--- a/src/Middleware/HeaderPropagation/test/HeaderPropagationMiddlewareTest.cs
+++ b/src/Middleware/HeaderPropagation/test/HeaderPropagationMiddlewareTest.cs
@@ -185,43 +185,5 @@ namespace Microsoft.AspNetCore.HeaderPropagation.Tests
             Assert.Contains("in", CapturedHeaders.Keys);
             Assert.Equal("Test", CapturedHeaders["in"]);
         }
-
-        [Fact]
-        public async Task HeaderInRequest_WithBleedAsyncLocal_HasCorrectValue()
-        {
-            // Arrange
-            Configuration.Headers.Add("in");
-
-            // Process first request
-            Context.Request.Headers.Add("in", "dirty");
-            await Middleware.Invoke(Context);
-
-            // Process second request
-            Context = new DefaultHttpContext();
-            Context.Request.Headers.Add("in", "test");
-            await Middleware.Invoke(Context);
-
-            // Assert
-            Assert.Contains("in", CapturedHeaders.Keys);
-            Assert.Equal(new[] { "test" }, CapturedHeaders["in"]);
-        }
-
-        [Fact]
-        public async Task NoHeaderInRequest_WithBleedAsyncLocal_DoesNotHaveIt()
-        {
-            // Arrange
-            Configuration.Headers.Add("in");
-
-            // Process first request
-            Context.Request.Headers.Add("in", "dirty");
-            await Middleware.Invoke(Context);
-
-            // Process second request
-            Context = new DefaultHttpContext();
-            await Middleware.Invoke(Context);
-
-            // Assert
-            Assert.Empty(CapturedHeaders);
-        }
     }
 }


### PR DESCRIPTION
Fixed by #14146 which starts each request on a fresh ExecutionContext