### PR TITLE
A quick collection of quick fixes

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -48,7 +48,7 @@ variables:
   - group: DotNet-MSRC-Storage
   - name: _InternalRuntimeDownloadArgs
     value: -DotNetRuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet -DotNetRuntimeSourceFeedKey $(dotnetclimsrc-read-sas-token-base64) /p:DotNetAssetRootAccessTokenSuffix='$(dotnetclimsrc-read-sas-token-base64)'
-  # The code signing doesn't use the aspnet build scripts, so the msbuild parameers have
+  # The code signing doesn't use the aspnet build scripts, so the msbuild parameters have
   # to be passed directly. This is awkward, since we pass the same info above, but we have
   # to have it in two different forms
   - name: _InternalRuntimeDownloadCodeSignArgs
@@ -100,14 +100,6 @@ stages:
         jobDisplayName: Code check
         agentOs: Windows
         steps:
-        - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - task: PowerShell@2
-            displayName: Setup Private Feeds Credentials
-            inputs:
-              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-              arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-            env:
-              Token: $(dn-bot-dnceng-artifact-feeds-rw)
         - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
           displayName: Run eng/scripts/CodeCheck.ps1
         artifacts:
@@ -135,15 +127,6 @@ stages:
       # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
       # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
       # The sign settings have been configured to
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
       - script: ./build.cmd
                 -ci
                 -arch x64
@@ -325,14 +308,6 @@ stages:
       agentOs: Linux
       useHostedUbuntu: false
       steps:
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
       - script: ./build.sh
             --ci
             --arch x64
@@ -565,14 +540,6 @@ stages:
       agentOs: Windows
       isTestingJob: true
       steps:
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
       - script: ./build.cmd -ci -all -pack $(_InternalRuntimeDownloadArgs)
         displayName: Build Repo
       - script: ./src/ProjectTemplates/build.cmd -ci -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true /bl:artifacts/log/template.pack.binlog"
@@ -702,7 +669,6 @@ stages:
       # Build the shared framework
       - script: ./build.cmd -ci -all -pack -arch x64 -buildNative /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.daily.build.x64.binlog
         displayName: Build shared fx
-      # Build the x86 shared framework
       - script: .\restore.cmd -ci /p:BuildInteropProjects=true
         displayName: Restore
       - script: .\build.cmd -ci -NoRestore -test -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildAllProjects=true /p:BuildInteropProjects=true /p:BuildNative=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -132,7 +132,6 @@ stages:
                 -arch x64
                 -pack
                 -all
-                -buildNative
                 /bl:artifacts/log/build.x64.binlog
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
@@ -145,7 +144,6 @@ stages:
                 -arch x86
                 -pack
                 -all
-                -buildNative
                 -noBuildJava
                 /p:OnlyPackPlatformSpecificPackages=true
                 /bl:artifacts/log/build.x86.binlog
@@ -504,7 +502,7 @@ stages:
       jobDisplayName: "Test: Windows Server 2016 x64"
       agentOs: Windows
       isTestingJob: true
-      buildArgs: -all -pack -test -BuildNative "/p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false" $(_InternalRuntimeDownloadArgs)
+      buildArgs: -all -pack -test "/p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false" $(_InternalRuntimeDownloadArgs)
       beforeBuild:
       - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
         displayName: Setup IISExpress test certificates and schema
@@ -643,11 +641,11 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./build.cmd -ci -all -pack -arch x64 -buildNative /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
+      - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
         displayName: Build shared fx
       - script: .\restore.cmd -ci /p:BuildInteropProjects=true
-        displayName: Restore
-      - script: .\build.cmd -ci -NoRestore -test -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildAllProjects=true /p:BuildInteropProjects=true /p:BuildNative=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+        displayName: Restore interop projects
+      - script: .\build.cmd -ci -NoRestore -test -all -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -667,11 +665,11 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./build.cmd -ci -all -pack -arch x64 -buildNative /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.daily.build.x64.binlog
+      - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.daily.build.x64.binlog
         displayName: Build shared fx
       - script: .\restore.cmd -ci /p:BuildInteropProjects=true
-        displayName: Restore
-      - script: .\build.cmd -ci -NoRestore -test -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildAllProjects=true /p:BuildInteropProjects=true /p:BuildNative=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+        displayName: Restore interop projects
+      - script: .\build.cmd -ci -NoRestore -test -all -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -694,7 +692,7 @@ stages:
       # Build the shared framework
       - script: ./restore.sh -ci
         displayName: Restore
