### PR TITLE
Port `-nobl` and `net5.0` changes from 'master'

### DIFF
--- a/.azure/pipelines/benchmarks.yml
+++ b/.azure/pipelines/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
     jobName: Windows_Build
     jobDisplayName: "Build only : Windows"
     agentOs: Windows
-    buildArgs: -ci -all -pack
+    buildArgs: -all -pack
     artifacts:
     - path: artifacts/
       includeForks: true

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -129,10 +129,10 @@ stages:
       # The sign settings have been configured to
       - script: ./build.cmd
                 -ci
+                -nobl
                 -arch x64
                 -pack
                 -all
-                /bl:artifacts/log/build.x64.binlog
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
         displayName: Build x64
@@ -141,12 +141,12 @@ stages:
       # This is going to actually build x86 native assets.
       - script: ./build.cmd
                 -ci
+                -nobl
                 -arch x86
                 -pack
                 -all
                 -noBuildJava
                 /p:OnlyPackPlatformSpecificPackages=true
-                /bl:artifacts/log/build.x86.binlog
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
         displayName: Build x86
@@ -154,6 +154,7 @@ stages:
       # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
       - script: .\src\SiteExtensions\build.cmd
                 -ci
+                -nobl
                 -pack
                 -noBuildDeps
                 $(_BuildArgs)
@@ -166,10 +167,10 @@ stages:
       # Sign check is disabled because it is run in a separate step below, after installers are built.
       - script: ./build.cmd
                 -ci
+                -nobl
                 -noBuild
                 -noRestore
                 -sign
-                /bl:artifacts/log/build.codesign.binlog
                 /p:DotNetSignType=$(_SignType)
                 $(_BuildArgs)
         displayName: Code sign packages
@@ -177,9 +178,9 @@ stages:
       # Windows installers bundle both x86 and x64 assets
       - script: ./build.cmd
                 -ci
+                -nobl
                 -sign
                 -buildInstallers
-                /bl:artifacts/log/installers.msbuild.binlog
                 /p:DotNetSignType=$(_SignType)
                 /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 $(_BuildArgs)
@@ -219,7 +220,6 @@ stages:
         -pack
         -noBuildNodeJS
         -noBuildJava
-        /bl:artifacts/log/build.win-arm.binlog
         /p:DotNetSignType=$(_SignType)
         /p:OnlyPackPlatformSpecificPackages=true
         /p:AssetManifestFileName=aspnetcore-win-arm.xml
@@ -249,7 +249,6 @@ stages:
         -pack
         -noBuildNodeJS
         -noBuildJava
-        /bl:artifacts/log/build.win-arm64.binlog
         /p:DotNetSignType=$(_SignType)
         /p:OnlyPackPlatformSpecificPackages=true
         /p:AssetManifestFileName=aspnetcore-win-arm64.xml
@@ -280,7 +279,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.macos.binlog
         -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -308,13 +306,13 @@ stages:
       steps:
       - script: ./build.sh
             --ci
+            --nobl
             --arch x64
             --pack
             --all
             --no-build-nodejs
             --no-build-java
             -p:OnlyPackPlatformSpecificPackages=true
-            -bl:artifacts/log/build.linux-x64.binlog
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
         displayName: Run build.sh
@@ -322,6 +320,7 @@ stages:
           git clean -xfd src/**/obj/
           ./dockerbuild.sh bionic \
             --ci \
+            --nobl \
             --arch x64 \
             --build-installers \
             --no-build-deps \
@@ -329,7 +328,6 @@ stages:
             -p:OnlyPackPlatformSpecificPackages=true \
             -p:BuildRuntimeArchive=false \
             -p:LinuxInstallerType=deb \
-            -bl:artifacts/log/build.deb.binlog \
             $(_BuildArgs) \
             $(_InternalRuntimeDownloadArgs)
         displayName: Build Debian installers
@@ -337,6 +335,7 @@ stages:
           git clean -xfd src/**/obj/
           ./dockerbuild.sh rhel \
             --ci \
+            --nobl \
             --arch x64 \
             --build-installers \
             --no-build-deps \
@@ -344,7 +343,6 @@ stages:
             -p:OnlyPackPlatformSpecificPackages=true \
             -p:BuildRuntimeArchive=false \
             -p:LinuxInstallerType=rpm \
-            -bl:artifacts/log/build.rpm.binlog \
             -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
             $(_BuildArgs) \
             $(_PublishArgs) \
@@ -376,7 +374,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.linux-arm.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -407,7 +404,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.arm64.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -433,7 +429,6 @@ stages:
       agentOs: Linux
       buildScript: ./dockerbuild.sh alpine
       buildArgs:
-        --ci
         --arch x64
         --os-name linux-musl
         --pack
@@ -441,7 +436,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.musl.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -468,7 +462,6 @@ stages:
       useHostedUbuntu: false
       buildScript: ./dockerbuild.sh ubuntu-alpine37
       buildArgs:
-        --ci
         --arch arm64
         --os-name linux-musl
         --pack
@@ -476,7 +469,6 @@ stages:
         --no-build-nodejs
         --no-build-java
         -p:OnlyPackPlatformSpecificPackages=true
-        -bl:artifacts/log/build.musl.binlog
         -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
         $(_BuildArgs)
         $(_PublishArgs)
@@ -507,7 +499,7 @@ stages:
       - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
         displayName: Setup IISExpress test certificates and schema
       afterBuild:
-      - powershell: "& ./build.ps1 -CI -NoBuild -Test /p:RunQuarantinedTests=true"
+      - powershell: "& ./build.ps1 -CI -nobl -NoBuild -Test /p:RunQuarantinedTests=true"
         displayName: Run Quarantined Tests
         continueOnError: true
       - task: PublishTestResults@2
@@ -538,11 +530,11 @@ stages:
       agentOs: Windows
       isTestingJob: true
       steps:
-      - script: ./build.cmd -ci -all -pack $(_InternalRuntimeDownloadArgs)
+      - script: ./build.cmd -ci -nobl -all -pack $(_InternalRuntimeDownloadArgs)
         displayName: Build Repo
-      - script: ./src/ProjectTemplates/build.cmd -ci -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true /bl:artifacts/log/template.pack.binlog"
+      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true"
         displayName: Pack Templates
-      - script: ./src/ProjectTemplates/build.cmd -ci -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true /bl:artifacts/log/template.test.binlog"
+      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
         displayName: Test Templates
       artifacts:
       - name: Windows_Test_Templates_Dumps
@@ -570,11 +562,11 @@ stages:
       - bash: "./eng/scripts/install-nginx-mac.sh"
         displayName: Installing Nginx
       afterBuild:
-      - bash: ./build.sh --ci --pack --no-build --no-restore --no-build-deps "/bl:artifacts/log/packages.pack.binlog"
+      - bash: ./build.sh --ci --nobl --pack --no-build --no-restore --no-build-deps
         displayName: Pack Packages (for Template tests)
-      - bash: ./src/ProjectTemplates/build.sh --ci --pack --no-restore --no-build-deps "/bl:artifacts/log/template.pack.binlog"
+      - bash: ./src/ProjectTemplates/build.sh --ci --nobl --pack --no-restore --no-build-deps
         displayName: Pack Templates (for Template tests)
