### PR TITLE
Use BuildTools internally too

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -103,8 +103,10 @@ jobs:
             queue: BuildPool.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
-          # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Server.Amd64.VS2019
+          ${{ if ne(parameters.isTestingJob, true) }}:
+            queue: BuildPool.Server.Amd64.VS2019.BT
+          ${{ if eq(parameters.isTestingJob, true) }}:
+            queue: BuildPool.Server.Amd64.VS2019
     variables:
     - AgentOsName: ${{ parameters.agentOs }}
     - ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
- BuildPool.Server.Amd64.VS2019.BT in particular (for non-testing jobs)
