### PR TITLE
Ignore error output from `Get-Process`

### DIFF
--- a/eng/scripts/StartDumpCollectionForHangingBuilds.ps1
+++ b/eng/scripts/StartDumpCollectionForHangingBuilds.ps1
@@ -81,7 +81,7 @@ Out-File -FilePath $sentinelFile -InputObject $JobName | Out-Null;
   [System.Diagnostics.Process []]$AliveProcesses = @();
   foreach ($candidate in $CandidateProcessNames) {
     try {
-      $candidateProcesses = Get-Process $candidate;
+      $candidateProcesses = Get-Process $candidate 2>$null
       $candidateProcesses | ForEach-Object { Write-Output "Found candidate process $candidate with PID '$($_.Id)'." };
       $AliveProcesses += $candidateProcesses;
     }


### PR DESCRIPTION
- allow FinishDumpCollectionForHangingBuilds.ps1 to complete w/o writing to `stderr`