### PR TITLE
Fix logging config and output redirection in DebugProxy

### DIFF
--- a/src/Components/WebAssembly/DebugProxy/src/Hosting/DebugProxyHost.cs
+++ b/src/Components/WebAssembly/DebugProxy/src/Hosting/DebugProxyHost.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -31,6 +32,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.Hosting
                 {
                     config.AddCommandLine(args);
                 }
+                config.SetBasePath(Directory.GetCurrentDirectory());
                 config.AddJsonFile("blazor-debugproxysettings.json", optional: true, reloadOnChange: true);
             })
             .ConfigureLogging((hostingContext, logging) =>

--- a/src/Components/WebAssembly/DebugProxy/src/MonoDebugProxy/ws-proxy/DevToolsProxy.cs
+++ b/src/Components/WebAssembly/DebugProxy/src/MonoDebugProxy/ws-proxy/DevToolsProxy.cs
@@ -320,10 +320,10 @@ namespace WebAssembly.Net.Debugging {
 		{
 			switch (priority) {
 			case "protocol":
-				//logger.LogTrace (msg);
+				logger.LogTrace (msg);
 				break;
 			case "verbose":
-				//logger.LogDebug (msg);
+				logger.LogDebug (msg);
 				break;
 			case "info":
 			case "warning":

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -55,6 +55,7 @@ namespace Microsoft.AspNetCore.Builder
             RemoveUnwantedEnvironmentVariables(processStartInfo.Environment);
 
             var debugProxyProcess = Process.Start(processStartInfo);
+            PassThroughConsoleOutput(debugProxyProcess);
             CompleteTaskWhenServerIsReady(debugProxyProcess, tcs);
 
             new CancellationTokenSource(DebugProxyLaunchTimeout).Token.Register(() =>
@@ -95,6 +96,14 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             return debugProxyPath;
+        }
+
+        private static void PassThroughConsoleOutput(Process process)
+        {
+            process.OutputDataReceived += (sender, eventArgs) =>
+            {
+                Console.WriteLine(eventArgs.Data);
+            };
         }
 
         private static void CompleteTaskWhenServerIsReady(Process aspNetProcess, TaskCompletionSource<string> taskCompletionSource)


### PR DESCRIPTION
- Set base path to current directory for ConfigurationBuilder in DebugProxyHost
- Redirect output from DebugProxy to console
- Enable verbose and protocol logs in MonoProxy

Here's are examples of output from the DebugProxy when running the `StandaloneApp` with the following `blazor-debugproxysettings.json` in the project root.

```
{
  "Logging": {
    "LogLevel": {
      "Default": "Debug"
    }
  }
}
```

![debug-proxy-host-log](https://user-images.githubusercontent.com/1857993/82702931-cb7f5a00-9c27-11ea-90c9-e85115c17fac.png)

![debug-proxy-host](https://user-images.githubusercontent.com/1857993/82703252-66783400-9c28-11ea-9a7c-45fbf9aac16b.png)

Addresses #22134
