### PR TITLE
Quarantining tests

### DIFF
--- a/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 [assembly: TestFramework("Microsoft.AspNetCore.E2ETesting.XunitTestFrameworkWithAssemblyFixture", "ProjectTemplates.Tests")]
 
-[assembly: AssemblyFixture(typeof(ProjectFactoryFixture))]
-[assembly: AssemblyFixture(typeof(SeleniumStandaloneServer))]
+[assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(ProjectFactoryFixture))]
+[assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(SeleniumStandaloneServer))]
 
 [assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/20479")]

--- a/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using Templates.Test.Helpers;
 using Xunit;
 
@@ -9,3 +10,5 @@ using Xunit;
 
 [assembly: AssemblyFixture(typeof(ProjectFactoryFixture))]
 [assembly: AssemblyFixture(typeof(SeleniumStandaloneServer))]
+
+[assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/20479")]

--- a/src/Security/Authentication/test/SecureDataFormatTests.cs
+++ b/src/Security/Authentication/test/SecureDataFormatTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Authentication.DataHandler
         }
 
         [Fact]
+        [QuarantinedTest]
         public void UnprotectWithDifferentPurposeFails()
         {
             var provider = ServiceProvider.GetRequiredService<IDataProtectionProvider>();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1415,6 +1415,7 @@ namespace Interop.FunctionalTests
         // Settings_InitialWindowSize_Lower_Client - Not configurable.
 
         [Theory]
+        [QuarantinedTest]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_InitialWindowSize_Server(string scheme)
         {

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -420,6 +420,7 @@ namespace Microsoft.DotNet.OpenApi.Add.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task OpenAPi_Add_URL_InvalidUrl()
         {
             var project = CreateBasicProject(withOpenApi: false);

--- a/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
+++ b/src/Tools/dotnet-watch/test/MsBuildFileSetFactoryTest.cs
@@ -77,6 +77,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task SingleTfm()
         {
             _tempDir


### PR DESCRIPTION
Quarantining tests that have been flaky as reported by whatsbroken as of build https://dev.azure.com/dnceng/public/_build/results?buildId=591163&view=results.

FYI, I did not quarantine the Microsoft.AspNetCore.NodeServices.Tests since the underlying issue was a CDN outage for nodejs.org. There has been discussion on making this more reliable at https://github.com/dotnet/aspnetcore/issues/20577. I'm not sure if the tradeoff for test coverage vs reliability makes it worthwhile to quarantine all node tests.