### PR TITLE
Remove tooling dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,22 +13,6 @@
       <Uri>https://github.com/dotnet/blazor</Uri>
       <Sha>dd7fb4d3931d556458f62642c2edfc59f6295bfb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Language" Version="5.0.0-preview.6.20276.6">
-      <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>1b16a37fc76ff0cc2b7a02486fb3eb0289f41738</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="5.0.0-preview.6.20276.6">
-      <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>1b16a37fc76ff0cc2b7a02486fb3eb0289f41738</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Razor" Version="5.0.0-preview.6.20276.6">
-      <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>1b16a37fc76ff0cc2b7a02486fb3eb0289f41738</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="5.0.0-preview.6.20276.6">
-      <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
-      <Sha>1b16a37fc76ff0cc2b7a02486fb3eb0289f41738</Sha>
-    </Dependency>
     <Dependency Name="dotnet-ef" Version="5.0.0-preview.6.20276.2">
       <Uri>https://github.com/dotnet/efcore</Uri>
       <Sha>46636e00447b1303e1ea439b68bfada1cdcb8393</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,11 +137,6 @@
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>5.0.0-preview.6.20276.2</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftEntityFrameworkCoreToolsPackageVersion>5.0.0-preview.6.20276.2</MicrosoftEntityFrameworkCoreToolsPackageVersion>
     <MicrosoftEntityFrameworkCorePackageVersion>5.0.0-preview.6.20276.2</MicrosoftEntityFrameworkCorePackageVersion>
-    <!-- Packages from dotnet/aspnetcore-tooling -->
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>5.0.0-preview.6.20276.6</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreRazorLanguagePackageVersion>5.0.0-preview.6.20276.6</MicrosoftAspNetCoreRazorLanguagePackageVersion>
-    <MicrosoftCodeAnalysisRazorPackageVersion>5.0.0-preview.6.20276.6</MicrosoftCodeAnalysisRazorPackageVersion>
-    <MicrosoftNETSdkRazorPackageVersion>5.0.0-preview.6.20276.6</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
   <!--
 


### PR DESCRIPTION
These have been migrated to this repo. I removed these dependencies in my merge PR https://github.com/dotnet/aspnetcore/pull/21581 but the darc update PR https://github.com/dotnet/aspnetcore/pull/22255 added them back. I disabled the darc dependency aspnetcore-tooling => aspnetcore yesterday so these updates won't happen again but I didn't realize a PR was opened before I did that. I'll check the ops manual to see if it needs to be updated to account for the migration.
