### PR TITLE
Improve exception when HTTP.sys can't register a prefix

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -79,12 +79,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_ALREADY_EXISTS)
                 {
-                    throw new HttpSysException((int)statusCode, string.Format(Resources.Exception_PrefixAlreadyRegistered, uriPrefix));
+                    throw new HttpSysException((int)statusCode, Resources.FormatException_PrefixAlreadyRegistered(uriPrefix));
                 }
-                else
+                if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_ACCESS_DENIED)
                 {
-                    throw new HttpSysException((int)statusCode);
+                    throw new HttpSysException((int)statusCode, Resources.FormatException_AccessDenied(uriPrefix, Environment.UserDomainName + @"\" + Environment.UserName));
                 }
+                throw new HttpSysException((int)statusCode);
             }
         }
 

--- a/src/Servers/HttpSys/src/Resources.resx
+++ b/src/Servers/HttpSys/src/Resources.resx
@@ -117,6 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Exception_AccessDenied" xml:space="preserve">
+    <value>The prefix '{0}' is not registered. Please run the following command as Administrator to register this prefix:
+netsh http add urlacl url={0} user={1}
+See "Preregister URL prefixes on the server" on https://go.microsoft.com/fwlink/?linkid=2127065 for more information.</value>
+  </data>
   <data name="Exception_ArrayTooSmall" xml:space="preserve">
     <value>The destination array is too small.</value>
   </data>

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
@@ -9,7 +9,9 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys.Listener
@@ -121,6 +123,19 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var response = await responseTask;
                 Assert.Equal(string.Empty, response);
             }
+        }
+
+        [ConditionalFact]
+        public void Server_RegisterUnavailablePrefix_ThrowsActionableHttpSysException()
+        {
+            var options = new HttpSysOptions();
+            options.UrlPrefixes.Add(UrlPrefix.Create("http", "example.org", "8080", ""));
+            var listener = new HttpSysListener(options, new LoggerFactory());
+
+            var exception = Assert.Throws<HttpSysException>(() => listener.Start());
+
+            Assert.Equal((int)UnsafeNclNativeMethods.ErrorCodes.ERROR_ACCESS_DENIED, exception.ErrorCode);
+            Assert.Contains($@"netsh http add urlacl url=http://example.org:8080/ user={Environment.UserDomainName}\{Environment.UserName}", exception.Message);
         }
 
         [ConditionalFact]

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
@@ -126,6 +126,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/pull/20718#issuecomment-618758634")]
         public void Server_RegisterUnavailablePrefix_ThrowsActionableHttpSysException()
         {
             var options = new HttpSysOptions();


### PR DESCRIPTION
Propose an actionable solution and include a link to the documentation.

@guardrex  Can you create an aka.ms link to https://docs.microsoft.com/aspnet/core/fundamentals/servers/httpsys#configure-windows-server that I could use in the exception message?