### PR TITLE
Make HTTP/1.1 startline parsing "safe"

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp.cs
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public HttpParser() { }
         public HttpParser(bool showErrorDetails) { }
         public bool ParseHeaders(TRequestHandler handler, ref System.Buffers.SequenceReader<byte> reader) { throw null; }
-        public bool ParseRequestLine(TRequestHandler handler, in System.Buffers.ReadOnlySequence<byte> buffer, out System.SequencePosition consumed, out System.SequencePosition examined) { throw null; }
+        public bool ParseRequestLine(TRequestHandler handler, ref System.Buffers.SequenceReader<byte> reader) { throw null; }
     }
     public enum HttpScheme
     {

--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp.cs
@@ -235,13 +235,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Http = 0,
         Https = 1,
     }
-    public enum HttpVersion
+    public enum HttpVersion : sbyte
     {
-        Unknown = -1,
-        Http10 = 0,
-        Http11 = 1,
-        Http2 = 2,
-        Http3 = 3,
+        Unknown = (sbyte)-1,
+        Http10 = (sbyte)0,
+        Http11 = (sbyte)1,
+        Http2 = (sbyte)2,
+        Http3 = (sbyte)3,
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct HttpVersionAndMethod
+    {
+        private int _dummyPrimitive;
+        public HttpVersionAndMethod(Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod method, int methodEnd) { throw null; }
+        public Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod Method { get { throw null; } }
+        public int MethodEnd { get { throw null; } }
+        public Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpVersion Version { get { throw null; } set { } }
     }
     public partial interface IHttpHeadersHandler
     {
@@ -252,7 +261,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     }
     public partial interface IHttpRequestLineHandler
     {
-        void OnStartLine(Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod method, Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpVersion version, System.Span<byte> target, System.Span<byte> path, System.Span<byte> query, System.Span<byte> customMethod, bool pathEncoded);
+        void OnStartLine(Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpVersionAndMethod versionAndMethod, Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.TargetOffsetPathLength targetPath, System.Span<byte> startLine);
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct TargetOffsetPathLength
+    {
+        private readonly int _dummyPrimitive;
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public TargetOffsetPathLength(int offset, int length, bool isEncoded) { throw null; }
+        public bool IsEncoded { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
+        public int Length { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
+        public int Offset { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
     }
 }
 namespace Microsoft.AspNetCore.Server.Kestrel.Https

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -310,10 +310,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // _consumedBytes aren't tracked for trailer headers, since headers have separate limits.
             if (_mode == Mode.TrailerHeaders)
             {
-                if (_context.TakeMessageHeaders(readableBuffer, trailers: true, out consumed, out examined))
+                var reader = new SequenceReader<byte>(readableBuffer);
+                if (_context.TakeMessageHeaders(ref reader, trailers: true))
                 {
+                    examined = reader.Position;
                     _mode = Mode.Complete;
                 }
+                else
+                {
+                    examined = readableBuffer.End;
+                }
+
+                consumed = reader.Position;
             }
 
             return _mode == Mode.Complete;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
@@ -47,8 +47,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
-            => Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
+        public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
+            => Connection.OnStartLine(versionAndMethod, targetPath, startLine);
 
         public void OnStaticIndexedHeader(int index)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpVersion.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpVersion.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public enum HttpVersion
+    public enum HttpVersion : sbyte
     {
         Unknown = -1,
         Http10 = 0,

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal interface IHttpParser<TRequestHandler> where TRequestHandler : IHttpHeadersHandler, IHttpRequestLineHandler
     {
-        bool ParseRequestLine(TRequestHandler handler, in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined);
+        bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader);
 
         bool ParseHeaders(TRequestHandler handler, ref SequenceReader<byte> reader);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpRequestLineHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpRequestLineHandler.cs
@@ -2,11 +2,85 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     public interface IHttpRequestLineHandler
     {
-        void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded);
+        void OnStartLine(
+            HttpVersionAndMethod versionAndMethod,
+            TargetOffsetPathLength targetPath,
+            Span<byte> startLine);
+    }
+
+    public struct HttpVersionAndMethod
+    {
+        private ulong _versionAndMethod;
+
+        public HttpVersionAndMethod(HttpMethod method, int methodEnd)
+        {
+            _versionAndMethod = ((ulong)(uint)methodEnd << 32) | ((ulong)method << 8);
+        }
+
+        public HttpVersion Version
+        {
+            get => (HttpVersion)(sbyte)(byte)_versionAndMethod;
+            set => _versionAndMethod = (_versionAndMethod & ~0xFFul) | (byte)value;
+        }
+
+        public HttpMethod Method => (HttpMethod)(byte)(_versionAndMethod >> 8);
+
+        public int MethodEnd => (int)(uint)(_versionAndMethod >> 32);
+    }
+
+    public readonly struct TargetOffsetPathLength
+    {
+        private readonly ulong _targetOffsetPathLength;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TargetOffsetPathLength(int offset, int length, bool isEncoded)
+        {
+            if (isEncoded)
+            {
+                length = -length;
+            }
+
+            _targetOffsetPathLength = ((ulong)offset << 32) | (uint)length;
+        }
+
+        public int Offset
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return (int)(_targetOffsetPathLength >> 32);
+            }
+        }
+
+        public int Length
+        {
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                var length = (int)_targetOffsetPathLength;
+                if (length < 0)
+                {
+                    length = -length;
+                }
+
+                return length;
+            }
+        }
+
+        public bool IsEncoded
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return (int)_targetOffsetPathLength < 0 ? true : false;
+            }
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
@@ -166,13 +166,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe static int IndexOfInvalidTokenChar(byte* s, int length)
+        public static int IndexOfInvalidTokenChar(ReadOnlySpan<byte> span)
         {
             var token = _token;
 
-            for (var i = 0; i < length; i++)
+            for (var i = 0; i < span.Length; i++)
             {
-                var c = s[i];
+                var c = span[i];
                 if (c >= (uint)token.Length || !token[c])
                 {
                     return i;

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.UTF8.GetBytes("\r\n\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
+            TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(headerValue, _http1Connection.RequestHeaders[headerName]);
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(extendedAsciiEncoding.GetBytes("\r\n\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var exception = Assert.Throws<InvalidOperationException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
+            var exception = Assert.Throws<InvalidOperationException>(() => TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
+            var exception = Assert.Throws<BadHttpRequestException>(() => TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
 #pragma warning restore CS0618 // Type or member is obsolete
             _transport.Input.AdvanceTo(_consumed, _examined);
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
+            var exception = Assert.Throws<BadHttpRequestException>(() => TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
 #pragma warning restore CS0618 // Type or member is obsolete
             _transport.Input.AdvanceTo(_consumed, _examined);
 
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLine1}\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var takeMessageHeaders = _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
+            var takeMessageHeaders = TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(takeMessageHeaders);
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLine2}\r\n"));
             readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            takeMessageHeaders = _http1Connection.TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
+            takeMessageHeaders = TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(takeMessageHeaders);
@@ -389,7 +389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(requestLineBytes);
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var returnValue = _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined);
+            var returnValue = TakeStartLine(readableBuffer, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(returnValue);
@@ -412,7 +412,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _application.Output.WriteAsync(requestLineBytes);
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-            var returnValue = _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined);
+            var returnValue = TakeStartLine(readableBuffer, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(returnValue);
@@ -426,7 +426,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes("G"));
 
-            _http1Connection.ParseRequest((await _transport.Input.ReadAsync()).Buffer, out _consumed, out _examined);
+            ParseRequest((await _transport.Input.ReadAsync()).Buffer, out _consumed, out _examined);
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             var expectedRequestHeadersTimeout = _serviceContext.ServerOptions.Limits.RequestHeadersTimeout.Ticks;
@@ -443,7 +443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 #pragma warning disable CS0618 // Type or member is obsolete
-            var exception = Assert.Throws<BadHttpRequestException>(() => _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+            var exception = Assert.Throws<BadHttpRequestException>(() => TakeStartLine(readableBuffer, out _consumed, out _examined));
 #pragma warning restore CS0618 // Type or member is obsolete
             _transport.Input.AdvanceTo(_consumed, _examined);
 
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+            TakeStartLine(readableBuffer, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target), exception.Message);
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+            TakeStartLine(readableBuffer, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target.EscapeNonPrintable()), exception.Message);
@@ -495,10 +495,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+            TakeStartLine(readableBuffer, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
-            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine.EscapeNonPrintable()), exception.Message);
+            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine[..^1].EscapeNonPrintable()), exception.Message);
         }
 
         [Theory]
@@ -513,7 +513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+             TakeStartLine(readableBuffer, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target.EscapeNonPrintable()), exception.Message);
@@ -531,7 +531,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+            TakeStartLine(readableBuffer, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target.EscapeNonPrintable()), exception.Message);
@@ -548,7 +548,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+            TakeStartLine(readableBuffer, out _consumed, out _examined));
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.Equal(405, exception.StatusCode);
@@ -795,7 +795,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
                 var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                    _http1Connection.TakeStartLine(readableBuffer, out _consumed, out _examined));
