### PR TITLE
Copy I18N assemblies when running without the linker

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.props
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <BlazorWebAssembly18NAssemblies>none</BlazorWebAssembly18NAssemblies> <!-- See Mono linker docs - allows comma-separated values from: none,all,cjk,mideast,other,rare,west -->
+    <BlazorWebAssemblyI18NAssemblies>none</BlazorWebAssemblyI18NAssemblies> <!-- See Mono linker docs - allows comma-separated values from: none,all,cjk,mideast,other,rare,west -->
     <AdditionalMonoLinkerOptions>--disable-opt unreachablebodies --verbose --strip-security true --exclude-feature com -v false -c link -u link -b true</AdditionalMonoLinkerOptions>
 
     <_BlazorJsPath Condition="'$(_BlazorJsPath)' == ''">$(MSBuildThisFileDirectory)..\tools\blazor\blazor.webassembly.js</_BlazorJsPath>

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.props
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <MonoLinkerI18NAssemblies>none</MonoLinkerI18NAssemblies> <!-- See Mono linker docs - allows comma-separated values from: none,all,cjk,mideast,other,rare,west -->
+    <BlazorWebAssembly18NAssemblies>none</BlazorWebAssembly18NAssemblies> <!-- See Mono linker docs - allows comma-separated values from: none,all,cjk,mideast,other,rare,west -->
     <AdditionalMonoLinkerOptions>--disable-opt unreachablebodies --verbose --strip-security true --exclude-feature com -v false -c link -u link -b true</AdditionalMonoLinkerOptions>
 
     <_BlazorJsPath Condition="'$(_BlazorJsPath)' == ''">$(MSBuildThisFileDirectory)..\tools\blazor\blazor.webassembly.js</_BlazorJsPath>

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -265,7 +265,7 @@
       Condition="'$(BuildingInsideVisualStudio)' != 'true' OR '$(DeployOnBuild)' != 'true'">
 
     <PropertyGroup>
-      <_BlazorLinkerAdditionalOptions>-l $(MonoLinkerI18NAssemblies) $(AdditionalMonoLinkerOptions)</_BlazorLinkerAdditionalOptions>
+      <_BlazorLinkerAdditionalOptions>-l $(BlazorWebAssembly18NAssemblies) $(AdditionalMonoLinkerOptions)</_BlazorLinkerAdditionalOptions>
     </PropertyGroup>
 
     <ItemGroup>
@@ -332,6 +332,14 @@
 
       <Output TaskParameter="Dependencies" ItemName="_BlazorResolvedAssemblyUnlinked" />
     </ResolveBlazorRuntimeDependencies>
+
+    <ItemGroup Condition="'$(BlazorWebAssembly18NAssemblies)' != 'none'">
+      <!--
+        Unless the user has asked for no-assemblies, copy all I18N assemblies to the build output.
+        We do not want to decipher the linker's format for passing in I18N options in our build targets
+      -->
+      <_BlazorResolvedAssemblyUnlinked Include="$(ComponentsWebAssemblyBaseClassLibraryPath)I18N*.dll" />
+    </ItemGroup>
 
     <!--
     Workaround for https://github.com/dotnet/aspnetcore/issues/19926. Using the files from their initial locations

--- a/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
+++ b/src/Components/WebAssembly/Build/src/targets/Blazor.MonoRuntime.targets
@@ -265,7 +265,7 @@
       Condition="'$(BuildingInsideVisualStudio)' != 'true' OR '$(DeployOnBuild)' != 'true'">
 
     <PropertyGroup>
-      <_BlazorLinkerAdditionalOptions>-l $(BlazorWebAssembly18NAssemblies) $(AdditionalMonoLinkerOptions)</_BlazorLinkerAdditionalOptions>
+      <_BlazorLinkerAdditionalOptions>-l $(BlazorWebAssemblyI18NAssemblies) $(AdditionalMonoLinkerOptions)</_BlazorLinkerAdditionalOptions>
     </PropertyGroup>
 
     <ItemGroup>
@@ -333,7 +333,7 @@
       <Output TaskParameter="Dependencies" ItemName="_BlazorResolvedAssemblyUnlinked" />
     </ResolveBlazorRuntimeDependencies>
 
