### PR TITLE
Fix build on clean CMD

### DIFF
--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Git": "2.22.0",
     "jdk": "11.0.3",
     "vs": {
-      "version": "16.3",
+      "version": "16.5",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",


### PR DESCRIPTION
Without that fix following error on clean cmd without MBuild on path
```
eng\tools\RepoTasks\RepoTasks.csproj : error : Version 5.0.100-preview.5.20251.2 of the .NET Core SDK requires at least version 16.5.0 of MSBuild. The current available version of MSBuild is 16.3.0.463.05. Change the .NET Core SDK specified in global.json to an older version that requires the MSBuild version currently available.
```