### PR TITLE
Remove workaround for templating encoding issue

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
@@ -1,5 +1,4 @@
-﻿
-@*#if (NoAuth)
+﻿@*#if (NoAuth)
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />


### PR DESCRIPTION
In https://github.com/dotnet/aspnetcore/pull/18213/, we added a workaround for [this](https://github.com/dotnet/templating/issues/2217) issue. We no longer need it as the original issue is fixed now.