### PR TITLE
Use a dedicated thread for timers in rather than a Timer

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Heartbeat.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Heartbeat.cs
@@ -58,7 +58,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 _trace.LogError(0, ex, $"{nameof(Heartbeat)}.{nameof(OnHeartbeat)}");
             }
 
-            Thread.Sleep(_interval);
         }
 
         private void TimerLoop()

--- a/src/Servers/Kestrel/Core/test/DateHeaderValueManagerTests.cs
+++ b/src/Servers/Kestrel/Core/test/DateHeaderValueManagerTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 heartbeat.OnHeartbeat();
 
                 Assert.Equal(future.ToString(Rfc1123DateFormat), dateHeaderValueManager.GetDateHeaderValues().String);
-                Assert.Equal(2, systemClock.UtcNowCalled);
+                Assert.Equal(4, systemClock.UtcNowCalled);
             }
         }
 


### PR DESCRIPTION
- This make it possible to still timeout various operations when there's thread pool starvation occurring.
- One downside is that the "heartbeatslow" warning that usually can communicate starvation to users is now gone.