-      - script: ./build.sh -ci --arch arm64 -test --no-build-nodejs -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildAllProjects=true /p:BuildNative=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: ./build.sh -ci --arch arm64 -test --no-build-nodejs --all -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
         displayName: Run build.sh helix arm64 target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/devBuilds.yml
+++ b/.azure/pipelines/devBuilds.yml
@@ -31,12 +31,12 @@ stages:
       steps:
       - script: git submodule init
       - script: git submodule update --recursive
-      - script: cd ./src/Components
       - script: ./build.cmd
                 -ci
                 -arch x64
                 /bl:artifacts/log/build.components.x64.binlog
         displayName: Build x64
+        workingDirectory: ./src/Components
       artifacts:
       - name: Windows_Logs
         path: artifacts/log/
@@ -56,12 +56,12 @@ stages:
       steps:
       - script: git submodule init
       - script: git submodule update --recursive
-      - script: cd ./src/Servers
       - script: ./build.cmd
                 -ci
                 -arch x64
                 /bl:artifacts/log/build.servers.x64.binlog
         displayName: Build x64
+        workingDirectory: ./src/Servers
       artifacts:
       - name: Windows_Logs
         path: artifacts/log/
@@ -81,12 +81,12 @@ stages:
       steps:
       - script: git submodule init
       - script: git submodule update --recursive
-      - script: cd ./src/ProjectTemplates
       - script: ./build.cmd
                 -ci
                 -arch x64
                 /bl:artifacts/log/build.projectTemplates.x64.binlog
         displayName: Build x64
+        workingDirectory: ./src/ProjectTemplates
       artifacts:
       - name: Windows_Logs
         path: artifacts/log/

