### PR TITLE
[release/3.1] Add .version file to shared framework zip

### DIFF
--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -67,7 +67,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- There is no way to suppress the .dev.runtimeconfig.json generation. -->
     <ProjectRuntimeConfigDevFilePath>$(IntermediateOutputPath)ignoreme.dev.runtimeconfig.json</ProjectRuntimeConfigDevFilePath>
 
-    <VersionFileIntermediateOutputPath>$(IntermediateOutputPath)$(SharedFxName).versions.txt</VersionFileIntermediateOutputPath>
+    <VersionTxtFileIntermediateOutputPath>$(IntermediateOutputPath)$(SharedFxName).versions.txt</VersionTxtFileIntermediateOutputPath>
+    <DotVersionFileIntermediateOutputPath>$(IntermediateOutputPath).version</DotVersionFileIntermediateOutputPath>
 
     <!-- The project representing the shared framework doesn't produce a .NET assembly or symbols. -->
     <DebugType>none</DebugType>
@@ -256,7 +257,12 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(VersionFileIntermediateOutputPath)"
+      File="$(VersionTxtFileIntermediateOutputPath)"
+      Lines="@(VersionLines)"
+      Overwrite="true" />
+
+    <WriteLinesToFile
+      File="$(DotVersionFileIntermediateOutputPath)"
       Lines="@(VersionLines)"
       Overwrite="true" />
   </Target>
@@ -397,7 +403,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="_ResolveSharedFrameworkContent" DependsOnTargets="ResolveReferences;Crossgen">
     <ItemGroup>
-      <SharedFxContent Include="$(VersionFileIntermediateOutputPath)" />
+      <SharedFxContent Include="$(DotVersionFileIntermediateOutputPath)" />
       <SharedFxContent Include="$(ProjectDepsFilePath)" />
       <SharedFxContent Include="$(ProjectRuntimeConfigFilePath)" />
       <SharedFxContent Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
@@ -496,7 +502,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           BeforeTargets="_GetPackageFiles">
 
     <ItemGroup>
-      <None Include="$(VersionFileIntermediateOutputPath)" Pack="true" PackagePath="." />
+      <None Include="$(VersionTxtFileIntermediateOutputPath)" Pack="true" PackagePath="." />
     </ItemGroup>
   </Target>
 

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void ItContainsVersionFile()
         {
-            var versionFile = Path.Combine(_sharedFxRoot, "Microsoft.AspNetCore.App.versions.txt");
+            var versionFile = Path.Combine(_sharedFxRoot, ".version");
             AssertEx.FileExists(versionFile);
             var lines = File.ReadAllLines(versionFile);
             Assert.Equal(2, lines.Length);


### PR DESCRIPTION
Attempts to resolve https://github.com/dotnet/aspnetcore/issues/21177 by including a `.version` file in our shared framework zip, and a `versions.txt` file in our shared framework .nupkg. This more closely mimics what happens in `microsoft.netcore.app`

Testing confirms that the shared framework zips now contain `.version` in `shared\Microsoft.AspNetCore.App\3.1.4`, while the .nupkg still includes a `versions.txt` file.