### PR TITLE
Get off the hosted ubuntu linux queue due to disk space limitations

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -323,6 +323,7 @@ stages:
       jobName: Linux_x64_build
       jobDisplayName: "Build: Linux x64"
       agentOs: Linux
+      useHostedUbuntu: false
       steps:
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - task: Bash@3


### PR DESCRIPTION
Our builds take more space than the hosted queue guarantees. Moving back to BYOC for this build.