### PR TITLE
[blazor-wasm] Fix weather.json

### DIFF
--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/sample-data/weather.json
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/sample-data/weather.json
@@ -2,31 +2,26 @@
   {
     "date": "2018-05-06",
     "temperatureC": 1,
-    "summary": "Freezing",
-    "temperatureF": 33
+    "summary": "Freezing"
   },
   {
     "date": "2018-05-07",
     "temperatureC": 14,
-    "summary": "Bracing",
-    "temperatureF": 57
+    "summary": "Bracing"
   },
   {
     "date": "2018-05-08",
     "temperatureC": -13,
-    "summary": "Freezing",
-    "temperatureF": 9
+    "summary": "Freezing"
   },
   {
     "date": "2018-05-09",
     "temperatureC": -16,
-    "summary": "Balmy",
-    "temperatureF": 4
+    "summary": "Balmy"
   },
   {
     "date": "2018-05-10",
     "temperatureC": -2,
-    "summary": "Chilly",
-    "temperatureF": 29
+    "summary": "Chilly"
   }
 ]


### PR DESCRIPTION
Removed "temperatureF" elements from weather.json as WeatherForecast class calculates the Fahrenheit temperature internally from the retrieved Celcius temperature and not from the retrieved json data.