### PR TITLE
Remove Obsolete constructor in RequestLocalizationMiddleware

### DIFF
--- a/src/Middleware/Localization/ref/Microsoft.AspNetCore.Localization.netcoreapp.cs
+++ b/src/Middleware/Localization/ref/Microsoft.AspNetCore.Localization.netcoreapp.cs
@@ -100,9 +100,6 @@ namespace Microsoft.AspNetCore.Localization
     }
     public partial class RequestLocalizationMiddleware
     {
-        [System.ObsoleteAttribute("This constructor is obsolete and will be removed in a future version. Use RequestLocalizationMiddleware(RequestDelegate next, IOptions<RequestLocalizationOptions> options, ILoggerFactory loggerFactory) instead")]
-        public RequestLocalizationMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.RequestLocalizationOptions> options) { }
-        [Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute]
         public RequestLocalizationMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.RequestLocalizationOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context) { throw null; }

--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -36,7 +36,6 @@ namespace Microsoft.AspNetCore.Localization
         /// <param name="options">The <see cref="RequestLocalizationOptions"/> representing the options for the
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used for logging.</param>
         /// <see cref="RequestLocalizationMiddleware"/>.</param>
-        [ActivatorUtilitiesConstructor]
         public RequestLocalizationMiddleware(RequestDelegate next, IOptions<RequestLocalizationOptions> options, ILoggerFactory loggerFactory)
         {
             if (options == null)
@@ -47,18 +46,6 @@ namespace Microsoft.AspNetCore.Localization
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = loggerFactory?.CreateLogger<RequestLocalizationMiddleware>() ?? throw new ArgumentNullException(nameof(loggerFactory));
             _options = options.Value;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestLocalizationMiddleware"/>.
-        /// </summary>
-        /// <param name="next">The <see cref="RequestDelegate"/> representing the next middleware in the pipeline.</param>
-        /// <param name="options">The <see cref="RequestLocalizationOptions"/> representing the options for the
-        /// <see cref="RequestLocalizationMiddleware"/>.</param>
-        [Obsolete("This constructor is obsolete and will be removed in a future version. Use RequestLocalizationMiddleware(RequestDelegate next, IOptions<RequestLocalizationOptions> options, ILoggerFactory loggerFactory) instead")]
-        public RequestLocalizationMiddleware(RequestDelegate next, IOptions<RequestLocalizationOptions> options)
-               : this(next, options, NullLoggerFactory.Instance)
-        {
         }
 
         /// <summary>


### PR DESCRIPTION
`ObsoleteAttribute` was added here. https://github.com/dotnet/aspnetcore/commit/ba8c6ccf6fd3eeb7fc42a159d362b15eae4fb3a0