### PR TITLE
Unblock use of `xcopy` `msbuild`

### DIFF
--- a/global.json
+++ b/global.json
@@ -22,7 +22,7 @@
         "Microsoft.VisualStudio.Component.Windows10SDK.17134"
       ]
     },
-    "xcopy-msbuild": "none"
+    "xcopy-msbuild": "16.5.0-alpha"
   },
   "msbuild-sdks": {
     "Yarn.MSBuild": "1.15.2",


### PR DESCRIPTION
- required for post-build processing; that runs on hosted agents
- means fallbacks may be attempted for local users without VS 16.6 unfortunately

This reverts 2989e23a2970 and switches to a RoslynTools.MSBuild version that exists