### PR TITLE
Build primarily with `dotnet msbuild`

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -639,7 +639,7 @@ stages:
       # Build the shared framework
       - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Build shared fx
-      - script: .\restore.cmd -ci -nobl /p:BuildInteropProjects=true
+      - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -projects src/Grpc/**/*.csproj
         displayName: Restore interop projects
       - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
                 /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -47,7 +47,8 @@ variables:
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-MSRC-Storage
   - name: _InternalRuntimeDownloadArgs
-    value: -DotNetRuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet -DotNetRuntimeSourceFeedKey $(dotnetclimsrc-read-sas-token-base64) /p:DotNetAssetRootAccessTokenSuffix='$(dotnetclimsrc-read-sas-token-base64)'
+    value: -DotNetRuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet -DotNetRuntimeSourceFeedKey
+           $(dotnetclimsrc-read-sas-token-base64) /p:DotNetAssetRootAccessTokenSuffix='$(dotnetclimsrc-read-sas-token-base64)'
   # The code signing doesn't use the aspnet build scripts, so the msbuild parameters have
   # to be passed directly. This is awkward, since we pass the same info above, but we have
   # to have it in two different forms
@@ -140,19 +141,21 @@ stages:
       - script: ./build.cmd
                 -ci
                 -nobl
+                -noBuildRepoTasks
                 -arch x86
                 -pack
                 -all
                 -noBuildJava
+                -noBuildNative
                 /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
         displayName: Build x86
 
-      # This is in a separate build step with -forceCoreMsbuild to workaround MAX_PATH limitations - https://github.com/Microsoft/msbuild/issues/53
       - script: .\src\SiteExtensions\build.cmd
                 -ci
                 -nobl
+                -noBuildRepoTasks
                 -pack
                 -noBuildDeps
                 $(_BuildArgs)
@@ -160,12 +163,13 @@ stages:
         condition: ne(variables['Build.Reason'], 'PullRequest')
         displayName: Build SiteExtension
 
-      # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If https://github.com/dotnet/arcade/issues/1957 is resolved,
-      # consider running code-signing inline with the other previous steps.
-      # Sign check is disabled because it is run in a separate step below, after installers are built.
+      # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If
+      # https://github.com/dotnet/arcade/issues/1957 is resolved, consider running code-signing inline with the other
+      # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
       - script: ./build.cmd
                 -ci
                 -nobl
+                -noBuildRepoTasks
                 -noBuild
                 -noRestore
                 -sign
@@ -177,6 +181,7 @@ stages:
       - script: ./build.cmd
                 -ci
                 -nobl
+                -noBuildRepoTasks
                 -sign
                 -buildInstallers
                 /p:DotNetSignType=$(_SignType)
@@ -492,7 +497,9 @@ stages:
       jobDisplayName: "Test: Windows Server 2016 x64"
       agentOs: Windows
       isTestingJob: true
-      buildArgs: -all -pack -test "/p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false" $(_InternalRuntimeDownloadArgs)
+      buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
+                 /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
+                 $(_InternalRuntimeDownloadArgs)
       beforeBuild:
       - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
         displayName: Setup IISExpress test certificates and schema
@@ -530,9 +537,9 @@ stages:
       steps:
       - script: ./build.cmd -ci -nobl -all -pack $(_InternalRuntimeDownloadArgs)
         displayName: Build Repo
-      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true"
+      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true"
         displayName: Pack Templates
-      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
+      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
         displayName: Test Templates
       artifacts:
       - name: Windows_Test_Templates_Dumps
@@ -634,7 +641,9 @@ stages:
         displayName: Build shared fx
       - script: .\restore.cmd -ci -nobl /p:BuildInteropProjects=true
         displayName: Restore interop projects
-      - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
+                /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
+                /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
         displayName: Run build.cmd helix target
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -28,9 +28,9 @@ jobs:
     # Build the shared framework
     - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    - script: ./build.cmd -ci -nobl -restore -noBuild -projects src/Grpc/**/*.csproj
+    - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
-    - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj
+    - script: .\build.cmd -ci -nobl -noBuildRepoTasks -NoRestore -test -all -projects eng\helix\helix.proj
               /p:IsHelixDaily=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true
               /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
@@ -52,7 +52,7 @@ jobs:
     steps:
     - script: ./restore.sh -ci -nobl
       displayName: Restore