+                TakeStartLine(readableBuffer, out _consumed, out _examined));
                 _transport.Input.AdvanceTo(_consumed, _examined);
 
                 Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(string.Empty), exception.Message);
@@ -969,6 +969,58 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var ex = Assert.Throws<BadHttpRequestException>(() => _http1Connection.EnsureHostHeaderExists());
 #pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(CoreStrings.FormatBadRequest_InvalidHostHeader_Detail("a=b"), ex.Message);
+        }
+
+
+        private bool TakeMessageHeaders(ReadOnlySequence<byte> readableBuffer, bool trailers, out SequencePosition consumed, out SequencePosition examined)
+        {
+            var reader = new SequenceReader<byte>(readableBuffer);
+            if (_http1Connection.TakeMessageHeaders(ref reader, trailers: trailers))
+            {
+                consumed = reader.Position;
+                examined = reader.Position;
+                return true;
+            }
+            else
+            {
+                consumed = reader.Position;
+                examined = readableBuffer.End;
+                return false;
+            }
+        }
+
+        private bool TakeStartLine(ReadOnlySequence<byte> readableBuffer, out SequencePosition consumed, out SequencePosition examined)
+        {
+            var reader = new SequenceReader<byte>(readableBuffer);
+            if (_http1Connection.TakeStartLine(ref reader))
+            {
+                consumed = reader.Position;
+                examined = reader.Position;
+                return true;
+            }
+            else
+            {
+                consumed = reader.Position;
+                examined = readableBuffer.End;
+                return false;
+            }
+        }
+
+        private bool ParseRequest(ReadOnlySequence<byte> readableBuffer, out SequencePosition consumed, out SequencePosition examined)
+        {
+            var reader = new SequenceReader<byte>(readableBuffer);
+            if (_http1Connection.ParseRequest(ref reader))
+            {
+                consumed = reader.Position;
+                examined = reader.Position;
+                return true;
+            }
+            else
+            {
+                consumed = reader.Position;
+                examined = readableBuffer.End;
+                return false;
+            }
         }
 
         private static async Task WaitForCondition(TimeSpan timeout, Func<bool> condition)

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -565,6 +565,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 PathEncoded = pathEncoded;
             }
 
