### PR TITLE
Fixed issues #17516

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             try
             {
                 context = (IISHttpContext)GCHandle.FromIntPtr(pvManagedHttpContext).Target;
-                context.AbortIO(clientDisconnect: true);
+                context?.AbortIO(clientDisconnect: true);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This fix is for the System.NullReferenceException HResult=0x80004003 Message=Object reference not set to an instance of an object.

Summary of the changes (Less than 80 chars)
 - Added validation for null for the context object.

Addresses #17516
