### PR TITLE
Avoid crashing in PollingFileWatcher

### DIFF
--- a/src/Tools/dotnet-watch/src/Internal/FileWatcher/PollingFileWatcher.cs
+++ b/src/Tools/dotnet-watch/src/Internal/FileWatcher/PollingFileWatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -188,7 +188,17 @@ namespace Microsoft.DotNet.Watcher.Internal
                 return;
             }
 
-            var entities = dirInfo.EnumerateFileSystemInfos("*.*");
+            IEnumerable<FileSystemInfo> entities;
+            try
+            {
+                entities = dirInfo.EnumerateFileSystemInfos("*.*");
+            }
+            // If the directory is deleted after the exists check this will throw and could crash the process
+            catch (DirectoryNotFoundException)
+            {
+                return;
+            }
+
             foreach (var entity in entities)
             {
                 fileAction(entity);


### PR DESCRIPTION
There is a race we haven't observed before where the test could finish and cleanup the temporary files it creates but the PollingFileWatcher is in the middle of scanning for changes.

This change will observe the exception and just not look at that directory during the current poll.

```
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Users\runner\AppData\Local\Temp\FileWatcherTests-5a01a8c78ee044dfb358a585c3696b83'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, Boolean isNormalized, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.FileSystemInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at Microsoft.DotNet.Watcher.Internal.PollingFileWatcher.ForeachEntityInDirectory(DirectoryInfo dirInfo, Action`1 fileAction) in /_/src/Tools/dotnet-watch/src/Internal/FileWatcher/PollingFileWatcher.cs:line 191
   at Microsoft.DotNet.Watcher.Internal.PollingFileWatcher.CheckForChangedFiles() in /_/src/Tools/dotnet-watch/src/Internal/FileWatcher/PollingFileWatcher.cs:line 105
   at Microsoft.DotNet.Watcher.Internal.PollingFileWatcher.PollingLoop() in /_/src/Tools/dotnet-watch/src/Internal/FileWatcher/PollingFileWatcher.cs:line 85
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ThreadHelper.ThreadStart()
```