### PR TITLE
Made changes to FileBufferWriteStream

### DIFF
--- a/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
+++ b/src/Http/WebUtilities/ref/Microsoft.AspNetCore.WebUtilities.netcoreapp.cs
@@ -77,6 +77,8 @@ namespace Microsoft.AspNetCore.WebUtilities
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public override System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
+        public System.Threading.Tasks.Task DrainBufferAsync(System.IO.Pipelines.PipeWriter destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task DrainBufferAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/Http/WebUtilities/src/PagedByteBuffer.cs
+++ b/src/Http/WebUtilities/src/PagedByteBuffer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -79,6 +80,23 @@ namespace Microsoft.AspNetCore.WebUtilities
                     page.Length;
 
                 stream.Write(page, 0, length);
+            }
+
+            ClearBuffers();
+        }
+
+        public async Task MoveToAsync(PipeWriter writer, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            for (var i = 0; i < Pages.Count; i++)
+            {
+                var page = Pages[i];
+                var length = (i == Pages.Count - 1) ?
+                    _currentPageIndex :
+                    page.Length;
+
+                await writer.WriteAsync(page.AsMemory(0, length), cancellationToken);
             }
 
             ClearBuffers();

--- a/src/Http/WebUtilities/test/FileBufferingWriteStreamTests.cs
+++ b/src/Http/WebUtilities/test/FileBufferingWriteStreamTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Microsoft.AspNetCore.WebUtilities
@@ -383,9 +384,9 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         private static byte[] ReadFileContent(FileStream fileStream)
         {
-            fileStream.Position = 0;
+            var fs = new FileStream(fileStream.Name, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.ReadWrite);
             using var memoryStream = new MemoryStream();
-            fileStream.CopyTo(memoryStream);
+            fs.CopyTo(memoryStream);
 
             return memoryStream.ToArray();
         }

--- a/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerOutputFormatter.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/XmlSerializerOutputFormatter.cs
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 if (fileBufferingWriteStream != null)
                 {
                     response.ContentLength = fileBufferingWriteStream.Length;
-                    await fileBufferingWriteStream.DrainBufferAsync(response.Body);
+                    await fileBufferingWriteStream.DrainBufferAsync(response.BodyWriter);
                 }
             }
             finally

--- a/src/Mvc/Mvc.Formatters.Xml/test/XmlSerializerOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/test/XmlSerializerOutputFormatterTest.cs
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         }
 
         [Fact]
-        public async Task XmlSerializerOutputFormatterDoesntFlushOutputStream()
+        public async Task XmlSerializerOutputFormatterWritesContentLengthResponse()
         {
             // Arrange
             var sampleInput = new DummyClass { SampleInt = 10 };
@@ -411,10 +411,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var outputFormatterContext = GetOutputFormatterContext(sampleInput, sampleInput.GetType());
 
             var response = outputFormatterContext.HttpContext.Response;
-            response.Body = FlushReportingStream.GetThrowingStream();
+            response.Body = Stream.Null;
 
             // Act & Assert
             await formatter.WriteAsync(outputFormatterContext);
+
+            Assert.NotNull(outputFormatterContext.HttpContext.Response.ContentLength);
         }
 
         public static IEnumerable<object[]> TypesForGetSupportedContentTypes

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 if (fileBufferingWriteStream != null)
                 {
                     response.ContentLength = fileBufferingWriteStream.Length;
-                    await fileBufferingWriteStream.DrainBufferAsync(response.Body);
+                    await fileBufferingWriteStream.DrainBufferAsync(response.BodyWriter);
                 }
             }
             finally

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs
@@ -305,6 +305,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var stream = new Mock<Stream> { CallBase = true };
             stream.Setup(v => v.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
+            stream.Setup(v => v.FlushAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             stream.SetupGet(s => s.CanWrite).Returns(true);
 
             var formatter = new NewtonsoftJsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared, new MvcOptions());
@@ -322,6 +323,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             stream.Verify(v => v.Write(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never());
             stream.Verify(v => v.Flush(), Times.Never());
+            Assert.NotNull(outputFormatterContext.HttpContext.Response.ContentLength);
         }
 
         private class TestableJsonOutputFormatter : NewtonsoftJsonOutputFormatter


### PR DESCRIPTION
- Make the internal FileStream write only
- Make a new readable stream over the same file in DrainBufferAsync to copy data to the buffer.
- Added an overload to DrainBufferAsync into a PipeWriter and use this overload in the 2 formatters in MVC. This should reduce the amount of copying from the internal buffer and reduces pinning (since these buffers are already pinned)

Fixes #21187 

PS: I can split this PR into 2 commits so that the overloads are added in the second commit.

I haven't run any performance tests as yet (do we have any @pranavkm?)
