### PR TITLE
Add nan as dev dependency to React templates (#22089)

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/package-lock.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/package-lock.json
@@ -6958,6 +6958,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -8524,6 +8525,11 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13310,6 +13316,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -14097,6 +14104,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/package.json
@@ -24,7 +24,8 @@
     "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.18.3"
+    "eslint-plugin-react": "^7.18.3",
+    "nan": "^2.14.1"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package-lock.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package-lock.json
@@ -7150,6 +7150,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -8716,6 +8717,11 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13610,6 +13616,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -14397,6 +14404,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.16.0",
+    "nan": "^2.14.1",
     "typescript": "3.6.4"
   },
   "scripts": {


### PR DESCRIPTION
Note: This is a cherry-pick of https://github.com/dotnet/aspnetcore/pull/22089 onto the 3.1 release branch.

#### Description

`nan` is an npm package that provides some helpful APIs for building native add-ons for Node. This package is a dependency of `fsvents`, another npm package that is used to watch for filesystem changes on macOS. The `webpack` dependency used by `create-react-app` brings in an older version of `fsevents` into our transitive dependencies but doesn't properly install the `nan` dependency.

This issue causes the `npm install` step to error our in our react and react-redux templates on macOS (since fsevents is a macOS-only package and other templates bring in the `nan` package to the dependency tree via other transitive dependencies).

To resolve this, we include `nan` as a dev dependency in the templates to ensure that it is installed.

#### Customer Impact

This issue was discovered during manual testing. It only impacts react and react-redux templates running on macOS.

This bug breaks the `dotnet run` and `dotnet publish` steps in the template project because the `npm install` step is unable to complete successfully as a result of the missing dependency.

As a workaround, customers can install the `nan` dependency manually in their `ClientApp` directories.

#### Regression?

This change contains no regressions.

#### Risk

The risk level of this change is **low** because:

* `nan` is included as a dev dependency and shouldn't affect production or runtime environments
* this fix was validated on the react and react-redux templates

Addresses https://github.com/aspnet/AspNetCore-ManualTests/issues/100
