### PR TITLE
Allow the ability to specify custom JsonSerializerOptions

### DIFF
--- a/src/Components/Server/test/ProtectedBrowserStorageTest.cs
+++ b/src/Components/Server/test/ProtectedBrowserStorageTest.cs
@@ -373,6 +373,15 @@ namespace Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 
             public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
                 => InvokeAsync<TValue>(identifier, cancellationToken: CancellationToken.None, args: args);
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object[] args)
+            {
+                Invocations.Add((identifier, args));
+                return (ValueTask<TValue>)NextInvocationResult;
+            }
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object[] args)
+                => InvokeAsync<TValue>(identifier, cancellationToken: CancellationToken.None, jsonSerializerOptions: jsonSerializerOptions, args: args);
         }
 
         class TestProtectedBrowserStorage : ProtectedBrowserStorage

--- a/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticationServiceTests.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticationServiceTests.cs
@@ -535,6 +535,18 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
                 return new ValueTask<TValue>((TValue)GetInvocationResult(identifier));
             }
 
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object[] args)
+            {
+                PastInvocations.Add((identifier, args));
+                return new ValueTask<TValue>((TValue)GetInvocationResult(identifier));
+            }
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object[] args)
+            {
+                PastInvocations.Add((identifier, args));
+                return new ValueTask<TValue>((TValue)GetInvocationResult(identifier));
+            }
+
             private object GetInvocationResult(string identifier)
             {
                 switch (identifier)

--- a/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticatorCoreTests.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticatorCoreTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Security.Claims;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -702,6 +703,18 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             }
 
             public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object[] args)
+            {
+                LastInvocation = (identifier, args);
+                return default;
+            }
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object[] args)
+            {
+                LastInvocation = (identifier, args);
+                return default;
+            }
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object[] args)
             {
                 LastInvocation = (identifier, args);
                 return default;

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSInProcessObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSInProcessObjectReference.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json;
 
 namespace Microsoft.JSInterop
 {
@@ -18,5 +19,15 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         TValue Invoke<TValue>(string identifier, params object?[]? args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function synchronously.
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>someScope.someFunction</c> on the target instance.</param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
+        TValue Invoke<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, params object?[]? args);
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSInProcessRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSInProcessRuntime.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text.Json;
+
 namespace Microsoft.JSInterop
 {
     /// <summary>
@@ -16,5 +18,15 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TResult"/> obtained by JSON-deserializing the return value.</returns>
         TResult Invoke<TResult>(string identifier, params object?[]? args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function synchronously.
+        /// </summary>
+        /// <typeparam name="TResult">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TResult"/> obtained by JSON-deserializing the return value.</returns>
+        TResult Invoke<TResult>(string identifier, JsonSerializerOptions jsonSerializerOptions, params object?[]? args);
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSObjectReference.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,5 +38,33 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously.
+        /// <para>
+        /// <see cref="JSRuntime"/> will apply timeouts to this operation based on the value configured in <see cref="JSRuntime.DefaultAsyncTimeout"/>. To dispatch a call with a different, or no timeout,
+        /// consider using <see cref="InvokeAsync{TValue}(string, CancellationToken, object[])" />.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>someScope.someFunction</c> on the target instance.</param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
+        ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object?[]? args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously.
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>someScope.someFunction</c> on the target instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
+        ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object?[]? args);
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSRuntime.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,5 +37,33 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously.
+        /// <para>
+        /// <see cref="JSRuntime"/> will apply timeouts to this operation based on the value configured in <see cref="JSRuntime.DefaultAsyncTimeout"/>. To dispatch a call with a different timeout, or no timeout,
+        /// consider using <see cref="InvokeAsync{TValue}(string, CancellationToken, object[])" />.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
+        ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object?[]? args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously.
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
+        ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object?[]? args);
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSRuntime.cs
@@ -42,7 +42,7 @@ namespace Microsoft.JSInterop
         /// Invokes the specified JavaScript function asynchronously.
         /// <para>
         /// <see cref="JSRuntime"/> will apply timeouts to this operation based on the value configured in <see cref="JSRuntime.DefaultAsyncTimeout"/>. To dispatch a call with a different timeout, or no timeout,
-        /// consider using <see cref="InvokeAsync{TValue}(string, CancellationToken, object[])" />.
+        /// consider using <see cref="InvokeAsync{TValue}(string, CancellationToken, JsonSerializerOptions, object[])" />.
         /// </para>
         /// </summary>
         /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSInProcessObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSInProcessObjectReference.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 
 namespace Microsoft.JSInterop.Implementation
 {
@@ -28,6 +28,14 @@ namespace Microsoft.JSInterop.Implementation
             ThrowIfDisposed();
 
             return _jsRuntime.Invoke<TValue>(identifier, Id, args);
+        }
+
+        /// <inheritdoc />
+        public TValue Invoke<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, params object?[]? args)
+        {
+            ThrowIfDisposed();
+
+            return _jsRuntime.Invoke<TValue>(identifier, Id, jsonSerializerOptions, args);
         }
 
         /// <inheritdoc />

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReference.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -47,6 +48,22 @@ namespace Microsoft.JSInterop.Implementation
             ThrowIfDisposed();
 
             return _jsRuntime.InvokeAsync<TValue>(Id, identifier, cancellationToken, args);
+        }
+
+        /// <inheritdoc />
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object?[]? args)
+        {
+            ThrowIfDisposed();
+
+            return _jsRuntime.InvokeAsync<TValue>(Id, identifier, jsonSerializerOptions, args);
+        }
+
+        /// <inheritdoc />
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object?[]? args)
+        {
+            ThrowIfDisposed();
+
+            return _jsRuntime.InvokeAsync<TValue>(Id, identifier, cancellationToken, jsonSerializerOptions, args);
         }
 
         /// <inheritdoc />

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntime.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.JSInterop.Implementation;
 using Microsoft.JSInterop.Infrastructure;
