### PR TITLE
[release/3.1] Move SDL validation to ringed release

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -73,8 +73,6 @@ variables:
              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
 
-    # used for post-build phases, internal builds only
-    - group: DotNet-AspNet-SDLValidation-Params
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _BuildArgs
       value: ''
@@ -714,18 +712,3 @@ stages:
       # See https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
       publishInstallersAndChecksums: true
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: false
-        continueOnError: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "AspNetCore"
-        -TsaCodebaseName "AspNetCore"
-        -TsaPublish $True
-        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -5,7 +5,5 @@
 -TsaCodebaseAdmin REDMOND\kevinpi
 -TsaBugAreaPath DevDiv\ASP.NET Core
 -TsaIterationPath DevDiv
--TsaRepositoryName aspnetcore
--TsaCodebaseName dotnet
 -TsaOnboard $True
 -TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,0 +1,11 @@
+-SourceToolsList @("policheck","credscan")
+-TsaInstanceURL https://devdiv.visualstudio.com/
+-TsaProjectName DEVDIV
+-TsaNotificationEmail aspnetcore-build@microsoft.com
+-TsaCodebaseAdmin REDMOND\kevinpi
+-TsaBugAreaPath DevDiv\ASP.NET Core
+-TsaIterationPath DevDiv
+-TsaRepositoryName aspnetcore
+-TsaCodebaseName dotnet
+-TsaOnboard $True
+-TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -9,3 +9,4 @@
 -TsaCodebaseName AspNetCore
 -TsaOnboard $True
 -TsaPublish $True
+-PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -5,5 +5,7 @@
 -TsaCodebaseAdmin REDMOND\kevinpi
 -TsaBugAreaPath DevDiv\ASP.NET Core
 -TsaIterationPath DevDiv
+-TsaRepositoryName AspNetCore
+-TsaCodebaseName AspNetCore
 -TsaOnboard $True
 -TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -3,7 +3,7 @@
 -TsaProjectName DEVDIV
 -TsaNotificationEmail aspnetcore-build@microsoft.com
 -TsaCodebaseAdmin REDMOND\kevinpi
--TsaBugAreaPath DevDiv\ASP.NET Core
+-TsaBugAreaPath "DevDiv\ASP.NET Core"
 -TsaIterationPath DevDiv
 -TsaRepositoryName AspNetCore
 -TsaCodebaseName AspNetCore


### PR DESCRIPTION
Moves SDL out of the repo build and into the ringed release pipeline, as per the goal of reducing build time. CC @Pilchie 