### PR TITLE
Always copy Mvc.Razor.Extensions.dll to razor sdk output

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/Microsoft.NET.Sdk.Razor.csproj
@@ -68,7 +68,7 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(RazorToolsOutput)" DestinationFolder="$(SdkOutputPath)tools\netcoreapp3.0\" SkipUnchangedFiles="true" ContinueOnError="true" />
-    <Copy SourceFiles="@(MvcRazorExtensionOutput)" DestinationFolder="$(SdkOutputPath)extensions\mvc-3-0\" SkipUnchangedFiles="true" ContinueOnError="true" Condition="'$(TargetFramework)'=='$(DefaultNetCoreTargetFramework)'">
+    <Copy SourceFiles="@(MvcRazorExtensionOutput)" DestinationFolder="$(SdkOutputPath)extensions\mvc-3-0\" SkipUnchangedFiles="true" ContinueOnError="true">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
     </Copy>
 


### PR DESCRIPTION
When I added the fix for the missing Mvc.Razor.Extensions.dll in https://github.com/dotnet/aspnetcore/commit/335364165f484beb235c0835b689f449ffb87657, I neglected to update the copy target that actually copies the file to the sdk output. It should no longer depend on the TFM that's being built.