### PR TITLE
Unskip BlazorServerTemplateWorks_IndividualAuth test

### DIFF
--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -81,10 +81,10 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalTheory(Skip = "See: https://github.com/dotnet/aspnetcore/issues/20520")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [SkipOnHelix("ef restore no worky")]
+        [SkipOnHelix("Selenium not supported on Helix.")]
         [QuarantinedTest]
         public async Task BlazorServerTemplateWorks_IndividualAuth(bool useLocalDB)
         {


### PR DESCRIPTION
I propose we undo skipping this test, see if the hangs happen again, then attempt to debug once we have the appropriate artifacts from a failing build.

There's no useful process dumps in the build linked in the issue referenced below. Also, I reran the PR build three times and wasn't able to reproduce the original hang that was reported.

Addresses #20520