-    - script: ./build.sh -ci --nobl --arch arm64 -test --no-build-nodejs --all -projects
+    - script: ./build.sh --ci --nobl --noBuildRepoTasks --arch arm64 -test --no-build-nodejs --all --projects
               $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
               /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -7,7 +7,7 @@ schedules:
     include:
     - master
   always: true
-    
+
 variables:
 - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
   - name: _UseHelixOpenQueues
@@ -15,8 +15,8 @@ variables:
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
   - name: _UseHelixOpenQueues
-    value: 'false'    
-    
+    value: 'false'
+
 jobs:
 - template: jobs/default-build.yml
   parameters:
@@ -30,7 +30,9 @@ jobs:
       displayName: Build shared fx
     - script: .\restore.cmd -ci /p:BuildInteropProjects=true
       displayName: Restore interop projects
-    - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj /p:IsHelixDaily=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj
+              /p:IsHelixDaily=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true
+              /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -39,7 +41,7 @@ jobs:
     - name: Helix_logs
       path: artifacts/log/
       publishOnError: true
-      
+
 # Helix ARM64
 - template: jobs/default-build.yml
   parameters:
@@ -50,7 +52,9 @@ jobs:
     steps:
     - script: ./restore.sh -ci -nobl
       displayName: Restore
-    - script: ./build.sh -ci --nobl --arch arm64 -test --no-build-nodejs --all -projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    - script: ./build.sh -ci --nobl --arch arm64 -test --no-build-nodejs --all -projects
+              $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
+              /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -28,7 +28,7 @@ jobs:
     # Build the shared framework
     - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    - script: .\restore.cmd -ci /p:BuildInteropProjects=true
+    - script: ./build.cmd -ci -nobl -restore -noBuild -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
     - script: .\build.cmd -ci -nobl -NoRestore -test -all -projects eng\helix\helix.proj
               /p:IsHelixDaily=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true

--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -30,6 +30,7 @@ jobs:
         flattenFolders: true
     - powershell: .\eng\common\build.ps1
         -ci
+        -nobl
         -restore
         -sign
         -publish

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -104,11 +104,16 @@ jobs:
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+          ${{ if ne(parameters.isTestingJob, true) }}:
+            # Visual Studio Build Tools
+            queue: BuildPool.Server.Amd64.VS2019.BT.Open
+          ${{ if eq(parameters.isTestingJob, true) }}:
+            # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
+            queue: BuildPool.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+          queue: BuildPool.Server.Amd64.VS2019
     variables:
     - AgentOsName: ${{ parameters.agentOs }}
     - ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -33,7 +33,7 @@ jobs:
     # Build the shared framework
     - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
       displayName: Build shared fx
-    - script: .\restore.cmd -ci /p:BuildInteropProjects=true
+    - script: ./build.cmd -ci -nobl -restore -noBuild -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
     - script: ./build.cmd -ci -noRestore -test -all -noBuildJava -noBuildNative -projects eng\helix\helix.proj
               /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -31,11 +31,11 @@ jobs:
     timeoutInMinutes: 240
     steps:
     # Build the shared framework
-    - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
+    - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
-    - script: ./build.cmd -ci -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+    - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
               /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -35,7 +35,9 @@ jobs:
       displayName: Build shared fx
     - script: .\restore.cmd -ci /p:BuildInteropProjects=true
       displayName: Restore interop projects
-    - script: .\build.cmd -ci -NoRestore -test -noBuildJava -all -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log -bl
+    - script: ./build.cmd -ci -noRestore -test -all -noBuildJava -noBuildNative -projects eng\helix\helix.proj
+              /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true
+              /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -33,11 +33,11 @@ jobs:
     # Build the shared framework
     - script: ./build.cmd -ci -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /bl:artifacts/log/helix.build.x64.binlog
       displayName: Build shared fx
-    - script: ./build.cmd -ci -nobl -restore -noBuild -projects src/Grpc/**/*.csproj
+    - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
-    - script: ./build.cmd -ci -noRestore -test -all -noBuildJava -noBuildNative -projects eng\helix\helix.proj
-              /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true
-              /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    - script: ./build.cmd -ci -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
+              /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -180,7 +180,7 @@
     <!-- Projects which reference Microsoft.AspNetCore.Mvc.Testing should import this targets file to ensure dependency .deps.json files are copied into test output. -->
     <MvcTestingTargets>$(MSBuildThisFileDirectory)src\Mvc\Mvc.Testing\src\Microsoft.AspNetCore.Mvc.Testing.targets</MvcTestingTargets>
     <!-- IIS native projects can only be built on Windows for x86 and x64. -->
