### PR TITLE
Avoid changing global state in CI runs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -19,6 +19,8 @@ pr:
     - '*'
 
 variables:
+- name: DOTNET_CLI_HOME
+  value: $(Agent.BuildDirectory)
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: _TeamName

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -122,6 +122,7 @@ jobs:
     - _BuildConfig: ${{ parameters.configuration }}
     - BuildConfiguration: ${{ parameters.configuration }}
     - BuildDirectory: ${{ parameters.buildDirectory }}
+    - DOTNET_CLI_HOME: $(Agent.BuildDirectory)
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - TeamName: AspNetCore
     - ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:


### PR DESCRIPTION
- set `$env:DOTNET_CLI_HOME` because we need to install global tools in this repo
- without this, we see `dotnet-serve` installation failures on unclean machines