### PR TITLE
Fix TimerAwaitable rooting

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Internal;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests
+{
+    public class TimerAwaitableTests
+    {
+        [Fact]
+        public void FinalizerRunsIfTimerAwaitableReferencesObject()
+        {
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            UseTimerAwaitableAndUnref(tcs);
+
+            // Make sure it *really* cleans up
+            for (int i = 0; i < 5; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            // Make sure the finalizer runs
+            Assert.True(tcs.Task.IsCompleted);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void UseTimerAwaitableAndUnref(TaskCompletionSource<object> tcs)
+        {
+            _ = new ObjectWithTimerAwaitable(tcs).Start();
+        }
+    }
+
+    // This object holds onto a TimerAwaitable referencing the callback (the async continuation is the callback)
+    // it also has a finalizer that triggers a tcs to callers can be notified when this object is being cleaned up.
+    public class ObjectWithTimerAwaitable
+    {
+        private readonly TimerAwaitable _timer;
+        private readonly TaskCompletionSource<object> _tcs;
+        private int _count;
+
+        public ObjectWithTimerAwaitable(TaskCompletionSource<object> tcs)
+        {
+            _tcs = tcs;
+            _timer = new TimerAwaitable(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            _timer.Start();
+        }
+
+        public async Task Start()
+        {
+            using (_timer)
+            {
+                while (await _timer)
+                {
+                    _count++;
+                }
+            }
+        }
+
+        ~ObjectWithTimerAwaitable()
+        {
+            _tcs.TrySetResult(null);
+        }
+    }
+}

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -15,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             UseTimerAwaitableAndUnref(tcs);
 
             // Make sure it *really* cleans up
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < 5 && !tcs.Task.IsCompleted; i++)
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
@@ -33,7 +36,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
     }
 
     // This object holds onto a TimerAwaitable referencing the callback (the async continuation is the callback)
-    // it also has a finalizer that triggers a tcs to callers can be notified when this object is being cleaned up.
+    // it also has a finalizer that triggers a tcs so callers can be notified when this object is being cleaned up.
     public class ObjectWithTimerAwaitable
     {
         private readonly TimerAwaitable _timer;


### PR DESCRIPTION
- This fixes an issue where components that use timer awaitable currently need to be explicitly stopped and disposed for it to be unrooted. This makes it possible to write a finalizer.

This pattern exists in a couple more places in the BCL:
- https://github.com/dotnet/runtime/blob/73b5ef88291d85b6c9393a5829fce25fd939aed3/src/libraries/Common/src/System/Net/WebSockets/ManagedWebSocket.cs#L209-L212
- https://github.com/dotnet/runtime/blob/73b5ef88291d85b6c9393a5829fce25fd939aed3/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs#L108-L112

It usually affects client APIs where disposal of resources happen if something is unreferenced.