### PR TITLE
[release/2.1] Make .msi GUIDs unique

### DIFF
--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <GuidInputs>$(Version);$(Platform)</GuidInputs>
-    <GuidInputs Condition="'$(IsFinalBuild)' != 'true'">$(GuidInputs);$(BuildNumber)</GuidInputs>
+    <GuidInputs Condition="'$(IsFinalBuild)' != 'true'">$(GuidInputs);$(BuildNumber);$(BuildNumber)</GuidInputs>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(OutputPath)..\InstallerTasks\InstallerTasks.dll" TaskName="RepoTasks.GenerateGuid" />

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GuidInputs>$(Version);$(Platform)</GuidInputs>
-    <GuidInputs Condition="'$(IsFinalBuild)' != 'true'">$(GuidInputs);$(BuildNumber);$(BuildNumber)</GuidInputs>
+    <GuidInputs>$(Version);$(Platform);$(BuildNumber)</GuidInputs>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(OutputPath)..\InstallerTasks\InstallerTasks.dll" TaskName="RepoTasks.GenerateGuid" />


### PR DESCRIPTION
Customers have reported issues with our .MSI's when repairing VS. We believe the issue is due to the ProductCode/ProductVersion of the installers not being unique per build, but instead being unique per package version. Passing BuildNumber to the GUID generator should fix the issue