### PR TITLE
Use correct version for 3.1 SiteExtension package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -211,7 +211,7 @@
     <!-- Packages from 2.1/2.2 branches used for site extension build -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>
-    <MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>3.1.3</MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>
+    <MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>3.1.3-servicing.20163.14</MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>
     <!-- 3rd party dependencies -->
     <AngleSharpPackageVersion>0.9.9</AngleSharpPackageVersion>
     <BenchmarkDotNetPackageVersion>0.12.0</BenchmarkDotNetPackageVersion>


### PR DESCRIPTION
This package has a non-stable version in 3.1 - update our reference to it so it has the correct version. Can get this into master via the branch merge bot

CC @mmitche since this is going into preview3 late-ish (but the build is broken without it)