-      - bash: ./build.sh --no-build --ci --test -p:RunQuarantinedTests=true
+      - bash: ./build.sh --no-build --ci --nobl --test -p:RunQuarantinedTests=true
         displayName: Run Quarantined Tests
         continueOnError: true
       - task: PublishTestResults@2
@@ -608,11 +600,11 @@ stages:
       - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
         displayName: Increase inotify limit
       afterBuild:
-      - bash: ./build.sh --ci --pack --no-build --no-restore --no-build-deps "/bl:artifacts/log/packages.pack.binlog"
+      - bash: ./build.sh --ci --nobl --pack --no-build --no-restore --no-build-deps
         displayName: Pack Packages (for Template tests)
-      - bash: ./src/ProjectTemplates/build.sh --ci --pack --no-restore --no-build-deps "/bl:artifacts/log/template.pack.binlog"
+      - bash: ./src/ProjectTemplates/build.sh --ci --nobl --pack --no-restore --no-build-deps
         displayName: Pack Templates (for Template tests)
-      - bash: ./build.sh --no-build --ci --test -p:RunQuarantinedTests=true
+      - bash: ./build.sh --no-build --ci --nobl --test -p:RunQuarantinedTests=true
         displayName: Run Quarantined Tests
         continueOnError: true
       - task: PublishTestResults@2
@@ -641,11 +633,11 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
+      - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Build shared fx
-      - script: .\restore.cmd -ci /p:BuildInteropProjects=true
+      - script: .\restore.cmd -ci -nobl /p:BuildInteropProjects=true
         displayName: Restore interop projects
-      - script: .\build.cmd -ci -NoRestore -test -all -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -665,11 +657,11 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.daily.build.x64.binlog
+      - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Build shared fx
-      - script: .\restore.cmd -ci /p:BuildInteropProjects=true
+      - script: .\restore.cmd -ci -nobl /p:BuildInteropProjects=true
         displayName: Restore interop projects
-      - script: .\build.cmd -ci -NoRestore -test -all -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -690,9 +682,9 @@ stages:
       timeoutInMinutes: 180
       steps:
       # Build the shared framework
-      - script: ./restore.sh -ci
+      - script: ./restore.sh -ci -nobl
         displayName: Restore
-      - script: ./build.sh -ci --arch arm64 -test --no-build-nodejs --all -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+      - script: ./build.sh -ci --nobl --arch arm64 -test --no-build-nodejs --all -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Run build.sh helix arm64 target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -729,7 +721,7 @@ stages:
             arguments: $(Build.SourcesDirectory)/NuGet.config $Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
-    - script: ./eng/scripts/ci-source-build.sh --ci --configuration Release /p:BuildManaged=true /p:BuildNodeJs=false
+    - script: ./eng/scripts/ci-source-build.sh --ci --nobl --configuration Release /p:BuildManaged=true /p:BuildNodeJs=false
       displayName: Run ci-source-build.sh
     - task: PublishBuildArtifacts@1
       displayName: Upload logs

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -191,13 +191,13 @@ jobs:
     - ${{ if eq(parameters.steps, '')}}:
       - ${{ if eq(parameters.buildScript, '') }}:
         - ${{ if eq(parameters.agentOs, 'Windows') }}:
-          - script: .\$(BuildDirectory)\build.cmd -ci /p:DotNetSignType=$(_SignType) -Configuration $(BuildConfiguration) $(BuildScriptArgs)
+          - script: .\$(BuildDirectory)\build.cmd -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs) /p:DotNetSignType=$(_SignType)
             displayName: Run build.cmd
         - ${{ if ne(parameters.agentOs, 'Windows') }}:
-          - script: ./$(BuildDirectory)/build.sh -ci -configuration $(BuildConfiguration) $(BuildScriptArgs)
+          - script: ./$(BuildDirectory)/build.sh --ci --nobl --configuration $(BuildConfiguration) $(BuildScriptArgs)
             displayName: Run build.sh
       - ${{ if ne(parameters.buildScript, '') }}:
-        - script: $(BuildScript) -Configuration $(BuildConfiguration) $(BuildScriptArgs)
+        - script: $(BuildScript) -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs)
           displayName: run $(BuildScript)
 
     - ${{ parameters.afterBuild }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,7 @@
 
     <IncludeSymbols>true</IncludeSymbols>
 
-    <DefaultNetCoreTargetFramework>netcoreapp5.0</DefaultNetCoreTargetFramework>
+    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
 
   <!-- Warnings and errors -->

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -14,7 +14,7 @@
     <RepoTasks.RemoveSharedFrameworkDependencies Condition="@(_BuildOutput->Count()) != 0"
       Files="@(_BuildOutput)"
       FrameworkOnlyPackages="@(AspNetCoreAppReference)"
-      SharedFrameworkTargetFramework="netcoreapp$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)" />
+      SharedFrameworkTargetFramework="net$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)" />
   </Target>
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -300,17 +300,17 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>09ee4814cb669e4b703a458c63483fa75a47c58f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20228.4">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20261.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>590a102630c7efc7ca6f652f7c6c47dee4c4086c</Sha>
+      <Sha>898e51ed5fdcc4871087ac5754ca9056e58e575d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20228.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20261.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>590a102630c7efc7ca6f652f7c6c47dee4c4086c</Sha>
+      <Sha>898e51ed5fdcc4871087ac5754ca9056e58e575d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20228.4">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20261.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>590a102630c7efc7ca6f652f7c6c47dee4c4086c</Sha>
+      <Sha>898e51ed5fdcc4871087ac5754ca9056e58e575d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.7.0-2.20259.1" CoherentParentDependency="Microsoft.AspNetCore.Razor.Language">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- Packages from dotnet/arcade -->
-    <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.20228.4</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.20261.9</MicrosoftDotNetGenAPIPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetPackageVersion>3.7.0-2.20259.1</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- Packages from dotnet/runtime -->

--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -40,17 +40,22 @@
     <PackageReference Include="Internal.AspNetCore.BuildTasks" PrivateAssets="All" Version="$(InternalAspNetCoreBuildTasksPackageVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <KnownAppHostPackOrFrameworkReferenceTfm>$(DefaultNetCoreTargetFramework)</KnownAppHostPackOrFrameworkReferenceTfm>
+    <KnownAppHostPackOrFrameworkReferenceTfm Condition="'$(KnownAppHostPackOrFrameworkReferenceTfm)' == 'net5.0'">netcoreapp5.0</KnownAppHostPackOrFrameworkReferenceTfm>
+  </PropertyGroup>
+
   <ItemGroup>
-    <!-- Workaround when there is no vNext SDK available, copy known apphost/framework reference info from 3.0 -->
+    <!-- Workaround when there is no vNext SDK available, copy known apphost/framework reference info from 3.1 -->
     <KnownAppHostPack
-      Include="@(KnownAppHostPack->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))"
-      TargetFramework="$(DefaultNetCoreTargetFramework)"
-      Condition="@(KnownAppHostPack->Count()) != '0' AND !(@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(DefaultNetCoreTargetFramework)')))"
+      Include="@(KnownAppHostPack->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))"
+      TargetFramework="$(KnownAppHostPackOrFrameworkReferenceTfm)"
+      Condition="@(KnownAppHostPack->Count()) != '0' AND !(@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(KnownAppHostPackOrFrameworkReferenceTfm)')))"
       />
     <KnownFrameworkReference
-      Include="@(KnownFrameworkReference->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))"
-      TargetFramework="$(DefaultNetCoreTargetFramework)"
-      Condition="@(KnownFrameworkReference->Count()) != '0' AND !(@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(DefaultNetCoreTargetFramework)')))"
+      Include="@(KnownFrameworkReference->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))"
+      TargetFramework="$(KnownAppHostPackOrFrameworkReferenceTfm)"
+      Condition="@(KnownFrameworkReference->Count()) != '0' AND !(@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(KnownAppHostPackOrFrameworkReferenceTfm)')))"
       />
   </ItemGroup>
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,6 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
+  [switch][Alias('nobl')]$excludeCIBinarylog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -58,6 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
+  Write-Host "  -excludeCIBinarylog     Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
@@ -134,7 +136,9 @@ try {
   }
 
   if ($ci) {
-    $binaryLog = $true
+    if (-not $excludeCIBinarylog) {
+      $binaryLog = $true
+    }
     $nodeReuse = $false
   }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,6 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
+  echo "  --excludeCIBinarylog     Don't output binary log (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -68,6 +69,7 @@ clean=false
 warn_as_error=true
 node_reuse=true
 binary_log=false
+exclude_ci_binary_log=false
 pipelines_log=false
 
 projects=''
@@ -97,6 +99,9 @@ while [[ $# > 0 ]]; do
       ;;
     -binarylog|-bl)
       binary_log=true
+      ;;
+    -excludeCIBinarylog|-nobl)
+      exclude_ci_binary_log=true
       ;;
     -pipelineslog|-pl)
       pipelines_log=true
