### PR TITLE
Update BenchmarkDotNet for 5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -207,7 +207,7 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>3.1.3-servicing.20163.14</MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>
     <!-- 3rd party dependencies -->
     <AngleSharpPackageVersion>0.9.9</AngleSharpPackageVersion>
-    <BenchmarkDotNetPackageVersion>0.12.0</BenchmarkDotNetPackageVersion>
+    <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>

--- a/src/Shared/BenchmarkRunner/DefaultCoreConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCoreConfig.cs
@@ -18,29 +18,29 @@ namespace BenchmarkDotNet.Attributes
     {
         public DefaultCoreConfig()
         {
-            Add(ConsoleLogger.Default);
-            Add(MarkdownExporter.GitHub);
+            AddLogger(ConsoleLogger.Default);
+            AddExporter(MarkdownExporter.GitHub);
 
-            Add(MemoryDiagnoser.Default);
-            Add(StatisticColumn.OperationsPerSecond);
-            Add(DefaultColumnProviders.Instance);
+            AddDiagnoser(MemoryDiagnoser.Default);
+            AddColumn(StatisticColumn.OperationsPerSecond);
+            AddColumnProvider(DefaultColumnProviders.Instance);
 
-            Add(JitOptimizationsValidator.FailOnError);
+            AddValidator(JitOptimizationsValidator.FailOnError);
 
-            Add(Job.Default
+            AddJob(Job.Default
 #if NETCOREAPP2_1
-                .With(CsProjCoreToolchain.From(NetCoreAppSettings.NetCoreApp21))
+                .WithToolchain(CsProjCoreToolchain.From(NetCoreAppSettings.NetCoreApp21))
 #elif NETCOREAPP3_0
-                .With(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.0", null, ".NET Core 3.0")))
+                .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.0", null, ".NET Core 3.0")))
 #elif NETCOREAPP3_1
-                .With(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.1", null, ".NET Core 3.1")))
+                .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.1", null, ".NET Core 3.1")))
 #elif NETCOREAPP5_0
-                .With(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp5.0", null, ".NET Core 5.0")))
+                .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp5.0", null, ".NET Core 5.0")))
 #else
 #error Target frameworks need to be updated.
 #endif
-                .With(new GcMode { Server = true })
-                .With(RunStrategy.Throughput));
+                .WithGcMode(new GcMode { Server = true })
+                .WithStrategy(RunStrategy.Throughput));
         }
     }
 }

--- a/src/Shared/BenchmarkRunner/DefaultCoreDebugConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCoreDebugConfig.cs
@@ -13,11 +13,11 @@ namespace BenchmarkDotNet.Attributes
     {
         public DefaultCoreDebugConfig()
         {
-            Add(ConsoleLogger.Default);
-            Add(JitOptimizationsValidator.DontFailOnError);
+            AddLogger(ConsoleLogger.Default);
+            AddValidator(JitOptimizationsValidator.DontFailOnError);
 
-            Add(Job.InProcess
-                .With(RunStrategy.Throughput));
+            AddJob(Job.InProcess
+                .WithStrategy(RunStrategy.Throughput));
         }
     }
 }

--- a/src/Shared/BenchmarkRunner/DefaultCorePerfLabConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCorePerfLabConfig.cs
@@ -17,23 +17,23 @@ namespace BenchmarkDotNet.Attributes
     {
         public DefaultCorePerfLabConfig()
         {
-            Add(ConsoleLogger.Default);
+            AddLogger(ConsoleLogger.Default);
 
-            Add(MemoryDiagnoser.Default);
-            Add(StatisticColumn.OperationsPerSecond);
-            Add(new ParamsSummaryColumn());
-            Add(DefaultColumnProviders.Statistics, DefaultColumnProviders.Metrics, DefaultColumnProviders.Descriptor);
+            AddDiagnoser(MemoryDiagnoser.Default);
+            AddColumn(StatisticColumn.OperationsPerSecond);
+            AddColumn(new ParamsSummaryColumn());
+            AddColumnProvider(DefaultColumnProviders.Statistics, DefaultColumnProviders.Metrics, DefaultColumnProviders.Descriptor);
 
-            Add(JitOptimizationsValidator.FailOnError);
+            AddValidator(JitOptimizationsValidator.FailOnError);
 
-            Add(Job.InProcess
-                .With(RunStrategy.Throughput));
+            AddJob(Job.InProcess
+                .WithStrategy(RunStrategy.Throughput));
 
-            Add(MarkdownExporter.GitHub);
+            AddExporter(MarkdownExporter.GitHub);
 
-            Add(new CsvExporter(
+            AddExporter(new CsvExporter(
                 CsvSeparator.Comma,
-                new Reports.SummaryStyle(printUnitsInHeader: true, printUnitsInContent: false, timeUnit: Horology.TimeUnit.Microsecond, sizeUnit: SizeUnit.KB)));
+                new Reports.SummaryStyle(cultureInfo: null, printUnitsInHeader: true, printUnitsInContent: false, timeUnit: Perfolizer.Horology.TimeUnit.Microsecond, sizeUnit: SizeUnit.KB)));
         }
     }
 }

--- a/src/Shared/BenchmarkRunner/DefaultCoreProfileConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCoreProfileConfig.cs
@@ -16,17 +16,17 @@ namespace BenchmarkDotNet.Attributes
     {
         public DefaultCoreProfileConfig()
         {
-            Add(ConsoleLogger.Default);
-            Add(MarkdownExporter.GitHub);
+            AddLogger(ConsoleLogger.Default);
+            AddExporter(MarkdownExporter.GitHub);
 
-            Add(MemoryDiagnoser.Default);
-            Add(StatisticColumn.OperationsPerSecond);
-            Add(DefaultColumnProviders.Instance);
+            AddDiagnoser(MemoryDiagnoser.Default);
+            AddColumn(StatisticColumn.OperationsPerSecond);
+            AddColumnProvider(DefaultColumnProviders.Instance);
 
-            Add(JitOptimizationsValidator.FailOnError);
+            AddValidator(JitOptimizationsValidator.FailOnError);
 
-            Add(Job.InProcess
-                .With(RunStrategy.Throughput));
+            AddJob(Job.InProcess
+                .WithStrategy(RunStrategy.Throughput));
         }
     }
 }

--- a/src/Shared/BenchmarkRunner/DefaultCoreValidationConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCoreValidationConfig.cs
@@ -12,9 +12,9 @@ namespace BenchmarkDotNet.Attributes
     {
         public DefaultCoreValidationConfig()
         {
-            Add(ConsoleLogger.Default);
+            AddLogger(ConsoleLogger.Default);
 
-            Add(Job.Dry.With(InProcessNoEmitToolchain.Instance));
+            AddJob(Job.Dry.WithToolchain(InProcessNoEmitToolchain.Instance));
         }
     }
 }


### PR DESCRIPTION
".NET Core" is now ".NET" and the detection logic in BDN needed to change to allow 5.0 apps to work. Which requires updating our reference.

All the changes were switching from Obsolete APIs to the suggestions.
