### PR TITLE
updating signalr js package readme

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -63,6 +63,7 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.20' ">
     <PackagesInPatch>
+      @aspnet/signalr;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/SignalR/clients/ts/signalr/README.md
+++ b/src/SignalR/clients/ts/signalr/README.md
@@ -1,5 +1,7 @@
 JavaScript and TypeScript clients for SignalR for ASP.NET Core
 
+> Note: The JavaScript and TypeScript clients for SignalR for ASP.NET Core have been moved to [@microsoft/signalr](https://www.npmjs.com/package/@microsoft/signalr). If you are already using `@aspnet/signalr` and are unsure when to move to `@microsoft/signalr`, check the [Feature Distribution](https://docs.microsoft.com/en-us/aspnet/core/signalr/client-features) chart in the ASP.NET Core SignalR documentation.
+
 ## Installation
 
 ```bash

--- a/src/SignalR/clients/ts/signalr/README.md
+++ b/src/SignalR/clients/ts/signalr/README.md
@@ -1,6 +1,6 @@
 JavaScript and TypeScript clients for SignalR for ASP.NET Core
 
-> Note: The JavaScript and TypeScript clients for SignalR for ASP.NET Core have been moved to [@microsoft/signalr](https://www.npmjs.com/package/@microsoft/signalr). If you are already using `@aspnet/signalr` and are unsure when to move to `@microsoft/signalr`, check the [Feature Distribution](https://docs.microsoft.com/en-us/aspnet/core/signalr/client-features) chart in the ASP.NET Core SignalR documentation.
+> Note: The JavaScript and TypeScript clients for SignalR for ASP.NET Core have been moved to [@microsoft/signalr](https://www.npmjs.com/package/@microsoft/signalr). If you are already using `@aspnet/signalr` and are unsure when to move to `@microsoft/signalr`, check the [Feature Distribution](https://docs.microsoft.com/en-us/aspnet/core/signalr/client-features) chart in the ASP.NET Core SignalR documentation. Newer client releases are compatible with older version of ASP.NET Core SignalR which means it is safe to upgrade the client before upgrading the server.
 
 ## Installation
 


### PR DESCRIPTION
per the doc issue reported [here](https://github.com/dotnet/aspnetcore/issues/21618), this update makes it more up-front which client customers should use, when their only knowledge of SignalR Is from perusing NPM packages, or who find their way here via OG SignalR docs. 

wasn't sure which branch to suggest as upstream - goal here is simply to update the npm readme for the pre-`@microsoft/signalr` era. 