### PR TITLE
arcade requires MSBuild 16.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Git": "2.22.0",
     "jdk": "11.0.3",
     "vs": {
-      "version": "16.0",
+      "version": "16.3",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
change vs required version 16.0 to 16.3

Addresses #bugnumber (in this specific format)
#16684

(Previously I did wrong request(at #21868) merge to master, but this should be PR to rel3.1. )