### PR TITLE
Remove the need for a global lock when building or publishing a project

### DIFF
--- a/src/ProjectTemplates/Shared/AspNetProcess.cs
+++ b/src/ProjectTemplates/Shared/AspNetProcess.cs
@@ -63,9 +63,9 @@ namespace Templates.Test.Helpers
                 Timeout = TimeSpan.FromMinutes(2)
             };
 
-            output.WriteLine("Running ASP.NET application...");
+            output.WriteLine("Running ASP.NET Core application...");
 
-            var arguments = published ? $"exec {dllPath}" : "run";
+            var arguments = published ? $"exec {dllPath}" : "run --no-build";
 
             logger?.LogInformation($"AspNetProcess - process: {DotNetMuxer.MuxerPathOrDefault()} arguments: {arguments}");
 

--- a/src/ProjectTemplates/Shared/ProcessLock.cs
+++ b/src/ProjectTemplates/Shared/ProcessLock.cs
@@ -24,7 +24,7 @@ namespace Templates.Test.Helpers
 
         public async Task WaitAsync(TimeSpan? timeout = null)
         {
-            timeout ??= TimeSpan.FromMinutes(2);
+            timeout ??= TimeSpan.FromMinutes(20);
             Assert.True(await Semaphore.WaitAsync(timeout.Value), $"Unable to acquire process lock for process {Name}");
         }
 


### PR DESCRIPTION
* Change template test build and publish to not perform dotnet restore
* Remove locking requirements for build and publish
* Increase timeout for dotnet new operations since it's network bound