+            public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
+            {
+                var method = versionAndMethod.Method;
+                var version = versionAndMethod.Version;
+                var customMethod = startLine[..versionAndMethod.MethodEnd];
+                var targetStart = targetPath.Offset;
+                var target = startLine[targetStart..];
+                var path = target[..targetPath.Length];
+                var query = target[targetPath.Length..];
+
+                Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiStringNonNullCharacters();
+                Version = HttpUtilities.VersionToString(version);
+                RawTarget = target.GetAsciiStringNonNullCharacters();
+                RawPath = path.GetAsciiStringNonNullCharacters();
+                Query = query.GetAsciiStringNonNullCharacters();
+                PathEncoded = targetPath.IsEncoded;
+            }
+
             public void OnStaticIndexedHeader(int index)
             {
                 throw new NotImplementedException();

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.True(parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            Assert.True(ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal(requestHandler.Method, expectedMethod);
             Assert.Equal(requestHandler.Version, expectedVersion);
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.False(parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            Assert.False(ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.False(parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            Assert.False(ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal(buffer.Start, consumed);
             Assert.True(buffer.Slice(examined).IsEmpty);
@@ -93,9 +93,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine.EscapeNonPrintable()), exception.Message);
+            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine[..^1].EscapeNonPrintable()), exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
 
@@ -117,9 +117,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(method.EscapeNonPrintable() + @" / HTTP/1.1\x0D\x0A"), exception.Message);
+            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(method.EscapeNonPrintable() + @" / HTTP/1.1\x0D"), exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
 
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(httpVersion), exception.Message);
             Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, exception.StatusCode);
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal("Invalid request line: ''", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             exception = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
-                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
+            ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(string.Empty), exception.Message);
             Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, exception.StatusCode);
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Encoding.ASCII.GetBytes("/"));
 
             var requestHandler = new RequestHandler();
