### PR TITLE
Avoid changing global state in CI runs II

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -19,8 +19,6 @@ pr:
     - '*'
 
 variables:
-- name: DOTNET_CLI_HOME
-  value: $(Agent.BuildDirectory)
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: _TeamName
@@ -704,14 +702,16 @@ stages:
       vmImage: 'ubuntu-16.04'
     variables:
       DotNetCoreSdkDir: $(Agent.ToolsDirectory)/dotnet
+      # This isn't needed in the path because build does not need to _use_ global tools.
+      DOTNET_CLI_HOME: $(System.DefaultWorkingDirectory)
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
     steps:
     - script: |
         source eng/common/native/common-library.sh
-        mkdir -p $HOME/bin
-        GetFile https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 $HOME/bin/jq
-        chmod +x $HOME/bin/jq
-        echo "##vso[task.prependpath]$HOME/bin"
+        mkdir -p $(System.DefaultWorkingDirectory)/.tools
+        GetFile https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 $(System.DefaultWorkingDirectory)/.tools/jq
+        chmod +x $(System.DefaultWorkingDirectory)/.tools/jq
+        echo "##vso[task.prependpath]$(System.DefaultWorkingDirectory)/.tools"
       displayName: Install jq
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - task: Bash@3

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -52,7 +52,7 @@ parameters:
   condition: ''
   # jobName: '' - use agentOs by default.
   # jobDisplayName: '' - use agentOs by default.
-  artifacts:  []
+  artifacts: []
   buildDirectory: ''
   buildScript: ''
   installTar: true
@@ -116,12 +116,13 @@ jobs:
     - BuildScriptArgs: ${{ parameters.buildArgs }}
     - _BuildConfig: ${{ parameters.configuration }}
     - BuildConfiguration: ${{ parameters.configuration }}
-    - BuildDirectory: ${{ parameters.buildDirectory }}
-    - DOTNET_CLI_HOME: $(Agent.BuildDirectory)
+    - ${{ if eq(parameters.buildDirectory, '') }}:
+      - BuildDirectory: $(System.DefaultWorkingDirectory)
+    - ${{ if ne(parameters.buildDirectory, '') }}:
+      - BuildDirectory: ${{ parameters.buildDirectory }}
+    - DOTNET_CLI_HOME: $(System.DefaultWorkingDirectory)
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - TeamName: AspNetCore
-    - ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:
-      - JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk\win-x64
     - ${{ if or(ne(parameters.codeSign, true), ne(variables['System.TeamProject'], 'internal')) }}:
       - _SignType: ''
     - ${{ if and(eq(parameters.codeSign, true), eq(variables['System.TeamProject'], 'internal')) }}:
@@ -164,6 +165,12 @@ jobs:
     - ${{ if and(eq(parameters.installTar, 'true'), eq(parameters.agentOs, 'Windows')) }}:
       - powershell: ./eng/scripts/InstallTar.ps1
         displayName: Find or install Tar
+    - ${{ if eq(parameters.agentOs, 'Windows') }}:
+      - powershell: Write-Host "##vso[task.prependpath]$(DOTNET_CLI_HOME)\.dotnet\tools"
+        displayName: Add dotnet tools to path
+    - ${{ if ne(parameters.agentOs, 'Windows') }}:
+      - script: echo "##vso[task.prependpath]$(DOTNET_CLI_HOME)/.dotnet/tools"
+        displayName: Add dotnet tools to path
 
     - ${{ parameters.beforeBuild }}
 
@@ -191,10 +198,10 @@ jobs:
     - ${{ if eq(parameters.steps, '')}}:
       - ${{ if eq(parameters.buildScript, '') }}:
         - ${{ if eq(parameters.agentOs, 'Windows') }}:
-          - script: .\$(BuildDirectory)\build.cmd -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs) /p:DotNetSignType=$(_SignType)
+          - script: $(BuildDirectory)\build.cmd -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs) /p:DotNetSignType=$(_SignType)
             displayName: Run build.cmd
         - ${{ if ne(parameters.agentOs, 'Windows') }}:
-          - script: ./$(BuildDirectory)/build.sh --ci --nobl --configuration $(BuildConfiguration) $(BuildScriptArgs)
+          - script: $(BuildDirectory)/build.sh --ci --nobl --configuration $(BuildConfiguration) $(BuildScriptArgs)
             displayName: Run build.sh
       - ${{ if ne(parameters.buildScript, '') }}:
         - script: $(BuildScript) -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs)
@@ -232,10 +239,7 @@ jobs:
         condition: and(or(succeeded(), eq('${{ artifact.publishOnError }}', 'true')), or(eq(variables['system.pullrequest.isfork'], false), eq('${{ artifact.includeForks }}', 'true')))
         continueOnError: true
         inputs:
