### PR TITLE
Refactor IdentityUser to extract an interface

### DIFF
--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TRole">The type of role objects.</typeparam>
     /// <typeparam name="TKey">The type of the primary key for users and roles.</typeparam>
     public class IdentityDbContext<TUser, TRole, TKey> : IdentityDbContext<TUser, TRole, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>, IdentityUserToken<TKey>>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
     {
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TRoleClaim">The type of the role claim object.</typeparam>
     /// <typeparam name="TUserToken">The type of the user token object.</typeparam>
     public abstract class IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> : IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>

--- a/src/Identity/EntityFrameworkCore/src/IdentityEntityFrameworkBuilderExtensions.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityEntityFrameworkBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -30,7 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddStores(IServiceCollection services, Type userType, Type roleType, Type contextType)
         {
-            var identityUserType = FindGenericBaseType(userType, typeof(IdentityUser<>));
+            var identityUserType = FindGenericInterfaceType(userType, typeof(IIdentityUser<>));
             if (identityUserType == null)
             {
                 throw new InvalidOperationException(Resources.NotIdentityUser);
@@ -108,6 +109,14 @@ namespace Microsoft.Extensions.DependencyInjection
                 type = type.BaseType;
             }
             return null;
+        }
+
+        private static TypeInfo FindGenericInterfaceType(Type currentType, Type genericInterfaceType)
+        {
+            return currentType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == genericInterfaceType)
+                ?.GetTypeInfo();
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TUser">The type of user objects.</typeparam>
     /// <typeparam name="TKey">The type of the primary key for users and roles.</typeparam>
     public class IdentityUserContext<TUser, TKey> : IdentityUserContext<TUser, TKey, IdentityUserClaim<TKey>, IdentityUserLogin<TKey>, IdentityUserToken<TKey>>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TKey : IEquatable<TKey>
     {
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TUserLogin">The type of the user login object.</typeparam>
     /// <typeparam name="TUserToken">The type of the user token object.</typeparam>
     public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken> : DbContext
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>
         where TUserLogin : IdentityUserLogin<TKey>
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
                 b.ToTable("AspNetUserLogins");
             });
 