-            var result = parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined);
+            var result = ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined);
 
             Assert.False(result);
             Assert.Equal(buffer.Start, consumed);
@@ -422,7 +422,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var badHttpRequestException = Assert.Throws<BadHttpRequestException>(() =>
 #pragma warning restore CS0618 // Type or member is obsolete
             {
-                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined);
+                ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined);
             });
 
             Assert.Equal(badHttpRequestException.StatusCode, StatusCodes.Status400BadRequest);
@@ -478,6 +478,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var result = parser.ParseHeaders(requestHandler, ref reader);
 
             Assert.True(result);
+        }
+
+
+        private bool ParseRequestLine(IHttpParser<RequestHandler> parser, RequestHandler requestHandler, ReadOnlySequence<byte> readableBuffer, out SequencePosition consumed, out SequencePosition examined)
+        {
+            var reader = new SequenceReader<byte>(readableBuffer);
+            if (parser.ParseRequestLine(requestHandler, ref reader))
+            {
+                consumed = reader.Position;
+                examined = reader.Position;
+                return true;
+            }
+            else
+            {
+                consumed = reader.Position;
+                examined = readableBuffer.End;
+                return false;
+            }
         }
 
         private void VerifyHeader(

--- a/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
+++ b/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var expectedMethod = (HttpMethod)intExpectedMethod;
             // Arrange
-            var block = new Span<byte>(Encoding.ASCII.GetBytes(input));
+            var block = new ReadOnlySpan<byte>(Encoding.ASCII.GetBytes(input));
 
             // Act
             var result = block.GetKnownMethod(out var knownMethod, out var length);
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var version = (HttpVersion)intVersion;
             // Arrange
-            var block = new Span<byte>(Encoding.ASCII.GetBytes(input));
+            var block = new ReadOnlySpan<byte>(Encoding.ASCII.GetBytes(input));
 
             // Act
             var result = block.GetKnownVersion(out HttpVersion knownVersion, out var length);

--- a/src/Servers/Kestrel/Core/test/KnownStringsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KnownStringsTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void GetsKnownMethod(byte[] methodData, int intExpectedMethod, int expectedLength, bool expectedResult)
         {
             var expectedMethod = (HttpMethod)intExpectedMethod;
-            var data = new Span<byte>(methodData);
+            var data = new ReadOnlySpan<byte>(methodData);
 
             var result = data.GetKnownMethod(out var method, out var length);
 

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Null(Http1Connection.QueryString);
 
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"POST {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -64,7 +65,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Null(Http1Connection.QueryString);
 
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -91,7 +93,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Null(Http1Connection.QueryString);
 
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -117,7 +120,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Null(Http1Connection.QueryString);
 
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"OPTIONS {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -140,7 +144,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var query = "?q=123&w=xyzw12";
             Http1Connection.Reset();
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"POST {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -184,7 +189,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             Http1Connection.Reset();
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             var prevRequestUrl = Http1Connection.RawTarget;
             var prevPath = Http1Connection.Path;
@@ -201,7 +207,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 // Parser decodes % encoding in place, so we need to recreate the ROS
                 ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+                reader = new SequenceReader<byte>(ros);
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
                 // Equal the inputs.
                 Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -234,7 +241,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             Http1Connection.Reset();
             ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+            reader = new SequenceReader<byte>(ros);
+            Parser.ParseRequestLine(ParsingHandler, ref reader);
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -275,7 +283,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             Http1Connection.Reset();
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             var prevRequestUrl = Http1Connection.RawTarget;
             var prevPath = Http1Connection.Path;
@@ -291,7 +300,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Null(Http1Connection.QueryString);
 
                 ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+                reader = new SequenceReader<byte>(ros);
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
                 // Equal the inputs.
                 Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -324,7 +334,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             Http1Connection.Reset();
             ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+            reader = new SequenceReader<byte>(ros);
+            Parser.ParseRequestLine(ParsingHandler, ref reader);
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -353,7 +364,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             Http1Connection.Reset();
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"OPTIONS {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             var prevRequestUrl = Http1Connection.RawTarget;
             var prevPath = Http1Connection.Path;
@@ -369,7 +381,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Null(Http1Connection.QueryString);
 
                 ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"OPTIONS {rawTarget} HTTP/1.1\r\n"));
