### PR TITLE
Don't produce binlogs in CI

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -100,7 +100,7 @@ stages:
         jobDisplayName: Code check
         agentOs: Windows
         steps:
-        - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
+        - powershell: ./eng/scripts/CodeCheck.ps1 -NodeReuse false $(_InternalRuntimeDownloadArgs)
           displayName: Run eng/scripts/CodeCheck.ps1
         artifacts:
         - name: Code_Check_Logs
@@ -128,11 +128,10 @@ stages:
       # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
       # The sign settings have been configured to
       - script: ./build.cmd
-                -ci
+                -NodeReuse false
                 -arch x64
                 -pack
                 -all
-                /bl:artifacts/log/build.x64.binlog
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
         displayName: Build x64
@@ -140,20 +139,19 @@ stages:
       # Build the x86 shared framework
       # This is going to actually build x86 native assets.
       - script: ./build.cmd
-                -ci
+                -NodeReuse false
                 -arch x86
                 -pack
                 -all
                 -noBuildJava
                 /p:OnlyPackPlatformSpecificPackages=true
-                /bl:artifacts/log/build.x86.binlog
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
         displayName: Build x86
 
       # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
       - script: .\src\SiteExtensions\build.cmd
-                -ci
+                -NodeReuse false
                 -pack
                 -noBuildDeps
                 $(_BuildArgs)
@@ -165,21 +163,19 @@ stages:
       # consider running code-signing inline with the other previous steps.
       # Sign check is disabled because it is run in a separate step below, after installers are built.
       - script: ./build.cmd
-                -ci
+                -NodeReuse false
                 -noBuild
                 -noRestore
                 -sign
-                /bl:artifacts/log/build.codesign.binlog
                 /p:DotNetSignType=$(_SignType)
                 $(_BuildArgs)
         displayName: Code sign packages
 
       # Windows installers bundle both x86 and x64 assets
       - script: ./build.cmd
-                -ci
+                -NodeReuse false
                 -sign
                 -buildInstallers
-                /bl:artifacts/log/installers.msbuild.binlog
                 /p:DotNetSignType=$(_SignType)
                 /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 $(_BuildArgs)
@@ -219,7 +215,6 @@ stages:
         -pack
         -noBuildNodeJS
         -noBuildJava
-        /bl:artifacts/log/build.win-arm.binlog
         /p:DotNetSignType=$(_SignType)
         /p:OnlyPackPlatformSpecificPackages=true
         /p:AssetManifestFileName=aspnetcore-win-arm.xml
@@ -249,7 +244,6 @@ stages:
         -pack
         -noBuildNodeJS
         -noBuildJava
-        /bl:artifacts/log/build.win-arm64.binlog
         /p:DotNetSignType=$(_SignType)
         /p:OnlyPackPlatformSpecificPackages=true
         /p:AssetManifestFileName=aspnetcore-win-arm64.xml
@@ -280,7 +274,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.macos.binlog
         -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -307,21 +300,20 @@ stages:
       useHostedUbuntu: false
       steps:
       - script: ./build.sh
-            --ci
+            --NodeReuse false
             --arch x64
             --pack
             --all
             --no-build-nodejs
             --no-build-java
             -p:OnlyPackPlatformSpecificPackages=true
-            -bl:artifacts/log/build.linux-x64.binlog
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
         displayName: Run build.sh
       - script: |
           git clean -xfd src/**/obj/
           ./dockerbuild.sh bionic \
-            --ci \
+            --NodeReuse false \
             --arch x64 \
             --build-installers \
             --no-build-deps \
@@ -329,14 +321,13 @@ stages:
             -p:OnlyPackPlatformSpecificPackages=true \
             -p:BuildRuntimeArchive=false \
             -p:LinuxInstallerType=deb \
-            -bl:artifacts/log/build.deb.binlog \
             $(_BuildArgs) \
             $(_InternalRuntimeDownloadArgs)
         displayName: Build Debian installers
       - script: |
           git clean -xfd src/**/obj/
           ./dockerbuild.sh rhel \
-            --ci \
+            --NodeReuse false \
             --arch x64 \
             --build-installers \
             --no-build-deps \
@@ -344,7 +335,6 @@ stages:
             -p:OnlyPackPlatformSpecificPackages=true \
             -p:BuildRuntimeArchive=false \
             -p:LinuxInstallerType=rpm \
-            -bl:artifacts/log/build.rpm.binlog \
             -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
             $(_BuildArgs) \
             $(_PublishArgs) \
@@ -376,7 +366,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.linux-arm.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -407,7 +396,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.arm64.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -433,7 +421,7 @@ stages:
       agentOs: Linux
       buildScript: ./dockerbuild.sh alpine
       buildArgs:
-        --ci
+        --NodeReuse false
         --arch x64
         --os-name linux-musl
         --pack
@@ -441,7 +429,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.musl.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -468,7 +455,7 @@ stages:
       useHostedUbuntu: false
       buildScript: ./dockerbuild.sh ubuntu-alpine37
       buildArgs:
-        --ci
+        --NodeReuse false
         --arch arm64
         --os-name linux-musl
         --pack
@@ -476,7 +463,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.musl.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -507,7 +493,7 @@ stages:
       - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
         displayName: Setup IISExpress test certificates and schema
       afterBuild:
-      - powershell: "& ./build.ps1 -CI -NoBuild -Test /p:RunQuarantinedTests=true"
+      - powershell: "& ./build.ps1 -NodeReuse false -NoBuild -Test /p:RunQuarantinedTests=true"
         displayName: Run Quarantined Tests
         continueOnError: true
       - task: PublishTestResults@2
