### PR TITLE
Typo in XML comments for AuthorizationMessageHandler

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/AuthorizationMessageHandler.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/AuthorizationMessageHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         }
 
         /// <summary>
-        /// Configures this handler to authorize outbound HTTP requests using an access token. The access token is only attached if only attached if at least one of
+        /// Configures this handler to authorize outbound HTTP requests using an access token. The access token is only attached if at least one of
         /// <paramref name="authorizedUrls" /> is a base of <see cref="HttpRequestMessage.RequestUri" />.
         /// </summary>
         /// <param name="authorizedUrls">The base addresses of endpoint URLs to which the token will be attached.</param>


### PR DESCRIPTION
I'm not a native english speaker but I'm pretty sure something is wrong here, or it's a condition too complicated for me to understand ;- )

Summary of the changes (Less than 80 chars)
 - Removed some text in comment
