### PR TITLE
Revert "Use BuildTools internally too"

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -112,10 +112,8 @@ jobs:
             queue: BuildPool.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
-          ${{ if ne(parameters.isTestingJob, true) }}:
-            queue: BuildPool.Server.Amd64.VS2019.BT
-          ${{ if eq(parameters.isTestingJob, true) }}:
-            queue: BuildPool.Server.Amd64.VS2019
+          # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
+          queue: BuildPool.Server.Amd64.VS2019
     variables:
     - AgentOsName: ${{ parameters.agentOs }}
     - ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
- internal builds now fail with `##[error]The remote provider was unable to process the request.`

This reverts commit 0483e2db95d2c953a872f89ca438fec019f44787.