### PR TITLE
Use encodeURIComponent instead of encodeURI to support returnURLs with many query params

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeRoute.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeRoute.js
@@ -28,7 +28,7 @@ export default class AuthorizeRoute extends Component {
         var link = document.createElement("a");
         link.href = this.props.path;
         const returnUrl = `${link.protocol}//${link.host}${link.pathname}${link.search}${link.hash}`;
-        const redirectUrl = `${ApplicationPaths.Login}?${QueryParameterNames.ReturnUrl}=${encodeURI(returnUrl)}`
+        const redirectUrl = `${ApplicationPaths.Login}?${QueryParameterNames.ReturnUrl}=${encodeURIComponent(returnUrl)}`
         if (!ready) {
             return <div></div>;
         } else {


### PR DESCRIPTION
 - When returnUrl has query parameters such as
https://authority/path?query=xxx&query1=xx1&query2=xx1,xx2
 - Login.js getReturnUrl computes the return URL as https://authority/path?query=xxx instead of https://authority/path?query=xxx&query1=xx1&query2=xx1,xx2