### PR TITLE
Do not ship SiteExtension in previews

### DIFF
--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -16,7 +16,8 @@
     <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
     <NoSemVer20>true</NoSemVer20>
     <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
+    <IsShipping>true</IsShipping>
+    <IsShipping Condition=" '$(PreReleaseVersionLabel)' == 'preview' ">false</IsShipping>
     <ReferenceReferenceAssemblies>false</ReferenceReferenceAssemblies>
     <ReferenceImplementationAssemblies>true</ReferenceImplementationAssemblies>
 

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -16,6 +16,7 @@
     <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
     <NoSemVer20>true</NoSemVer20>
     <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
     <ReferenceReferenceAssemblies>false</ReferenceReferenceAssemblies>
     <ReferenceImplementationAssemblies>true</ReferenceImplementationAssemblies>
 


### PR DESCRIPTION
We've generally avoided shipping the SiteExtension in preview releases. (Plus the one we did push to NuGet didn't contain the 3.1 bits and was breaking the SiteExtension experience since App Service will just grab the highest versioned package)

I'll file an issue to track re-enabling near the end of 5.0.
