### PR TITLE
Jfheins/improve error message

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -122,6 +122,7 @@ export class HubConnectionBuilder {
     public withUrl(url: string, options: IHttpConnectionOptions): HubConnectionBuilder;
     public withUrl(url: string, transportTypeOrOptions?: IHttpConnectionOptions | HttpTransportType): HubConnectionBuilder {
         Arg.isRequired(url, "url");
+        Arg.isNotEmpty(url, "url");
 
         this.url = url;
 

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -19,6 +19,11 @@ export class Arg {
             throw new Error(`The '${name}' argument is required.`);
         }
     }
+    public static isNotEmpty(val: string, name: string): void {
+        if (!val || val.match(/^\s*$/)) {
+            throw new Error(`The '${name}' argument should not be empty.`);
+        }
+    }
 
     public static isIn(val: any, values: any, name: string): void {
         // TypeScript enums have keys for **both** the name and the value of each enum member on the type itself.

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -73,12 +73,15 @@ class CapturingConsole {
 registerUnhandledRejectionHandler();
 
 describe("HubConnectionBuilder", () => {
-    eachMissingValue((val, name) => {
-        it(`withUrl throws if url is ${name}`, () => {
+
+    for (const val of [undefined, null, ""]) {
+        it(`withUrl throws if url is ${String(val)}`, () => {
             const builder = new HubConnectionBuilder();
             expect(() => builder.withUrl(val!)).toThrow("The 'url' argument is required.");
         });
+    }
 
+    eachMissingValue((val, name) => {
         it(`withHubProtocol throws if protocol is ${name}`, () => {
             const builder = new HubConnectionBuilder();
             expect(() => builder.withHubProtocol(val!)).toThrow("The 'protocol' argument is required.");

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -73,11 +73,10 @@ class CapturingConsole {
 registerUnhandledRejectionHandler();
 
 describe("HubConnectionBuilder", () => {
-
     for (const val of [undefined, null, ""]) {
         it(`withUrl throws if url is ${String(val)}`, () => {
             const builder = new HubConnectionBuilder();
-            expect(() => builder.withUrl(val!)).toThrow("The 'url' argument is required.");
+            expect(() => builder.withUrl(val!)).toThrow(/The 'url' argument (is required|should not be empty)./);
         });
     }
 


### PR DESCRIPTION
Adds parameter checking in withURL so that it fails early with a more appropriate error message.
This is a breaking change: If code called withURL with an empty string and then again with a meaningful value, this will now thow.

Addresses #21231
