### PR TITLE
Skip NodeServicesTests on Helix OSX.1014.Amd64.Open queue

### DIFF
--- a/src/Middleware/NodeServices/test/NodeServicesTest.cs
+++ b/src/Middleware/NodeServices/test/NodeServicesTest.cs
@@ -5,12 +5,13 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.NodeServices.HostingModels;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNetCore.NodeServices
 {
-    [Obsolete("Use Microsoft.AspNetCore.SpaServices.Extensions")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/21350", Queues = "OSX.1014.Amd64.Open")]
     public class NodeServicesTest : IDisposable
     {
         private readonly INodeServices _nodeServices;


### PR DESCRIPTION
- Node.js cannot be found in PATH

Mitigates #21350 

See https://dev.azure.com/dnceng/public/_build/results?buildId=623874&view=ms.vss-test-web.build-test-results-tab&runId=19502522&paneView=debug&resultId=107607