### PR TITLE
Added some kestrel event counters

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                         _transportConnectionManager.AddConnection(id, kestrelConnection);
 
                         Log.ConnectionAccepted(connection.ConnectionId);
-                        KestrelEventSource.Log.ConnectionQueued(connection);
+                        KestrelEventSource.Log.ConnectionQueuedStart(connection);
 
                         ThreadPool.UnsafeQueueUserWorkItem(kestrelConnection, preferLocal: false);
                     }

--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                         _transportConnectionManager.AddConnection(id, kestrelConnection);
 
                         Log.ConnectionAccepted(connection.ConnectionId);
+                        KestrelEventSource.Log.ConnectionQueued(connection);
 
                         ThreadPool.UnsafeQueueUserWorkItem(kestrelConnection, preferLocal: false);
                     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -82,6 +82,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             Reset();
 
             _http1Output.Dispose();
+
+            if (IsUpgraded)
+            {
+                KestrelEventSource.Log.RequestUpgradedStop(this);
+
+                ServiceContext.ConnectionManager.UpgradedConnectionCount.ReleaseOne();
+            }
         }
 
         public void OnInputOrOutputCompleted()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -76,19 +76,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected override void OnRequestProcessingEnded()
         {
-            TimeoutControl.StartDrainTimeout(MinResponseDataRate, ServerOptions.Limits.MaxResponseBufferSize);
-
-            // Prevent RequestAborted from firing. Free up unneeded feature references.
-            Reset();
-
-            _http1Output.Dispose();
-
             if (IsUpgraded)
             {
                 KestrelEventSource.Log.RequestUpgradedStop(this);
 
                 ServiceContext.ConnectionManager.UpgradedConnectionCount.ReleaseOne();
             }
+
+            TimeoutControl.StartDrainTimeout(MinResponseDataRate, ServerOptions.Limits.MaxResponseBufferSize);
+
+            // Prevent RequestAborted from firing. Free up unneeded feature references.
+            Reset();
+
+            _http1Output.Dispose();
         }
 
         public void OnInputOrOutputCompleted()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -293,6 +293,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             IsUpgraded = true;
 
+            KestrelEventSource.Log.RequestUpgradedStart(this);
+
             ConnectionFeatures.Get<IDecrementConcurrentConnectionCountFeature>()?.ReleaseConnection();
 
             StatusCode = StatusCodes.Status101SwitchingProtocols;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -136,6 +136,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public int LocalPort { get; set; }
         public string Scheme { get; set; }
         public HttpMethod Method { get; set; }
+        public string MethodText => ((IHttpRequestFeature)this).Method;
         public string PathBase { get; set; }
 
         public string Path { get; set; }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw;
             }
 
-            KestrelEventSource.Log.RequestQueued(_currentHeadersStream);
+            KestrelEventSource.Log.RequestQueued(_currentHeadersStream, AspNetCore.Http.HttpProtocol.Http2);
             // Must not allow app code to block the connection handling loop.
             ThreadPool.UnsafeQueueUserWorkItem(_currentHeadersStream, preferLocal: false);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw;
             }
 
-            KestrelEventSource.Log.RequestQueued(_currentHeadersStream, AspNetCore.Http.HttpProtocol.Http2);
+            KestrelEventSource.Log.RequestQueuedStart(_currentHeadersStream, AspNetCore.Http.HttpProtocol.Http2);
             // Must not allow app code to block the connection handling loop.
             ThreadPool.UnsafeQueueUserWorkItem(_currentHeadersStream, preferLocal: false);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1002,6 +1002,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw;
             }
 