@@ -23,11 +22,11 @@ namespace Microsoft.JSInterop
                     id => new JSInProcessObjectReference(this, id)));
         }
 
-        internal TValue Invoke<TValue>(string identifier, long targetInstanceId, params object?[]? args)
+        internal TValue Invoke<TValue>(string identifier, long targetInstanceId, JsonSerializerOptions jsonSerializerOptions, params object?[]? args)
         {
             var resultJson = InvokeJS(
                 identifier,
-                JsonSerializer.Serialize(args, JsonSerializerOptions),
+                JsonSerializer.Serialize(args, jsonSerializerOptions),
                 JSCallResultTypeHelper.FromGeneric<TValue>(),
                 targetInstanceId);
 
@@ -39,7 +38,7 @@ namespace Microsoft.JSInterop
                 return default!;
             }
 
-            return JsonSerializer.Deserialize<TValue>(resultJson, JsonSerializerOptions)!;
+            return JsonSerializer.Deserialize<TValue>(resultJson, jsonSerializerOptions)!;
         }
 
         /// <summary>
@@ -50,7 +49,18 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         public TValue Invoke<TValue>(string identifier, params object?[]? args)
-            => Invoke<TValue>(identifier, 0, args);
+            => Invoke<TValue>(identifier, 0, JsonSerializerOptions, args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function synchronously.
+        /// </summary>
+        /// <typeparam name="TResult">The JSON-serializable return type.</typeparam>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="jsonSerializerOptions">JSON serialization options to use during serialization/deserialization of the args and return value.</param> 
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TResult"/> obtained by JSON-deserializing the return value.</returns>
+        public TResult Invoke<TResult>(string identifier, JsonSerializerOptions jsonSerializerOptions, params object?[]? args)
+            => Invoke<TResult>(identifier, 0, jsonSerializerOptions, args);
 
         /// <summary>
         /// Performs a synchronous function invocation.

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -66,7 +66,7 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
-            => InvokeAsync<TValue>(JsonSerializerOptions, 0, identifier, args);
+            => InvokeAsync<TValue>(0, identifier, JsonSerializerOptions, args);
 
         /// <summary>
         /// Invokes the specified JavaScript function asynchronously.
@@ -80,7 +80,7 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
-            => InvokeAsync<TValue>(JsonSerializerOptions, 0, identifier, cancellationToken, args);
+            => InvokeAsync<TValue>(0, identifier, cancellationToken, JsonSerializerOptions, args);
 
         /// <summary>
         /// Invokes the specified JavaScript function asynchronously.
@@ -95,7 +95,7 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object?[]? args)
-            => InvokeAsync<TValue>(jsonSerializerOptions, 0, identifier, args);
+            => InvokeAsync<TValue>(0, identifier, jsonSerializerOptions, args);
 
         /// <summary>
         /// Invokes the specified JavaScript function asynchronously.
