### PR TITLE
[SignalR] Fix DataProtection with parallel tests

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.IO;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Routing;
@@ -49,6 +51,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                                 IssuerSigningKey = SecurityKey
                             };
                     });
+
+            // Since tests run in parallel, it's possible multiple servers will startup and read files being written by another test
+            // Use a unique directory per server to avoid this collision
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(Directory.CreateDirectory(Path.GetRandomFileName()));
         }
 
         public void Configure(IApplicationBuilder app)

--- a/src/SignalR/server/SignalR/test/Startup.cs
+++ b/src/SignalR/server/SignalR/test/Startup.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.IO;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
@@ -63,6 +65,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             services.AddAuthorization();
 
             services.AddSingleton<IAuthorizationHandler, TestAuthHandler>();
+
+            // Since tests run in parallel, it's possible multiple servers will startup and read files being written by another test
+            // Use a unique directory per server to avoid this collision
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(Directory.CreateDirectory(Path.GetRandomFileName()));
         }
 
         public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21249

Replaces https://github.com/dotnet/aspnetcore/pull/21252

Our functional tests spin up a server per test. Since tests can run in parallel, it was possible for 2 tests to start at the same time, and during the server startup DataProtection will either find a key or create one and write it to file. This could cause issues with one of the servers writing the file while the other tries to read it resulting in a failure.