+            KestrelEventSource.Log.RequestQueued(_currentHeadersStream);
             // Must not allow app code to block the connection handling loop.
             ThreadPool.UnsafeQueueUserWorkItem(_currentHeadersStream, preferLocal: false);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override void Execute()
         {
-            KestrelEventSource.Log.RequestDequeued(this);
+            KestrelEventSource.Log.RequestDequeued(this, AspNetCore.Http.HttpProtocol.Http2);
             // REVIEW: Should we store this in a field for easy debugging?
             _ = ProcessRequestsAsync(_application);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override void Execute()
         {
-            KestrelEventSource.Log.RequestDequeued(this, AspNetCore.Http.HttpProtocol.Http2);
+            KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http2);
             // REVIEW: Should we store this in a field for easy debugging?
             _ = ProcessRequestsAsync(_application);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Abstractions;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
@@ -19,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override void Execute()
         {
+            KestrelEventSource.Log.RequestDequeued(this);
             // REVIEW: Should we store this in a field for easy debugging?
             _ = ProcessRequestsAsync(_application);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -243,6 +243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                         {
                             _streams[streamId] = http3Stream;
                         }
+                        KestrelEventSource.Log.RequestQueued(stream, AspNetCore.Http.HttpProtocol.Http3);
                         ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
                     }
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -243,7 +243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                         {
                             _streams[streamId] = http3Stream;
                         }
-                        KestrelEventSource.Log.RequestQueued(stream, AspNetCore.Http.HttpProtocol.Http3);
+                        KestrelEventSource.Log.RequestQueuedStart(stream, AspNetCore.Http.HttpProtocol.Http3);
                         ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
                     }
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public override void Execute()
         {
-            KestrelEventSource.Log.RequestDequeued(this, AspNetCore.Http.HttpProtocol.Http3);
+            KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http3);
 
             if (_requestHeaderParsingState == Http3Stream.RequestHeaderParsingState.Ready)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Abstractions;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
@@ -17,6 +18,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public override void Execute()
         {
+            KestrelEventSource.Log.RequestDequeued(this, AspNetCore.Http.HttpProtocol.Http3);
+
             if (_requestHeaderParsingState == Http3Stream.RequestHeaderParsingState.Ready)
             {
                 _ = ProcessRequestAsync(_application);

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -107,13 +107,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             {
                 Log.LogCritical(0, ex, $"Unexpected exception in {nameof(HttpConnection)}.{nameof(ProcessRequestsAsync)}.");
             }
-            finally
-            {
-                if (_http1Connection?.IsUpgraded == true)
-                {
-                    _context.ServiceContext.ConnectionManager.UpgradedConnectionCount.ReleaseOne();
-                }
-            }
         }
 
         // For testing only

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
@@ -40,6 +40,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
             try
             {
+                KestrelEventSource.Log.ConnectionDequeued(connectionContext);
+
                 Logger.ConnectionStart(connectionContext.ConnectionId);
                 KestrelEventSource.Log.ConnectionStart(connectionContext);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
             try
             {
-                KestrelEventSource.Log.ConnectionDequeued(connectionContext);
+                KestrelEventSource.Log.ConnectionQueuedStop(connectionContext);
 
                 Logger.ConnectionStart(connectionContext.ConnectionId);
                 KestrelEventSource.Log.ConnectionStart(connectionContext);

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -102,15 +102,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             // avoid allocating the trace identifier unless logging is enabled
             if (IsEnabled())
             {
-                RequestStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier);
+                RequestStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path, httpProtocol.MethodText);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(3, Level = EventLevel.Informational)]
-        private void RequestStart(string connectionId, string requestId)
+        private void RequestStart(string connectionId, string requestId, string httpVersion, string path, string method)
         {
-            WriteEvent(3, connectionId, requestId);
+            WriteEvent(3, connectionId, requestId, httpVersion, path, method);
         }
 
         [NonEvent]
@@ -119,15 +119,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             // avoid allocating the trace identifier unless logging is enabled
             if (IsEnabled())
             {
-                RequestStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier);
+                RequestStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path, httpProtocol.MethodText);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(4, Level = EventLevel.Informational)]
-        private void RequestStop(string connectionId, string requestId)
+        private void RequestStop(string connectionId, string requestId, string httpVersion, string path, string method)
         {
-            WriteEvent(4, connectionId, requestId);
+            WriteEvent(4, connectionId, requestId, httpVersion, path, method);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -283,15 +283,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             Interlocked.Increment(ref _currentUpgradedHttpRequests);
             if (IsEnabled())
             {
-                RequestUpgradedStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier);
+                RequestUpgradedStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path, httpProtocol.MethodText);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(13, Level = EventLevel.Informational)]
-        private void RequestUpgradedStart(string connectionId, string requestId)
+        private void RequestUpgradedStart(string connectionId, string requestId, string httpVersion, string path, string method)
         {
-            WriteEvent(13, connectionId, requestId);
+            WriteEvent(13, connectionId, requestId, httpVersion, path, method);
         }
 
         [NonEvent]
