### PR TITLE
Add BuildNumber to SiteExtension build

### DIFF
--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -27,8 +27,8 @@
     <Reference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.2.1" Version="$(MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion)" PrivateAssets="All" />
     <Reference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.2.2" Version="$(MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion)" PrivateAssets="All" />
     <!-- When updating this add the previous SiteExtension(s) to the list above -->
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x64" Version="$(PackageVersion)-$(_PreReleaseLabel)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x86" Version="$(PackageVersion)-$(_PreReleaseLabel)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x64" Version="$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x86" Version="$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20617

#### Description

The SiteExtension build internalizes non-shipping packages in it's build, the CI adds build numbers to the package version so the SiteExtension build needs to reference the correct versions with build numbers.

#### Customer Impact

* Was the bug reported by a customer? Yes in #20617
* How does the bug impact the customer? Can't install the site extension in Azure App Service to get logs in blob working.
* Are there any workarounds? If so, why are they not acceptable alternatives? They can modify their apps to install a package and add some code to their app

1. Add a package reference to Microsoft.AspNetCore.AzureAppServicesIntegration with the same major-minor version as ASP.NET Core (i.e. 3.0 or 3.1).

2. Call .UseAzureAppServices on your IWebHostBuilder. 
```
Host.CreateDefaultBuilder(args)
    .ConfigureWebHostDefaults(webBuilder =>
    {
        webBuilder.UseStartup<Startup>()
            .UseAzureAppServices(); // <-- Add this
    });
```

#### Regression?
Technically no since this hasn't worked in 3.1 before.

#### Risk
None