### PR TITLE
Allow specify timeout when download dependencies

### DIFF
--- a/eng/tools/RepoTasks/DownloadFile.cs
+++ b/eng/tools/RepoTasks/DownloadFile.cs
@@ -30,6 +30,8 @@ namespace RepoTasks
 
         public int MaxRetries { get; set; } = 5;
 
+        public int Timeout { get; set; } = 100;
+
         [Required]
         public string DestinationPath { get; set; }
 
@@ -102,6 +104,7 @@ namespace RepoTasks
 
             using (var httpClient = new HttpClient())
             {
+                httpClient.Timeout = TimeSpan.FromSeconds(Timeout);
                 for (int retryNumber = 0; retryNumber < MaxRetries; retryNumber++)
                 {
                     try

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -386,6 +386,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="_DownloadAndExtractDotNetRuntime" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <DownloadFile Condition=" ! Exists('$(DotNetRuntimeArchive)')"
       Uri="$(DotNetRuntimeDownloadUrl)"
+      Timeout="100"
       PrivateUri="$(DotNetRuntimePrivateDownloadUrl)"
       PrivateUriSuffix="$(DotNetAssetRootAccessTokenSuffix)"
       DestinationPath="$(DotNetRuntimeArchive)" />

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -40,6 +40,7 @@
 
     <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFileName)') "
                   Uri="$(DotNetAssetRootUrl)%(RemoteAsset.Identity)"
+                  Timeout="100"
                   PrivateUri="$(DotNetPrivateAssetRootUrl)%(RemoteAsset.Identity)"
                   PrivateUriSuffix="$(DotNetAssetRootAccessTokenSuffix)"
                   DestinationPath="$(DepsPath)%(RemoteAsset.TargetFileName)" />


### PR DESCRIPTION
Usually downloding previews .NET take around two minutes for me
With parameters for timeout, developer at least can manually increase timeouts.
100 seconds is default value for timeouts for HttpClient

