### PR TITLE
fix : failureStatus

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
+++ b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                 {
                     var duration = stopwatch.GetElapsedTime();
                     entry = new HealthReportEntry(
-                        status: HealthStatus.Unhealthy,
+                        status: registration.FailureStatus,
                         description: "A timeout occurred while running check.",
                         duration: duration,
                         exception: ex,
@@ -136,7 +136,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                 {
                     var duration = stopwatch.GetElapsedTime();
                     entry = new HealthReportEntry(
-                        status: HealthStatus.Unhealthy,
+                        status: registration.FailureStatus,
                         description: ex.Message,
                         duration: duration,
                         exception: ex,


### PR DESCRIPTION
use HealthCheckRegistration.FailureStatus when CheckHealthAsync failure;

the "failureStatus"  param  in   HealthChecksBuilderAddCheckExtensions.Add never used;

Fixes https://github.com/dotnet/aspnetcore/issues/22503