### PR TITLE
Fix SpaServices extensions hangs (#17277)

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/Util/EventedStreamReader.cs
+++ b/src/Middleware/SpaServices.Extensions/src/Util/EventedStreamReader.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.NodeServices.Util
                 // get the rest
                 if (lineBreakPos < 0 && startPos < chunkLength)
                 {
-                    _linesBuffer.Append(buf, startPos, chunkLength);
+                    _linesBuffer.Append(buf, startPos, chunkLength - startPos);
                 }
             }
         }


### PR DESCRIPTION
Fixed adding a string with a large number of trailing zeros to StringBuilder, which sometimes caused the thread to hang.

Summary of the changes
 - Only a significant portion of the buffer will be added.

Addresses #17277
