### PR TITLE
Unconditionally enable razor pages in hosted template. Fixes #20791

### DIFF
--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
@@ -73,9 +73,7 @@ namespace ComponentsWebAssembly_CSharp.Server
 #endif
 
             services.AddControllersWithViews();
-#if (IndividualLocalAuth)
             services.AddRazorPages();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -119,9 +117,7 @@ namespace ComponentsWebAssembly_CSharp.Server
 #endif
             app.UseEndpoints(endpoints =>
             {
-#if (IndividualLocalAuth)
                 endpoints.MapRazorPages();
-#endif
                 endpoints.MapControllers();
                 endpoints.MapFallbackToFile("index.html");
             });


### PR DESCRIPTION
The new error page is only used if Razor Pages is enabled, hence we need to enable it all the time now.