### PR TITLE
Change condition for publishing to transport feed

### DIFF
--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -308,7 +308,7 @@
                     ManifestCommit="$(CommitHash)"
                     ManifestName="aspnet"
                     MaxClients="$(PushToBlobFeed_MaxClients)"
-                    Condition="@(PackageToPublish->Count()) != 0" />
+                    Condition="@(PackageToPublishToTransport->Count()) != 0" />
 
     <PushToBlobFeed ExpectedFeedUrl="$(PublishBlobFeedUrl)"
                     AccountKey="$(PublishBlobFeedKey)"


### PR DESCRIPTION
Attempts (again) to fix https://github.com/dotnet/aspnetcore-internal/issues/3387

My previous PR confirmed that the VS.Redist packages are present in `PackageToPublishToTransport` when we call `PushToBlobFeed`, and my local testing confirms that any Items passed as `ItemsToPush` will get pushed regardless of their metadata, so the only thing I can think of is that the `PublishToTransportFeed` target gets invoked multiple times, and during the invocation where we try to publish the VS.Redist packages, the `PackageToPublish` Item is empty. This PR changes the condition so that the publish is contingent on the size of the actual Item it tries to push.

I'm not sure what the best way would be to test this - ideally I could run a dummy ProdCon build that would actually publish stuff, instead of jury-rigging a TeamCity build of just AspNetCore which can't actually publish to the transport feed - @mmitche is that possible?