### PR TITLE
Adds instruction for creating JAVA_HOME env variable

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -33,7 +33,9 @@ Building ASP.NET Core on Windows requires:
     ```
 
     However, the build should find any JDK 11 or newer installation on the machine.
-   * Set JAVA_HOME environment variable with the path of java installation directory (Gradle needs this for execution)
+   * Set the `JAVA_HOME` environment variable with the path of the java installation directory if your installation did not do that automatically. (Gradle needs this for execution.)
+      * This will be `RepoRoot/.tools/jdk/win-x64/` if you used the `InstallJdk.ps1` script
+      * This will be `C:/Program FIles/Java/jdk<version>/` if you installed the JDK globally
 * Chrome - Selenium-based tests require a version of Chrome to be installed. Download and install it from <https://www.google.com/chrome>
 
 ### macOS/Linux

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -33,6 +33,7 @@ Building ASP.NET Core on Windows requires:
     ```
 
     However, the build should find any JDK 11 or newer installation on the machine.
+   * Set JAVA_HOME environment variable with the path of java installation directory (Gradle needs this for execution)
 * Chrome - Selenium-based tests require a version of Chrome to be installed. Download and install it from <https://www.google.com/chrome>
 
 ### macOS/Linux


### PR DESCRIPTION
JAVA_HOME environment variable is required by Gradle. Gradle compilation fails otherwise.

Summary of the changes (Less than 80 chars)
 - Updates docs/BuildFromSource.md to add instruction for adding JAVA_HOME env variable

No bug raised
