### PR TITLE
Revert "Handle IIS OnCompleted callbacks later #17268 (#17756)"

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
@@ -23,33 +23,32 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             _application = application;
         }
 
-        public override async Task ProcessRequestAsync()
+        public override async Task<bool> ProcessRequestAsync()
         {
+            InitializeContext();
+
             var context = default(TContext);
             var success = true;
 
             try
             {
-                InitializeContext();
+                context = _application.CreateContext(this);
 
-                try
-                {
-                    context = _application.CreateContext(this);
-
-                    await _application.ProcessRequestAsync(context);
-                }
-                catch (BadHttpRequestException ex)
-                {
-                    SetBadRequestState(ex);
-                    ReportApplicationError(ex);
-                    success = false;
-                }
-                catch (Exception ex)
-                {
-                    ReportApplicationError(ex);
-                    success = false;
-                }
-
+                await _application.ProcessRequestAsync(context);
+            }
+            catch (BadHttpRequestException ex)
+            {
+                SetBadRequestState(ex);
+                ReportApplicationError(ex);
+                success = false;
+            }
+            catch (Exception ex)
+            {
+                ReportApplicationError(ex);
+                success = false;
+            }
+            finally
+            {
                 await CompleteResponseBodyAsync();
                 _streams.Stop();
 
@@ -59,18 +58,36 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                     // Dispose
                 }
 
-                if (!_requestAborted)
+                if (_onCompleted != null)
                 {
-                    await ProduceEnd();
+                    await FireOnCompleted();
                 }
-                else if (!HasResponseStarted && _requestRejectedException == null)
-                {
-                    // If the request was aborted and no response was sent, there's no
-                    // meaningful status code to log.
-                    StatusCode = 0;
-                    success = false;
-                }
+            }
 
+            if (!_requestAborted)
+            {
+                await ProduceEnd();
+            }
+            else if (!HasResponseStarted && _requestRejectedException == null)
+            {
+                // If the request was aborted and no response was sent, there's no
+                // meaningful status code to log.
+                StatusCode = 0;
+                success = false;
+            }
+
+            try
+            {
+                _application.DisposeContext(context, _applicationException);
+            }
+            catch (Exception ex)
+            {
+                // TODO Log this
+                _applicationException = _applicationException ?? ex;
+                success = false;
+            }
+            finally
+            {
                 // Complete response writer and request reader pipe sides
                 _bodyOutput.Dispose();
                 _bodyInputPipe?.Reader.Complete();
@@ -89,36 +106,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                     await _readBodyTask;
                 }
             }
-            catch (Exception ex)
-            {
-                success = false;
-                ReportApplicationError(ex);
-            }
-            finally
-            {
-                // We're done with anything that touches the request or response, unblock the client.
-                PostCompletion(ConvertRequestCompletionResults(success));
-
-                if (_onCompleted != null)
-                {
-                    await FireOnCompleted();
-                }
-
-                try
-                {
-                    _application.DisposeContext(context, _applicationException);
-                }
-                catch (Exception ex)
-                {
-                    ReportApplicationError(ex);
-                }
-            }
-        }
-
-        private static NativeMethods.REQUEST_NOTIFICATION_STATUS ConvertRequestCompletionResults(bool success)
-        {
-            return success ? NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_CONTINUE
-                           : NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_FINISH_REQUEST;
+            return success;
         }
     }
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResponseBodyTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResponseBodyTests.cs
@@ -30,12 +30,5 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         {
             Assert.Equal(20, (await _fixture.Client.GetByteArrayAsync($"/FlushedPipeAndThenUnflushedPipe")).Length);
         }
-
-        [ConditionalFact]
-        [RequiresNewHandler]
-        public async Task ResponseBodyTest_BodyCompletionNotBlockedByOnCompleted()
-        {
-            Assert.Equal("SlowOnCompleted", await _fixture.Client.GetStringAsync($"/SlowOnCompleted"));
-        }
     }
 }

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1016,12 +1016,5 @@ namespace TestSite
 
             await context.Response.WriteAsync(httpsPort.HasValue ? httpsPort.Value.ToString() : "NOVALUE");
         }
-
-        public async Task SlowOnCompleted(HttpContext context)
-        {
-            // This shouldn't block the response or the server from shutting down.
-            context.Response.OnCompleted(() => Task.Delay(TimeSpan.FromMinutes(5)));
-            await context.Response.WriteAsync("SlowOnCompleted");
-        }
     }
 }


### PR DESCRIPTION
#20796 This is a direct revert of #17756 because it was causing AVs with ApplicationInsights. I'll re-open #17268, but from my current reading here I don't think there's a clean way to fix the original latency issue in IIS without re-introducing races like this.