### PR TITLE
If not waiting for data, allocate memory before checking anything

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     internal sealed class SocketConnection : TransportConnection
     {
         private static readonly int MinAllocBufferSize = SlabMemoryPool.BlockSize / 2;
+        private static readonly int MinAllocNoWaitBufferSize = MinAllocBufferSize / 2;
         private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
@@ -192,7 +193,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             if (!_waitForData)
             {
                 // Ensure we have some reasonable amount of buffer space to start.
-                buffer = input.GetMemory(MinAllocBufferSize);
+                buffer = input.GetMemory(MinAllocNoWaitBufferSize);
             }
 
             while (true)
@@ -221,7 +222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 {
                     // If not waiting for data allocate another buffer immediately after flushing,
                     // to try and aquire some before the reader takes the lock.
-                    buffer = input.GetMemory(MinAllocBufferSize);
+                    buffer = input.GetMemory(MinAllocNoWaitBufferSize);
                 }
 
                 var paused = !flushTask.IsCompleted;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     internal sealed class SocketConnection : TransportConnection
     {
         private static readonly int MinAllocBufferSize = SlabMemoryPool.BlockSize / 2;
-        private static readonly int MinAllocNoWaitBufferSize = MinAllocBufferSize / 2;
         private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
@@ -193,7 +192,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             if (!_waitForData)
             {
                 // Ensure we have some reasonable amount of buffer space to start.
-                buffer = input.GetMemory(MinAllocNoWaitBufferSize);
+                buffer = input.GetMemory(MinAllocBufferSize);
             }
 
             while (true)
@@ -222,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 {
                     // If not waiting for data allocate another buffer immediately after flushing,
                     // to try and aquire some before the reader takes the lock.
-                    buffer = input.GetMemory(MinAllocNoWaitBufferSize);
+                    buffer = input.GetMemory(MinAllocBufferSize);
                 }
 
                 var paused = !flushTask.IsCompleted;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -216,14 +216,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
                 input.Advance(bytesReceived);
 
+                var flushTask = input.FlushAsync();
                 if (!_waitForData)
                 {
-                    // If not waiting for data allocate another buffer before flushing,
-                    // to reduce reader/writer contention on MemoryPool.
+                    // If not waiting for data allocate another buffer immediately after flushing,
+                    // to try and aquire some before the reader takes the lock.
                     buffer = input.GetMemory(MinAllocBufferSize);
                 }
-
-                var flushTask = input.FlushAsync();
 
                 var paused = !flushTask.IsCompleted;
 


### PR DESCRIPTION
To reduce contention between reader and writer on the MemoryPool (as no-delay in the no wait scenario) seen in https://github.com/dotnet/runtime/pull/36956#issuecomment-633646586

Its a race to see if it can get it before the Flush is picked up; but the Flush invalidatees outstanding Memory, so we can't do it before the Flush :-/