### PR TITLE
Silence the runtime output from the debugger

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -297,7 +297,7 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
 
     MONO.mono_wasm_setenv("MONO_URI_DOTNETRELATIVEORABSOLUTE", "true");
     const load_runtime = cwrap('mono_wasm_load_runtime', null, ['string', 'number']);
-    load_runtime(appBinDirName, hasDebuggingEnabled() ? 1 : 0);
+    load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);
     MONO.mono_wasm_runtime_ready ();
     attachInteropInvoker();
     onReady();

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -297,6 +297,7 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
 
     MONO.mono_wasm_setenv("MONO_URI_DOTNETRELATIVEORABSOLUTE", "true");
     const load_runtime = cwrap('mono_wasm_load_runtime', null, ['string', 'number']);
+    // -1 enables debugging with logging disabled. 0 disables debugging entirely.
     load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);
     MONO.mono_wasm_runtime_ready ();
     attachInteropInvoker();


### PR DESCRIPTION
 - Pass -1 instead of 1 when enabling debugging
 
The runtime now supports log levels for the managed debugger when enabling debugging.  By passing -1 you can disable all the debug output. This is just an informational pr in case this is desirable.