@@ -538,11 +524,11 @@ stages:
       agentOs: Windows
       isTestingJob: true
       steps:
-      - script: ./build.cmd -ci -all -pack $(_InternalRuntimeDownloadArgs)
+      - script: ./build.cmd -NodeReuse false -all -pack $(_InternalRuntimeDownloadArgs)
         displayName: Build Repo
-      - script: ./src/ProjectTemplates/build.cmd -ci -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true /bl:artifacts/log/template.pack.binlog"
+      - script: ./src/ProjectTemplates/build.cmd -NodeReuse false -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true"
         displayName: Pack Templates
-      - script: ./src/ProjectTemplates/build.cmd -ci -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true /bl:artifacts/log/template.test.binlog"
+      - script: ./src/ProjectTemplates/build.cmd -NodeReuse false -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
         displayName: Test Templates
       artifacts:
       - name: Windows_Test_Templates_Dumps
@@ -570,11 +556,11 @@ stages:
       - bash: "./eng/scripts/install-nginx-mac.sh"
         displayName: Installing Nginx
       afterBuild:
-      - bash: ./build.sh --ci --pack --no-build --no-restore --no-build-deps "/bl:artifacts/log/packages.pack.binlog"
+      - bash: ./build.sh --NodeReuse false --pack --no-build --no-restore --no-build-deps
         displayName: Pack Packages (for Template tests)
-      - bash: ./src/ProjectTemplates/build.sh --ci --pack --no-restore --no-build-deps "/bl:artifacts/log/template.pack.binlog"
+      - bash: ./src/ProjectTemplates/build.sh --NodeReuse false --pack --no-restore --no-build-deps
         displayName: Pack Templates (for Template tests)
-      - bash: ./build.sh --no-build --ci --test -p:RunQuarantinedTests=true
+      - bash: ./build.sh --no-build --NodeReuse false --test -p:RunQuarantinedTests=true
         displayName: Run Quarantined Tests
         continueOnError: true
       - task: PublishTestResults@2
@@ -608,11 +594,11 @@ stages:
       - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
         displayName: Increase inotify limit
       afterBuild:
-      - bash: ./build.sh --ci --pack --no-build --no-restore --no-build-deps "/bl:artifacts/log/packages.pack.binlog"
+      - bash: ./build.sh --NodeReuse false --pack --no-build --no-restore --no-build-deps
         displayName: Pack Packages (for Template tests)
-      - bash: ./src/ProjectTemplates/build.sh --ci --pack --no-restore --no-build-deps "/bl:artifacts/log/template.pack.binlog"
+      - bash: ./src/ProjectTemplates/build.sh --NodeReuse false --pack --no-restore --no-build-deps
         displayName: Pack Templates (for Template tests)
-      - bash: ./build.sh --no-build --ci --test -p:RunQuarantinedTests=true
+      - bash: ./build.sh --no-build --NodeReuse false --test -p:RunQuarantinedTests=true
         displayName: Run Quarantined Tests
         continueOnError: true
       - task: PublishTestResults@2
@@ -641,11 +627,11 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
+      - script: ./build.cmd -NodeReuse false -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Build shared fx
-      - script: .\restore.cmd -ci /p:BuildInteropProjects=true
+      - script: .\restore.cmd -NodeReuse false /p:BuildInteropProjects=true
         displayName: Restore interop projects
-      - script: .\build.cmd -ci -NoRestore -test -all -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: .\build.cmd -NodeReuse false -NoRestore -test -all -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -665,11 +651,11 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.daily.build.x64.binlog
+      - script: ./build.cmd -NodeReuse false -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Build shared fx
-      - script: .\restore.cmd -ci /p:BuildInteropProjects=true
+      - script: .\restore.cmd -NodeReuse false /p:BuildInteropProjects=true
         displayName: Restore interop projects
-      - script: .\build.cmd -ci -NoRestore -test -all -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: .\build.cmd -NodeReuse false -NoRestore -test -all -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -690,9 +676,9 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./restore.sh -ci
+      - script: ./restore.sh -NodeReuse false
         displayName: Restore
-      - script: ./build.sh -ci --arch arm64 -test --no-build-nodejs --all -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: ./build.sh -NodeReuse false --arch arm64 -test --no-build-nodejs --all -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
         displayName: Run build.sh helix arm64 target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -729,7 +715,7 @@ stages:
             arguments: $(Build.SourcesDirectory)/NuGet.config $Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
-    - script: ./eng/scripts/ci-source-build.sh --ci --configuration Release /p:BuildManaged=true /p:BuildNodeJs=false
+    - script: ./eng/scripts/ci-source-build.sh --NodeReuse false --configuration Release /p:BuildManaged=true /p:BuildNodeJs=false
       displayName: Run ci-source-build.sh
     - task: PublishBuildArtifacts@1
       displayName: Upload logs


### PR DESCRIPTION
There is an msbuild bug causing some of our builds to OOM when the binlogs get too large (some detain in https://github.com/microsoft/msbuild/pull/3579). For now let's stop building them until the bug is fixed (devs can check the `/bl` switch back in to their PR builds if they want to produce binlogs on a case-by-case basis until then)

@riarenas @JohnTortugo am I right that replacing `-ci` w/ `-NodeReuse false` will give us the same behavior as before, minus the binlogs?