### PR TITLE
Quarantine dotnet-user-secrets InitCommandTests

### DIFF
--- a/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
                 {
                     _reporter.Verbose(outputBuilder.ToString());
                     _reporter.Verbose(errorBuilder.ToString());
+                    _reporter.Error($"Exit code: {process.ExitCode}");
                     throw new InvalidOperationException(Resources.FormatError_ProjectFailedToLoad(projectFile));
                 }
 

--- a/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
@@ -15,7 +15,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.SecretManager.Tools.Tests
 {
-    [QuarantinedTest]
     public class InitCommandTests : IClassFixture<UserSecretsTestFixture>
     {
         private UserSecretsTestFixture _fixture;
@@ -33,6 +32,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         private CommandContext MakeCommandContext() => new CommandContext(null, new TestReporter(_output), _console);
 
         [Fact]
+        [QuarantinedTest]
         public void AddsSecretIdToProject()
         {
             var projectDir = _fixture.CreateProject(null);
@@ -45,6 +45,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void AddsSpecificSecretIdToProject()
         {
             const string SecretId = "TestSecretId";
@@ -59,6 +60,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void AddsEscapedSpecificSecretIdToProject()
         {
             const string SecretId = @"<lots of XML invalid values>&";
@@ -73,6 +75,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void DoesNotGenerateIdForProjectWithSecretId()
         {
             const string SecretId = "AlreadyExists";
@@ -115,6 +118,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void OverridesIdForProjectWithSecretId()
         {
             const string SecretId = "AlreadyExists";

--- a/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.SecretManager.Tools.Tests
 {
+    [QuarantinedTest]
     public class InitCommandTests : IClassFixture<UserSecretsTestFixture>
     {
         private UserSecretsTestFixture _fixture;


### PR DESCRIPTION
InitCommandTests caused the latest official build to fail with the following error.

```
System.InvalidOperationException : Could not load the MSBuild project '/tmp/usersecretstest/a20b03aa-de4a-4b52-8cdb-4fe9cbc456fc/TestProject.csproj'.
at Microsoft.Extensions.SecretManager.Tools.Internal.ProjectIdResolver.Resolve(String project, String configuration) in /_/src/Tools/dotnet-user-secrets/src/Internal/ProjectIdResolver.cs:line 101
at Microsoft.Extensions.SecretManager.Tools.Tests.InitCommandTests.AddsSecretIdToProject() in /_/src/Tools/dotnet-user-secrets/test/InitCommandTest.cs:line 43
```

@dotnet/aspnet-build