--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -28,14 +28,6 @@ jobs:
         contents: '**/*.nupkg'
         targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(BuildConfiguration)/shipping/
         flattenFolders: true
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - powershell: .\eng\common\build.ps1
         -ci
         -restore

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -171,27 +171,28 @@ jobs:
 
     - ${{ parameters.beforeBuild }}
 
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - ${{ if eq(parameters.agentOs, 'Windows') }}:
+        - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+          - task: PowerShell@2
+            displayName: Setup Private Feeds Credentials
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+              arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+            env:
+              Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - ${{ if ne(parameters.agentOs, 'Windows') }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
     - ${{ if ne(parameters.steps, '')}}:
       - ${{ parameters.steps }}
     - ${{ if eq(parameters.steps, '')}}:
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - ${{ if eq(parameters.agentOs, 'Windows') }}:
-          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            - task: PowerShell@2
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - ${{ if ne(parameters.agentOs, 'Windows') }}:
-          - task: Bash@3
-            displayName: Setup Private Feeds Credentials
-            inputs:
-              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-              arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-            env:
-              Token: $(dn-bot-dnceng-artifact-feeds-rw)
       - ${{ if eq(parameters.buildScript, '') }}:
         - ${{ if eq(parameters.agentOs, 'Windows') }}:
           - script: .\$(BuildDirectory)\build.cmd -ci /p:DotNetSignType=$(_SignType) -Configuration $(BuildConfiguration) $(BuildScriptArgs)

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -31,11 +31,11 @@ jobs:
     timeoutInMinutes: 240
     steps:
     # Build the shared framework
-    - script: ./build.cmd -ci -all -pack -arch x64 -buildNative /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
+    - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
       displayName: Build shared fx
     - script: .\restore.cmd -ci /p:BuildInteropProjects=true
-      displayName: Restore
-    - script: .\build.cmd -ci -NoRestore -test -noBuildJava -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildAllProjects=true /p:BuildInteropProjects=true /p:BuildNative=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      displayName: Restore interop projects
+    - script: .\build.cmd -ci -NoRestore -test -noBuildJava -all -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,6 @@
 ﻿<Project>
+  <Import Project="eng\Common.props" />
+
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
@@ -121,12 +123,7 @@
 
   <!-- Compilation options which apply to all languages. Language-specific options should be set in eng/targets/$(lang).Common.props -->
   <PropertyGroup>
-    <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
-    <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
-    <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
-    <TargetRuntimeIdentifier>$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
 
     <!-- This defines the list of RIDs supported by the ASP.NET Core shared framework. -->
     <SupportedRuntimeIdentifiers>
@@ -179,7 +176,7 @@
     <!-- Projects which reference Microsoft.AspNetCore.Mvc.Testing should import this targets file to ensure dependency .deps.json files are copied into test output. -->
     <MvcTestingTargets>$(MSBuildThisFileDirectory)src\Mvc\Mvc.Testing\src\Microsoft.AspNetCore.Mvc.Testing.targets</MvcTestingTargets>
     <!-- IIS native projects can only be built on Windows for x86 and x64. -->
-    <BuildIisNativeProjects Condition="'$(BuildNative)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64')">true</BuildIisNativeProjects>
+    <BuildIisNativeProjects Condition=" $(BuildNative) AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') ">true</BuildIisNativeProjects>
     <!-- This property is shared by several projects to layout the AspNetCore.App targeting pack for installers -->
     <TargetingPackLayoutRoot>$(ArtifactsObjDir)TargetingPack.Layout\$(Configuration)\</TargetingPackLayoutRoot>
     <!-- This property is shared by several projects to layout the AspNetCore.App shared framework for installers -->

--- a/build.ps1
+++ b/build.ps1
@@ -185,7 +185,8 @@ if ($DumpProcesses -or $CI) {
 if ($All) {
     $MSBuildArguments += '/p:BuildAllProjects=true'
 }
-elseif ($Projects) {
+
+if ($Projects) {
     if (![System.IO.Path]::IsPathRooted($Projects))
     {
         $Projects = Join-Path (Get-Location) $Projects
@@ -193,7 +194,7 @@ elseif ($Projects) {
     $MSBuildArguments += "/p:ProjectToBuild=$Projects"
 }
 # When adding new sub-group build flags, add them to this check.
-elseif((-not $BuildNative) -and (-not $BuildManaged) -and (-not $BuildNodeJS) -and (-not $BuildInstallers) -and (-not $BuildJava)) {
+elseif (-not ($All -or $BuildNative -or $BuildManaged -or $BuildNodeJS -or $BuildInstallers -or $BuildJava)) {
     Write-Warning "No default group of projects was specified, so building the 'managed' and its dependent subsets of projects. Run ``build.cmd -help`` for more details."
 
     # This goal of this is to pick a sensible default for `build.cmd` with zero arguments.
@@ -203,7 +204,7 @@ elseif((-not $BuildNative) -and (-not $BuildManaged) -and (-not $BuildNodeJS) -a
 }
 
 if ($BuildManaged -or ($All -and (-not $NoBuildManaged))) {
-    if ((-not $BuildNodeJS) -and (-not $NoBuildNodeJS)) {
+    if (-not ($BuildNodeJS -or $NoBuildNodeJS)) {
         $node = Get-Command node -ErrorAction Ignore -CommandType Application
 
         if ($node) {

--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ Options:
     --no-build-repo-tasks             Suppress building RepoTasks.
 
     --all                             Build all project types.
-    --[no-]build-native               Build native projects (C, C++).
+    --[no-]build-native               Build native projects (C, C++). Ignored in most cases i.e. with `dotnet msbuild`.
     --[no-]build-managed              Build managed projects (C#, F#, VB).
     --[no-]build-nodejs               Build NodeJS projects (TypeScript, JS).
     --[no-]build-java                 Build Java projects.
@@ -74,7 +74,7 @@ Options:
     --ci                              Apply CI specific settings and environment variables.
     --binarylog|-bl                   Use a binary logger
     --verbosity|-v                    MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
-    
+
     --dotnet-runtime-source-feed      Additional feed that can be used when downloading .NET runtimes
     --dotnet-runtime-source-feed-key  Key for feed that can be used when downloading .NET runtimes
 
@@ -223,9 +223,11 @@ done
 
 if [ "$build_all" = true ]; then
     msbuild_args[${#msbuild_args[*]}]="-p:BuildAllProjects=true"
-elif [ ! -z "$build_projects" ]; then
+fi
+
+if [ ! -z "$build_projects" ]; then
     msbuild_args[${#msbuild_args[*]}]="-p:ProjectToBuild=$build_projects"
-elif [ -z "$build_managed" ] && [ -z "$build_nodejs" ] && [ -z "$build_java" ] && [ -z "$build_native" ] && [ -z "$build_installers" ]; then
+elif [ "$build_all" != true ] && [ -z "$build_managed$build_nodejs$build_java$build_native$build_installers" ]; then
     # This goal of this is to pick a sensible default for `build.sh` with zero arguments.
     # We believe the most common thing our contributors will work on is C#, so if no other build group was picked, build the C# projects.
     __warn "No default group of projects was specified, so building the 'managed' and its dependent subset of projects. Run ``build.sh --help`` for more details."
@@ -287,7 +289,7 @@ msbuild_args[${#msbuild_args[*]}]="-verbosity:$verbosity"
 
 # Set up additional runtime args
 toolset_build_args=()
-if [ ! -z "$dotnet_runtime_source_feed" ] || [ ! -z "$dotnet_runtime_source_feed_key" ]; then
+if [ ! -z "$dotnet_runtime_source_feed$dotnet_runtime_source_feed_key" ]; then
     runtimeFeedArg="/p:DotNetRuntimeSourceFeed=$dotnet_runtime_source_feed"
     runtimeFeedKeyArg="/p:DotNetRuntimeSourceFeedKey=$dotnet_runtime_source_feed_key"
     msbuild_args[${#msbuild_args[*]}]=$runtimeFeedArg

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -160,7 +160,7 @@ On macOS/Linux:
 ./build.sh
 ```
 
-By default, all of the C# projects are built. Some C# projects require NodeJS to be installed to compile JavaScript assets which are then checked in as source. If NodeJS is detected on the path, the NodeJS projects will be compiled as part of building C# projects. If NodeJS is not detected on the path, the JavaScript assets checked in previously will be used instead. To disable building NodeJS projects, specify /p:BuildNodeJs=false on the command line.
+By default, all of the C# projects are built. Some C# projects require NodeJS to be installed to compile JavaScript assets which are then checked in as source. If NodeJS is detected on the path, the NodeJS projects will be compiled as part of building C# projects. If NodeJS is not detected on the path, the JavaScript assets checked in previously will be used instead. To disable building NodeJS projects, specify `-noBuildNodeJS` or `--no-build-nodejs` on the command line.
 
 ### Using `dotnet` on command line in this repo
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,14 +1,5 @@
 <Project>
-  <PropertyGroup>
-    <TargetRuntimeIdentifier Condition="'$(TargetRuntimeIdentifier)' == ''">$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(BuildAllProjects)' == 'true' ">
-    <BuildNative Condition="'$(BuildNative)' == ''">true</BuildNative>
-    <BuildManaged Condition="'$(BuildManaged)' == ''">true</BuildManaged>
-    <BuildNodeJS Condition="'$(BuildNodeJS)' == ''">true</BuildNodeJS>
-    <BuildJava Condition="'$(BuildJava)' == ''">true</BuildJava>
-  </PropertyGroup>
+  <Import Project="Common.props" />
 
   <!-- These projects are always excluded, even when -projects is specified on command line. -->
   <ItemGroup>
@@ -102,8 +93,8 @@
           <AdditionalProperties Condition="'$(TargetArchitecture)' == 'x86'">Platform=Win32</AdditionalProperties>
         </NativeProjects>
 
-        <ProjectToBuild Condition=" '$(BuildNative)' == 'true'" Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" />
-        <ProjectToExclude Condition=" '$(BuildNative)' != 'true'" Include="@(NativeProjects)" />
+        <ProjectToBuild Condition=" $(BuildNative) " Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" />
+        <ProjectToExclude Condition=" !$(BuildNative) " Include="@(NativeProjects)" />
 
         <NodeJsProjects Include="
                           $(RepoRoot)src\Components\Web.JS\Microsoft.AspNetCore.Components.Web.JS.npmproj;

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -1,0 +1,25 @@
+<Project>
+  <PropertyGroup>
+    <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
+    <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
+    <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+    <TargetRuntimeIdentifier Condition="'$(TargetRuntimeIdentifier)' == ''">$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(BuildAllProjects)' == 'true' ">
+    <!-- Ignore $(BuildNative) when using MSBuild Core, on non-Windows platforms, or when C++ bits are missing. -->
+    <BuildNative Condition=" '$(MSBuildRuntimeType)' == 'Core' ">false</BuildNative>
+    <BuildNative Condition=" '$(TargetOsName)' != 'win' ">false</BuildNative>
+    <BuildNative Condition=" '$(VCTargetsPath)' == '' ">false</BuildNative>
+    <BuildNative Condition=" '$(BuildNative)' == '' ">true</BuildNative>
+
+    <BuildManaged Condition="'$(BuildManaged)' == ''">true</BuildManaged>
+    <BuildNodeJS Condition="'$(BuildNodeJS)' == ''">true</BuildNodeJS>
+    <BuildJava Condition="'$(BuildJava)' == ''">true</BuildJava>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BuildNative Condition=" '$(BuildNative)' == '' ">false</BuildNative>
+  </PropertyGroup>
+</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,6 +1,6 @@
 <Project>
-
   <!-- See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Signing.md for details. -->
+  <Import Project="Common.props" />
 
   <ItemGroup>
     <!-- Reset Arcade's defaults. -->
@@ -69,7 +69,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetRuntimeIdentifier Condition="'$(TargetRuntimeIdentifier)' == ''">$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
     <BaseRedistNetCorePath>$(ArtifactsObjDir)RedistSharedFx.Layout\$(Configuration)\</BaseRedistNetCorePath>
     <RedistNetCorePath>$(BaseRedistNetCorePath)$(TargetRuntimeIdentifier)\</RedistNetCorePath>
   </PropertyGroup>

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -48,10 +48,10 @@ try {
     if ($ci) {
         # Install dotnet.exe
         if ($DotNetRuntimeSourceFeed -or $DotNetRuntimeSourceFeedKey) {
-            & $repoRoot/restore.cmd -ci -NoBuildNodeJS -DotNetRuntimeSourceFeed $DotNetRuntimeSourceFeed -DotNetRuntimeSourceFeedKey $DotNetRuntimeSourceFeedKey
+            & $repoRoot/restore.cmd -ci -noBuildNodeJS -DotNetRuntimeSourceFeed $DotNetRuntimeSourceFeed -DotNetRuntimeSourceFeedKey $DotNetRuntimeSourceFeedKey
         }
         else{
-            & $repoRoot/restore.cmd -ci -NoBuildNodeJS
+            & $repoRoot/restore.cmd -ci -noBuildNodeJS
         }
     }
 

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -36,7 +36,7 @@
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
     </Exec>
 
-    <Error Text="Building *.npmproj but NodeJS was not detected on path. Ensure NodeJS is on path or disable building NodeJS projects with /p:BuildNodeJs=false. Skipping NodeJS projects will also skip managed projects depending on them, including Components, Mvc and Analysers." Condition="'$(ErrorCode)' != '0'"/>
+    <Error Text="Building *.npmproj but NodeJS was not detected on path. Ensure NodeJS is on path or disable building NodeJS projects with -noBuildNodeJS or --no-build-nodejs. Skipping NodeJS projects will also skip managed projects depending on them, including Components, Mvc and Analysers." Condition="'$(ErrorCode)' != '0'"/>
   </Target>
 
   <Target Name="Restore">

--- a/eng/targets/ResolveIisReferences.targets
+++ b/eng/targets/ResolveIisReferences.targets
@@ -5,40 +5,35 @@ with the right MSBuild incantations to get output copied to the right place.
 
 -->
 <Project>
-  <Choose>
-    <!-- IIS native projects only build on Windows with MSBuild.exe -->
-    <When Condition="'$(OS)' == 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">
-      <ItemGroup Condition="@(NativeProjectReference->Count()) != 0 AND '$(BuildNative)' != 'false' ">
-        <!-- TODO: investigate building just one arch at a time. -->
-        <ProjectReference Include="@(NativeProjectReference)">
-          <!-- Set the arch-->
-          <SetPlatform>Platform=%(Platform)</SetPlatform>
-          <SetPlatform Condition="'%(Platform)' == 'x86'">Platform=Win32</SetPlatform>
-          <!-- The base path for the output. -->
-          <LinkBase>%(Platform)\%(HandlerPath)\</LinkBase>
-          <!-- This reference assembly doesn't need -->
-          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-          <!-- NativeContent is a custom type of item group which is assigned a target path after project references are resolved.  -->
-          <OutputItemType>NativeContent</OutputItemType>
-          <!-- This instructs the ProjectRef protocol to collect symbols as well as built output -->
-          <Targets>Build;BuiltProjectOutputGroup;DebugSymbolsProjectOutputGroup</Targets>
-          <!-- Optimization. Native projects don't have a .NET TargetFramework -->
-          <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-          <UndefineProperties>TargetFramework</UndefineProperties>
-          <!-- Don't put this reference into generated .nuspec -->
-          <PrivateAssets>All</PrivateAssets>
-          <!-- Publish assets from this reference -->
-          <Publish>true</Publish>
-        </ProjectReference>
-
-        <NativeProjectReference Remove="@(NativeProjectReference)" />
-      </ItemGroup>
-    </When>
-  </Choose>
+  <!-- IIS native projects only build on Windows with MSBuild.exe -->
+  <ItemGroup Condition="@(NativeProjectReference->Count()) != 0 AND $(BuildNative) ">
+    <!-- TODO: investigate building just one arch at a time. -->
+    <ProjectReference Include="@(NativeProjectReference)">
+      <!-- Set the arch-->
+      <SetPlatform>Platform=%(Platform)</SetPlatform>
+      <SetPlatform Condition="'%(Platform)' == 'x86'">Platform=Win32</SetPlatform>
+      <!-- The base path for the output. -->
+      <LinkBase>%(Platform)\%(HandlerPath)\</LinkBase>
+      <!-- This reference assembly doesn't need -->
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <!-- NativeContent is a custom type of item group which is assigned a target path after project references are resolved.  -->
+      <OutputItemType>NativeContent</OutputItemType>
+      <!-- This instructs the ProjectRef protocol to collect symbols as well as built output -->
+      <Targets>Build;BuiltProjectOutputGroup;DebugSymbolsProjectOutputGroup</Targets>
+      <!-- Optimization. Native projects don't have a .NET TargetFramework -->
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <UndefineProperties>TargetFramework</UndefineProperties>
+      <!-- Don't put this reference into generated .nuspec -->
+      <PrivateAssets>All</PrivateAssets>
+      <!-- Publish assets from this reference -->
+      <Publish>true</Publish>
+    </ProjectReference>
+    <NativeProjectReference Remove="@(NativeProjectReference)" />
+  </ItemGroup>
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"
-          Condition=" @(NativeProjectReference->Count()) != 0 AND '$(BuildNative)' == 'false' ">
+          Condition=" @(NativeProjectReference->Count()) != 0 AND !$(BuildNative) ">
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -native` to build native projects. Run `build.cmd -managed -native` to build both C# and C++." />
   </Target>
 

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -126,7 +126,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <Reference Include="microsoft.netcore.app.runtime.$(RuntimeIdentifier)" ExcludeAssets="All" PrivateAssets="All" />
 
-    <ProjectReference Condition="'$(BuildIisNativeProjects)' == 'true' AND '$(BuildNative)' != 'false' AND '$(VCTargetsPath)' != ''" Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
+    <ProjectReference Condition=" '$(BuildIisNativeProjects)' == 'true' "
+        Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
       <SetPlatform>Platform=$(TargetArchitecture)</SetPlatform>
       <SetPlatform Condition="'$(TargetArchitecture)' == 'x86'">Platform=Win32</SetPlatform>
       <!-- Custom attribute used to distinguish managed from native references. -->
@@ -214,7 +215,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"
-          Condition=" '$(BuildIisNativeProjects)' == 'true' AND '$(BuildNative)' == 'false' ">
+          Condition=" '$(BuildIisNativeProjects)' == 'true' AND !$(BuildNative) ">
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -BuildNative -BuildManaged` to build both C# and C++." />
   </Target>
 
@@ -496,7 +497,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="IncludeVersionFile"
-          DependsOnTargets="GenerateSharedFxVersionsFiles" 
+          DependsOnTargets="GenerateSharedFxVersionsFiles"
           BeforeTargets="_GetPackageFiles">
 
     <ItemGroup>

--- a/src/Servers/IIS/AspNetCoreModuleV2/Symbols/Microsoft.AspNetCore.ANCMSymbols.csproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/Symbols/Microsoft.AspNetCore.ANCMSymbols.csproj
@@ -28,7 +28,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BuildIisNativeProjects)' == 'true' AND '$(VCTargetsPath)' != ''">
+  <ItemGroup Condition=" '$(BuildIisNativeProjects)' == 'true' ">
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="$(NativeVCPlatform)" />
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="$(NativeVCPlatform)" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -28,7 +28,7 @@
         Condition="'$(BuildIisNativeProjects)' == 'true' AND !Exists('$(AspNetCoreModuleV2InProcessHandlerDll)')" />
   </Target>
 
-  <ItemGroup Condition="'$(BuildIisNativeProjects)' == 'true' AND '$(VCTargetsPath)' != ''">
+  <ItemGroup Condition=" '$(BuildIisNativeProjects)' == 'true' ">
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj" Platform="x64" />
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj" Platform="Win32" />
   </ItemGroup>

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
@@ -34,7 +34,7 @@
           Condition="!Exists('$(AspNetCoreModuleV2ShimDll)') OR !Exists('$(AspNetCoreModuleV2OutOfProcessHandlerDll)')" />
   </Target>
 
-  <ItemGroup Condition="'$(BuildIisNativeProjects)' == 'true' AND '$(VCTargetsPath)' != '' AND '$(TestGroupName)' != 'IISNewHandler.FunctionalTests'">
+  <ItemGroup Condition="'$(BuildIisNativeProjects)' == 'true' AND '$(TestGroupName)' != 'IISNewHandler.FunctionalTests'">
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="x64"/>
     <NativeProjectReference Include="$(MSBuildThisFileDirectory)..\..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" Platform="x64" />
 

--- a/src/SiteExtensions/build.cmd
+++ b/src/SiteExtensions/build.cmd
@@ -1,26 +1,40 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..
 
-ECHO Building Microsoft.AspNetCore.Runtime.SiteExtension
-CALL %RepoRoot%\build.cmd -arch x64 -projects %~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj /bl:artifacts/log/SiteExtensions-Runtime-x64.binlog %*
-CALL %RepoRoot%\build.cmd -arch x86 -projects %~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj /bl:artifacts/log/SiteExtensions-Runtime-x86.binlog %*
-
+ECHO Building x64 Microsoft.AspNetCore.Runtime.SiteExtension
+CALL "%RepoRoot%\build.cmd" -arch x64 -projects "%~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj" ^
+    /bl:artifacts/log/SiteExtensions-Runtime-x86.binlog %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
 
-ECHO Building LoggingBranch
-REM /p:DisableTransitiveFrameworkReferences=true is needed to prevent SDK from picking up transitive references to Microsoft.AspNetCore.App as framework references https://github.com/dotnet/sdk/pull/3221
-CALL %RepoRoot%\build.cmd -forceCoreMsbuild -arch x64 -projects %~dp0LoggingBranch\LB.csproj /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x64.binlog %*
-CALL %RepoRoot%\build.cmd -forceCoreMsbuild -arch x86 -projects %~dp0LoggingBranch\LB.csproj /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x86.binlog %*
+ECHO Building x86 Microsoft.AspNetCore.Runtime.SiteExtension
+CALL "%RepoRoot%\build.cmd" -arch x86 -projects "%~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj" ^
+    /bl:artifacts/log/SiteExtensions-Runtime-x86.binlog %*
+IF %ERRORLEVEL% NEQ 0 (
+   EXIT /b %ErrorLevel%
+)
 
+ECHO Building x64 LoggingBranch
+REM /p:DisableTransitiveFrameworkReferences=true is needed to prevent SDK from picking up transitive references to
+REM Microsoft.AspNetCore.App as framework references https://github.com/dotnet/sdk/pull/3221
+CALL "%RepoRoot%\build.cmd" -forceCoreMsbuild -arch x64 -projects "%~dp0LoggingBranch\LB.csproj" ^
+    /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x64.binlog %*
+IF %ERRORLEVEL% NEQ 0 (
+   EXIT /b %ErrorLevel%
+)
+
+ECHO Building x86 LoggingBranch
+CALL "%RepoRoot%\build.cmd" -forceCoreMsbuild -arch x86 -projects "%~dp0LoggingBranch\LB.csproj" ^
+    /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x86.binlog %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
 
 ECHO Building Microsoft.AspNetCore.AzureAppServices.SiteExtension
-CALL %RepoRoot%\build.cmd -forceCoreMsbuild -projects %~dp0LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj /bl:artifacts/log/SiteExtensions-LoggingAggregate.binlog %*
-
+CALL "%RepoRoot%\build.cmd" -forceCoreMsbuild -projects ^
+    "%~dp0LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj" ^
+    /bl:artifacts/log/SiteExtensions-LoggingAggregate.binlog %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )


### PR DESCRIPTION
- simplify devBuilds.yml
- clean up SiteExtensions/build.cmd
- move `SetupNugetSources` script invocations above `parameters.beforeBuild`
- ensure `$(BuildNative)` is always set correctly
- support `-all` together with `-projects`
- consistently use `--build-*`

(Mostly found while working on #20748. Some parts will make it easier to use `dotnet` more if we continue down that road.)