### PR TITLE
unquarantine some user secrets tests

### DIFF
--- a/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         private CommandContext MakeCommandContext() => new CommandContext(null, new TestReporter(_output), _console);
 
         [Fact]
-        [QuarantinedTest]
         public void AddsSecretIdToProject()
         {
             var projectDir = _fixture.CreateProject(null);
@@ -59,7 +58,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void AddsEscapedSpecificSecretIdToProject()
         {
             const string SecretId = @"<lots of XML invalid values>&";
@@ -74,7 +72,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void DoesNotGenerateIdForProjectWithSecretId()
         {
             const string SecretId = "AlreadyExists";

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        [QuarantinedTest]
         public void Error_MissingId(string id)
         {
             var project = Path.Combine(_fixture.CreateProject(id), "TestProject.csproj");
@@ -83,7 +82,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [QuarantinedTest]
         public void SetSecrets(bool fromCurrentDirectory)
         {
             var secrets = new KeyValuePair<string, string>[]
@@ -149,7 +147,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void SetSecret_Update_Existing_Secret()
         {
             var projectPath = _fixture.GetTempSecretProject();
@@ -187,7 +184,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void Remove_Non_Existing_Secret()
         {
             var projectPath = _fixture.GetTempSecretProject();
@@ -197,7 +193,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void Remove_Is_Case_Insensitive()
         {
             var projectPath = _fixture.GetTempSecretProject();
@@ -214,7 +209,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void List_Flattens_Nested_Objects()
         {
             string secretId;
@@ -264,7 +258,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
         public void List_Empty_Secrets_File()
         {
             var projectPath = _fixture.GetTempSecretProject();
@@ -273,7 +266,6 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             Assert.Contains(Resources.Error_No_Secrets_Found, _console.GetOutput());
         }
 
-        [QuarantinedTest]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
As discussed in the quarantine test review meeting, we're going to start letting some tests that have passed 100% of the time for at least a month out of quarantine. Normally we'd also want to have seen some kind of investigation, but these tests predate our infrastructure for tracking that and we've since lost most of the logging and diagnostic data that would help with investigation.

I'm starting with `dotnet-user-secrets.Tests` and we'll take it a little slow to ensure we don't send our failure rate skyrocketing.