### PR TITLE
[Blazor][Wasm] Fix typo preventing the service worker from being removed on publish

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -178,7 +178,7 @@
 
   <Target Name="_OmitServiceWorkerContent"
     Condition="'$(ServiceWorkerAssetsManifest)' != ''"
-    BeforeTargets="AssignTargetPaths;ResolveCurrentProjectStaticWebAssets">
+    BeforeTargets="AssignTargetPaths;ResolveCurrentProjectStaticWebAssetsInputs">
 
     <ItemGroup>
       <!-- Don't emit the service worker source files to the output -->


### PR DESCRIPTION
* Fixes a typo that prevented the service worker from being removed during publish