@@ -156,8 +161,10 @@ done
 
 if [[ "$ci" == true ]]; then
   pipelines_log=true
-  binary_log=true
   node_reuse=false
+  if [[ "$exclude_ci_binary_log" == false ]]; then
+    binary_log=true
+  fi
 fi
 
 . "$scriptroot/tools.sh"

--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
   <ItemGroup>
     <!-- Clear references, the SDK may add some depending on UsuingToolXxx settings, but we only want to restore the following -->

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -6,6 +6,7 @@
     <Python>py -3</Python>
     <CoreRun>%HELIX_CORRELATION_PAYLOAD%\Core_Root\CoreRun.exe</CoreRun>
     <BaselineCoreRun>%HELIX_CORRELATION_PAYLOAD%\Baseline_Core_Root\CoreRun.exe</BaselineCoreRun>
+    
     <HelixPreCommands>$(HelixPreCommands);call %HELIX_CORRELATION_PAYLOAD%\performance\tools\machine-setup.cmd;set PYTHONPATH=%HELIX_WORKITEM_PAYLOAD%\scripts%3B%HELIX_WORKITEM_PAYLOAD%</HelixPreCommands>
     <ArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts</ArtifactsDirectory>
     <BaselineArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
@@ -38,6 +39,13 @@
     <DotnetExe>$(PerformanceDirectory)/tools/dotnet/$(Architecture)/dotnet</DotnetExe>
     <Percent>%25</Percent>
     <XMLResults>$HELIX_WORKITEM_ROOT/testResults.xml</XMLResults>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' == 'Windows_NT'">
