### PR TITLE
!temporary! Require `msbuild` from VS2019 16.6

### DIFF
--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Git": "2.22.0",
     "jdk": "11.0.3",
     "vs": {
-      "version": "16.5",
+      "version": "16.6",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",


### PR DESCRIPTION
- already running on AzDO agents with this VS version installed
- should be able to revert this once I get `dotnet msbuild` working well