### PR TITLE
Add .version file to shared framework zip

### DIFF
--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -67,7 +67,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- There is no way to suppress the .dev.runtimeconfig.json generation. -->
     <ProjectRuntimeConfigDevFilePath>$(IntermediateOutputPath)ignoreme.dev.runtimeconfig.json</ProjectRuntimeConfigDevFilePath>
 
-    <VersionFileIntermediateOutputPath>$(IntermediateOutputPath)$(SharedFxName).versions.txt</VersionFileIntermediateOutputPath>
+    <VersionTxtFileIntermediateOutputPath>$(IntermediateOutputPath)$(SharedFxName).versions.txt</VersionTxtFileIntermediateOutputPath>
+    <DotVersionFileIntermediateOutputPath>$(IntermediateOutputPath).version</DotVersionFileIntermediateOutputPath>
 
     <!-- The project representing the shared framework doesn't produce a .NET assembly or symbols. -->
     <DebugType>none</DebugType>
@@ -259,7 +260,12 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(VersionFileIntermediateOutputPath)"
+      File="$(VersionTxtFileIntermediateOutputPath)"
+      Lines="@(VersionLines)"
+      Overwrite="true" />
+
+    <WriteLinesToFile
+      File="$(DotVersionFileIntermediateOutputPath)"
       Lines="@(VersionLines)"
       Overwrite="true" />
   </Target>
@@ -402,7 +408,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="_ResolveSharedFrameworkContent" DependsOnTargets="ResolveReferences;Crossgen">
     <ItemGroup>
-      <SharedFxContent Include="$(VersionFileIntermediateOutputPath)" />
+      <SharedFxContent Include="$(DotVersionFileIntermediateOutputPath)" />
       <SharedFxContent Include="$(ProjectDepsFilePath)" />
       <SharedFxContent Include="$(ProjectRuntimeConfigFilePath)" />
       <SharedFxContent Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
@@ -501,7 +507,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           BeforeTargets="_GetPackageFiles">
 
     <ItemGroup>
-      <None Include="$(VersionFileIntermediateOutputPath)" Pack="true" PackagePath="." />
+      <None Include="$(VersionTxtFileIntermediateOutputPath)" Pack="true" PackagePath="." />
     </ItemGroup>
   </Target>
 

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void ItContainsVersionFile()
         {
-            var versionFile = Path.Combine(_sharedFxRoot, "Microsoft.AspNetCore.App.versions.txt");
+            var versionFile = Path.Combine(_sharedFxRoot, ".version");
             AssertEx.FileExists(versionFile);
             var lines = File.ReadAllLines(versionFile);
             Assert.Equal(2, lines.Length);

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore
     {
         private readonly string _expectedTfm;
         private readonly string _expectedRid;
+        private readonly string _expectedVersionFileName;
         private readonly string _sharedFxRoot;
         private readonly ITestOutputHelper _output;
 
@@ -26,6 +27,7 @@ namespace Microsoft.AspNetCore
             _sharedFxRoot = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNET_RUNTIME_PATH"))
                 ? Path.Combine(TestData.GetTestDataValue("SharedFrameworkLayoutRoot"), "shared", TestData.GetTestDataValue("RuntimePackageVersion"))
                 : Environment.GetEnvironmentVariable("ASPNET_RUNTIME_PATH");
+            _expectedVersionFileName = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNET_RUNTIME_PATH")) ? ".version" : "Microsoft.AspNetCore.App.versions.txt";
         }
 
         [Fact]
@@ -133,7 +135,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void ItContainsVersionFile()
         {
-            var versionFile = Path.Combine(_sharedFxRoot, ".version");
+            var versionFile = Path.Combine(_sharedFxRoot, _expectedVersionFileName);
             AssertEx.FileExists(versionFile);
             var lines = File.ReadAllLines(versionFile);
             Assert.Equal(2, lines.Length);


### PR DESCRIPTION
Manual port of https://github.com/dotnet/aspnetcore/pull/21548

Attempts to resolve https://github.com/dotnet/aspnetcore/issues/21177 by including a `.version` file in our shared framework zip, and a `versions.txt` file in our shared framework .nupkg. This more closely mimics what happens in `microsoft.netcore.app`

Testing confirms that the shared framework zips now contain `.version` in `shared\Microsoft.AspNetCore.App\3.1.4`, while the .nupkg still includes a `versions.txt` file.