### PR TITLE
Define default unpkg file for SignalR JS client

### DIFF
--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -7,6 +7,7 @@
   "typings": "./dist/esm/index.d.ts",
   "umd": "./dist/browser/signalr.js",
   "umd_name": "signalR",
+  "unpkg": "./dist/browser/signalr.js",
   "directories": {
     "test": "spec"
   },


### PR DESCRIPTION
Fixes #20696

Add an `unpkg` property to redirect to the unminified *signalr.js* file. The following comment from @BrennanConroy got me thinking 🤔: https://github.com/dotnet/AspNetCore.Docs/pull/17685#discussion_r405956109
