### PR TITLE
Add retries when initial connection fails

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
@@ -139,8 +139,6 @@ namespace Templates.Test
 
         private void TestBasicNavigation()
         {
-            // Give components.server enough time to load so that it can replace
-            // the prerendered content before we start making assertions.
             var retries = 3;
             var connected = false;
             do

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +26,7 @@ namespace Templates.Test
 
         public Project Project { get; private set; }
 
-        [ConditionalFact(Skip = "This test ran for over an hour")]
+        [Fact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/20172")]
         public async Task BlazorServerTemplateWorks_NoAuth()
         {
@@ -139,7 +141,23 @@ namespace Templates.Test
         {
             // Give components.server enough time to load so that it can replace
             // the prerendered content before we start making assertions.
-            Thread.Sleep(5000);
+            var retries = 3;
+            var connected = false;
+            do
+            {
+                try
+                {
+                    Browser.Contains("Information: WebSocket connected to",
+                        () => string.Join(Environment.NewLine, Browser.GetBrowserLogs(LogLevel.Info).Select(b => b.Message)));
+                    connected = true;
+                }
+                catch (TimeoutException) when(retries-- > 0)
+                {
+                    Browser.Navigate().Refresh();
+                }
+            } while (!connected && retries > 0);
+
+
             Browser.Exists(By.TagName("ul"));
             // <title> element gets project ID injected into it during template execution
             Browser.Equal(Project.ProjectName.Trim(), () => Browser.Title.Trim());

--- a/src/ProjectTemplates/ProjectTemplatesNoDeps.slnf
+++ b/src/ProjectTemplates/ProjectTemplatesNoDeps.slnf
@@ -6,7 +6,8 @@
       "Web.ItemTemplates\\Microsoft.DotNet.Web.ItemTemplates.csproj",
       "Web.ProjectTemplates\\Microsoft.DotNet.Web.ProjectTemplates.csproj",
       "Web.Spa.ProjectTemplates\\Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj",
-      "test\\ProjectTemplates.Tests.csproj"
+      "test\\ProjectTemplates.Tests.csproj",
+      "BlazorTemplates.Tests\\BlazorTemplates.Tests.csproj"
     ]
   }
 }


### PR DESCRIPTION
In this particular case, the client failed to connect with `Error: WebSocket closed with status code: 1006`. The recommendation here is to collect server logs. Unfortunately the linked build is old and deleted, so we no longer have any logs to look at. 

Given that the Blazor auth tests appear to continue running just fine and this test works locally, the change I have:

a) Adds some retries in case the browser is unable to establish the SignalR connection
b) Change the connection detection to be more robust than tossing in a delay.