### PR TITLE
Fix intermediate path for service worker assets

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -5,7 +5,7 @@
     BeforeTargets="_ResolveBlazorOutputs;_ResolveBlazorFilesToCompress">
 
     <PropertyGroup>
-      <_ServiceWorkerAssetsManifestIntermediateOutputPath>$(_BlazorIntermediateOutputPath)$(ServiceWorkerAssetsManifest)</_ServiceWorkerAssetsManifestIntermediateOutputPath>
+      <_ServiceWorkerAssetsManifestIntermediateOutputPath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), $(_BlazorIntermediateOutputPath)))$(ServiceWorkerAssetsManifest)</_ServiceWorkerAssetsManifestIntermediateOutputPath>
       <_ServiceWorkerAssetsManifestFullPath>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(_ServiceWorkerAssetsManifestIntermediateOutputPath)'))</_ServiceWorkerAssetsManifestFullPath>
     </PropertyGroup>
 
@@ -19,7 +19,7 @@
         <SourceId>$(PackageId)</SourceId>
         <ContentRoot>$([MSBuild]::NormalizeDirectory('$(TargetDir)wwwroot\'))</ContentRoot>
         <BasePath>$(StaticWebAssetBasePath)</BasePath>
-        <RelativePath>$([MSBuild]::MakeRelative($([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(_BlazorIntermediateOutputPath)')), $(_ServiceWorkerAssetsManifestFullPath)))</RelativePath>
+        <RelativePath>$(ServiceWorkerAssetsManifest)</RelativePath>
       </_ManifestStaticWebAsset>
 
       <StaticWebAsset Include="@(_ManifestStaticWebAsset)" />

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
@@ -325,6 +325,30 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
             Assert.FileDoesNotExist(result, buildOutputDirectory, "wwwroot", "_framework", "_bin", "I18N.West.dll");
         }
 
+        [Fact]
+        public async Task Build_WithCustomOutputPath_Works()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone", additionalProjects: new[] { "razorclasslibrary" });
+
+            project.AddDirectoryBuildContent(
+@"<PropertyGroup>
+    <BaseOutputPath>$(MSBuildThisFileDirectory)build\bin\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)build\obj\</BaseIntermediateOutputPath>
+</PropertyGroup>");
+
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, args: "/restore");
+            Assert.BuildPassed(result);
+
+            var compressedFilesPath = Path.Combine(
+                project.DirectoryPath,
+                "build",
+                project.IntermediateOutputDirectory,
+                "compressed");
+
+            Assert.True(Directory.Exists(compressedFilesPath));
+        }
+
         private static GenerateBlazorBootJson.BootJsonData ReadBootJsonData(MSBuildResult result, string path)
         {
             return JsonSerializer.Deserialize<GenerateBlazorBootJson.BootJsonData>(

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/ProjectDirectory.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/ProjectDirectory.cs
@@ -172,6 +172,20 @@ $@"<Project>
             File.WriteAllText(ProjectFilePath, updated);
         }
 
+        internal void AddDirectoryBuildContent(string content)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            var filepath = Path.Combine(DirectoryPath, "Directory.Build.props");
+
+            var existing = File.ReadAllText(filepath);
+            var updated = existing.Replace("<!-- Test Placeholder -->", content);
+            File.WriteAllText(filepath, updated);
+        }
+
         public void Dispose()
         {
             if (PreserveWorkingDirectory)

--- a/src/Components/WebAssembly/Build/testassets/Directory.Build.props
+++ b/src/Components/WebAssembly/Build/testassets/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
     <Import Project="Before.Directory.Build.props" Condition="Exists('Before.Directory.Build.props')" />
 
+    <!-- Test Placeholder -->
+
     <PropertyGroup>
       <RepoRoot Condition="'$(RepoRoot)' ==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), global.json))\</RepoRoot>
       <ComponentsRoot>$(RepoRoot)src\Components\</ComponentsRoot>


### PR DESCRIPTION
The way we currently set up the `_ServiceWorkerAssetsManifestFullPath` property in our build targets doesn't work with scenarios where users set custom intermediate output paths.

The MSBuild docs recommend that people use fully qualified paths when overriding the property. A consequence of this is that we end up creating a `_ServiceWorkerAssetsManifestFullPath` that looks like this when we do a simple concatenation.

```
C:\sourcecode\BlazorProject\build\C:\sourcecode\BlazorProject\build\object
```

I added a conditional check to make sure we don't improperly construct the property here.

It looks like this is the only place where we do this with the IntermediateOutputPath so we should be good elsewhere.

Addresses #20994