-    <ItemGroup Condition="'$(BlazorWebAssembly18NAssemblies)' != 'none'">
+    <ItemGroup Condition="'$(BlazorWebAssemblyI18NAssemblies)' != 'none'">
       <!--
         Unless the user has asked for no-assemblies, copy all I18N assemblies to the build output.
         We do not want to decipher the linker's format for passing in I18N options in our build targets

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
@@ -297,6 +297,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
 
             Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.dll");
             Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.Other.dll");
+            // When running without linker, we copy all I18N assemblies. Look for one additional
+            Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.West.dll");
         }
 
         [Fact]
@@ -320,6 +322,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
 
             Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.dll");
             Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.Other.dll");
+            Assert.FileDoesNotExist(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.West.dll");
         }
 
         private static GenerateBlazorBootJson.BootJsonData ReadBootJsonData(MSBuildResult result, string path)

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
@@ -276,6 +276,28 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             Assert.Contains("ja/standalone.resources.dll", satelliteResources["ja"].Keys);
         }
 
+
+        [Fact]
+        public async Task Build_WithI8NOption_CopiesI8NAssembliesWithoutLinkerEnabled()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone", additionalProjects: new[] { "razorclasslibrary" });
+            project.AddProjectFileContent(
+@"
+<PropertyGroup>
+    <BlazorWebAssembly18NAssemblies>other</BlazorWebAssembly18NAssemblies>
+</PropertyGroup>");
+
+            var result = await MSBuildProcessManager.DotnetMSBuild(project);
+
+            Assert.BuildPassed(result);
+
+            var buildOutputDirectory = project.BuildOutputDirectory;
+
+            Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.dll");
+            Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.Other.dll");
+        }
+
         private static GenerateBlazorBootJson.BootJsonData ReadBootJsonData(MSBuildResult result, string path)
         {
             return JsonSerializer.Deserialize<GenerateBlazorBootJson.BootJsonData>(

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
@@ -282,9 +282,33 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
         {
             // Arrange
             using var project = ProjectDirectory.Create("standalone", additionalProjects: new[] { "razorclasslibrary" });
+            project.Configuration = "Debug";
             project.AddProjectFileContent(
 @"
 <PropertyGroup>
+    <BlazorWebAssembly18NAssemblies>other</BlazorWebAssembly18NAssemblies>
+</PropertyGroup>");
+
+            var result = await MSBuildProcessManager.DotnetMSBuild(project);
+
+            Assert.BuildPassed(result);
+
+            var buildOutputDirectory = project.BuildOutputDirectory;
+
+            Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.dll");
+            Assert.FileExists(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.Other.dll");
+        }
+
+        [Fact]
+        public async Task Build_WithI8NOption_CopiesI8NAssembliesWithLinkerEnabled()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone", additionalProjects: new[] { "razorclasslibrary" });
+            project.Configuration = "Debug";
+            project.AddProjectFileContent(
+@"
+<PropertyGroup>
+    <BlazorWebAssemblyEnableLinking>true</BlazorWebAssemblyEnableLinking>
     <BlazorWebAssembly18NAssemblies>other</BlazorWebAssembly18NAssemblies>
 </PropertyGroup>");
 

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
@@ -286,7 +286,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             project.AddProjectFileContent(
 @"
 <PropertyGroup>
-    <BlazorWebAssembly18NAssemblies>other</BlazorWebAssembly18NAssemblies>
+    <BlazorWebAssemblyI18NAssemblies>other</BlazorWebAssemblyI18NAssemblies>
 </PropertyGroup>");
 
             var result = await MSBuildProcessManager.DotnetMSBuild(project);
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
 @"
 <PropertyGroup>
     <BlazorWebAssemblyEnableLinking>true</BlazorWebAssemblyEnableLinking>
-    <BlazorWebAssembly18NAssemblies>other</BlazorWebAssembly18NAssemblies>
+    <BlazorWebAssemblyI18NAssemblies>other</BlazorWebAssemblyI18NAssemblies>
 </PropertyGroup>");
 
             var result = await MSBuildProcessManager.DotnetMSBuild(project);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20517

Also rename `MonoLinkerI18NAssemblies` -> `BlazorWebAssemblyI18NAssemblies`