### PR TITLE
Fix race in gRPC interop test logging

### DIFF
--- a/src/Grpc/test/InteropTests/Helpers/WebsiteProcess.cs
+++ b/src/Grpc/test/InteropTests/Helpers/WebsiteProcess.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Internal;
@@ -19,8 +15,6 @@ namespace InteropTests.Helpers
         private readonly Process _process;
         private readonly ProcessEx _processEx;
         private readonly TaskCompletionSource<object> _startTcs;
-        private readonly StringBuilder _consoleOut = new StringBuilder();
-        private object _consoleLock = new object();
         private static readonly Regex NowListeningRegex = new Regex(@"^\s*Now listening on: .*:(?<port>\d*)$");
 
         public string ServerPort { get; private set; }
@@ -59,10 +53,6 @@ namespace InteropTests.Helpers
             var data = e.Data;
             if (data != null)
             {
-                lock (_consoleLock)
-                {
-                    _consoleOut.AppendLine(data);
-                }
                 var m = NowListeningRegex.Match(data);
                 if (m.Success)
                 {
@@ -78,27 +68,6 @@ namespace InteropTests.Helpers
 
         public void Dispose()
         {
-            _process.OutputDataReceived -= Process_OutputDataReceived;
-
-            string consoleOut;
-            lock (_consoleLock)
-            {
-                consoleOut = _consoleOut.ToString();
-            }
-
-            var attributes = Assembly.GetExecutingAssembly()
-                .GetCustomAttributes<AssemblyMetadataAttribute>();
-            var serverLogPath = attributes.SingleOrDefault(a => a.Key == "ServerLogPath")?.Value;
-            if (!string.IsNullOrEmpty(serverLogPath))
-            {
-                File.WriteAllText(serverLogPath, consoleOut);
-            }
-            else
-            {
-                var logDir = Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "logs");
-                Directory.CreateDirectory(logDir);
-                File.WriteAllText(Path.Combine(logDir, "InteropServer.log"), consoleOut);
-            }
             _processEx.Dispose();
         }
     }

--- a/src/Grpc/test/InteropTests/InteropTests.cs
+++ b/src/Grpc/test/InteropTests/InteropTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using InteropTests.Helpers;
 using Microsoft.AspNetCore.Testing;
@@ -27,6 +26,7 @@ namespace InteropTests
         }
 
         [Theory]
+        [QuarantinedTest]
         [MemberData(nameof(TestCaseData))]
         public async Task InteropTestCase(string name)
         {

--- a/src/Grpc/test/InteropTests/InteropTests.cs
+++ b/src/Grpc/test/InteropTests/InteropTests.cs
@@ -26,7 +26,6 @@ namespace InteropTests
         }
 
         [Theory]
-        [QuarantinedTest]
         [MemberData(nameof(TestCaseData))]
         public async Task InteropTestCase(string name)
         {


### PR DESCRIPTION
After fixing the flakiness issue as discussed offline, I decided to remove it all together. Given that the server logs are already captured via ITestOutputHelper, there's no need for the additional logging logic. These logs are a relic of the time when we only had one server for the entire test suite and wanted a separate server log.