### PR TITLE
Revert "Quarantine all ProjectTemplate tests until dotnet new lock is…

### DIFF
--- a/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
@@ -10,5 +10,3 @@ using Xunit;
 
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(ProjectFactoryFixture))]
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(SeleniumStandaloneServer))]
-
-[assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/21748")]


### PR DESCRIPTION
Reverting quarantining all project tests. With https://github.com/dotnet/aspnetcore/pull/21753 merged, we should be able to revert. Going to wait on a few CI runs before merging to confirm the fix worked.