+    <CoreRunArgument>--corerun %HELIX_CORRELATION_PAYLOAD%\dotnet-mono\shared\Microsoft.NETCore.App\5.0.0\corerun.exe</CoreRunArgument>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' != 'Windows_NT'">
+    <CoreRunArgument>--corerun $(BaseDirectory)/dotnet-mono/shared/Microsoft.NETCore.App/5.0.0/corerun</CoreRunArgument>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -3,7 +3,7 @@ Param(
     [string] $CoreRootDirectory,
     [string] $BaselineCoreRootDirectory,
     [string] $Architecture="x64",
-    [string] $Framework="netcoreapp5.0",
+    [string] $Framework="net5.0",
     [string] $CompilationMode="Tiered",
     [string] $Repository=$env:BUILD_REPOSITORY_NAME,
     [string] $Branch=$env:BUILD_SOURCEBRANCH,
@@ -12,8 +12,12 @@ Param(
     [string] $RunCategories="Libraries Runtime",
     [string] $Csproj="src\benchmarks\micro\MicroBenchmarks.csproj",
     [string] $Kind="micro",
+    [switch] $LLVM,
+    [switch] $MonoInterpreter,
+    [switch] $MonoAOT, 
     [switch] $Internal,
     [switch] $Compare,
+    [string] $MonoDotnet="",
     [string] $Configurations="CompilationMode=$CompilationMode RunKind=$Kind"
 )
 
@@ -31,7 +35,8 @@ $HelixSourcePrefix = "pr"
 
 $Queue = "Windows.10.Amd64.ClientRS4.DevEx.15.8.Open"
 
-if ($Framework.StartsWith("netcoreapp")) {
+# TODO: Implement a better logic to determine if Framework is .NET Core or >= .NET 5.
+if ($Framework.StartsWith("netcoreapp") -or ($Framework -eq "net5.0")) {
     $Queue = "Windows.10.Amd64.ClientRS5.Open"
 }
 
@@ -47,6 +52,21 @@ if ($Internal) {
     $ExtraBenchmarkDotNetArguments = ""
     $Creator = ""
     $HelixSourcePrefix = "official"
+}
+
+if($MonoDotnet -ne "")
+{
+    $Configurations += " LLVM=$LLVM MonoInterpreter=$MonoInterpreter MonoAOT=$MonoAOT"
+    if($ExtraBenchmarkDotNetArguments -eq "")
+    {
+        #FIX ME: We need to block these tests as they don't run on mono for now
+        $ExtraBenchmarkDotNetArguments = "--exclusion-filter *Perf_Image* *Perf_NamedPipeStream*"
+    }
+    else
+    {
+        #FIX ME: We need to block these tests as they don't run on mono for now
+        $ExtraBenchmarkDotNetArguments += " --exclusion-filter *Perf_Image* *Perf_NamedPipeStream*"
+    }
 }
 
 # FIX ME: This is a workaround until we get this from the actual pipeline
@@ -67,6 +87,13 @@ if ($RunFromPerformanceRepo) {
 }
 else {
     git clone --branch master --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
+}
+
+if($MonoDotnet -ne "")
+{
+    $UsingMono = "true"
+    $MonoDotnetPath = (Join-Path $PayloadDirectory "dotnet-mono")
+    Move-Item -Path $MonoDotnet -Destination $MonoDotnetPath
 }
 
 if ($UseCoreRun) {
@@ -104,6 +131,7 @@ Write-PipelineSetVariable -Name 'UseCoreRun' -Value "$UseCoreRun" -IsMultiJobVar
 Write-PipelineSetVariable -Name 'UseBaselineCoreRun' -Value "$UseBaselineCoreRun" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'RunFromPerfRepo' -Value "$RunFromPerformanceRepo" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'Compare' -Value "$Compare" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'MonoDotnet' -Value "$UsingMono" -IsMultiJobVariable $false
 
 # Helix Arguments
 Write-PipelineSetVariable -Name 'Creator' -Value "$Creator" -IsMultiJobVariable $false

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -4,7 +4,7 @@ source_directory=$BUILD_SOURCESDIRECTORY
 core_root_directory=
 baseline_core_root_directory=
 architecture=x64
-framework=netcoreapp5.0
+framework=net5.0
 compilation_mode=tiered
 repository=$BUILD_REPOSITORY_NAME
 branch=$BUILD_SOURCEBRANCH
@@ -12,13 +12,18 @@ commit_sha=$BUILD_SOURCEVERSION
 build_number=$BUILD_BUILDNUMBER
 internal=false
 compare=false
+mono_dotnet=
 kind="micro"
+llvm=false
+monointerpreter=false
+monoaot=false
 run_categories="Libraries Runtime"
 csproj="src\benchmarks\micro\MicroBenchmarks.csproj"
 configurations="CompliationMode=$compilation_mode RunKind=$kind"
 run_from_perf_repo=false
 use_core_run=true
 use_baseline_core_run=true
+using_mono=false
 
 while (($# > 0)); do
   lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -65,6 +70,7 @@ while (($# > 0)); do
       ;;
     --kind)
       kind=$2
+      configurations="CompliationMode=$compilation_mode RunKind=$kind"
       shift 2
       ;;
     --runcategories)
@@ -78,6 +84,22 @@ while (($# > 0)); do
     --internal)
       internal=true
       shift 1
+      ;;
+    --llvm)
+      llvm=true
+      shift 1
+      ;;
+    --monointerpreter)
+      monointerpreter=true
+      shift 1
+      ;;
+    --monoaot)
+      monoaot=true
+      shift 1
+      ;;
+    --monodotnet)
+      mono_dotnet=$2
+      shift 2
       ;;
     --compare)
       compare=true
@@ -107,6 +129,7 @@ while (($# > 0)); do
       echo "  --kind <value>                 Related to csproj. The kind of benchmarks that should be run. Defaults to micro"
       echo "  --runcategories <value>        Related to csproj. Categories of benchmarks to run. Defaults to \"coreclr corefx\""
       echo "  --internal                     If the benchmarks are running as an official job."
+      echo "  --monodotnet                   Pass the path to the mono dotnet for mono performance testing."
       echo ""
       exit 0
       ;;
@@ -164,6 +187,10 @@ if [[ "$internal" == true ]]; then
     fi
 fi
 
+if [[ "$mono_dotnet" != "" ]]; then
+    configurations="$configurations LLVM=$llvm MonoInterpreter=$monointerpreter MonoAOT=$monoaot"
+fi
+
 common_setup_arguments="--channel master --queue $queue --build-number $build_number --build-configs $configurations --architecture $architecture"
 setup_arguments="--repository https://github.com/$repository --branch $branch --get-perf-hash --commit-sha $commit_sha $common_setup_arguments"
 
@@ -184,6 +211,12 @@ else
     
     docs_directory=$performance_directory/docs
     mv $docs_directory $workitem_directory
+fi
+
+if [[ "$mono_dotnet" != "" ]]; then
+    using_mono=true
+    mono_dotnet_path=$payload_directory/dotnet-mono
+    mv $mono_dotnet $mono_dotnet_path
 fi
 
 if [[ "$use_core_run" = true ]]; then
@@ -221,3 +254,4 @@ Write-PipelineSetVariable -name "HelixSourcePrefix" -value "$helix_source_prefix
 Write-PipelineSetVariable -name "Kind" -value "$kind" -is_multi_job_variable false
 Write-PipelineSetVariable -name "_BuildConfig" -value "$architecture.$kind.$framework" -is_multi_job_variable false
 Write-PipelineSetVariable -name "Compare" -value "$compare" -is_multi_job_variable false
+Write-PipelineSetVariable -name "MonoDotnet" -value "$using_mono" -is_multi_job_variable false

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -59,14 +59,15 @@ try {
 
   if( $msbuildEngine -eq "vs") {
     # Ensure desktop MSBuild is available for sdk tasks.
-    if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "vs" )) {
-      $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.4`" }") -MemberType NoteProperty
+    if( -not ($GlobalJson.tools.PSObject.Properties.Name -contains "vs" )) {
+      $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.4.0-alpha" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.5.0-alpha" -MemberType NoteProperty
     }
 
-    InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"
   }
 
   $taskProject = GetSdkTaskProject $task

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -40,6 +40,8 @@ parameters:
   Net5Preview3ChannelId: 739
   Net5Preview4ChannelId: 856
   Net5Preview5ChannelId: 857
+  NetCoreSDK313xxChannelId: 759
+  NetCoreSDK313xxInternalChannelId: 760
   NetCoreSDK314xxChannelId: 921
   NetCoreSDK314xxInternalChannelId: 922
   
@@ -66,7 +68,7 @@ stages:
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/common/post-build/check-channel-consistency.ps1
           arguments: -PromoteToChannels "$(TargetChannels)"
-            -AvailableChannelIds ${{parameters.NetEngLatestChannelId}},${{parameters.NetEngValidationChannelId}},${{parameters.NetDev5ChannelId}},${{parameters.GeneralTestingChannelId}},${{parameters.NETCoreToolingDevChannelId}},${{parameters.NETCoreToolingReleaseChannelId}},${{parameters.NETInternalToolingChannelId}},${{parameters.NETCoreExperimentalChannelId}},${{parameters.NetEngServicesIntChannelId}},${{parameters.NetEngServicesProdChannelId}},${{parameters.Net5Preview3ChannelId}},${{parameters.Net5Preview4ChannelId}},${{parameters.Net5Preview5ChannelId}},${{parameters.NetCoreSDK314xxChannelId}},${{parameters.NetCoreSDK314xxInternalChannelId}}
+            -AvailableChannelIds ${{parameters.NetEngLatestChannelId}},${{parameters.NetEngValidationChannelId}},${{parameters.NetDev5ChannelId}},${{parameters.GeneralTestingChannelId}},${{parameters.NETCoreToolingDevChannelId}},${{parameters.NETCoreToolingReleaseChannelId}},${{parameters.NETInternalToolingChannelId}},${{parameters.NETCoreExperimentalChannelId}},${{parameters.NetEngServicesIntChannelId}},${{parameters.NetEngServicesProdChannelId}},${{parameters.Net5Preview3ChannelId}},${{parameters.Net5Preview4ChannelId}},${{parameters.Net5Preview5ChannelId}},${{parameters.NetCoreSDK313xxChannelId}},${{parameters.NetCoreSDK313xxInternalChannelId}},${{parameters.NetCoreSDK314xxChannelId}},${{parameters.NetCoreSDK314xxInternalChannelId}}
 
   - job:
     displayName: NuGet Validation
@@ -405,6 +407,32 @@ stages:
     stageName: 'NETCore_SDK_314xx_Internal_Publishing'
     channelName: '.NET Core SDK 3.1.4xx Internal'
     channelId: ${{ parameters.NetCoreSDK314xxInternalChannelId }}
+    transportFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json'
+    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v3/index.json'
+    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-symbols/nuget/v3/index.json' 
+
+- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+  parameters:
+    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+    dependsOn: ${{ parameters.publishDependsOn }}
+    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+    stageName: 'NETCore_SDK_313xx_Publishing'
+    channelName: '.NET Core SDK 3.1.3xx'
+    channelId: ${{ parameters.NetCoreSDK313xxChannelId }}
+    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'
+    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
+    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-symbols/nuget/v3/index.json'
+
+- template: \eng\common\templates\post-build\channels\generic-internal-channel.yml
+  parameters:
+    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+    dependsOn: ${{ parameters.publishDependsOn }}
+    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+    stageName: 'NETCore_SDK_313xx_Internal_Publishing'
+    channelName: '.NET Core SDK 3.1.3xx Internal'
+    channelId: ${{ parameters.NetCoreSDK313xxInternalChannelId }}
     transportFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json'
     shippingFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v3/index.json'
     symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-symbols/nuget/v3/index.json' 

--- a/eng/helix/content/RunTests/RunTests.csproj
+++ b/eng/helix/content/RunTests/RunTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -48,10 +48,10 @@ try {
     if ($ci) {
         # Install dotnet.exe
         if ($DotNetRuntimeSourceFeed -or $DotNetRuntimeSourceFeedKey) {
-            & $repoRoot/restore.cmd -ci -noBuildNodeJS -DotNetRuntimeSourceFeed $DotNetRuntimeSourceFeed -DotNetRuntimeSourceFeedKey $DotNetRuntimeSourceFeedKey
+            & $repoRoot/restore.cmd -ci -nobl -noBuildNodeJS -DotNetRuntimeSourceFeed $DotNetRuntimeSourceFeed -DotNetRuntimeSourceFeedKey $DotNetRuntimeSourceFeedKey
         }
         else{
-            & $repoRoot/restore.cmd -ci -noBuildNodeJS
+            & $repoRoot/restore.cmd -ci -nobl -noBuildNodeJS
         }
     }
 

--- a/eng/targets/ReferenceAssembly.targets
+++ b/eng/targets/ReferenceAssembly.targets
@@ -50,7 +50,8 @@
       Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
     <PropertyGroup>
       <_RefSourceFileTFM>$(TargetFramework)</_RefSourceFileTFM>
-      <_RefSourceFileTFM Condition="$(TargetFramework.StartsWith('netcoreapp'))">netcoreapp</_RefSourceFileTFM>
+      <_RefSourceFileTFM Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
+          $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))">netcoreapp</_RefSourceFileTFM>
       <_RefProjectFileTFM>$(TargetFramework)</_RefProjectFileTFM>
       <_RefProjectFileTFM Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">%24(DefaultNetCoreTargetFramework)</_RefProjectFileTFM>
 

--- a/eng/tools/RepoTasks/RepoTasks.tasks
+++ b/eng/tools/RepoTasks/RepoTasks.tasks
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <_RepoTaskAssemblyFolder Condition="'$(MSBuildRuntimeType)' == 'core'">netcoreapp5.0</_RepoTaskAssemblyFolder>
+    <_RepoTaskAssemblyFolder Condition="'$(MSBuildRuntimeType)' == 'core'">net5.0</_RepoTaskAssemblyFolder>
     <_RepoTaskAssemblyFolder Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_RepoTaskAssemblyFolder>
     <_RepoTaskAssembly>$(ArtifactsBinDir)RepoTasks\Release\$(_RepoTaskAssemblyFolder)\RepoTasks.dll</_RepoTaskAssembly>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -25,7 +25,7 @@
   },
   "msbuild-sdks": {
     "Yarn.MSBuild": "1.15.2",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20228.4"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20261.9",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20261.9"
   }
 }

--- a/src/Components/Blazor/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
+++ b/src/Components/Blazor/Build/test/BuildIntegrationTests/BuildIntegrationTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Blazor.Build
         {
             // Arrange
             using var project = ProjectDirectory.Create("blazorhosted", additionalProjects: new[] { "standalone", "razorclasslibrary", });
-            project.TargetFramework = "netcoreapp5.0";
+            project.TargetFramework = "net5.0";
             var result = await MSBuildProcessManager.DotnetMSBuild(project);
 
             Assert.BuildPassed(result);

--- a/src/Components/Blazor/Build/test/BuildIntegrationTests/PublishIntegrationTest.cs
+++ b/src/Components/Blazor/Build/test/BuildIntegrationTests/PublishIntegrationTest.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Blazor.Build
         {
             // Arrange
             using var project = ProjectDirectory.Create("blazorhosted", additionalProjects: new[] { "standalone", "razorclasslibrary", });
-            project.TargetFramework = "netcoreapp5.0";
+            project.TargetFramework = "net5.0";
             var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish");
 
             Assert.BuildPassed(result);
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Blazor.Build
         {
             // Arrange
             using var project = ProjectDirectory.Create("blazorhosted", additionalProjects: new[] { "standalone", "razorclasslibrary", });
-            project.TargetFramework = "netcoreapp5.0";
+            project.TargetFramework = "net5.0";
             var result = await MSBuildProcessManager.DotnetMSBuild(project, "Build");
 
             Assert.BuildPassed(result);

--- a/src/Components/Blazor/Build/testassets/blazorhosted/blazorhosted.csproj
+++ b/src/Components/Blazor/Build/testassets/blazorhosted/blazorhosted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <DisableImplicitComponentsAnalyzers>true</DisableImplicitComponentsAnalyzers>
   </PropertyGroup>
 

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.multitarget.nuspec
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.multitarget.nuspec
@@ -9,7 +9,7 @@
         <dependency id="Microsoft.JSInterop" version="$jsInteropPackageVersion$" exclude="Build,Analyzers" />
         <dependency id="System.ComponentModel.Annotations" version="$systemComponentModelAnnotationsPackageVersion$" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework=".NETCoreApp5.0">
+      <group targetFramework=".net5.0">
         <dependency id="Microsoft.AspNetCore.Components.Analyzers" version="$componentAnalyzerPackageVersion$" />
         <dependency id="Microsoft.AspNetCore.Authorization" version="$authorizationPackageVersion$" exclude="Build,Analyzers" />
         <dependency id="Microsoft.JSInterop" version="$jsInteropPackageVersion$" exclude="Build,Analyzers" />

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.netcoreapp.nuspec
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.netcoreapp.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     $CommonMetadataElements$
     <dependencies>
-      <group targetFramework=".NETCoreApp5.0">
+      <group targetFramework=".net5.0">
         <dependency id="Microsoft.AspNetCore.Components.Analyzers" version="$componentAnalyzerPackageVersion$" />
         <dependency id="Microsoft.AspNetCore.Authorization" version="$authorizationPackageVersion$" exclude="Build,Analyzers" />
         <dependency id="Microsoft.JSInterop" version="$jsInteropPackageVersion$" exclude="Build,Analyzers" />

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Tests
             var applicationName = "CreateDefaultBuilderApp";
             var deploymentParameters = new DeploymentParameters(Path.Combine(GetTestSitesPath(), applicationName), ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64)
             {
-                TargetFramework = "netcoreapp5.0",
+                TargetFramework = "net5.0",
                 HostingModel =  HostingModel.InProcess
             };
 
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Tests
         {
             var deploymentParameters = new DeploymentParameters(Path.Combine(GetTestSitesPath(), applicationName), ServerType.Kestrel, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64)
             {
-                TargetFramework = "netcoreapp5.0",
+                TargetFramework = "net5.0",
             };
 
             if (setTestEnvVars)

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     $CommonMetadataElements$
     <dependencies>
-      <group targetFramework=".NETCoreApp5.0">
+      <group targetFramework=".net5.0">
         <dependency id="Microsoft.Extensions.FileProviders.Abstractions" version="$AbstractionsPackageVersion$" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp.nuspec
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     $CommonMetadataElements$
     <dependencies>
-      <group targetFramework=".NETCoreApp5.0">
+      <group targetFramework=".net5.0">
         <dependency id="Microsoft.Extensions.FileProviders.Abstractions" version="$AbstractionsPackageVersion$" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore
         public SharedFxTests(ITestOutputHelper output)
         {
             _output = output;
-            _expectedTfm = "netcoreapp" + TestData.GetSharedFxVersion().Substring(0, 3);
+            _expectedTfm = "net" + TestData.GetSharedFxVersion().Substring(0, 3);
             _expectedRid = TestData.GetSharedFxRuntimeIdentifier();
             _sharedFxRoot = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNET_RUNTIME_PATH"))
                 ? Path.Combine(TestData.GetTestDataValue("SharedFrameworkLayoutRoot"), "shared", TestData.GetTestDataValue("RuntimePackageVersion"))

--- a/src/Hosting/Server.IntegrationTesting/src/Common/Tfm.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/Tfm.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         public const string NetCoreApp22 = "netcoreapp2.2";
         public const string NetCoreApp30 = "netcoreapp3.0";
         public const string NetCoreApp31 = "netcoreapp3.1";
-        public const string NetCoreApp50 = "netcoreapp5.0";
+        public const string Net50 = "net5.0";
 
         public static bool Matches(string tfm1, string tfm2)
         {

--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
                     RuntimeArchitecture.x64)
                 {
                     EnvironmentName = "Shutdown",
-                    TargetFramework = Tfm.NetCoreApp50,
+                    TargetFramework = Tfm.Net50,
                     ApplicationType = ApplicationType.Portable,
                     PublishApplicationBeforeDeployment = true,
                     StatusMessagesEnabled = false

--- a/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
+++ b/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
         public WebHostBuilderTests(ITestOutputHelper output) : base(output) { }
 
         public static TestMatrix TestVariants => TestMatrix.ForServers(ServerType.Kestrel)
-                .WithTfms(Tfm.NetCoreApp50);
+                .WithTfms(Tfm.Net50);
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnTester.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnTester.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             {
                 Scheme = (ssl ? Uri.UriSchemeHttps : Uri.UriSchemeHttp),
                 ApplicationType = ApplicationType.Portable,
-                TargetFramework = "netcoreapp5.0",
+                TargetFramework = "Net5.0",
                 EnvironmentName = environment,
                 SiteName = "HttpTestSite", // This is configured in the Http.config
                 ServerConfigTemplateContent = (server == ServerType.IISExpress) ? File.ReadAllText(configPath) : null,

--- a/src/MusicStore/test/MusicStore.E2ETests/DotnetRunTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/DotnetRunTests.cs
@@ -17,7 +17,7 @@ namespace E2ETests
     {
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.Kestrel)
-                .WithTfms(Tfm.NetCoreApp50);
+                .WithTfms(Tfm.Net50);
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]

--- a/src/MusicStore/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
@@ -18,7 +18,7 @@ namespace E2ETests
     {
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllArchitectures();
 

--- a/src/MusicStore/test/MusicStore.E2ETests/OpenIdConnectTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/OpenIdConnectTests.cs
@@ -15,7 +15,7 @@ namespace E2ETests
     {
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel)
-                .WithTfms(Tfm.NetCoreApp50);
+                .WithTfms(Tfm.Net50);
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]

--- a/src/MusicStore/test/MusicStore.E2ETests/PublishAndRunTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/PublishAndRunTests.cs
@@ -16,7 +16,7 @@ namespace E2ETests
     {
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllHostingModels()
                 .WithAllArchitectures();

--- a/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/SmokeTests.cs
@@ -17,7 +17,7 @@ namespace E2ETests
     {
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllHostingModels();
 

--- a/src/MusicStore/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
@@ -244,7 +244,7 @@ namespace E2ETests
                     _remoteDeploymentConfig.AccountName,
                     _remoteDeploymentConfig.AccountPassword)
                 {
-                    TargetFramework = Tfm.NetCoreApp50,
+                    TargetFramework = Tfm.Net50,
                     ApplicationBaseUriHint = applicationBaseUrl,
                     ApplicationType = applicationType
                 };

--- a/src/MusicStore/test/MusicStore.E2ETests/StoreSmokeTests.cs
+++ b/src/MusicStore/test/MusicStore.E2ETests/StoreSmokeTests.cs
@@ -34,7 +34,7 @@ namespace E2ETests
                     EnvironmentName = "SocialTesting",
                     PublishApplicationBeforeDeployment = true,
                     PreservePublishedApplicationForDebugging = Helpers.PreservePublishedApplicationForDebugging,
-                    TargetFramework = Tfm.NetCoreApp50,
+                    TargetFramework = Tfm.Net50,
                     UserAdditionalCleanup = parameters =>
                     {
                         DbUtils.DropDatabase(musicStoreDbName, logger);

--- a/src/ProjectTemplates/BlazorTemplates.Tests/Infrastructure/Directory.Build.props.in
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/Infrastructure/Directory.Build.props.in
@@ -1,6 +1,6 @@
 <Project>
 <!-- This file gets copied above the template test projects so that we disconnect the templates from the rest of the repository -->
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/ProjectTemplates/BlazorWasm.ProjectTemplates/content/BlazorWasm-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/BlazorWasm.ProjectTemplates/content/BlazorWasm-CSharp/.template.config/template.json
@@ -85,12 +85,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
@@ -337,12 +337,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -86,12 +86,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -82,12 +82,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
@@ -41,11 +41,11 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "defaultValue": "netcoreapp5.0"
+      "defaultValue": "net5.0"
     },
     "ExcludeLaunchSettings": {
       "type": "parameter",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -47,11 +47,11 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "defaultValue": "netcoreapp5.0"
+      "defaultValue": "net5.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -316,12 +316,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -306,12 +306,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -87,12 +87,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -209,12 +209,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -82,12 +82,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/template.json
@@ -47,12 +47,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
@@ -177,12 +177,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
@@ -178,12 +178,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
@@ -87,12 +87,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp5.0",
-      "defaultValue": "netcoreapp5.0"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/ProjectTemplates/scripts/Test-Template.ps1
+++ b/src/ProjectTemplates/scripts/Test-Template.ps1
@@ -32,7 +32,7 @@ function Test-Template($templateName, $templateArgs, $templateNupkg, $isSPA) {
         $proj = "$tmpDir/$templateName.$extension"
         $projContent = Get-Content -Path $proj -Raw
         $projContent = $projContent -replace ('<Project Sdk="Microsoft.NET.Sdk.Web">', "<Project Sdk=""Microsoft.NET.Sdk.Web"">
-  <Import Project=""$PSScriptRoot/../test/bin/Debug/netcoreapp5.0/TestTemplates/TemplateTests.props"" />
+  <Import Project=""$PSScriptRoot/../test/bin/Debug/net5.0/TestTemplates/TemplateTests.props"" />
   <ItemGroup>
     <PackageReference Include=""Microsoft.NET.Sdk.Razor"" Version=""`$(MicrosoftNETSdkRazorPackageVersion)"" />
   </ItemGroup>
@@ -42,7 +42,7 @@ function Test-Template($templateName, $templateArgs, $templateNupkg, $isSPA) {
         $projContent | Set-Content $proj
         dotnet.exe ef migrations add mvc
         dotnet.exe publish --configuration Release
-        dotnet.exe bin\Release\netcoreapp5.0\publish\$templateName.dll
+        dotnet.exe bin\Release\net5.0\publish\$templateName.dll
     }
     finally {
         Pop-Location

--- a/src/ProjectTemplates/test/Infrastructure/Directory.Build.props.in
+++ b/src/ProjectTemplates/test/Infrastructure/Directory.Build.props.in
@@ -1,6 +1,6 @@
 <Project>
 <!-- This file gets copied above the template test projects so that we disconnect the templates from the rest of the repository -->
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithApplicationTypes(ApplicationType.Portable)
                 .WithAllHostingModels();
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllHostingModels();
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CommonStartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CommonStartupTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllHostingModels();
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllHostingModels();
 
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         [RequiresNewShim]
         public async Task SetsConnectionCloseHeader()
         {
-            // Only tests OutOfProcess as the Connection header is removed for out of process and not inprocess. 
+            // Only tests OutOfProcess as the Connection header is removed for out of process and not inprocess.
             // This test checks a quirk to allow setting the Connection header.
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAncmV2InProcess();
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes()
                 .WithAllHostingModels();
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/AspNetCorePortTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithApplicationTypes(ApplicationType.Portable);
 
         public static IEnumerable<object[]> InvalidTestVariants
@@ -90,13 +90,13 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
         public async Task ShutdownMultipleTimesWorks(TestVariant variant)
         {
             // Must publish to set env vars in web.config
-            var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);    
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
 
             var deploymentResult = await DeployAsync(deploymentParameters);
-            
+
             // Shutdown once
             var response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
-            
+
             // Wait for server to start again.
             int i;
             for (i = 0; i < 10; i++)
@@ -108,16 +108,16 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
                     break;
                 }
             }
-            
+
             if (i == 10)
             {
                 // Didn't restart after 10 retries
                 Assert.False(true);
             }
-            
+
             // Shutdown again
             response = await deploymentResult.HttpClient.GetAsync("/Shutdown");
-            
+
             // return if server starts again.
             for (i = 0; i < 10; i++)
             {
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
                     return;
                 }
             }
-            
+
             // Test failure if this happens.
             Assert.False(true);
         }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/HelloWorldTest.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/OutOfProcess/HelloWorldTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.OutOfProcess
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllApplicationTypes();
 
         [ConditionalTheory]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/PublishedSitesFixture.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/PublishedSitesFixture.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
                     RuntimeFlavor = RuntimeFlavor.CoreClr,
                     RuntimeArchitecture = RuntimeArchitecture.x64,
                     HostingModel = hostingModel,
-                    TargetFramework = Tfm.NetCoreApp50
+                    TargetFramework = Tfm.Net50
                 });
         }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISTestSiteFixture.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Utilities/IISTestSiteFixture.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             {
                 RuntimeArchitecture = RuntimeArchitecture.x64,
                 RuntimeFlavor =  RuntimeFlavor.CoreClr,
-                TargetFramework = Tfm.NetCoreApp50,
+                TargetFramework = Tfm.Net50,
                 HostingModel = HostingModel.InProcess,
                 PublishApplicationBeforeDeployment = true,
                 ApplicationPublisher = new PublishedApplicationPublisher(Helpers.GetInProcessTestSitesName()),

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithApplicationTypes(ApplicationType.Portable)
                 .WithAllHostingModels();
 

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
-                .WithTfms(Tfm.NetCoreApp50);
+                .WithTfms(Tfm.Net50);
 
         [ConditionalTheory]
         [RequiresIIS(IISCapability.WindowsAuthentication)]

--- a/src/Servers/Kestrel/samples/http2cat/http2cat.csproj
+++ b/src/Servers/Kestrel/samples/http2cat/http2cat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -14,14 +14,14 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Include="$(SharedSourceRoot)ServerInfrastructure\SharedStrings.resx" Link="Shared\SharedStrings.resx">
       <ManifestResourceName>Microsoft.AspNetCore.Server.SharedStrings</ManifestResourceName>
@@ -32,7 +32,7 @@
       <Generator></Generator>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="TaskTimeoutExtensions.cs" />
   </ItemGroup>

--- a/src/Servers/test/FunctionalTests/HelloWorldTest.cs
+++ b/src/Servers/test/FunctionalTests/HelloWorldTest.cs
@@ -21,7 +21,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.Nginx, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithApplicationTypes(ApplicationType.Portable)
                 .WithAllHostingModels()
                 .WithAllArchitectures();

--- a/src/Servers/test/FunctionalTests/NtlmAuthenticationTest.cs
+++ b/src/Servers/test/FunctionalTests/NtlmAuthenticationTest.cs
@@ -22,7 +22,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.HttpSys, ServerType.Kestrel)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllHostingModels();
 
         [ConditionalTheory]

