### PR TITLE
Endpoint-based concurrency limiter

### DIFF
--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEndpointConventionBuilderExtensions.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEndpointConventionBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEndpointConventionBuilderExtensions.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.ConcurrencyLimiter;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Concurrency limit extension methods for <see cref="IEndpointConventionBuilder"/>
+    /// </summary>
+    public static class ConcurrencyLimiterEndpointConventionBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the concurrency limit with LIFO stack as queueing strategy to the endpoint(s).
+        /// </summary>
+        /// <typeparam name="TBuilder"></typeparam>
+        /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+        /// <param name="maxConcurrentRequests">
+        /// Maximum number of concurrent requests. Any extras will be queued on the server. 
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        /// <param name="requestQueueLimit">
+        ///Maximum number of queued requests before the server starts rejecting connections with '503 Service Unavailible'.
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        /// <returns></returns>
+        public static TBuilder RequireStackPolicy<TBuilder>(this TBuilder builder,
+            int maxConcurrentRequests,
+            int requestQueueLimit)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Add(endpoints =>
+            {
+                endpoints.Metadata.Add(new StackPolicyAttribute(maxConcurrentRequests, requestQueueLimit));
+            });
+
+            return builder;
+        }
+        /// <summary>
+        /// Adds the concurrency limit with FIFO stack as queueing strategy to the endpoint(s).
+        /// </summary>
+        /// <typeparam name="TBuilder"></typeparam>
+        /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+        /// <param name="maxConcurrentRequests">
+        /// Maximum number of concurrent requests. Any extras will be queued on the server. 
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        /// <param name="requestQueueLimit">
+        ///Maximum number of queued requests before the server starts rejecting connections with '503 Service Unavailible'.
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        /// <returns></returns>
+        public static TBuilder RequireQueuePolicy<TBuilder>(this TBuilder builder,
+            int maxConcurrentRequests,
+            int requestQueueLimit)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Add(endpoints =>
+            {
+                endpoints.Metadata.Add(new QueuePolicyAttribute(maxConcurrentRequests, requestQueueLimit));
+            });
+
+            return builder;
+        }
+        /// <summary>
+        /// Suppresses the concurrency limit to the endpoint(s).
+        /// </summary>
+        /// <typeparam name="TBuilder"></typeparam>
+        /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+        /// <returns></returns>
+        public static TBuilder SupressQueuePolicy<TBuilder>(this TBuilder builder)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Add(endpoints =>
+            {
+                endpoints.Metadata.Add(SuppressQueuePolicyMetadata.Default);
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEndpointConventionBuilderExtensions.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEndpointConventionBuilderExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Builder
             return builder;
         }
         /// <summary>
-        /// Adds the concurrency limit with FIFO stack as queueing strategy to the endpoint(s).
+        /// Adds the concurrency limit with FIFO queue as queueing strategy to the endpoint(s).
         /// </summary>
         /// <typeparam name="TBuilder"></typeparam>
         /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Builder
 
             builder.Add(endpoints =>
             {
-                endpoints.Metadata.Add(SuppressQueuePolicyMetadata.Default);
+                endpoints.Metadata.Add(new SuppressQueuePolicyAttribute());
             });
 
             return builder;

--- a/src/Middleware/ConcurrencyLimiter/src/ISuppressQueuePolicyMetadata.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ISuppressQueuePolicyMetadata.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter
+{
+    public interface ISuppressQueuePolicyMetadata
+    {
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicyServiceCollectionExtensions.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicyServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class QueuePolicyServiceCollectionExtensions
     {
         /// <summary>
-        /// Tells <see cref="ConcurrencyLimiterMiddleware"/> to use a FIFO queue as its queueing strategy.
+        /// Tells <see cref="ConcurrencyLimiterMiddleware"/> to use a FIFO queue as its default queueing strategy.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
         /// <param name="configure">Set the options used by the queue.
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Tells <see cref="ConcurrencyLimiterMiddleware"/> to use a LIFO stack as its queueing strategy.
+        /// Tells <see cref="ConcurrencyLimiterMiddleware"/> to use a LIFO stack as its default queueing strategy.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
         /// <param name="configure">Set the options used by the queue.

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicyAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicyAttribute.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class QueuePolicyAttribute : Attribute, IQueuePolicy
+    {
+        private readonly QueuePolicy _queuePolicy;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="maxConcurrentRequests">
+        /// Maximum number of concurrent requests. Any extras will be queued on the server. 
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        /// <param name="requestQueueLimit">
+        ///Maximum number of queued requests before the server starts rejecting connections with '503 Service Unavailible'.
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        public QueuePolicyAttribute(int maxConcurrentRequests, int requestQueueLimit)
+        {
+            _queuePolicy = new QueuePolicy(Options.Create(new QueuePolicyOptions()
+            {
+                MaxConcurrentRequests = maxConcurrentRequests,
+                RequestQueueLimit = requestQueueLimit
+            }));
+        }
+
+        public void OnExit()
+            => _queuePolicy.OnExit();
+
+
+        public ValueTask<bool> TryEnterAsync()
+            => _queuePolicy.TryEnterAsync();
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicyAttribute.cs
@@ -11,13 +11,14 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.AspNetCore.ConcurrencyLimiter
 {
     /// <summary>
-    /// 
+    /// Specifies that the class or method that this attribute applied to requires limit concurrency request with FIFO queue as queueing strategy.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class QueuePolicyAttribute : Attribute, IQueuePolicy
     {
         private readonly QueuePolicy _queuePolicy;
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="QueuePolicyAttribute"/> class.
         /// </summary>
         /// <param name="maxConcurrentRequests">
         /// Maximum number of concurrent requests. Any extras will be queued on the server. 
@@ -35,11 +36,12 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
                 RequestQueueLimit = requestQueueLimit
             }));
         }
-
+        /// <inheritdoc />
         public void OnExit()
             => _queuePolicy.OnExit();
 
 
+        /// <inheritdoc />
         public ValueTask<bool> TryEnterAsync()
             => _queuePolicy.TryEnterAsync();
     }

--- a/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
@@ -11,13 +11,13 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.AspNetCore.ConcurrencyLimiter
 {
     /// <summary>
-    /// 
+    /// Specifies that the class or method that this attribute applied to requires limit concurrency request with LIFO stack as queueing strategy.
     /// </summary>
     public class StackPolicyAttribute : Attribute, IQueuePolicy
     {
         private readonly StackPolicy _stackPolicy;
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="StackPolicyAttribute"/> class.
         /// </summary>
         /// <param name="maxConcurrentRequests">
         /// Maximum number of concurrent requests. Any extras will be queued on the server. 
@@ -36,9 +36,11 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
             }));
         }
 