-    <BuildIisNativeProjects Condition=" $(BuildNative) AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') ">true</BuildIisNativeProjects>
+    <BuildIisNativeProjects Condition=" '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') ">true</BuildIisNativeProjects>
     <!-- This property is shared by several projects to layout the AspNetCore.App targeting pack for installers -->
     <TargetingPackLayoutRoot>$(ArtifactsObjDir)TargetingPack.Layout\$(Configuration)\</TargetingPackLayoutRoot>
     <!-- This property is shared by several projects to layout the AspNetCore.App shared framework for installers -->

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -5,7 +5,8 @@
   <Import Project="SharedFramework.Local.props" />
 
   <!-- This is temporary until we can use FrameworkReference to build our own packages. -->
-  <Target Name="RemoveSharedFrameworkOnlyRefsFromNuspec" AfterTargets="Pack">
+  <Target Name="RemoveSharedFrameworkOnlyRefsFromNuspec" AfterTargets="Pack"
+      Condition=" '$(MSBuildRuntimeType)' == 'core' ">
     <ItemGroup>
       <_BuildOutput Include="$(ArtifactsShippingPackagesDir)*.nupkg"
                     Exclude="$(ArtifactsShippingPackagesDir)*.symbols.nupkg" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -84,14 +84,12 @@
                         Include="$(RepoRoot)src\Installers\Rpm\**\*.*proj" />
       </ItemGroup>
 
-      <ItemGroup>
-        <NativeProjects Condition=" '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') "
-                        Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)">
-          <!-- Required to prevent triggering double-builds. See src\Servers\IIS\ResolveIisReferences.targets for details. -->
-          <AdditionalProperties Condition="'$(TargetArchitecture)' == 'x64'">Platform=x64</AdditionalProperties>
-          <AdditionalProperties Condition="'$(TargetArchitecture)' == 'x86'">Platform=Win32</AdditionalProperties>
-        </NativeProjects>
+      <ItemGroup Condition=" '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') ">
+        <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=x64" />
+        <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=Win32" />
+      </ItemGroup>
 
+      <ItemGroup>
         <ProjectToBuild Condition=" $(BuildNative) " Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" />
         <ProjectToExclude Condition=" !$(BuildNative) " Include="@(NativeProjects)" />
 

--- a/eng/scripts/GenerateProjectList.ps1
+++ b/eng/scripts/GenerateProjectList.ps1
@@ -1,10 +1,18 @@
 param(
     [switch]$ci
 )
-$ErrorActionPreference = 'stop'
 
+$ErrorActionPreference = 'stop'
+$msbuildEngine = 'dotnet'
 $repoRoot = Resolve-Path "$PSScriptRoot/../.."
 