--- a/src/Servers/test/FunctionalTests/ResponseCompressionTests.cs
+++ b/src/Servers/test/FunctionalTests/ResponseCompressionTests.cs
@@ -33,7 +33,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix NoCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.Nginx,  ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -45,7 +45,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix HostCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Nginx)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -57,7 +57,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix AppCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.HttpSys) // No pass-through compression for nginx
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -69,7 +69,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix HostAndAppCompressionTestVariants
             => TestMatrix.ForServers(ServerType.IISExpress, ServerType.Kestrel, ServerType.Nginx, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllHostingModels();
 
         [ConditionalTheory]

--- a/src/Servers/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/test/FunctionalTests/ResponseTests.cs
@@ -26,7 +26,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(/* ServerType.IISExpress, https://github.com/dotnet/aspnetcore/issues/6168, */ ServerType.Kestrel, ServerType.Nginx, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50)
+                .WithTfms(Tfm.Net50)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -52,7 +52,7 @@ namespace ServerComparison.FunctionalTests
 
         public static TestMatrix SelfhostTestVariants
             => TestMatrix.ForServers(ServerType.Kestrel, ServerType.HttpSys)
-                .WithTfms(Tfm.NetCoreApp50);
+                .WithTfms(Tfm.Net50);
 
         // Connection Close tests do not work through reverse proxies
         [ConditionalTheory]

--- a/src/Shared/BenchmarkRunner/DefaultCoreConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCoreConfig.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Attributes
 #elif NETCOREAPP3_1
                 .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.1", null, ".NET Core 3.1")))
 #elif NETCOREAPP5_0
-                .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp5.0", null, ".NET Core 5.0")))
+                .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("net5.0", null, ".NET Core 5.0")))
 #else
 #error Target frameworks need to be updated.
 #endif

