### PR TITLE
Deflake TimeAwaitable finalizer test

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
@@ -19,8 +19,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             UseTimerAwaitableAndUnref(tcs);
 
+            var timeout = tcs.Task.OrTimeout();
+
             // Make sure it *really* cleans up
-            for (int i = 0; i < 5 && !tcs.Task.IsCompleted; i++)
+            while (!timeout.IsCompleted)
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             // Make sure the finalizer runs
-            Assert.True(tcs.Task.IsCompleted);
+            Assert.True(timeout.IsCompletedSuccessfully);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -45,12 +45,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
     {
         private readonly TimerAwaitable _timer;
         private readonly TaskCompletionSource<object> _tcs;
-        private int _count;
 
         public ObjectWithTimerAwaitable(TaskCompletionSource<object> tcs)
         {
             _tcs = tcs;
-            _timer = new TimerAwaitable(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            _timer = new TimerAwaitable(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
             _timer.Start();
         }
 
@@ -60,7 +59,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             {
                 while (await _timer)
                 {
-                    _count++;
                 }
             }
         }

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
@@ -14,22 +14,16 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
     {
         [Fact]
         [QuarantinedTest]
-        public void FinalizerRunsIfTimerAwaitableReferencesObject()
+        public async Task FinalizerRunsIfTimerAwaitableReferencesObject()
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             UseTimerAwaitableAndUnref(tcs);
 
-            var timeout = tcs.Task.OrTimeout();
-
-            // Make sure it *really* cleans up
-            while (!timeout.IsCompleted)
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
 
             // Make sure the finalizer runs
-            Assert.True(timeout.IsCompletedSuccessfully);
+            await tcs.Task.OrTimeout();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -49,7 +43,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public ObjectWithTimerAwaitable(TaskCompletionSource<object> tcs)
         {
             _tcs = tcs;
-            _timer = new TimerAwaitable(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
+            _timer = new TimerAwaitable(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
             _timer.Start();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21517

I'm not really sure who was rooting this. I'm guessing some async state machine stuff since we do `_ = new ObjectWithTimerAwaitable(tcs).Start();` so there could be a race where it's still rooted while we're running the GC