### PR TITLE
[3.1] Remove Code_check job from publish-build-assets.yml `dependsOn`

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -51,7 +51,6 @@ variables:
   # to have it in two different forms
   - name: _InternalRuntimeDownloadCodeSignArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
@@ -73,6 +72,9 @@ variables:
              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+
+    # used for post-build phases, internal builds only
+    - group: DotNet-AspNet-SDLValidation-Params
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _BuildArgs
       value: ''
@@ -80,9 +82,6 @@ variables:
       value: test
     - name: _PublishArgs
       value: ''
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-AspNet-SDLValidation-Params
 
 stages:
 - stage: build
@@ -699,7 +698,6 @@ stages:
           - CodeSign_Xplat_Linux_musl_x64
           - CodeSign_Xplat_Linux_musl_arm64
           # In addition to the dependencies above, ensure the build was successful overall.
-          - Code_check
           - Linux_Test
           - MacOS_Test
           - Source_Build


### PR DESCRIPTION
- nit: remove redundant conditions for easier reading