--- a/src/Shared/ErrorPage/GeneratePage.ps1
+++ b/src/Shared/ErrorPage/GeneratePage.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(Mandatory = $true)][string]$ToolingRepoPath
 )
 
-$ToolPath = Join-Path $ToolingRepoPath "artifacts\bin\RazorPageGenerator\Debug\netcoreapp5.0\dotnet-razorpagegenerator.exe"
+$ToolPath = Join-Path $ToolingRepoPath "artifacts\bin\RazorPageGenerator\Debug\net5.0\dotnet-razorpagegenerator.exe"
 
 if (!(Test-Path $ToolPath)) {
     throw "Unable to find razor page generator tool at $ToolPath"

--- a/src/SignalR/clients/ts/FunctionalTests/scripts/run-tests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/run-tests.ts
@@ -245,7 +245,7 @@ function runJest(httpsUrl: string, httpUrl: string) {
 
 (async () => {
     try {
-        const serverPath = path.resolve(ARTIFACTS_DIR, "bin", "SignalR.Client.FunctionalTestApp", configuration, "netcoreapp5.0", "SignalR.Client.FunctionalTestApp.dll");
+        const serverPath = path.resolve(ARTIFACTS_DIR, "bin", "SignalR.Client.FunctionalTestApp", configuration, "net5.0", "SignalR.Client.FunctionalTestApp.dll");
 
         debug(`Launching Functional Test Server: ${serverPath}`);
         let desiredServerUrl = "https://127.0.0.1:0;http://127.0.0.1:0";

--- a/src/SignalR/publish-apps.ps1
+++ b/src/SignalR/publish-apps.ps1
@@ -1,4 +1,4 @@
-param($RootDirectory = (Get-Location), $Framework = "netcoreapp5.0", $Runtime = "win-x64", $CommitHash, $BranchName, $BuildNumber)
+param($RootDirectory = (Get-Location), $Framework = "net5.0", $Runtime = "win-x64", $CommitHash, $BranchName, $BuildNumber)
 
 # De-Powershell the path
 $RootDirectory = (Convert-Path $RootDirectory)

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.OpenApi.Tests
         protected readonly TextWriter _output = new StringWriter();
         protected readonly TextWriter _error = new StringWriter();
         protected readonly ITestOutputHelper _outputHelper;
-        protected const string TestTFM = "netcoreapp5.0";
+        protected const string TestTFM = "net5.0";
 
         protected const string Content = @"{""x-generator"": ""NSwag""}";
         protected const string ActualUrl = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/api-with-examples.yaml";

--- a/src/Tools/dotnet-user-secrets/test/UserSecretsTestFixture.cs
+++ b/src/Tools/dotnet-user-secrets/test/UserSecretsTestFixture.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
         private const string ProjectTemplate = @"<Project ToolsVersion=""15.0"" Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     {0}
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>

--- a/src/Tools/dotnet-watch/test/ProgramTests.cs
+++ b/src/Tools/dotnet-watch/test/ProgramTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         {
             _tempDir
                 .WithCSharpProject("testproj")
-                .WithTargetFrameworks("netcoreapp5.0")
+                .WithTargetFrameworks("net5.0")
                 .Dir()
                 .WithFile("Program.cs")
                 .Create();

--- a/src/Tools/dotnet-watch/test/TestProjects/AppWithDeps/AppWithDeps.csproj
+++ b/src/Tools/dotnet-watch/test/TestProjects/AppWithDeps/AppWithDeps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Tools/dotnet-watch/test/TestProjects/GlobbingApp/GlobbingApp.csproj
+++ b/src/Tools/dotnet-watch/test/TestProjects/GlobbingApp/GlobbingApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>exe</OutputType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Tools/dotnet-watch/test/TestProjects/KitchenSink/KitchenSink.csproj
+++ b/src/Tools/dotnet-watch/test/TestProjects/KitchenSink/KitchenSink.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Tools/dotnet-watch/test/TestProjects/NoDepsApp/NoDepsApp.csproj
+++ b/src/Tools/dotnet-watch/test/TestProjects/NoDepsApp/NoDepsApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
* Update dependencies from https://github.com/dotnet/arcade build 20200511.9
  - Microsoft.DotNet.Arcade.Sdk: 5.0.0-beta.20228.4 => 5.0.0-beta.20261.9
  - Microsoft.DotNet.GenAPI: 5.0.0-beta.20228.4 => 5.0.0-beta.20261.9
  - Microsoft.DotNet.Helix.Sdk: 5.0.0-beta.20228.4 => 5.0.0-beta.20261.9

* Pre-emptively take -nobl change

* Disable binlogs in CI

* Fix build.sh to know about -nobl

* Align build.ps1|sh with latest Arcade parameters
  - do not enable binary logs by default in CI builds
  - leave `-binaryLog` and `-excludeCIBinaryLog` handling to eng/common/tools.ps1|sh
    - was unnecessary since `-bl /bl:{some name}` worked fine, ignoring OOMs

nit: document `-excludeCIBinarylog` a bit more

* Do not pass unknown options into CodeCheck.ps1

* Pass `-ci -nobl` into remaining CI build jobs

* Switch default TFM to `net5.0`

* Update missing project templates tfms

* Add more `-ci -nobl`
  - needed because _all_ builds in the pipeline are implicitly CI builds
    - default-build.yml adds `-ci` when script wasn't explicit

* Default templates to net5.0

* PR feedback

* Update TFMs in explicit .nuspec files

* Update TFMs in test projects

* Update TFMs in test C# code

* Update TFMs in infrastructure files

* Future-proof a check for `net5.0` or later
  - avoid comparisons involving `$(TargetFramework)` in .targets files
    - fine to compare it with `''` or `$(DefaultNetCoreTargetFramework)`

* !fixup! Undo a couple of earlier fixes
  - remove a duplicate `$()` setting
  - correct the one remaining versioned `#if` define
    - did not make it `#if NETCOREAPP` because benchmarks test numerous .NET Core TFMs

* Disable binary logs in CodeCheck.ps1

* Specify `-ci -nobl` just once when using `parameters.buildArgs`

* Restore `$binaryLog` default logic

This cherry-picks most of d5849f3534403caf665157c4e1045432a35e3951 into this branch
- [master] Update dependencies from dotnet/arcade dotnet/aspnetcore-tooling (#21630)
- does not include dotnet/aspnetcore-tooling updates

Co-authored-by: dotnet-maestro[bot] <42748379+dotnet-maestro[bot]@users.noreply.github.com>
Co-authored-by: Will Godbe <wigodbe@microsoft.com>
Co-authored-by: Viktor Hofer <viktor.hofer@microsoft.com>
