### PR TITLE
[Helix] Force overwrite when installing app runtime

### DIFF
--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -109,7 +109,7 @@ namespace RunTests
                                 entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
                                 entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                             {
-                                entry.ExtractToFile(Path.Combine(appRuntimePath, entry.Name));
+                                entry.ExtractToFile(Path.Combine(appRuntimePath, entry.Name, overwrite: true));
                             }
                         }
                     }

--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -109,7 +109,7 @@ namespace RunTests
                                 entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
                                 entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                             {
-                                entry.ExtractToFile(Path.Combine(appRuntimePath, entry.Name, overwrite: true));
+                                entry.ExtractToFile(Path.Combine(appRuntimePath, entry.Name), overwrite: true);
                             }
                         }
                     }


### PR DESCRIPTION
When the sdk runtime is the same as the runtime