### PR TITLE
Add support for listening to arbitrary endpoints

### DIFF
--- a/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp.cs
+++ b/src/Servers/Kestrel/Core/ref/Microsoft.AspNetCore.Server.Kestrel.Core.netcoreapp.cs
@@ -139,6 +139,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader Configure(Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }
         public void ConfigureEndpointDefaults(System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> configureOptions) { }
         public void ConfigureHttpsDefaults(System.Action<Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions> configureOptions) { }
+        public void Listen(System.Net.EndPoint endPoint) { }
+        public void Listen(System.Net.EndPoint endPoint, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> configure) { }
         public void Listen(System.Net.IPAddress address, int port) { }
         public void Listen(System.Net.IPAddress address, int port, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> configure) { }
         public void Listen(System.Net.IPEndPoint endPoint) { }
@@ -156,6 +158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
     {
         internal ListenOptions() { }
         public System.IServiceProvider ApplicationServices { get { throw null; } }
+        public System.Net.EndPoint EndPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public ulong FileHandle { get { throw null; } }
         public System.Net.IPEndPoint IPEndPoint { get { throw null; } }
         public Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions KestrelServerOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -225,9 +225,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         /// <summary>
-        /// Bind to given IP endpoint.
+        /// Bind to the given IP endpoint.
         /// </summary>
         public void Listen(IPEndPoint endPoint)
+        {
+            Listen((EndPoint)endPoint);
+        }
+
+        /// <summary>
+        /// Bind to the given endpoint.
+        /// </summary>
+        /// <param name="endPoint"></param>
+        public void Listen(EndPoint endPoint)
         {
             Listen(endPoint, _ => { });
         }
@@ -237,6 +246,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// The callback configures endpoint-specific settings.
         /// </summary>
         public void Listen(IPEndPoint endPoint, Action<ListenOptions> configure)
+        {
+            Listen((EndPoint)endPoint, configure);
+        }
+
+        /// <summary>
+        /// Bind to given IP address and port.
+        /// The callback configures endpoint-specific settings.
+        /// </summary>
+        public void Listen(EndPoint endPoint, Action<ListenOptions> configure)
         {
             if (endPoint == null)
             {

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         /// <summary>
-        /// Bind to given IP address and port.
+        /// Bind to the given endpoint.
         /// The callback configures endpoint-specific settings.
         /// </summary>
         public void Listen(EndPoint endPoint, Action<ListenOptions> configure)

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal readonly List<Func<ConnectionDelegate, ConnectionDelegate>> _middleware = new List<Func<ConnectionDelegate, ConnectionDelegate>>();
         internal readonly List<Func<MultiplexedConnectionDelegate, MultiplexedConnectionDelegate>> _multiplexedMiddleware = new List<Func<MultiplexedConnectionDelegate, MultiplexedConnectionDelegate>>();
 
-        internal ListenOptions(IPEndPoint endPoint)
+        internal ListenOptions(EndPoint endPoint)
         {
             EndPoint = endPoint;
         }
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             EndPoint = new FileHandleEndPoint(fileHandle, handleType);
         }
 
-        internal EndPoint EndPoint { get; set; }
+        public EndPoint EndPoint { get; internal set; }
 
         // IPEndPoint is mutable so port 0 can be updated to the bound port.
         /// <summary>

--- a/src/Servers/Kestrel/Core/test/ListenOptionsTests.cs
+++ b/src/Servers/Kestrel/Core/test/ListenOptionsTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -44,6 +45,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.NotNull(clone.KestrelServerOptions);
             Assert.NotNull(serviceProvider);
             Assert.Same(serviceProvider, clone.ApplicationServices);
+        }
+
+        [Fact]
+        public void ListenOptionsSupportsAnyEndPoint()
+        {
+            var listenOptions = new ListenOptions(new UriEndPoint(new Uri("http://127.0.0.1:5555")));
+            Assert.IsType<UriEndPoint>(listenOptions.EndPoint);
+            Assert.Equal("http://127.0.0.1:5555/", ((UriEndPoint)listenOptions.EndPoint).Uri.ToString());
         }
     }
 }

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportFactoryTests.cs
@@ -20,6 +20,13 @@ namespace Sockets.BindTests
             var socketTransportFactory = new SocketTransportFactory(Options.Create(new SocketTransportOptions()), Mock.Of<ILoggerFactory>());
             await Assert.ThrowsAsync<NotSupportedException>(async () => await socketTransportFactory.BindAsync(new FileHandleEndPoint(0, FileHandleType.Auto)));
         }
+
+        [Fact]
+        public async Task ThrowsNotImplementedExceptionWhenBindingToUriEndPoint()
+        {
+            var socketTransportFactory = new SocketTransportFactory(Options.Create(new SocketTransportOptions()), Mock.Of<ILoggerFactory>());
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await socketTransportFactory.BindAsync(new UriEndPoint(new Uri("http://127.0.0.1:5554"))));
+        }
     }
 }
 


### PR DESCRIPTION
- This adds support for kestrel using arbitrary transports with any endpoint. This lets the consumer set an endpoint that flows all the way to the transport.
- Added tests

Fixes #12428