### PR TITLE
Twofactor remember me now checks security stamp

### DIFF
--- a/src/Identity/Core/ref/Microsoft.AspNetCore.Identity.netcoreapp.cs
+++ b/src/Identity/Core/ref/Microsoft.AspNetCore.Identity.netcoreapp.cs
@@ -171,7 +171,6 @@ namespace Microsoft.AspNetCore.Identity
         public virtual System.Threading.Tasks.Task<TUser> ValidateSecurityStampAsync(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<bool> ValidateSecurityStampAsync(TUser user, string securityStamp) { throw null; }
-        [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task<TUser> ValidateTwoFactorSecurityStampAsync(System.Security.Claims.ClaimsPrincipal principal) { throw null; }
     }
     public partial class TwoFactorSecurityStampValidator<TUser> : Microsoft.AspNetCore.Identity.SecurityStampValidator<TUser>, Microsoft.AspNetCore.Identity.ISecurityStampValidator, Microsoft.AspNetCore.Identity.ITwoFactorSecurityStampValidator where TUser : class

--- a/src/Identity/test/InMemory.Test/FunctionalTest.cs
+++ b/src/Identity/test/InMemory.Test/FunctionalTest.cs
@@ -253,9 +253,9 @@ namespace Microsoft.AspNetCore.Identity.InMemory
             var transaction4 = await SendAsync(server, "http://example.com/signoutEverywhere", transaction2.CookieNameValue);
             Assert.Equal(HttpStatusCode.OK, transaction4.Response.StatusCode);
 
-            // Doesn't validate until after interval has passed
+            // Now validates immediately
             var transaction5 = await SendAsync(server, "http://example.com/isTwoFactorRememebered", transaction2.CookieNameValue);
-            Assert.Equal(HttpStatusCode.OK, transaction5.Response.StatusCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, transaction5.Response.StatusCode);
 
             // Wait for validation interval
             clock.Add(TimeSpan.FromMinutes(30));

--- a/src/Identity/test/Shared/PocoModel/PocoUser.cs
+++ b/src/Identity/test/Shared/PocoModel/PocoUser.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         public PocoUser()
         {
             Id = Guid.NewGuid().ToString();
+            SecurityStamp = new Guid().ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for https://github.com/dotnet/aspnetcore/issues/21985

Note: we actually did account for this behavior already, the security stamp validator for the actual login cookie checks every 30 minutes, so leaving the remember me cookie permanently doesn't prevent the stamp from being invalidated and blocking login, but updating the security stamp does not invalidate the Remember TFA Client cookie.  

That said, it doesn't seem unreasonable to force the user to have to remember their clients again on a security stamp update.

Thoughts? @blowdart @ajcvickers 