### PR TITLE
Inconsistency between file name and type name.

### DIFF
--- a/src/Analyzers/Analyzers/src/BuildServiceProviderAnalyzer.cs
+++ b/src/Analyzers/Analyzers/src/BuildServiceProviderAnalyzer.cs
@@ -7,11 +7,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.AspNetCore.Analyzers
 {
-    internal class BuildServiceProviderValidator
+    internal class BuildServiceProviderAnalyzer
     {
         private readonly StartupAnalysis _context;
 
-        public BuildServiceProviderValidator(StartupAnalysis context)
+        public BuildServiceProviderAnalyzer(StartupAnalysis context)
         {
             _context = context;
         }

--- a/src/Analyzers/Analyzers/src/StartupAnalyzer.cs
+++ b/src/Analyzers/Analyzers/src/StartupAnalyzer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Analyzers
                 {
                     var analysis = builder.Build();
                     new UseMvcAnalyzer(analysis).AnalyzeSymbol(context);
-                    new BuildServiceProviderValidator(analysis).AnalyzeSymbol(context);
+                    new BuildServiceProviderAnalyzer(analysis).AnalyzeSymbol(context);
                     new UseAuthorizationAnalyzer(analysis).AnalyzeSymbol(context);
                 });
 


### PR DESCRIPTION
`BuildServiceProviderAnalyzer.cs` and type `BuildServiceProviderValidator` are inconsistent.
