### PR TITLE
Return types that could be loaded

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApplicationParts/AssemblyPart.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationParts/AssemblyPart.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
                 }
                 catch (ReflectionTypeLoadException ex)
                 {
-                    return ex.Types;
+                    return ex.Types.Select(x => x.GetTypeInfo());
                 }
             }
         }

--- a/src/Mvc/Mvc.Core/src/ApplicationParts/AssemblyPart.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationParts/AssemblyPart.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
                 }
                 catch (ReflectionTypeLoadException ex)
                 {
-                    return ex.Types.Select(x => x.GetTypeInfo());
+                    return ex.Types.Where(type => type != null).Select(type => type.GetTypeInfo());
                 }
             }
         }

--- a/src/Mvc/Mvc.Core/src/ApplicationParts/AssemblyPart.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationParts/AssemblyPart.cs
@@ -33,8 +33,19 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         public override string Name => Assembly.GetName().Name;
 
         /// <inheritdoc />
-        public IEnumerable<TypeInfo> Types => Assembly.DefinedTypes;
-
-        
+        public IEnumerable<TypeInfo> Types
+        {
+            get
+            {
+                try
+                {
+                    return Assembly.DefinedTypes;
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    return ex.Types;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Assemblies may define types that cannot be loaded. This behavior should not halt the startup process, especially considering that the assembly may be a vendor assembly that is not under the control of the developer. 

Instead of halting the process, catch the `ReflectionTypeLoadException` and return the types that could be loaded.