### PR TITLE
[5.0-preview3] Remove Code_check job from publish-build-assets.yml `dependsOn`

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -76,6 +76,9 @@ variables:
              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+
+    # used for post-build phases, internal builds only
+    - group: DotNet-AspNet-SDLValidation-Params
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _BuildArgs
       value: ''
@@ -83,9 +86,6 @@ variables:
       value: test
     - name: _PublishArgs
       value: ''
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-AspNet-SDLValidation-Params
 
 stages:
 - stage: build
@@ -176,8 +176,7 @@ stages:
                 -noBuildDeps
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
-        # Disabled until 3.1.3 is released
-        condition: false
+        condition: ne(variables['Build.Reason'], 'PullRequest')
         displayName: Build SiteExtension
 
       # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
@@ -798,7 +797,6 @@ stages:
           - CodeSign_Xplat_Linux_musl_x64
           - CodeSign_Xplat_Linux_musl_arm64
           # In addition to the dependencies above, ensure the build was successful overall.
-          - Code_check
           - Linux_Test
           - MacOS_Test
           - Source_Build


### PR DESCRIPTION
- re-enable the "Build SiteExtension" build step!
- nit: remove redundant conditions for easier reading