### PR TITLE
Don't count start line toward header size limit

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private string _parsedRawTarget = null;
         private Uri _parsedAbsoluteRequestTarget;
 
-        private int _remainingRequestHeadersBytesAllowed;
+        private long _remainingRequestHeadersBytesAllowed;
 
         public Http1Connection(HttpConnectionContext context)
         {
@@ -213,6 +213,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return TrimAndTakeMessageHeaders(ref reader, trailers);
             }
 
+            var alreadyConsumed = reader.Consumed;
+
             try
             {
                 var result = _parser.ParseHeaders(new Http1ParsingHandler(this, trailers), ref reader);
@@ -225,7 +227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             finally
             {
-                _remainingRequestHeadersBytesAllowed -= (int)reader.Consumed;
+                _remainingRequestHeadersBytesAllowed -= reader.Consumed - alreadyConsumed;
             }
 
             bool TrimAndTakeMessageHeaders(ref SequenceReader<byte> reader, bool trailers)
@@ -248,7 +250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 finally
                 {
-                    _remainingRequestHeadersBytesAllowed -= (int)reader.Consumed;
+                    _remainingRequestHeadersBytesAllowed -= trimmedReader.Consumed;
                 }
             }
         }


### PR DESCRIPTION
At first I thought this regression was caused the recent PR to make header parsing safe, but it looks like it was actually introduced prior to our 3.0 release by #8076. @anurse 

This issue only occurs when start line and the headers are received separately, and the total length of the request headers in bytes is close enough to the limit that counting the start line towards it pushes it over. So pretty rare.

We have a bunch tests where the length of the request headers is close enough to the limit that the start line pushes it over, but before this there were no tests that guaranteed that the headers are received separately. After seeing the existing tests repro once locally, I was able to get it to reliably repro by uncommenting the following:

https://github.com/dotnet/aspnetcore/blob/be76a0322c870951637d253f4cc67c757241b785/src/Servers/Kestrel/shared/test/StreamBackedTestConnection.cs#L81-L88

That's not the type of thing we'd want to keep uncommented all the time though since that would slow down test runs about 10x.

@benaadams 