@@ -300,15 +300,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             Interlocked.Decrement(ref _currentUpgradedHttpRequests);
             if (IsEnabled())
             {
-                RequestUpgradedStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier);
+                RequestUpgradedStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path, httpProtocol.MethodText);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(14, Level = EventLevel.Informational)]
-        private void RequestUpgradedStop(string connectionId, string requestId)
+        private void RequestUpgradedStop(string connectionId, string requestId, string httpVersion, string path, string method)
         {
-            WriteEvent(14, connectionId, requestId);
+            WriteEvent(14, connectionId, requestId, httpVersion, path, method);
         }
 
         protected override void OnEventCommand(EventCommandEventArgs command)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -12,6 +14,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
     internal sealed class KestrelEventSource : EventSource
     {
         public static readonly KestrelEventSource Log = new KestrelEventSource();
+
+        private IncrementingPollingCounter _connectionsPerSecondCounter;
+        private PollingCounter _totalConnectionsCounter;
+        private PollingCounter _currentConnectionsCounter;
+        private PollingCounter _connectionQueueLengthCounter;
+
+        private long _totalConnections;
+        private long _currentConnections;
+        private long _connectionQueueLength;
 
         private KestrelEventSource()
         {
@@ -29,6 +40,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public void ConnectionStart(BaseConnectionContext connection)
         {
             // avoid allocating strings unless this event source is enabled
+            Interlocked.Increment(ref _totalConnections);
+            Interlocked.Increment(ref _currentConnections);
+
             if (IsEnabled())
             {
                 ConnectionStart(
@@ -55,6 +69,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [NonEvent]
         public void ConnectionStop(BaseConnectionContext connection)
         {
+            Interlocked.Decrement(ref _currentConnections);
             if (IsEnabled())
             {
                 ConnectionStop(connection.ConnectionId);
@@ -66,16 +81,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private void ConnectionStop(string connectionId)
         {
             WriteEvent(2, connectionId);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(5, Level = EventLevel.Verbose)]
-        public void ConnectionRejected(string connectionId)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(5, connectionId);
-            }
         }
 
         [NonEvent]
@@ -110,6 +115,101 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private void RequestStop(string connectionId, string requestId)
         {
             WriteEvent(4, connectionId, requestId);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(5, Level = EventLevel.Verbose)]
+        public void ConnectionRejected(string connectionId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(5, connectionId);
+            }
+        }
+
+        [NonEvent]
+        public void ConnectionQueued(BaseConnectionContext connection)
+        {
+            Interlocked.Increment(ref _connectionQueueLength);
+            if (IsEnabled())
+            {
+                ConnectionQueued(
+                    connection.ConnectionId,
+                    connection.LocalEndPoint?.ToString(),
+                    connection.RemoteEndPoint?.ToString());
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(6, Level = EventLevel.Verbose)]
+        private void ConnectionQueued(string connectionId,
+            string localEndPoint,
+            string remoteEndPoint)
+        {
+            WriteEvent(
+                6,
+                connectionId,
+                localEndPoint,
+                remoteEndPoint
+            );
+        }
+
+        [NonEvent]
+        public void ConnectionDequeued(BaseConnectionContext connection)
+        {
+            Interlocked.Decrement(ref _connectionQueueLength);
+            if (IsEnabled())
+            {
+                ConnectionDequeued(
+                    connection.ConnectionId,
+                    connection.LocalEndPoint?.ToString(),
+                    connection.RemoteEndPoint?.ToString());
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(7, Level = EventLevel.Verbose)]
+        private void ConnectionDequeued(string connectionId,
+            string localEndPoint,
+            string remoteEndPoint)
+        {
+            WriteEvent(
+                7,
+                connectionId,
+                localEndPoint,
+                remoteEndPoint
+            );
+        }
+
+
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            if (command.Command == EventCommand.Enable)
+            {
+                // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
+                // They aren't disabled afterwards...
+
+                _connectionsPerSecondCounter ??= new IncrementingPollingCounter("requests-per-second", this, () => _totalConnections)
+                {
+                    DisplayName = "Connection Rate",
+                    DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+                };
+
+                _totalConnectionsCounter ??= new PollingCounter("total-connections", this, () => _totalConnections)
+                {
+                    DisplayName = "Total Connections",
+                };
+
+                _currentConnectionsCounter ??= new PollingCounter("current-connections", this, () => _currentConnections)
+                {
+                    DisplayName = "Current Connections"
+                };
+
+                _connectionQueueLengthCounter ??= new PollingCounter("connection-queue-length", this, () => _connectionQueueLength)
+                {
+                    DisplayName = "Connection Queue Length"
+                };
+            }
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -218,15 +218,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             {
                 // TODO: Write this without a string allocation using WriteEventData
                 var applicationProtocol = feature == null ? null : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
-                TlsHandshakeStop(connectionContext.ConnectionId, feature?.Protocol.ToString(), applicationProtocol);
+                TlsHandshakeStop(connectionContext.ConnectionId, feature?.Protocol.ToString(), applicationProtocol, feature?.HostName);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(9, Level = EventLevel.Verbose)]
-        private void TlsHandshakeStop(string connectionId, string applicationProtocol, string sslProtocols)
+        private void TlsHandshakeStop(string connectionId, string applicationProtocol, string sslProtocols, string hostName)
         {
-            WriteEvent(9, connectionId, sslProtocols, applicationProtocol);
+            WriteEvent(9, connectionId, sslProtocols, applicationProtocol, hostName);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
                 // They aren't disabled afterwards...
 
-                _connectionsPerSecondCounter ??= new IncrementingPollingCounter("requests-per-second", this, () => _totalConnections)
+                _connectionsPerSecondCounter ??= new IncrementingPollingCounter("connections-per-second", this, () => _totalConnections)
                 {
                     DisplayName = "Connection Rate",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -141,12 +141,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [NonEvent]
-        public void ConnectionQueued(BaseConnectionContext connection)
+        public void ConnectionQueuedStart(BaseConnectionContext connection)
         {
             Interlocked.Increment(ref _connectionQueueLength);
             if (IsEnabled())
             {
-                ConnectionQueued(
+                ConnectionQueuedStart(
                     connection.ConnectionId,
                     connection.LocalEndPoint?.ToString(),
                     connection.RemoteEndPoint?.ToString());
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(6, Level = EventLevel.Informational)]
-        private void ConnectionQueued(string connectionId,
+        private void ConnectionQueuedStart(string connectionId,
             string localEndPoint,
             string remoteEndPoint)
         {
@@ -168,12 +168,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [NonEvent]
-        public void ConnectionDequeued(BaseConnectionContext connection)
+        public void ConnectionQueuedStop(BaseConnectionContext connection)
         {
             Interlocked.Decrement(ref _connectionQueueLength);
             if (IsEnabled())
             {
-                ConnectionDequeued(
+                ConnectionQueuedStop(
                     connection.ConnectionId,
                     connection.LocalEndPoint?.ToString(),
                     connection.RemoteEndPoint?.ToString());
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(7, Level = EventLevel.Informational)]
-        private void ConnectionDequeued(string connectionId,
+        private void ConnectionQueuedStop(string connectionId,
             string localEndPoint,
             string remoteEndPoint)
         {
@@ -242,37 +242,37 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [NonEvent]
-        public void RequestQueued(HttpProtocol httpProtocol, string httpVersion)
+        public void RequestQueuedStart(HttpProtocol httpProtocol, string httpVersion)
         {
             Interlocked.Increment(ref _httpRequestQueueLength);
             // avoid allocating the trace identifier unless logging is enabled
             if (IsEnabled())
             {
-                RequestQueued(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpVersion);
+                RequestQueuedStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpVersion);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(11, Level = EventLevel.Informational)]
-        private void RequestQueued(string connectionId, string requestId, string httpVersion)
+        private void RequestQueuedStart(string connectionId, string requestId, string httpVersion)
         {
             WriteEvent(11, connectionId, requestId, httpVersion);
         }
 
         [NonEvent]
-        public void RequestDequeued(HttpProtocol httpProtocol, string httpVersion)
+        public void RequestQueuedStop(HttpProtocol httpProtocol, string httpVersion)
         {
             Interlocked.Decrement(ref _httpRequestQueueLength);
             // avoid allocating the trace identifier unless logging is enabled
             if (IsEnabled())
             {
-                RequestDequeued(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpVersion);
+                RequestQueuedStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpVersion);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(12, Level = EventLevel.Informational)]
-        private void RequestDequeued(string connectionId, string requestId, string httpVersion)
+        private void RequestQueuedStop(string connectionId, string requestId, string httpVersion)
         {
             WriteEvent(12, connectionId, requestId, httpVersion);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(1, Level = EventLevel.Verbose)]
+        [Event(1, Level = EventLevel.Informational)]
         private void ConnectionStart(string connectionId,
             string localEndPoint,
             string remoteEndPoint)
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(2, Level = EventLevel.Verbose)]
+        [Event(2, Level = EventLevel.Informational)]
         private void ConnectionStop(string connectionId)
         {
             WriteEvent(2, connectionId);
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(3, Level = EventLevel.Verbose)]
+        [Event(3, Level = EventLevel.Informational)]
         private void RequestStart(string connectionId, string requestId)
         {
             WriteEvent(3, connectionId, requestId);
@@ -122,14 +122,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(4, Level = EventLevel.Verbose)]
+        [Event(4, Level = EventLevel.Informational)]
         private void RequestStop(string connectionId, string requestId)
         {
             WriteEvent(4, connectionId, requestId);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(5, Level = EventLevel.Verbose)]
+        [Event(5, Level = EventLevel.Informational)]
         public void ConnectionRejected(string connectionId)
         {
             if (IsEnabled())
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(6, Level = EventLevel.Verbose)]
+        [Event(6, Level = EventLevel.Informational)]
         private void ConnectionQueued(string connectionId,
             string localEndPoint,
             string remoteEndPoint)
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(7, Level = EventLevel.Verbose)]
+        [Event(7, Level = EventLevel.Informational)]
         private void ConnectionDequeued(string connectionId,
             string localEndPoint,
             string remoteEndPoint)
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(8, Level = EventLevel.Verbose)]
+        [Event(8, Level = EventLevel.Informational)]
         private void TlsHandshakeStart(string connectionId, string sslProtocols)
         {
             WriteEvent(8, connectionId, sslProtocols);
@@ -217,20 +217,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             if (IsEnabled())
             {
                 // TODO: Write this without a string allocation using WriteEventData
-                var applicationProtocol = feature == null ? null : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
-                TlsHandshakeStop(connectionContext.ConnectionId, feature?.Protocol.ToString(), applicationProtocol, feature?.HostName);
+                var applicationProtocol = feature == null ? string.Empty : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
+                var sslProtocols = feature?.Protocol.ToString() ?? string.Empty;
+                var hostName = feature?.HostName ?? string.Empty;
+                TlsHandshakeStop(connectionContext.ConnectionId, sslProtocols, applicationProtocol, hostName);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(9, Level = EventLevel.Verbose)]
-        private void TlsHandshakeStop(string connectionId, string applicationProtocol, string sslProtocols, string hostName)
+        [Event(9, Level = EventLevel.Informational)]
+        private void TlsHandshakeStop(string connectionId, string sslProtocols, string applicationProtocol, string hostName)
         {
             WriteEvent(9, connectionId, sslProtocols, applicationProtocol, hostName);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(10, Level = EventLevel.Verbose)]
+        [Event(10, Level = EventLevel.Error)]
         public void TlsHandshakeFailed(string connectionId)
         {
             Interlocked.Increment(ref _failedTlsHandshakes);
@@ -249,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(11, Level = EventLevel.Verbose)]
+        [Event(11, Level = EventLevel.Informational)]
         private void RequestQueued(string connectionId, string requestId, string httpVersion)
         {
             WriteEvent(11, connectionId, requestId, httpVersion);
@@ -267,7 +269,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Event(12, Level = EventLevel.Verbose)]
+        [Event(12, Level = EventLevel.Informational)]
         private void RequestDequeued(string connectionId, string requestId, string httpVersion)
         {
             WriteEvent(12, connectionId, requestId, httpVersion);

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -16,6 +16,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     {
         public X509Certificate2 ClientCertificate { get; set; }
 
+        public string HostName { get; set; }
+
         public ReadOnlyMemory<byte> ApplicationProtocol { get; set; }
 
         public SslProtocols Protocol { get; set; }

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -169,6 +169,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                     {
                         selector = (sender, name) =>
                         {
+                            feature.HostName = name;
                             context.Features.Set(sslStream);
                             var cert = _serverCertificateSelector(context, name);
                             if (cert != null)


### PR DESCRIPTION
## Connection counters
- Connection queue length - This is the amount of connections accepted and queued in the thread pool.
- Connection count - The number of connections
- Total connections - The total number of connections.
- Connection Rate - Connections per second

## TLS counters
- Total TLS handshakes - The total number of TLS handshakes
- Current TLS handshakes - The number of TLS handshakes being performed currently
- Failed TLS handshakes - The number of failed TLS handshakes
- TLS handshake Rate - TLS handshake per second

## Request counters
- Request Queue Length - The number of HTTP/2 and HTTP/3 connections queued in the thread pool.
- Current Upgraded Requests - The number of HTTP/1 requests that are currently upgraded (basiacally the number of concurrent websocket connections)

- Also added event source events to Kestrel (which I'm beginning to get very conflicted about 😄 )

Contributes to #4769

Notes: The Request Queue Length only works for HTTP/2 and HTTP/3. The Connection Queue doubles as the request queue for HTTP/1.

cc @shirhatti 