-            builder.Entity<TUserToken>(b => 
+            builder.Entity<TUserToken>(b =>
             {
                 b.HasKey(t => new { t.UserId, t.LoginProvider, t.Name });
 

--- a/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
@@ -15,7 +15,8 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// Creates a new instance of a persistence store for the specified user type.
     /// </summary>
     /// <typeparam name="TUser">The type representing a user.</typeparam>
-    public class UserOnlyStore<TUser> : UserOnlyStore<TUser, DbContext, string> where TUser : IdentityUser<string>, new()
+    public class UserOnlyStore<TUser> : UserOnlyStore<TUser, DbContext, string>
+        where TUser : class, IIdentityUser<string>, new()
     {
         /// <summary>
         /// Constructs a new instance of <see cref="UserOnlyStore{TUser}"/>.
@@ -31,7 +32,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TUser">The type representing a user.</typeparam>
     /// <typeparam name="TContext">The type of the data context class used to access the store.</typeparam>
     public class UserOnlyStore<TUser, TContext> : UserOnlyStore<TUser, TContext, string>
-        where TUser : IdentityUser<string>
+        where TUser : class, IIdentityUser<string>
         where TContext : DbContext
     {
         /// <summary>
@@ -49,7 +50,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TContext">The type of the data context class used to access the store.</typeparam>
     /// <typeparam name="TKey">The type of the primary key for a role.</typeparam>
     public class UserOnlyStore<TUser, TContext, TKey> : UserOnlyStore<TUser, TContext, TKey, IdentityUserClaim<TKey>, IdentityUserLogin<TKey>, IdentityUserToken<TKey>>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
@@ -85,7 +86,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         IUserAuthenticatorKeyStore<TUser>,
         IUserTwoFactorRecoveryCodeStore<TUser>,
         IProtectedUserStore<TUser>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TContext : DbContext
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>, new()

--- a/src/Identity/EntityFrameworkCore/src/UserStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserStore.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// </summary>
     /// <typeparam name="TUser">The type representing a user.</typeparam>
     public class UserStore<TUser> : UserStore<TUser, IdentityRole, DbContext, string>
-        where TUser : IdentityUser<string>, new()
+        where TUser : class, IIdentityUser<string>, new()
     {
         /// <summary>
         /// Constructs a new instance of <see cref="UserStore{TUser}"/>.
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TRole">The type representing a role.</typeparam>
     /// <typeparam name="TContext">The type of the data context class used to access the store.</typeparam>
     public class UserStore<TUser, TRole, TContext> : UserStore<TUser, TRole, TContext, string>
-        where TUser : IdentityUser<string>
+        where TUser : class, IIdentityUser<string>
         where TRole : IdentityRole<string>
         where TContext : DbContext
     {
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     /// <typeparam name="TContext">The type of the data context class used to access the store.</typeparam>
     /// <typeparam name="TKey">The type of the primary key for a role.</typeparam>
     public class UserStore<TUser, TRole, TContext, TKey> : UserStore<TUser, TRole, TContext, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityUserToken<TKey>, IdentityRoleClaim<TKey>>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TContext : DbContext
         where TKey : IEquatable<TKey>
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
     public class UserStore<TUser, TRole, TContext, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken, TRoleClaim> :
         UserStoreBase<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken, TRoleClaim>,
         IProtectedUserStore<TUser>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TContext : DbContext
         where TKey : IEquatable<TKey>

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryContext.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
     }
 
     public class InMemoryContext<TUser, TRole, TKey> : IdentityDbContext<TUser, TRole, TKey>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
     {
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 
     public abstract class InMemoryContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> :
             IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/SqlStoreOnlyUsersTestBase.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/SqlStoreOnlyUsersTestBase.cs
@@ -16,7 +16,7 @@ using Xunit;
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
 {
     public abstract class SqlStoreOnlyUsersTestBase<TUser, TKey> : UserManagerSpecificationTestBase<TUser, TKey>, IClassFixture<ScratchDatabaseFixture>
-        where TUser : IdentityUser<TKey>, new()
+        where TUser : class, IIdentityUser<TKey>, new()
         where TKey : IEquatable<TKey>
     {
         private readonly ScratchDatabaseFixture _fixture;

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/SqlStoreTestBase.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/SqlStoreTestBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
     // TODO: Add test variation with non IdentityDbContext
 
     public abstract class SqlStoreTestBase<TUser, TRole, TKey> : IdentitySpecificationTestBase<TUser, TRole, TKey>, IClassFixture<ScratchDatabaseFixture>
-        where TUser : IdentityUser<TKey>, new()
+        where TUser : class, IIdentityUser<TKey>, new()
         where TRole : IdentityRole<TKey>, new()
         where TKey : IEquatable<TKey>
     {

--- a/src/Identity/Extensions.Stores/src/IIdentityUser.cs
+++ b/src/Identity/Extensions.Stores/src/IIdentityUser.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IIdentityUser<TKey> where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        /// Gets or sets the number of failed login attempts for the current user.
+        /// </summary>
+        int AccessFailedCount { get; set; }
+
+        /// <summary>
+        /// A random value that must change whenever a user is persisted to the store
+        /// </summary>
+        string ConcurrencyStamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email address for this user.
+        /// </summary>
+        string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating if a user has confirmed their email address.
+        /// </summary>
+        /// <value>True if the email address has been confirmed, otherwise false.</value>
+        bool EmailConfirmed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary key for this user.
+        /// </summary>
+        TKey Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating if the user could be locked out.
+        /// </summary>
+        /// <value>True if the user could be locked out, otherwise false.</value>
+        bool LockoutEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date and time, in UTC, when any user lockout ends.
+        /// </summary>
+        /// <remarks>
+        /// A value in the past means the user is not locked out.
+        /// </remarks>
+        DateTimeOffset? LockoutEnd { get; set; }
+
+        /// <summary>
+        /// Gets or sets the normalized email address for this user.
+        /// </summary>
+        string NormalizedEmail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the normalized user name for this user.
+        /// </summary>
+        string NormalizedUserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a salted and hashed representation of the password for this user.
+        /// </summary>
+        string PasswordHash { get; set; }
+
+        /// <summary>
+        /// Gets or sets a telephone number for the user.
+        /// </summary>
+        string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating if a user has confirmed their telephone address.
+        /// </summary>
+        /// <value>True if the telephone number has been confirmed, otherwise false.</value>
+        bool PhoneNumberConfirmed { get; set; }
+
+        /// <summary>
+        /// A random value that must change whenever a users credentials change (password changed, login removed)
+        /// </summary>
+        string SecurityStamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating if two factor authentication is enabled for this user.
+        /// </summary>
+        /// <value>True if 2fa is enabled, otherwise false.</value>
+        bool TwoFactorEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user name for this user.
+        /// </summary>
+        string UserName { get; set; }
+    }
+}

--- a/src/Identity/Extensions.Stores/src/IdentityUser.cs
+++ b/src/Identity/Extensions.Stores/src/IdentityUser.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Identity
     /// Represents a user in the identity system
     /// </summary>
     /// <typeparam name="TKey">The type used for the primary key for the user.</typeparam>
-    public class IdentityUser<TKey> where TKey : IEquatable<TKey>
+    public class IdentityUser<TKey> : IIdentityUser<TKey> where TKey : IEquatable<TKey>
     {
         /// <summary>
         /// Initializes a new instance of <see cref="IdentityUser{TKey}"/>.
@@ -55,93 +55,56 @@ namespace Microsoft.AspNetCore.Identity
             UserName = userName;
         }
 
-        /// <summary>
-        /// Gets or sets the primary key for this user.
-        /// </summary>
+        /// <inheritdoc/>
         [PersonalData]
         public virtual TKey Id { get; set; }
 
-        /// <summary>
-        /// Gets or sets the user name for this user.
-        /// </summary>
+        /// <inheritdoc/>
         [ProtectedPersonalData]
         public virtual string UserName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the normalized user name for this user.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual string NormalizedUserName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email address for this user.
-        /// </summary>
+        /// <inheritdoc/>
         [ProtectedPersonalData]
         public virtual string Email { get; set; }
 
-        /// <summary>
-        /// Gets or sets the normalized email address for this user.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual string NormalizedEmail { get; set; }
 
-        /// <summary>
-        /// Gets or sets a flag indicating if a user has confirmed their email address.
-        /// </summary>
-        /// <value>True if the email address has been confirmed, otherwise false.</value>
+        /// <inheritdoc/>
         [PersonalData]
         public virtual bool EmailConfirmed { get; set; }
 
-        /// <summary>
-        /// Gets or sets a salted and hashed representation of the password for this user.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual string PasswordHash { get; set; }
 
-        /// <summary>
-        /// A random value that must change whenever a users credentials change (password changed, login removed)
-        /// </summary>
+        /// <inheritdoc/>
         public virtual string SecurityStamp { get; set; }
 
-        /// <summary>
-        /// A random value that must change whenever a user is persisted to the store
-        /// </summary>
+        /// <inheritdoc/>
         public virtual string ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
 
-        /// <summary>
-        /// Gets or sets a telephone number for the user.
-        /// </summary>
+        /// <inheritdoc/>
         [ProtectedPersonalData]
         public virtual string PhoneNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets a flag indicating if a user has confirmed their telephone address.
-        /// </summary>
-        /// <value>True if the telephone number has been confirmed, otherwise false.</value>
+        /// <inheritdoc/>
         [PersonalData]
         public virtual bool PhoneNumberConfirmed { get; set; }
 
-        /// <summary>
-        /// Gets or sets a flag indicating if two factor authentication is enabled for this user.
-        /// </summary>
-        /// <value>True if 2fa is enabled, otherwise false.</value>
+        /// <inheritdoc/>
         [PersonalData]
         public virtual bool TwoFactorEnabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the date and time, in UTC, when any user lockout ends.
-        /// </summary>
-        /// <remarks>
-        /// A value in the past means the user is not locked out.
-        /// </remarks>
+        /// <inheritdoc/>
         public virtual DateTimeOffset? LockoutEnd { get; set; }
 
-        /// <summary>
-        /// Gets or sets a flag indicating if the user could be locked out.
-        /// </summary>
-        /// <value>True if the user could be locked out, otherwise false.</value>
+        /// <inheritdoc/>
         public virtual bool LockoutEnabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the number of failed login attempts for the current user.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual int AccessFailedCount { get; set; }
 
         /// <summary>

--- a/src/Identity/Extensions.Stores/src/UserStoreBase.cs
+++ b/src/Identity/Extensions.Stores/src/UserStoreBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Identity
         IUserAuthenticationTokenStore<TUser>,
         IUserAuthenticatorKeyStore<TUser>,
         IUserTwoFactorRecoveryCodeStore<TUser>
-        where TUser : IdentityUser<TKey>
+        where TUser : class, IIdentityUser<TKey>
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>, new()
         where TUserLogin : IdentityUserLogin<TKey>, new()
@@ -1087,8 +1087,8 @@ namespace Microsoft.AspNetCore.Identity
     public abstract class UserStoreBase<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken, TRoleClaim> :
         UserStoreBase<TUser, TKey, TUserClaim, TUserLogin, TUserToken>,
         IUserRoleStore<TUser>
-        where TUser : IdentityUser<TKey>
-        where TRole : IdentityRole<TKey> 
+        where TUser : class, IIdentityUser<TKey>
+        where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>, new()
         where TUserRole : IdentityUserRole<TKey>, new()


### PR DESCRIPTION
Summary of the changes
 - Create an `IIdentityUser` interface.
 - Update all appropriate code to check for the interface instead of the implementation.

Addresses [#12242](https://github.com/dotnet/aspnetcore/issues/12242)
