### PR TITLE
Improve tests for logging configuration support

### DIFF
--- a/src/Components/test/E2ETest/Tests/WebAssemblyLoggingTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLoggingTest.cs
@@ -85,11 +85,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.FindElement(By.Id("log-none")).Click();
             Browser.FindElement(By.Id("log-trace")).Click();
             Browser.FindElement(By.Id("log-debug")).Click();
-            AssertLastLogMessage(LogLevel.Info, "Test log message");
+            Browser.FindElement(By.Id("log-information")).Click();
+            // The Warning minimum log-level is only set on the PrependMessage
+            // logger so the last info log will be processed by the default
+            // logger but not the PrependMessage one.
+            AssertLastLogMessage(LogLevel.Info, "info: BasicTestApp.ErrorComponent[0]");
 
             // These severity levels are displayed
-            Browser.FindElement(By.Id("log-information")).Click();
-            AssertLastLogMessage(LogLevel.Info, "[Custom logger] This is a Information message with count=4");
             Browser.FindElement(By.Id("log-warning")).Click();
             AssertLastLogMessage(LogLevel.Warning, "[Custom logger] This is a Warning message with count=5");
             Browser.FindElement(By.Id("log-error")).Click();

--- a/src/Components/test/testassets/BasicTestApp/PrependMessageLoggerProvider.cs
+++ b/src/Components/test/testassets/BasicTestApp/PrependMessageLoggerProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.JSInterop;
 
 namespace BasicTestApp
 {
+    [ProviderAlias("PrependMessage")]
     internal class PrependMessageLoggerProvider : ILoggerProvider
     {
         ILogger _logger;

--- a/src/Components/test/testassets/BasicTestApp/Program.cs
+++ b/src/Components/test/testassets/BasicTestApp/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.WebAssembly.Http;
 using Microsoft.AspNetCore.Components.WebAssembly.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.JSInterop;
@@ -37,9 +38,11 @@ namespace BasicTestApp
                     policy.RequireAssertion(ctx => ctx.User.Identity.Name?.StartsWith("B") ?? false));
             });
 
+            builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
+
             builder.Logging.Services.AddSingleton<ILoggerProvider, PrependMessageLoggerProvider>(s =>
                 new PrependMessageLoggerProvider(builder.Configuration["Logging:PrependMessage:Message"], s.GetService<IJSRuntime>()));
-            builder.Logging.AddConfiguration(builder.Configuration);
+            
 
             var host = builder.Build();
             ConfigureCulture(host);

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/appsettings.json
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/appsettings.json
@@ -3,9 +3,9 @@
   "key2": "Default key2-value",
   "Logging": {
     "PrependMessage": {
-      "Message":  "Custom logger",
+      "Message": "Custom logger",
       "LogLevel": {
-        "Default": "Information"
+        "Default": "Warning"
       }
     }
   }


### PR DESCRIPTION
- Avoids using "Information" as the log level used in tests since it is the default anyways
- Fixes how logging configuration is initialized
- Fixes provider alias on custom logging provider

Addresses #20969 
