### PR TITLE
Avoid trying to fix the trusted root certificates

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -157,8 +157,9 @@ namespace Microsoft.AspNetCore.Certificates.Generation
         {
             var result = EnsureCertificateResult.Succeeded;
 
-            var certificates = ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true, requireExportable: true).Concat(
-                ListCertificates(StoreName.My, StoreLocation.LocalMachine, isValid: true, requireExportable: true));
+            var currentUserCertificates = ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true, requireExportable: true);
+            var trustedCertificates = ListCertificates(StoreName.My, StoreLocation.LocalMachine, isValid: true, requireExportable: true);
+            var certificates = currentUserCertificates.Concat(trustedCertificates);
 
             var filteredCertificates = certificates.Where(c => c.Subject == Subject);
             var excludedCertificates = certificates.Except(filteredCertificates);
@@ -177,7 +178,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 {
                     // Skip this step if the command is not interactive,
                     // as we don't want to prompt on first run experience.
-                    foreach (var candidate in certificates)
+                    foreach (var candidate in currentUserCertificates)
                     {
                         var status = CheckCertificateState(candidate, true);
                         if (!status.Result)


### PR DESCRIPTION
* The tool fails when a trusted certificate has already been installed.
* We were trying to fix the key for the localhost certificates on the system keychain (which don't have a key)
* This fix filters the certificates to fix to those found in the current user personal store (login keychain).
* I verified running multiple combinations of `dotnet dev-certs` with `--clean` and `--trust`.
  * Unfortunately we can't have automation for these cases as trying to access the key requires user interaction.
  * We will be expanding the set of CTI cases to cover this scenarios.