-                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+                reader = new SequenceReader<byte>(ros);
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
                 // Equal the inputs.
                 Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -400,7 +413,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             Http1Connection.Reset();
             ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n"));
-            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+            reader = new SequenceReader<byte>(ros);
+            Parser.ParseRequestLine(ParsingHandler, ref reader);
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -431,7 +445,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             Http1Connection.Reset();
             var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
-            Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
             var prevRequestUrl = Http1Connection.RawTarget;
             var prevPath = Http1Connection.Path;
@@ -447,7 +462,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Null(Http1Connection.QueryString);
 
                 ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
-                Assert.True(Parser.ParseRequestLine(ParsingHandler, ros, out _, out _));
+                reader = new SequenceReader<byte>(ros);
+                Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
 
                 // Equal the inputs.
                 Assert.Equal(rawTarget, Http1Connection.RawTarget);
@@ -478,7 +494,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             Http1Connection.Reset();
             ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"CONNECT {rawTarget} HTTP/1.1\r\n"));
-            Parser.ParseRequestLine(ParsingHandler, ros, out _, out _);
+            reader = new SequenceReader<byte>(ros);
+            Parser.ParseRequestLine(ParsingHandler, ref reader);
 
             // Equal the inputs.
             Assert.Equal(rawTarget, Http1Connection.RawTarget);

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
@@ -112,8 +112,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             public void OnHeadersComplete(bool endStream)
                 => RequestHandler.Connection.OnHeadersComplete();
 
