### PR TITLE
[release/5.0-preview3] Remove Code_check job from publish-build-assets.yml `dependsOn`…

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -76,6 +76,9 @@ variables:
              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+
+    # used for post-build phases, internal builds only
+    - group: DotNet-AspNet-SDLValidation-Params
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _BuildArgs
       value: ''
@@ -83,9 +86,6 @@ variables:
       value: test
     - name: _PublishArgs
       value: ''
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-AspNet-SDLValidation-Params
 
 stages:
 - stage: build
@@ -797,7 +797,6 @@ stages:
           - CodeSign_Xplat_Linux_musl_x64
           - CodeSign_Xplat_Linux_musl_arm64
           # In addition to the dependencies above, ensure the build was successful overall.
-          - Code_check
           - Linux_Test
           - MacOS_Test
           - Source_Build


### PR DESCRIPTION
… (#20558)

- nit: remove redundant conditions for easier reading