### PR TITLE
Fixup reference to M.AspNetCore.Components.WebAssembly.HttpHandler

### DIFF
--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -40,4 +40,26 @@
   <Import Project="WebAssembly\Build\src\ReferenceFromSource.props" Condition="'$(ReferenceBlazorBuildLocally)' == 'true'" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
+
+  <ItemGroup Condition="'$(FixupWebAssemblyHttpHandlerReference)' == 'true'">
+    <ProjectReference
+      Include="$(RepoRoot)src\Components\WebAssembly\WebAssemblyHttpHandler\src\Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj"
+      CopyLocal="false" />
+  </ItemGroup>
+
+  <Target Name="_FixupReferenceToWebAssemblyHttpHandler"
+    Condition="'$(FixupWebAssemblyHttpHandlerReference)' == 'true'"
+    AfterTargets="_ResolveBlazorInputs"
+    BeforeTargets="_ResolveBlazorOutputs">
+    <!--
+      ProjectReference doesn't really play well with IncludeAssets behavior you get when referencing
+      the package with IncludeAssets="compile".
+    -->
+    <ItemGroup>
+      <_HttpHandlerAssembly Include="@(_BlazorUserRuntimeAssembly)"
+        Condition="%(_BlazorUserRuntimeAssembly.ProjectReferenceOriginalItemSpec) == '$(RepoRoot)src\Components\WebAssembly\WebAssemblyHttpHandler\src\Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj'" />
+
+      <_BlazorUserRuntimeAssembly Remove="@(_HttpHandlerAssembly)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -15,9 +15,7 @@
     <Reference Include="Microsoft.JSInterop.WebAssembly" />
     <ProjectReference
       Include="..\..\WebAssemblyHttpHandler\src\Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj"
-      IncludeAssets="commit"
-      ReferenceOutputAssembly="false"
-      Private="true" />
+      IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Client/HostedInAspNet.Client.csproj
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Client/HostedInAspNet.Client.csproj
@@ -7,6 +7,7 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <!-- Disable compression in this project so that we can validate that it can be disabled -->
     <BlazorEnableCompression>false</BlazorEnableCompression>
+    <FixupWebAssemblyHttpHandlerReference>true</FixupWebAssemblyHttpHandlerReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/testassets/StandaloneApp/StandaloneApp.csproj
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/StandaloneApp.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <ReferenceBlazorBuildLocally>true</ReferenceBlazorBuildLocally>
     <RazorLangVersion>3.0</RazorLangVersion>
+    <FixupWebAssemblyHttpHandlerReference>true</FixupWebAssemblyHttpHandlerReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Client/Wasm.Authentication.Client.csproj
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Client/Wasm.Authentication.Client.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <ReferenceBlazorBuildLocally>true</ReferenceBlazorBuildLocally>
+    <FixupWebAssemblyHttpHandlerReference>true</FixupWebAssemblyHttpHandlerReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,7 @@
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
     <Reference Include="Microsoft.Extensions.Http" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -10,6 +10,8 @@
 
     <!-- Resx generation on Resources.resx only -->
     <GenerateResxSource>false</GenerateResxSource>
+
+    <FixupWebAssemblyHttpHandlerReference>true</FixupWebAssemblyHttpHandlerReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,9 +21,6 @@
     <Reference Include="Microsoft.AspNetCore.Components.Authorization" />
     <Reference Include="Microsoft.AspNetCore.Components.DataAnnotations.Validation" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
-    <ProjectReference
-      Include="..\..\..\WebAssembly\WebAssemblyHttpHandler\src\Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj"
-      CopyLocal="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,18 +30,5 @@
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx" GenerateSource="true" />
   </ItemGroup>
-
-  <Target Name="_FixupRefAssembly" AfterTargets="_ResolveBlazorInputs" BeforeTargets="_ResolveBlazorOutputs">
-    <!--
-      ProjectReference doesn't really play well with IncludeAssets behavior you get when referencing
-      the package with IncludeAssets="compile".
-    -->
-    <ItemGroup>
-      <_HttpHandlerAssembly Include="@(_BlazorUserRuntimeAssembly)"
-        Condition="%(_BlazorUserRuntimeAssembly.ProjectReferenceOriginalItemSpec) == '..\..\..\WebAssembly\WebAssemblyHttpHandler\src\Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj'" />
-
-      <_BlazorUserRuntimeAssembly Remove="@(_HttpHandlerAssembly)" />
-    </ItemGroup>
-  </Target>
 
 </Project>


### PR DESCRIPTION
…ndler

As part of attempting to fix the reference in the test project (which ultimately wasn't needed), I messed up the package reference in the WebAssembly package
This fixes the package reference and removes unnecessary code from the test project