-& "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" `
+try {
+  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" `
     /t:GenerateProjectList `
     /bl:artifacts/log/genprojlist.binlog
+} finally {
+  Remove-Item variable:global:_BuildTool -ErrorAction Ignore
+  Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore
+  Remove-Item variable:global:_ToolsetBuildProj -ErrorAction Ignore
+  Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
+}

--- a/eng/scripts/GenerateProjectList.ps1
+++ b/eng/scripts/GenerateProjectList.ps1
@@ -3,7 +3,7 @@ param(
 )
 
 $ErrorActionPreference = 'stop'
-$excludeCIBinarylog = true
+$excludeCIBinarylog = $true
 $msbuildEngine = 'dotnet'
 $repoRoot = Resolve-Path "$PSScriptRoot/../.."
 

--- a/eng/scripts/GenerateProjectList.ps1
+++ b/eng/scripts/GenerateProjectList.ps1
@@ -7,9 +7,7 @@ $msbuildEngine = 'dotnet'
 $repoRoot = Resolve-Path "$PSScriptRoot/../.."
 
 try {
-  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" `
-    /t:GenerateProjectList `
-    /bl:artifacts/log/genprojlist.binlog
+  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci -nobl "$repoRoot/eng/CodeGen.proj" /t:GenerateProjectList
 } finally {
   Remove-Item variable:global:_BuildTool -ErrorAction Ignore
   Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore

--- a/eng/scripts/GenerateProjectList.ps1
+++ b/eng/scripts/GenerateProjectList.ps1
@@ -3,11 +3,12 @@ param(
 )
 
 $ErrorActionPreference = 'stop'
+$excludeCIBinarylog = true
 $msbuildEngine = 'dotnet'
 $repoRoot = Resolve-Path "$PSScriptRoot/../.."
 
 try {
-  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci -nobl "$repoRoot/eng/CodeGen.proj" /t:GenerateProjectList
+  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" /t:GenerateProjectList
 } finally {
   Remove-Item variable:global:_BuildTool -ErrorAction Ignore
   Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore

--- a/eng/scripts/GenerateReferenceAssemblies.ps1
+++ b/eng/scripts/GenerateReferenceAssemblies.ps1
@@ -7,7 +7,7 @@ $repoRoot = Resolve-Path "$PSScriptRoot/../.."
 
 try {
   # eng/common/msbuild.ps1 builds the Debug configuration unless there's a $Configuration variable. Match that here.
-  & "$repoRoot\build.ps1"  -ci:$ci -nobl -buildNative -configuration Debug
+  & "$repoRoot\build.ps1"  -ci:$ci -nobl -noBuildRepoTasks -noRestore -buildNative -configuration Debug
 
   Remove-Item variable:global:_BuildTool -ErrorAction Ignore
   Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore
@@ -15,9 +15,7 @@ try {
   Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
 
   $msbuildEngine = 'dotnet'
-  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" `
-    /t:GenerateReferenceSources `
-    /bl:artifacts/log/genrefassemblies.binlog
+  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci -nobl "$repoRoot/eng/CodeGen.proj" /t:GenerateReferenceSources
 } finally {
   Remove-Item variable:global:_BuildTool -ErrorAction Ignore
   Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore

--- a/eng/scripts/GenerateReferenceAssemblies.ps1
+++ b/eng/scripts/GenerateReferenceAssemblies.ps1
@@ -14,8 +14,9 @@ try {
   Remove-Item variable:global:_ToolsetBuildProj -ErrorAction Ignore
   Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
 
+  $excludeCIBinarylog = true
   $msbuildEngine = 'dotnet'
-  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci -nobl "$repoRoot/eng/CodeGen.proj" /t:GenerateReferenceSources
+  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" /t:GenerateReferenceSources
 } finally {
   Remove-Item variable:global:_BuildTool -ErrorAction Ignore
   Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore

--- a/eng/scripts/GenerateReferenceAssemblies.ps1
+++ b/eng/scripts/GenerateReferenceAssemblies.ps1
@@ -1,10 +1,26 @@
 param(
     [switch]$ci
 )
-$ErrorActionPreference = 'stop'
 
+$ErrorActionPreference = 'stop'
 $repoRoot = Resolve-Path "$PSScriptRoot/../.."
 
-& "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" `
+try {
+  # eng/common/msbuild.ps1 builds the Debug configuration unless there's a $Configuration variable. Match that here.
+  & "$repoRoot\build.ps1"  -ci:$ci -nobl -buildNative -configuration Debug
+
+  Remove-Item variable:global:_BuildTool -ErrorAction Ignore
+  Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore
+  Remove-Item variable:global:_ToolsetBuildProj -ErrorAction Ignore
+  Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
+
+  $msbuildEngine = 'dotnet'
+  & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" `
     /t:GenerateReferenceSources `
     /bl:artifacts/log/genrefassemblies.binlog
+} finally {
+  Remove-Item variable:global:_BuildTool -ErrorAction Ignore
+  Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore
+  Remove-Item variable:global:_ToolsetBuildProj -ErrorAction Ignore
+  Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
+}

--- a/eng/scripts/GenerateReferenceAssemblies.ps1
+++ b/eng/scripts/GenerateReferenceAssemblies.ps1
@@ -14,7 +14,7 @@ try {
   Remove-Item variable:global:_ToolsetBuildProj -ErrorAction Ignore
   Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
 
-  $excludeCIBinarylog = true
+  $excludeCIBinarylog = $true
   $msbuildEngine = 'dotnet'
   & "$repoRoot\eng\common\msbuild.ps1" -ci:$ci "$repoRoot/eng/CodeGen.proj" /t:GenerateReferenceSources
 } finally {

--- a/eng/targets/ResolveIisReferences.targets
+++ b/eng/targets/ResolveIisReferences.targets
@@ -30,11 +30,4 @@ with the right MSBuild incantations to get output copied to the right place.
     </ProjectReference>
     <NativeProjectReference Remove="@(NativeProjectReference)" />
   </ItemGroup>
-
-  <Target Name="_WarnAboutUnbuiltNativeDependencies"
-          BeforeTargets="Build"
-          Condition=" @(NativeProjectReference->Count()) != 0 AND !$(BuildNative) ">
-    <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -native` to build native projects. Run `build.cmd -managed -native` to build both C# and C++." />
-  </Target>
-
 </Project>

--- a/global.json
+++ b/global.json
@@ -22,7 +22,7 @@
     "Git": "2.22.0",
     "jdk": "11.0.3",
     "vs": {
-      "version": "16.6",
+      "version": "16.5",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",

--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -117,6 +117,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <FrameworkListFileName>RuntimeList.xml</FrameworkListFileName>
     <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
+
+    <NativePlatform>$(TargetArchitecture)</NativePlatform>
+    <NativePlatform Condition=" '$(NativePlatform)' == 'x86' ">Win32</NativePlatform>
   </PropertyGroup>
 
   <ItemGroup>
@@ -127,10 +130,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <Reference Include="microsoft.netcore.app.runtime.$(RuntimeIdentifier)" ExcludeAssets="All" PrivateAssets="All" />
 
-    <ProjectReference Condition=" '$(BuildIisNativeProjects)' == 'true' "
+    <ProjectReference Condition=" '$(BuildIisNativeProjects)' == 'true' AND $(BuildNative) "
         Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
-      <SetPlatform>Platform=$(TargetArchitecture)</SetPlatform>
-      <SetPlatform Condition="'$(TargetArchitecture)' == 'x86'">Platform=Win32</SetPlatform>
+      <SetPlatform>Platform=$(NativePlatform)</SetPlatform>
       <!-- Custom attribute used to distinguish managed from native references. -->
       <IsNativeImage>true</IsNativeImage>
       <!-- A custom item group to be used in targets later.  -->
@@ -138,6 +140,11 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <!-- C++ projects don't invoke GetTargetPath by default when building. -->
       <Targets>Build;GetTargetPath</Targets>
     </ProjectReference>
+
+    <_ResolvedNativeProjectReferencePaths Condition=" '$(BuildIisNativeProjects)' == 'true' AND !$(BuildNative) "
+        Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll">
+      <IsNativeImage>true</IsNativeImage>
+    </_ResolvedNativeProjectReferencePaths>
   </ItemGroup>
 
   <ItemGroup>
@@ -216,7 +223,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"
-          Condition=" '$(BuildIisNativeProjects)' == 'true' AND !$(BuildNative) ">
+          Condition=" '$(BuildIisNativeProjects)' == 'true' AND !$(BuildNative) AND
+              !EXISTS('$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll') ">
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -BuildNative -BuildManaged` to build both C# and C++." />
   </Target>
 

--- a/src/SiteExtensions/build.cmd
+++ b/src/SiteExtensions/build.cmd
@@ -18,21 +18,21 @@ IF %ERRORLEVEL% NEQ 0 (
 ECHO Building x64 LoggingBranch
 REM /p:DisableTransitiveFrameworkReferences=true is needed to prevent SDK from picking up transitive references to
 REM Microsoft.AspNetCore.App as framework references https://github.com/dotnet/sdk/pull/3221
-CALL "%RepoRoot%\build.cmd" -forceCoreMsbuild -arch x64 -projects "%~dp0LoggingBranch\LB.csproj" ^
+CALL "%RepoRoot%\build.cmd" -arch x64 -projects "%~dp0LoggingBranch\LB.csproj" ^
     /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x64.binlog %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
 
 ECHO Building x86 LoggingBranch
-CALL "%RepoRoot%\build.cmd" -forceCoreMsbuild -arch x86 -projects "%~dp0LoggingBranch\LB.csproj" ^
+CALL "%RepoRoot%\build.cmd" -arch x86 -projects "%~dp0LoggingBranch\LB.csproj" ^
     /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x86.binlog %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
 
 ECHO Building Microsoft.AspNetCore.AzureAppServices.SiteExtension
-CALL "%RepoRoot%\build.cmd" -forceCoreMsbuild -projects ^
+CALL "%RepoRoot%\build.cmd" -projects ^
     "%~dp0LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj" ^
     /bl:artifacts/log/SiteExtensions-LoggingAggregate.binlog %*
 IF %ERRORLEVEL% NEQ 0 (


### PR DESCRIPTION
- make `dotnet msbuild` the default on Windows too
- enable building managed projects depending on native assets
- revert move to VS2019.Pre queues