### PR TITLE
Quarantine test that caused test abort

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -559,6 +559,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        [QuarantinedTest]
         public async Task TraceIdentifierIsUnique()
         {
             const int identifierLength = 22;


### PR DESCRIPTION
```
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.IO.InvalidDataException: No StatusCode found in ''
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport.InMemoryHttpClientSlim.GetStatus(String response) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryHttpClientSlim.cs:line 113
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport.InMemoryHttpClientSlim.ReadResponse(Stream stream) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryHttpClientSlim.cs:line 97
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport.InMemoryHttpClientSlim.GetStringAsync(Uri requestUri, Boolean validateCertificate) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryHttpClientSlim.cs:line 43
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport.InMemoryHttpClientSlim.GetStringAsync(String requestUri, Boolean validateCertificate) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryHttpClientSlim.cs:line 29
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.RequestTests.<>c__DisplayClass14_0.<<TraceIdentifierIsUnique>b__1>d.MoveNext() in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs:line 579
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__139_1(Object state)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```
https://dev.azure.com/dnceng/internal/_build/results?buildId=611424&view=ms.vss-test-web.build-test-results-tab&runId=19196678&resultId=120268&paneView=attachments