### PR TITLE
Add additional constructor to HealthReport

### DIFF
--- a/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netcoreapp.cs
+++ b/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netcoreapp.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
     }
     public sealed partial class HealthReport
     {
+        public HealthReport(System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry> entries, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus status, System.TimeSpan totalDuration) { }
         public HealthReport(System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry> entries, System.TimeSpan totalDuration) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry> Entries { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus Status { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }

--- a/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netstandard2.0.cs
+++ b/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netstandard2.0.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
     }
     public sealed partial class HealthReport
     {
+        public HealthReport(System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry> entries, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus status, System.TimeSpan totalDuration) { }
         public HealthReport(System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry> entries, System.TimeSpan totalDuration) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry> Entries { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus Status { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }

--- a/src/HealthChecks/Abstractions/src/HealthReport.cs
+++ b/src/HealthChecks/Abstractions/src/HealthReport.cs
@@ -17,9 +17,23 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// <param name="entries">A <see cref="IReadOnlyDictionary{TKey, T}"/> containing the results from each health check.</param>
         /// <param name="totalDuration">A value indicating the time the health check service took to execute.</param>
         public HealthReport(IReadOnlyDictionary<string, HealthReportEntry> entries, TimeSpan totalDuration)
+            : this(
+                entries,
+                CalculateAggregateStatus(entries?.Values ?? throw new ArgumentNullException(nameof(entries))),
+                totalDuration)
+        {
+        }
+
+        /// <summary>
+        /// Create a new <see cref="HealthReport"/> from the specified results.
+        /// </summary>
+        /// <param name="entries">A <see cref="IReadOnlyDictionary{TKey, T}"/> containing the results from each health check.</param>
+        /// <param name="status">A <see cref="HealthStatus"/> representing the aggregate status of all the health checks.</param>
+        /// <param name="totalDuration">A value indicating the time the health check service took to execute.</param>
+        public HealthReport(IReadOnlyDictionary<string, HealthReportEntry> entries, HealthStatus status, TimeSpan totalDuration)
         {
             Entries = entries;
-            Status = CalculateAggregateStatus(entries.Values);
+            Status = status;
             TotalDuration = totalDuration;
         }
 
@@ -43,7 +57,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// </summary>
         public TimeSpan TotalDuration { get; }
 
-        private HealthStatus CalculateAggregateStatus(IEnumerable<HealthReportEntry> entries)
+        private static HealthStatus CalculateAggregateStatus(IEnumerable<HealthReportEntry> entries)
         {
             // This is basically a Min() check, but we know the possible range, so we don't need to walk the whole list
             var currentValue = HealthStatus.Healthy;


### PR DESCRIPTION
I need to override HealthStatus calculation logic. I planed to replace HealthCheckService and put desired logic there. However, the appropriate method returns HealthReport with built-in logic which cannot be replaced. This PR adds possibility to put custom logic.