### PR TITLE
Improve handling for shared values in Blazor Server

### DIFF
--- a/src/Components/Blazor/Blazor/test/Rendering/RenderRegistryTest.cs
+++ b/src/Components/Blazor/Blazor/test/Rendering/RenderRegistryTest.cs
@@ -1,0 +1,27 @@
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Blazor.Rendering
+{
+    public class RenderRegistryTest
+    {
+        [Fact]
+        public void RendererRegistry_Find_ThrowsErrorOnNonWASM()
+        {
+            // Act
+            Exception ex = Assert.Throws<ArgumentException>(() => RendererRegistry.Find(123));
+
+            // Assert
+            Assert.Equal("There is no renderer with ID 123.", ex.Message);
+        }
+        [Fact]
+        public void RendererRegistry_Remove_DoesNothingOnNonWASM()
+        {
+            // Act
+            var result = RendererRegistry.TryRemove(123);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -537,8 +537,8 @@ namespace Microsoft.AspNetCore.Components
             return ConvertToNullableBoolCore(obj, culture, out value);
         }
 
-        internal static BindParser<bool> ConvertToBool = ConvertToBoolCore;
-        internal static BindParser<bool?> ConvertToNullableBool = ConvertToNullableBoolCore;
+        internal readonly static BindParser<bool> ConvertToBool = ConvertToBoolCore;
+        internal readonly static BindParser<bool?> ConvertToNullableBool = ConvertToNullableBoolCore;
 
         private static bool ConvertToBoolCore(object obj, CultureInfo culture, out bool value)
         {

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// </summary>
     public class InputNumber<TValue> : InputBase<TValue>
     {
-        private static string _stepAttributeValue; // Null by default, so only allows whole numbers as per HTML spec
+        private readonly static string _stepAttributeValue; // Null by default, so only allows whole numbers as per HTML spec
 
         static InputNumber()
         {

--- a/src/Components/WebAssembly/WebAssembly/src/Rendering/RendererRegistry.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Rendering/RendererRegistry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
 {
@@ -14,27 +15,36 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
         // them even though we might still receive incoming events from JS.
 
         private static int _nextId;
-        private static Dictionary<int, WebAssemblyRenderer> _renderers = new Dictionary<int, WebAssemblyRenderer>();
+        private static Dictionary<int, WebAssemblyRenderer> _renderers;
+
+        static RendererRegistry()
+        {
+            bool _isWebAssembly = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+            if (_isWebAssembly)
+            {
+                _renderers = new Dictionary<int, WebAssemblyRenderer>();
+            }
+        }
 
         internal static WebAssemblyRenderer Find(int rendererId)
         {
-            return _renderers.ContainsKey(rendererId)
-                ? _renderers[rendererId]
+            return _renderers != null && _renderers.ContainsKey(rendererId)
+                ? _renderers?[rendererId]
                 : throw new ArgumentException($"There is no renderer with ID {rendererId}.");
         }
 
         public static int Add(WebAssemblyRenderer renderer)
         {
             var id = _nextId++;
-            _renderers.Add(id, renderer);
+            _renderers?.Add(id, renderer);
             return id;
         }
 
         public static bool TryRemove(int rendererId)
         {
-            if (_renderers.ContainsKey(rendererId))
+            if (_renderers != null && _renderers.ContainsKey(rendererId))
             {
-                _renderers.Remove(rendererId);
+                _renderers?.Remove(rendererId);
                 return true;
             }
             else


### PR DESCRIPTION
**Changes in this PR**
- Throws `InvalidOperationException` in RendererRegistry APIs are being invoked from non-WASM runtimes
- Makes more values `readonly`

The original issue pointed out that the `EventArgs.Empty` value is shared and we need to ensure that it is immutable. From what I can see, it is already set as a read-only property so we shouldn't expect any unwarranted mutations here.

Addresses #11849