@@ -110,23 +110,23 @@ namespace Microsoft.JSInterop
         /// <param name="args">JSON-serializable arguments.</param>
         /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value.</returns>
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object?[]? args)
-            => InvokeAsync<TValue>(jsonSerializerOptions, 0, identifier, cancellationToken, args);
+            => InvokeAsync<TValue>(0, identifier, cancellationToken, jsonSerializerOptions, args);
 
         internal async ValueTask<TValue> InvokeAsync<TValue>(long targetInstanceId, string identifier, object?[]? args)
         {
-            return await InvokeAsync<TValue>(JsonSerializerOptions, targetInstanceId, identifier, args);
+            return await InvokeAsync<TValue>(targetInstanceId, identifier, JsonSerializerOptions, args);
         }
 
-        internal async ValueTask<TValue> InvokeAsync<TValue>(JsonSerializerOptions jsonSerializerOptions, long targetInstanceId, string identifier, object?[]? args)
+        internal async ValueTask<TValue> InvokeAsync<TValue>(long targetInstanceId, string identifier, JsonSerializerOptions jsonSerializerOptions, object?[]? args)
         {
             if (DefaultAsyncTimeout.HasValue)
             {
                 using var cts = new CancellationTokenSource(DefaultAsyncTimeout.Value);
                 // We need to await here due to the using
-                return await InvokeAsync<TValue>(jsonSerializerOptions, targetInstanceId, identifier, cts.Token, args);
+                return await InvokeAsync<TValue>(targetInstanceId, identifier, cts.Token, jsonSerializerOptions, args);
             }
 
-            return await InvokeAsync<TValue>(jsonSerializerOptions, targetInstanceId, identifier, CancellationToken.None, args);
+            return await InvokeAsync<TValue>(targetInstanceId, identifier, CancellationToken.None, jsonSerializerOptions, args);
         }
 
         internal async ValueTask<TValue> InvokeAsync<TValue>(
@@ -135,14 +135,14 @@ namespace Microsoft.JSInterop
             CancellationToken cancellationToken,
             object?[]? args)
         {
-            return await InvokeAsync<TValue>(JsonSerializerOptions, targetInstanceId, identifier, cancellationToken, args);
+            return await InvokeAsync<TValue>(targetInstanceId, identifier, cancellationToken, JsonSerializerOptions, args);
         }
 
         internal ValueTask<TValue> InvokeAsync<TValue>(
-            JsonSerializerOptions jsonSerializerOptions,
             long targetInstanceId,
             string identifier,
             CancellationToken cancellationToken,
+            JsonSerializerOptions jsonSerializerOptions,
             object?[]? args)
         {
             var taskId = Interlocked.Increment(ref _nextPendingTaskId);

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -155,7 +155,7 @@ namespace Microsoft.JSInterop
                     CleanupTasksAndRegistrations(taskId);
                 });
             }