-            public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
-                => RequestHandler.Connection.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
+            public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
+                => RequestHandler.Connection.OnStartLine(versionAndMethod, targetPath, startLine);
 
             public void OnStaticIndexedHeader(int index)
             {

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionBenchmark.cs
@@ -79,13 +79,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         private void ParseData()
         {
-            if (!_parser.ParseRequestLine(new Adapter(this), _buffer, out var consumed, out var examined))
+            var reader = new SequenceReader<byte>(_buffer);
+            if (!_parser.ParseRequestLine(new Adapter(this), ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }
-
-            _buffer = _buffer.Slice(consumed, _buffer.End);
-            var reader = new SequenceReader<byte>(_buffer);
 
             if (!_parser.ParseHeaders(new Adapter(this), ref reader))
             {

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionParsingOverheadBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http1ConnectionParsingOverheadBenchmark.cs
@@ -77,12 +77,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             _http1Connection.Reset();
 
-            if (!_http1Connection.TakeStartLine(_buffer, out var consumed, out var examined))
+            var reader = new SequenceReader<byte>(_buffer);
+            if (!_http1Connection.TakeStartLine(ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestLine();
             }
 
-            if (!_http1Connection.TakeMessageHeaders(_buffer, trailers: false, out consumed, out examined))
+            if (!_http1Connection.TakeMessageHeaders(ref reader, trailers: false))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }
@@ -92,7 +93,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             _http1Connection.Reset();
 
-            if (!_http1Connection.TakeStartLine(_buffer, out var consumed, out var examined))
+            var reader = new SequenceReader<byte>(_buffer);
+            if (!_http1Connection.TakeStartLine(ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestLine();
             }
@@ -102,7 +104,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             _http1Connection.Reset();
 
-            if (!_http1Connection.TakeMessageHeaders(_buffer, trailers: false, out var consumed, out var examined))
+            var reader = new SequenceReader<byte>(_buffer);
+            if (!_http1Connection.TakeMessageHeaders(ref reader, trailers: false))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
@@ -10,7 +10,7 @@ using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMe
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
-    internal class HttpParserBenchmark : IHttpRequestLineHandler, IHttpHeadersHandler
+    public class HttpParserBenchmark : IHttpRequestLineHandler, IHttpHeadersHandler
     {
         private readonly HttpParser<Adapter> _parser = new HttpParser<Adapter>();
 

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
@@ -63,14 +63,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         private void ParseData()
         {
-            if (!_parser.ParseRequestLine(new Adapter(this), _buffer, out var consumed, out var examined))
+            var reader = new SequenceReader<byte>(_buffer);
+            if (!_parser.ParseRequestLine(new Adapter(this), ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
             }
 
-            _buffer = _buffer.Slice(consumed, _buffer.End);
-
-            var reader = new SequenceReader<byte>(_buffer);
             if (!_parser.ParseHeaders(new Adapter(this), ref reader))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/HttpParserBenchmark.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+        public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
         {
         }
 
@@ -114,8 +114,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             public void OnHeadersComplete(bool endStream)
                 => RequestHandler.OnHeadersComplete(endStream);
 
-            public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
-                => RequestHandler.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
+            public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
+                => RequestHandler.OnStartLine(versionAndMethod, targetPath, startLine);
 
             public void OnStaticIndexedHeader(int index)
             {

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/KnownStringsBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/KnownStringsBenchmark.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return GetKnownMethod(data);
         }
 
-        private int GetKnownMethod(Span<byte> data)
+        private int GetKnownMethod(ReadOnlySpan<byte> data)
         {
             int len = 0;
             HttpMethod method;
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             int len = 0;
             HttpVersion version;
-            Span<byte> data = _version;
+            ReadOnlySpan<byte> data = _version;
             for (int i = 0; i < loops; i++)
             {
                 data.GetKnownVersion(out version, out var length);

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
     internal class NullParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
     {
         private readonly byte[] _startLine = Encoding.ASCII.GetBytes("GET /plaintext HTTP/1.1\r\n");
-        private readonly byte[] _target = Encoding.ASCII.GetBytes("/plaintext");
         private readonly byte[] _hostHeaderName = Encoding.ASCII.GetBytes("Host");
         private readonly byte[] _hostHeaderValue = Encoding.ASCII.GetBytes("www.example.com");
         private readonly byte[] _acceptHeaderName = Encoding.ASCII.GetBytes("Accept");
@@ -35,13 +34,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         public bool ParseRequestLine(TRequestHandler handler, in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
         {
-            handler.OnStartLine(HttpMethod.Get,
-                HttpVersion.Http11,
-                new Span<byte>(_target),
-                new Span<byte>(_target),
-                Span<byte>.Empty,
-                Span<byte>.Empty,
-                false);
+            Span<byte> startLine = _startLine;
+
+            handler.OnStartLine(
+                new HttpVersionAndMethod(HttpMethod.Get, 3) { Version = HttpVersion.Http11 },
+                new TargetOffsetPathLength(3, startLine.Length - 3, false),
+                startLine);
 
             consumed = buffer.Start;
             examined = buffer.End;

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/NullParser.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Net.Http;
 using System.Text;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
@@ -32,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return true;
         }
 
-        public bool ParseRequestLine(TRequestHandler handler, in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
+        public bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
         {
             Span<byte> startLine = _startLine;
 
@@ -40,9 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 new HttpVersionAndMethod(HttpMethod.Get, 3) { Version = HttpVersion.Http11 },
                 new TargetOffsetPathLength(3, startLine.Length - 3, false),
                 startLine);
-
-            consumed = buffer.Start;
-            examined = buffer.End;
 
             return true;
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 foreach (var requestLine in HttpParsingData.RequestLineInvalidData)
                 {
-                    data.Add(requestLine, CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine.EscapeNonPrintable()));
+                    data.Add(requestLine, CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine[..^1].EscapeNonPrintable()));
                 }
 
                 foreach (var target in HttpParsingData.TargetWithEncodedNullCharData)


### PR DESCRIPTION
To @blowdart with ❤

Contributes to https://github.com/dotnet/aspnetcore/issues/4720

HttpParserBenchmark
```
|               Method | branch |     Mean |        Op/s |  Delta |
|--------------------- |------- |---------:|------------:|-------:|
| PlaintextTechEmpower | master | 157.8 ns | 6,336,737.4 |        |
| PlaintextTechEmpower |     PR | 128.4 ns | 7,785,593.2 | +22.9% |
|      JsonTechEmpower | master | 153.1 ns | 6,531,862.7 |        |
|      JsonTechEmpower |     PR | 121.1 ns | 8,257,583.2 | +22.4% |
|           LiveAspNet | master | 290.2 ns | 3,445,507.2 |        |
|           LiveAspNet |     PR | 253.1 ns | 3,950,427.6 | +14.7% |
|              Unicode | master | 379.4 ns | 2,635,542.4 |        |
|              Unicode |     PR | 343.5 ns | 2,911,272.1 | +10.5% |
```
RequestParsingBenchmark
```
|                                   Method | branch |       Mean |        Op/s |   Delta |
|----------------------------------------- |------- |-----------:|------------:|--------:|
|                     PlaintextTechEmpower | master | 1,704.2 ns |   586,783.6 |         |
|                     PlaintextTechEmpower |     PR | 1,614.5 ns |   619,386.1 |   +5.6% |
|                     PlaintextAbsoluteUri | master | 1,702.6 ns |   587,352.9 |         |
|                     PlaintextAbsoluteUri |     PR | 1,726.9 ns |   579,077.9 |   -1.4% |
|            PipelinedPlaintextTechEmpower | master | 1,128.2 ns |   886,346.0 |         |
|            PipelinedPlaintextTechEmpower |     PR |   614.3 ns | 1,627,875.8 |  +83.7% |
| PipelinedPlaintextTechEmpowerDrainBuffer | master |   828.5 ns | 1,207,026.1 |         |
| PipelinedPlaintextTechEmpowerDrainBuffer |     PR |   366.0 ns | 2,731,959.8 | +126.3% |
|                               LiveAspNet | master | 2,134.2 ns |   468,554.1 |         |
|                               LiveAspNet |     PR | 2,049.2 ns |   488,006.4 |   +4.1% |
|                      PipelinedLiveAspNet | master |   972.8 ns | 1,027,913.4 |         |
|                      PipelinedLiveAspNet |     PR |   946.9 ns | 1,056,081.1 |   +2.7% |
|                                  Unicode | master | 2,366.1 ns |   422,630.0 |         |
|                                  Unicode |     PR | 1,990.7 ns |   502,340.7 |  +18.9% |
|                         UnicodePipelined | master | 1,267.4 ns |   789,038.1 |         |
|                         UnicodePipelined |     PR | 1,249.9 ns |   800,045.8 |   +1.4% |
```


Http1ConnectionBenchmark
```
|               Method | branch |     Mean |        Op/s |   Delta |
|--------------------- |------- |---------:|------------:|--------:|
| PlaintextTechEmpower | master | 385.8 ns | 2,591,838.0 |         |
| PlaintextTechEmpower |     PR | 336.0 ns | 2,975,969.6 |  +14.8% |
|           LiveAspNet | master | 627.7 ns | 1,593,051.6 |         |
|           LiveAspNet |     PR | 570.7 ns | 1,752,097.0 |  +10.0% |
```

**Note:** this will require a corresponding change to the Platform versions due to change in internal api

Resolves: https://github.com/dotnet/aspnetcore/issues/20518

/cc @davidfowl @adamsitnik 