+        /// <inheritdoc />
         public void OnExit()
             => _stackPolicy.OnExit();
 
+        /// <inheritdoc />
         public ValueTask<bool> TryEnterAsync()
             => _stackPolicy.TryEnterAsync();
     }

--- a/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class StackPolicyAttribute : Attribute, IQueuePolicy
+    {
+        private readonly StackPolicy _stackPolicy;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="maxConcurrentRequests">
+        /// Maximum number of concurrent requests. Any extras will be queued on the server. 
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        /// <param name="requestQueueLimit">
+        ///Maximum number of queued requests before the server starts rejecting connections with '503 Service Unavailible'.
+        /// This option is highly application dependant, and must be configured by the application.
+        /// </param>
+        public StackPolicyAttribute(int maxConcurrentRequests, int requestQueueLimit)
+        {
+            _stackPolicy = new StackPolicy(Options.Create(new QueuePolicyOptions()
+            {
+                MaxConcurrentRequests = maxConcurrentRequests,
+                RequestQueueLimit = requestQueueLimit
+            }));
+        }
+
+        public void OnExit()
+            => _stackPolicy.OnExit();
+
+        public ValueTask<bool> TryEnterAsync()
+            => _stackPolicy.TryEnterAsync();
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/StackPolicyAttribute.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
     /// <summary>
     /// Specifies that the class or method that this attribute applied to requires limit concurrency request with LIFO stack as queueing strategy.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class StackPolicyAttribute : Attribute, IQueuePolicy
     {
         private readonly StackPolicy _stackPolicy;

--- a/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyAttribute.cs
@@ -12,7 +12,8 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
     /// <summary>
     /// Specifies that the class or method that this attribute applied to does not limit concurrency request.
     /// </summary>
-    public class SuppressQueuePolicyAttribute : ISuppressQueuePolicyMetadata
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class SuppressQueuePolicyAttribute : Attribute, ISuppressQueuePolicyMetadata
     {
     }
 }

--- a/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyAttribute.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyAttribute.cs
@@ -9,8 +9,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.ConcurrencyLimiter
 {
-    internal class SuppressQueuePolicyMetadata : ISuppressQueuePolicyMetadata
+    /// <summary>
+    /// Specifies that the class or method that this attribute applied to does not limit concurrency request.
+    /// </summary>
+    public class SuppressQueuePolicyAttribute : ISuppressQueuePolicyMetadata
     {
-        public static ISuppressQueuePolicyMetadata Default = new SuppressQueuePolicyMetadata();
     }
 }

--- a/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyMetadata.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyMetadata.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyMetadata.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/SuppressQueuePolicyMetadata.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter
+{
+    internal class SuppressQueuePolicyMetadata : ISuppressQueuePolicyMetadata
+    {
+        public static ISuppressQueuePolicyMetadata Default = new SuppressQueuePolicyMetadata();
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEndpointConventionBuilderExtensionsTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEndpointConventionBuilderExtensionsTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Xunit;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests
+{
+    public class ConcurrencyLimiterEndpointConventionBuilderExtensionsTests
+    {
+        [Fact]
+        public void RequireStackPolicy_StackPolicyAttribute()
+        {
+            // Arrange
+            var builder = new TestEndpointConventionBuilder();
+
+            // Act
+            builder.RequireStackPolicy(maxConcurrentRequests: 1, requestQueueLimit: 1);
+
+            // Assert
+            var convention = Assert.Single(builder.Conventions);
+            var endpoint = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+            convention(endpoint);
+
+            Assert.IsAssignableFrom<StackPolicyAttribute>(Assert.Single(endpoint.Metadata));
+        }
+        [Fact]
+        public void RequireQueuePolicy_QueuePolicyAttribute()
+        {
+            // Arrange
+            var builder = new TestEndpointConventionBuilder();
+
+            // Act
+            builder.RequireQueuePolicy(maxConcurrentRequests: 1, requestQueueLimit: 1);
+
+            // Assert
+            var convention = Assert.Single(builder.Conventions);
+            var endpoint = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+            convention(endpoint);
+
+            Assert.IsAssignableFrom<QueuePolicyAttribute>(Assert.Single(endpoint.Metadata));
+        }
+        [Fact]
+        public void SupressQueuePolicy_ISuppressQueuePolicyMetadata()
+        {
+            // Arrange
+            var builder = new TestEndpointConventionBuilder();
+
+            // Act
+            builder.SupressQueuePolicy();
+
+            // Assert
+            var convention = Assert.Single(builder.Conventions);
+            var endpoint = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+            convention(endpoint);
+
+            Assert.IsAssignableFrom<ISuppressQueuePolicyMetadata>(Assert.Single(endpoint.Metadata));
+        }
+        private class TestEndpointConventionBuilder : IEndpointConventionBuilder
+        {
+            public IList<Action<EndpointBuilder>> Conventions { get; } = new List<Action<EndpointBuilder>>();
+
+            public void Add(Action<EndpointBuilder> convention)
+            {
+                Conventions.Add(convention);
+            }
+        }
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/test/Microsoft.AspNetCore.ConcurrencyLimiter.Tests.csproj
+++ b/src/Middleware/ConcurrencyLimiter/test/Microsoft.AspNetCore.ConcurrencyLimiter.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -13,5 +13,6 @@
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.ConcurrencyLimiter" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
   </ItemGroup>
 </Project>

--- a/src/Middleware/ConcurrencyLimiter/test/MiddlewareTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/MiddlewareTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests
                 });
 
             var httpContext = new DefaultHttpContext();
-            httpContext.SetEndpoint(CreateEndpoint(new SuppressQueuePolicyMetadata()));
+            httpContext.SetEndpoint(CreateEndpoint(new SuppressQueuePolicyAttribute()));
 
             await middleware.Invoke(httpContext);
 

--- a/src/Middleware/ConcurrencyLimiter/test/QueuePolicyAttributeTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/QueuePolicyAttributeTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests
+{
+    public class QueuePolicyAttributeTests
+    {
+        [Fact]
+        public void DoesNotWaitIfSpaceAvailible()
+        {
+            var s = TestUtils.CreateQueuePolicyAttribute(2);
+
+            var t1 = s.TryEnterAsync();
+            Assert.True(t1.IsCompleted);
+
+            var t2 = s.TryEnterAsync();
+            Assert.True(t2.IsCompleted);
+
+            var t3 = s.TryEnterAsync();
+            Assert.False(t3.IsCompleted);
+        }
+
+        [Fact]
+        public async Task WaitsIfNoSpaceAvailible()
+        {
+            var s = TestUtils.CreateQueuePolicyAttribute(1);
+            Assert.True(await s.TryEnterAsync().OrTimeout());
+
+            var waitingTask = s.TryEnterAsync();
+            Assert.False(waitingTask.IsCompleted);
+
+            s.OnExit();
+            Assert.True(await waitingTask.OrTimeout());
+        }
+
+        [Fact]
+        public async Task IsEncapsulated()
+        {
+            var s1 = TestUtils.CreateQueuePolicyAttribute(1);
+            var s2 = TestUtils.CreateQueuePolicy(1);
+
+            Assert.True(await s1.TryEnterAsync().OrTimeout());
+            Assert.True(await s2.TryEnterAsync().OrTimeout());
+        }
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/test/StackPolicyAttributeTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/StackPolicyAttributeTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests
+{
+    public class StackPolicyAttributeTests
+    {
+
+        [Fact]
+        public static void BaseFunctionality()
+        {
+            var stack = TestUtils.CreateStackPolicyAttribute(0, 2);
+
+            var task1 = stack.TryEnterAsync();
+
+            Assert.False(task1.IsCompleted);
+
+            stack.OnExit();
+
+            Assert.True(task1.IsCompleted && task1.Result);
+        }
+
+        [Fact]
+        public static void OldestRequestOverwritten()
+        {
+            var stack = TestUtils.CreateStackPolicyAttribute(0, 3);
+
+            var task1 = stack.TryEnterAsync();
+            Assert.False(task1.IsCompleted);
+            var task2 = stack.TryEnterAsync();
+            Assert.False(task2.IsCompleted);
+            var task3 = stack.TryEnterAsync();
+            Assert.False(task3.IsCompleted);
+
+            var task4 = stack.TryEnterAsync();
+
+            Assert.True(task1.IsCompleted);
+            Assert.False(task1.Result);
+
+            Assert.False(task2.IsCompleted);
+            Assert.False(task3.IsCompleted);
+            Assert.False(task4.IsCompleted);
+        }
+
+        [Fact]
+        public static void RespectsMaxConcurrency()
+        {
+            var stack = TestUtils.CreateStackPolicyAttribute(2, 2);
+
+            var task1 = stack.TryEnterAsync();
+            Assert.True(task1.IsCompleted);
+
+            var task2 = stack.TryEnterAsync();
+            Assert.True(task2.IsCompleted);
+
+            var task3 = stack.TryEnterAsync();
+            Assert.False(task3.IsCompleted);
+        }
+
+        [Fact]
+        public static void ExitRequestsPreserveSemaphoreState()
+        {
+            var stack = TestUtils.CreateStackPolicyAttribute(1, 2);
+            var task1 = stack.TryEnterAsync();
+            Assert.True(task1.IsCompleted && task1.Result);
+
+            var task2 = stack.TryEnterAsync();
+            Assert.False(task2.IsCompleted);
+
+            stack.OnExit();  // t1 exits, should free t2 to return
+            Assert.True(task2.IsCompleted && task2.Result);
+
+            stack.OnExit();  // t2 exists, there's now a free spot in server
+
+            var task3 = stack.TryEnterAsync();
+            Assert.True(task3.IsCompleted && task3.Result);
+        }
+
+        [Fact]
+        public static void StaleRequestsAreProperlyOverwritten()
+        {
+            var stack = TestUtils.CreateStackPolicyAttribute(0, 4);
+
+            var task1 = stack.TryEnterAsync();
+            stack.OnExit();
+            Assert.True(task1.IsCompleted);
+
+            var task2 = stack.TryEnterAsync();
+            stack.OnExit();
+            Assert.True(task2.IsCompleted);
+        }
+
+        [Fact]
+        public static async Task OneTryEnterAsyncOneOnExit()
+        {
+            var stack = TestUtils.CreateStackPolicyAttribute(1, 4);
+
+            Assert.Throws<InvalidOperationException>(() => stack.OnExit());
+
+            await stack.TryEnterAsync();
+
+            stack.OnExit();
+
+            Assert.Throws<InvalidOperationException>(() => stack.OnExit());
+        }
+    }
+}

--- a/src/Middleware/ConcurrencyLimiter/test/TestUtils.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/TestUtils.cs
@@ -66,6 +66,16 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests
 
             return new QueuePolicy(options);
         }
+
+        internal static QueuePolicyAttribute CreateQueuePolicyAttribute(int maxConcurrentRequests, int requestQueueLimit = 100)
+        {
+            return new QueuePolicyAttribute(maxConcurrentRequests, requestQueueLimit);
+        }
+
+        internal static StackPolicyAttribute CreateStackPolicyAttribute(int maxConcurrentRequests, int requestQueueLimit = 100)
+        {
+            return new StackPolicyAttribute(maxConcurrentRequests, requestQueueLimit);
+        }
     }
 
     internal class TestQueue : IQueuePolicy


### PR DESCRIPTION
I have another PR diffs https://github.com/dotnet/aspnetcore/pull/19324,this PR has **less breaking-changes** and much more compatibility.I have added following features:
 - Add extension methods for `IEndpointConventionBuilder`.
 - Suppress concurrency limiter for specific endpoint.
 - Add endpoint-based queue policy
 - Add test case for middleware and type created in this PR. 

Addresses #19823 (in this specific format)
