### PR TITLE
Modified connection error to stream error in case of too long headers.

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _totalParsedHeaderSize += HeaderField.RfcOverhead + name.Length + value.Length;
             if (_totalParsedHeaderSize > _context.ServiceContext.ServerOptions.Limits.MaxRequestHeadersTotalSize)
             {
-                throw new Http2ConnectionErrorException(CoreStrings.BadRequest_HeadersExceedMaxTotalSize, Http2ErrorCode.PROTOCOL_ERROR);
+                throw new Http2StreamErrorException(CoreStrings.BadRequest_HeadersExceedMaxTotalSize, Http2ErrorCode.PROTOCOL_ERROR);
             }
 
             ValidateHeader(name, value);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - HeaderValidation OnHeader method modified to send http2 stream error instead of connection error.

Addresses #17861 
