### PR TITLE
Add a transport package for Mvc.Razor.Extensions pdbs

### DIFF
--- a/src/Razor/tools/Microsoft.Aspnetcore.Razor.Internal.Transport/Microsoft.AspNetCore.Razor.Internal.Transport.csproj
+++ b/src/Razor/tools/Microsoft.Aspnetcore.Razor.Internal.Transport/Microsoft.AspNetCore.Razor.Internal.Transport.csproj
@@ -5,12 +5,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" ReferenceOutputAssembly="false" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" ReferenceOutputAssembly="false" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" ReferenceOutputAssembly="false" />
 
     <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.pdb" PackagePath="pdb" />
     <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.pdb" PackagePath="pdb" />

--- a/src/Razor/tools/Microsoft.Aspnetcore.Razor.Internal.Transport/Microsoft.AspNetCore.Razor.Internal.Transport.csproj
+++ b/src/Razor/tools/Microsoft.Aspnetcore.Razor.Internal.Transport/Microsoft.AspNetCore.Razor.Internal.Transport.csproj
@@ -13,10 +13,14 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" ReferenceOutputAssembly="false" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" ReferenceOutputAssembly="false" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" ReferenceOutputAssembly="false" />
+    <Reference Include="Microsoft.AspNetCore.Razor.Language" ReferenceOutputAssembly="false" />
+    <Reference Include="Microsoft.CodeAnalysis.Razor" ReferenceOutputAssembly="false" />
 
     <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.pdb" PackagePath="pdb" />
     <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.pdb" PackagePath="pdb" />
     <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.pdb" PackagePath="pdb" />
+    <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Language\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Razor.Language.pdb" PackagePath="pdb" />
+    <Content Include="$(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.Razor.pdb" PackagePath="pdb" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/tools/RazorExtensionsTransport/RazorExtensionsTransport.csproj
+++ b/src/Razor/tools/RazorExtensionsTransport/RazorExtensionsTransport.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Transport package for Mvc.Razor.Extensions pdbs. For internal use only.</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X" />
+
+    <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.pdb" PackagePath="pdb" />
+    <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.pdb" PackagePath="pdb" />
+    <Content Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.pdb" PackagePath="pdb" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Turns out aspnetcore-tooling needs to get access to pdbs for Mvc.Razor.Extensions.* packages for building MPacks: https://github.com/dotnet/aspnetcore-tooling/blob/a6dd79a61c90527e4ecde89a0e138a609a815010/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj#L60-L62. It looks like the easiest way is to build a transport package in aspnetcore. Thoughts?
