### PR TITLE
Ignitor fixups

### DIFF
--- a/src/Components/Ignitor/src/BlazorClient.cs
+++ b/src/Components/Ignitor/src/BlazorClient.cs
@@ -333,7 +333,7 @@ namespace Ignitor
             return null;
         }
 
-        public async Task<bool> ConnectAsync(Uri uri, Action<HubConnectionBuilder, Uri>? configure = null, bool connectAutomatically = true)
+        public async Task<bool> ConnectAsync(Uri uri, bool connectAutomatically = true, Action<HubConnectionBuilder, Uri>? configure = null)
         {
             var builder = new HubConnectionBuilder();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHubProtocol, IgnitorMessagePackHubProtocol>());

--- a/src/Components/Ignitor/src/BlazorClient.cs
+++ b/src/Components/Ignitor/src/BlazorClient.cs
@@ -333,11 +333,12 @@ namespace Ignitor
             return null;
         }
 
-        public async Task<bool> ConnectAsync(Uri uri, bool connectAutomatically = true)
+        public async Task<bool> ConnectAsync(Uri uri, Action<HubConnectionBuilder, Uri>? configure = null, bool connectAutomatically = true)
         {
             var builder = new HubConnectionBuilder();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHubProtocol, IgnitorMessagePackHubProtocol>());
-            builder.WithUrl(GetHubUrl(uri));
+            var hubUrl = GetHubUrl(uri);
+            builder.WithUrl(hubUrl);
             builder.ConfigureLogging(l =>
             {
                 l.SetMinimumLevel(LogLevel.Trace);
@@ -346,6 +347,8 @@ namespace Ignitor
                     l.AddProvider(LoggerProvider);
                 }
             });
+
+            configure?.Invoke(builder, hubUrl);
 
             _hubConnection = builder.Build();
 

--- a/src/Components/Ignitor/src/ElementHive.cs
+++ b/src/Components/Ignitor/src/ElementHive.cs
@@ -264,8 +264,14 @@ namespace Ignitor
 
                 case RenderTreeFrameType.ElementReferenceCapture:
                     {
-                        // No action for reference captures.
-                        break;
+                        if (parent is ElementNode)
+                        {
+                            return 0; // A "capture" is a child in the diff, but has no node in the DOM
+                        }
+                        else
+                        {
+                            throw new Exception("Reference capture frames can only be children of element frames.");
+                        }
                     }
 
                 case RenderTreeFrameType.Markup:

--- a/src/Components/Ignitor/src/ElementNode.cs
+++ b/src/Components/Ignitor/src/ElementNode.cs
@@ -88,7 +88,7 @@ namespace Ignitor
             return DispatchEventCore(connection, Serialize(webEventDescriptor), Serialize(args));
         }
 
-        internal Task ClickAsync(HubConnection connection)
+        public Task ClickAsync(HubConnection connection)
         {
             if (!Events.TryGetValue("click", out var clickEventDescriptor))
             {


### PR DESCRIPTION
* Do not throw if an ElementReferenceCapture node is encountered.
* Allow configuring the HubConnectionBuilder
* Make useful API public