-            _pendingTasks[taskId] = new PendingTask { JsonSerializerOptions = jsonSerializerOptions, TaskCompletionSource = tcs };
+            _pendingTasks[taskId] = new PendingTask(jsonSerializerOptions, tcs);
 
             try
             {
@@ -301,9 +301,15 @@ namespace Microsoft.JSInterop
         /// </summary>
         private readonly struct PendingTask
         {
-            public JsonSerializerOptions JsonSerializerOptions { get; init; }
+            public PendingTask(JsonSerializerOptions jsonSerializerOptions, object taskCompletionSource)
+            {
+                JsonSerializerOptions = jsonSerializerOptions;
+                TaskCompletionSource = taskCompletionSource;
+            }
 
-            public Object TaskCompletionSource { get; init; }
+            public JsonSerializerOptions JsonSerializerOptions { get; }
+
+            public Object TaskCompletionSource { get; }
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -10,6 +10,8 @@ Microsoft.JSInterop.IJSObjectReference
 Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSRuntime
+Microsoft.JSInterop.IJSRuntime.InvokeAsync<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
+Microsoft.JSInterop.IJSRuntime.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSRuntime.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSRuntime.InvokeAsync<TValue>(string! identifier, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSUnmarshalledObjectReference

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -68,6 +68,8 @@ Microsoft.JSInterop.JSObjectReferenceExtensions
 Microsoft.JSInterop.JSRuntime
 Microsoft.JSInterop.JSRuntime.DefaultAsyncTimeout.get -> System.TimeSpan?
 Microsoft.JSInterop.JSRuntime.DefaultAsyncTimeout.set -> void
+Microsoft.JSInterop.JSRuntime.InvokeAsync<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
+Microsoft.JSInterop.JSRuntime.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.JSRuntime.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.JSRuntime.InvokeAsync<TValue>(string! identifier, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.JSRuntime.JSRuntime() -> void

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ Microsoft.JSInterop.IJSInProcessObjectReference.Invoke<TValue>(string! identifie
 Microsoft.JSInterop.IJSInProcessRuntime
 Microsoft.JSInterop.IJSInProcessRuntime.Invoke<TResult>(string! identifier, params object?[]? args) -> TResult
 Microsoft.JSInterop.IJSObjectReference
+Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
+Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.IJSRuntime

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -3,8 +3,10 @@ Microsoft.JSInterop.DotNetObjectReference
 Microsoft.JSInterop.DotNetObjectReference<TValue>.Dispose() -> void
 Microsoft.JSInterop.DotNetObjectReference<TValue>.Value.get -> TValue!
 Microsoft.JSInterop.IJSInProcessObjectReference
+Microsoft.JSInterop.IJSInProcessObjectReference.Invoke<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, params object?[]? args) -> TValue
 Microsoft.JSInterop.IJSInProcessObjectReference.Invoke<TValue>(string! identifier, params object?[]? args) -> TValue
 Microsoft.JSInterop.IJSInProcessRuntime
+Microsoft.JSInterop.IJSInProcessRuntime.Invoke<TResult>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, params object?[]? args) -> TResult
 Microsoft.JSInterop.IJSInProcessRuntime.Invoke<TResult>(string! identifier, params object?[]? args) -> TResult
 Microsoft.JSInterop.IJSObjectReference
 Microsoft.JSInterop.IJSObjectReference.InvokeAsync<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
@@ -28,6 +30,7 @@ Microsoft.JSInterop.IJSUnmarshalledRuntime.InvokeUnmarshalled<T0, TResult>(strin
 Microsoft.JSInterop.IJSUnmarshalledRuntime.InvokeUnmarshalled<TResult>(string! identifier) -> TResult
 Microsoft.JSInterop.Implementation.JSInProcessObjectReference
 Microsoft.JSInterop.Implementation.JSInProcessObjectReference.Dispose() -> void
+Microsoft.JSInterop.Implementation.JSInProcessObjectReference.Invoke<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, params object?[]? args) -> TValue
 Microsoft.JSInterop.Implementation.JSInProcessObjectReference.Invoke<TValue>(string! identifier, params object?[]? args) -> TValue
 Microsoft.JSInterop.Implementation.JSInProcessObjectReference.JSInProcessObjectReference(Microsoft.JSInterop.JSInProcessRuntime! jsRuntime, long id) -> void
 Microsoft.JSInterop.Implementation.JSObjectReference
@@ -61,6 +64,7 @@ Microsoft.JSInterop.JSException.JSException(string! message) -> void
 Microsoft.JSInterop.JSException.JSException(string! message, System.Exception! innerException) -> void
 Microsoft.JSInterop.JSInProcessObjectReferenceExtensions
 Microsoft.JSInterop.JSInProcessRuntime
+Microsoft.JSInterop.JSInProcessRuntime.Invoke<TResult>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, params object?[]? args) -> TResult
 Microsoft.JSInterop.JSInProcessRuntime.Invoke<TValue>(string! identifier, params object?[]? args) -> TValue
 Microsoft.JSInterop.JSInProcessRuntime.JSInProcessRuntime() -> void
 Microsoft.JSInterop.JSInProcessRuntimeExtensions

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -33,6 +33,8 @@ Microsoft.JSInterop.Implementation.JSInProcessObjectReference.JSInProcessObjectR
 Microsoft.JSInterop.Implementation.JSObjectReference
 Microsoft.JSInterop.Implementation.JSObjectReference.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.JSInterop.Implementation.JSObjectReference.Id.get -> long
+Microsoft.JSInterop.Implementation.JSObjectReference.InvokeAsync<TValue>(string! identifier, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
+Microsoft.JSInterop.Implementation.JSObjectReference.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, System.Text.Json.JsonSerializerOptions! jsonSerializerOptions, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.Implementation.JSObjectReference.InvokeAsync<TValue>(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.Implementation.JSObjectReference.InvokeAsync<TValue>(string! identifier, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.Implementation.JSObjectReference.JSObjectReference(Microsoft.JSInterop.JSRuntime! jsRuntime, long id) -> void

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/UnsupportedJavaScriptRuntime.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/UnsupportedJavaScriptRuntime.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
@@ -10,14 +11,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
     internal class UnsupportedJavaScriptRuntime : IJSRuntime
     {
+        private const string _preRenderScriptError = "JavaScript interop calls cannot be issued during server-side prerendering, because the page has not yet loaded in the browser. Prerendered components must wrap any JavaScript interop calls in conditional logic to ensure those interop calls are not attempted during prerendering.";
+
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object[] args)
         {
-            throw new InvalidOperationException("JavaScript interop calls cannot be issued during server-side prerendering, because the page has not yet loaded in the browser. Prerendered components must wrap any JavaScript interop calls in conditional logic to ensure those interop calls are not attempted during prerendering.");
+            throw new InvalidOperationException(_preRenderScriptError);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, JsonSerializerOptions jsonSerializerOptions, object[] args)
+        {
+            throw new InvalidOperationException(_preRenderScriptError);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, JsonSerializerOptions jsonSerializerOptions, object[] args)
+        {
+            throw new InvalidOperationException(_preRenderScriptError);
         }
 
         ValueTask<TValue> IJSRuntime.InvokeAsync<TValue>(string identifier, object[] args)
         {
-            throw new InvalidOperationException("JavaScript interop calls cannot be issued during server-side prerendering, because the page has not yet loaded in the browser. Prerendered components must wrap any JavaScript interop calls in conditional logic to ensure those interop calls are not attempted during prerendering.");
+            throw new InvalidOperationException(_preRenderScriptError);
         }
     }
 }


### PR DESCRIPTION
Allow the ability to specify custom JsonSerializerOptions when calling the `IJSInterop.InvokeAsync<T>` methods.

Summary of the changes
- Added 2 method overrides to the `IJSInterop.InvokeAsync<T>` methods that allow passing a custom JsonSerializerOptions object for both serialization and deserialization of the args and return value.

Addresses #12685