-          ${{ if eq(parameters.buildDirectory, '') }}:
-            pathtoPublish: ${{ artifact.path }}
-          ${{ if ne(parameters.buildDirectory, '') }}:
-            pathtoPublish: ${{ parameters.buildDirectory }}\${{ artifact.path }}
+          pathtoPublish: $(BuildDirectory)/${{ artifact.path }}
           ${{ if eq(artifact.name, '') }}:
             artifactName: artifacts-$(AgentOsName)-$(BuildConfiguration)
           ${{ if ne(artifact.name, '') }}:

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -80,7 +80,7 @@ jobs:
       enableMicrobuild: true
       enablePublishBuildAssets: true
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-    enablePublishTestResults: true # publish test results to AzDO (populates AzDO Tests tab)
+    enablePublishTestResults: ${{ eq(parameters.isTestingJob, 'true') }} # publish test results to AzDO (populates AzDO Tests tab)
     enableTelemetry: true
     helixRepo: dotnet/aspnetcore
     helixType: build.product/
@@ -247,18 +247,7 @@ jobs:
           artifactType: Container
           parallel: true
 
-    - ${{ if eq(parameters.isTestingJob, true) }}:
-      - task: PublishTestResults@2
-        displayName: Publish VSTest test results
-        condition: always()
-        continueOnError: true
-        inputs:
-          testRunTitle: $(AgentOsName)-$(BuildConfiguration)
-          testRunner: vstest
-          testResultsFiles: '**/artifacts/**/*.trx'
-          mergeTestResults: true
-          buildConfiguration: $(BuildConfiguration)
-          buildPlatform: $(AgentOsName)
+    - ${{ if and(eq(parameters.isTestingJob, true), ne(parameters.jobName, 'Windows_Templates_Test')) }}:
       - task: PublishTestResults@2
         displayName: Publish js test results
         condition: always()
@@ -267,12 +256,3 @@ jobs:
           testResultsFiles: '**/artifacts/log/**/*.junit.xml'
           buildConfiguration: $(BuildConfiguration)
           buildPlatform: $(AgentOsName)
-      - task: PublishTestResults@2
-        displayName: Publish Java test results
-        condition: always()
-        inputs:
-          testRunner: junit
-          testResultsFiles: '**/TEST-junit-jupiter.xml'
-          buildConfiguration: $(BuildConfiguration)
-          buildPlatform: $(AgentOsName)
-          mergeTestResults: true

--- a/build.ps1
+++ b/build.ps1
@@ -369,6 +369,9 @@ if ($BinaryLog) {
     if (-not $bl) {
         $MSBuildArguments += "/bl:" + (Join-Path $LogDir "Build.binlog")
     }
+} elseif ($CI) {
+    # Ensure the artifacts/log directory isn't empty to avoid warnings.
+    New-Item (Join-Path $LogDir "empty.log") -ItemType File -ErrorAction SilentlyContinue >$null
 }
 
 # Capture MSBuild crash logs

--- a/build.sh
+++ b/build.sh
@@ -338,6 +338,9 @@ if [[ "$binary_log" == true ]]; then
     if [[ "$found" == false ]]; then
         msbuild_args[${#msbuild_args[*]}]="/bl:$log_dir/Build.binlog"
     fi
+elif [[ "$ci" == true ]]; then
+    # Ensure the artifacts/log directory isn't empty to avoid warnings.
+    touch "$log_dir/empty.log"
 fi
 
 # Capture MSBuild crash logs

--- a/eng/scripts/install-nginx-linux.sh
+++ b/eng/scripts/install-nginx-linux.sh
@@ -2,8 +2,12 @@
 
 set -euo pipefail
 
+scriptroot="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+reporoot="$(dirname "$(dirname "$scriptroot")")"
+nginxinstall="$reporoot/.tools/nginx"
+
 curl -sSL http://nginx.org/download/nginx-1.14.2.tar.gz | tar zxfv - -C /tmp && cd /tmp/nginx-1.14.2/
-./configure --prefix=$HOME/nginxinstall --with-http_ssl_module --without-http_rewrite_module
+./configure --prefix=$nginxinstall --with-http_ssl_module --without-http_rewrite_module
 make
 make install
-echo "##vso[task.prependpath]$HOME/nginxinstall/sbin"
+echo "##vso[task.prependpath]$nginxinstall/sbin"


### PR DESCRIPTION
- move `dotnet` tools into `.dotnet/`
  - add `dotnet` tools to `$PATH`
- install `jq` in `.tools/`
- install `nginx` in `.tools/nginx`