### PR TITLE
Add support for reading json in multipart/form-data requests

### DIFF
--- a/src/Http/Http.Features/src/IFormCollection.cs
+++ b/src/Http/Http.Features/src/IFormCollection.cs
@@ -90,5 +90,13 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         /// <returns>The files included with the request.</returns>
         IFormFileCollection Files { get; }
+
+#if NETCOREAPP
+        bool TryGetContentType(string sectionName, out StringValues contentType)
+        {
+            contentType = default;
+            return false;
+        }
+#endif
     }
 }

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -160,6 +160,7 @@ namespace Microsoft.AspNetCore.Http.Features
                 else if (HasMultipartFormContentType(contentType))
                 {
                     var formAccumulator = new KeyValueAccumulator();
+                    var contentTypesAccumulator = new KeyValueAccumulator();
 
                     var boundary = GetBoundary(contentType, _options.MultipartBoundaryLengthLimit);
                     var multipartReader = new MultipartReader(boundary, _request.Body)
@@ -176,6 +177,8 @@ namespace Microsoft.AspNetCore.Http.Features
                         {
                             throw new InvalidDataException("Form section has invalid Content-Disposition value: " + section.ContentDisposition);
                         }
+
+                        contentTypesAccumulator.Append(contentDisposition.Name.Value, section.ContentType);
 
                         if (contentDisposition.IsFileDisposition())
                         {
@@ -243,7 +246,7 @@ namespace Microsoft.AspNetCore.Http.Features
 
                     if (formAccumulator.HasValues)
                     {
-                        formFields = new FormCollection(formAccumulator.GetResults(), files);
+                        formFields = new FormCollection(formAccumulator.GetResults(), files, contentTypesAccumulator.GetResults());
                     }
                 }
             }

--- a/src/Http/Http/src/FormCollection.cs
+++ b/src/Http/Http/src/FormCollection.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.Http
     {
         public static readonly FormCollection Empty = new FormCollection();
         private static readonly string[] EmptyKeys = Array.Empty<string>();
-        private static readonly StringValues[] EmptyValues = Array.Empty<StringValues>();
         private static readonly Enumerator EmptyEnumerator = new Enumerator();
         // Pre-box
         private static readonly IEnumerator<KeyValuePair<string, StringValues>> EmptyIEnumeratorType = EmptyEnumerator;
@@ -24,6 +23,7 @@ namespace Microsoft.AspNetCore.Http
         private static IFormFileCollection EmptyFiles = new FormFileCollection();
 
         private IFormFileCollection _files;
+        private readonly Dictionary<string, StringValues> _contentTypes;
 
         private FormCollection()
         {
@@ -31,10 +31,16 @@ namespace Microsoft.AspNetCore.Http
         }
 
         public FormCollection(Dictionary<string, StringValues> fields, IFormFileCollection files = null)
+            : this(fields, files, contentTypes: null)
+        {
+        }
+
+        public FormCollection(Dictionary<string, StringValues> fields, IFormFileCollection files, Dictionary<string, StringValues> contentTypes)
         {
             // can be null
             Store = fields;
             _files = files;
+            _contentTypes = contentTypes;
         }
 
         public IFormFileCollection Files
@@ -46,7 +52,7 @@ namespace Microsoft.AspNetCore.Http
             private set { _files = value; }
         }
 
-        private Dictionary<string, StringValues> Store { get; set; }
+        private Dictionary<string, StringValues> Store { get; }
 
         /// <summary>
         /// Get or sets the associated value from the collection as a single string.
@@ -168,6 +174,12 @@ namespace Microsoft.AspNetCore.Http
             }
             // Boxed Enumerator
             return Store.GetEnumerator();
+        }
+
+        public bool TryGetContentType(string sectionName, out StringValues contentType)
+        {
+            contentType = default;
+            return _contentTypes != null && _contentTypes.TryGetValue(sectionName, out contentType);
         }
 
         public struct Enumerator : IEnumerator<KeyValuePair<string, StringValues>>

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingSource.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingSource.cs
@@ -24,6 +24,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             isFromRequest: true);
 
         /// <summary>
+        /// A <see cref="BindingSource"/> for a multipart section.
+        /// </summary>
+        public static readonly BindingSource MultipartSection = new BindingSource(
+            "MultipartSection",
+            nameof(MultipartSection),
+            isGreedy: true,
+            isFromRequest: true);
+
+        /// <summary>
         /// A <see cref="BindingSource"/> for a custom model binder (unknown data source).
         /// </summary>
         public static readonly BindingSource Custom = new BindingSource(

--- a/src/Mvc/Mvc.Core/src/FromMultipartSection.cs
+++ b/src/Mvc/Mvc.Core/src/FromMultipartSection.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Specifies that a parameter or property should be bound using the request body.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class FromMultipartSectionAttribute : Attribute, IBindingSourceMetadata
+    {
+        /// <inheritdoc />
+        public BindingSource BindingSource => BindingSource.MultipartSection;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNetCore.Mvc
             options.ModelBinderProviders.Add(new ServicesModelBinderProvider());
             options.ModelBinderProviders.Add(new BodyModelBinderProvider(options.InputFormatters, _readerFactory, _loggerFactory, options));
             options.ModelBinderProviders.Add(new HeaderModelBinderProvider());
+            options.ModelBinderProviders.Add(new MultipartSectionModelBinderProvider(options.InputFormatters, _readerFactory, _loggerFactory, options));
             options.ModelBinderProviders.Add(new FloatingPointTypeModelBinderProvider());
             options.ModelBinderProviders.Add(new EnumTypeModelBinderProvider(options));
             options.ModelBinderProviders.Add(new SimpleTypeModelBinderProvider());

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderWorker.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderWorker.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    internal class BodyModelBinderWorker
+    {
+        private readonly IList<IInputFormatter> _formatters;
+        private readonly Func<Stream, Encoding, TextReader> _readerFactory;
+        private readonly ILogger _logger;
+        private readonly MvcOptions _options;
+
+        public BodyModelBinderWorker(
+            IList<IInputFormatter> formatters,
+            IHttpRequestStreamReaderFactory readerFactory,
+            ILogger logger,
+            MvcOptions options)
+        {
+            _formatters = formatters;
+            _readerFactory = readerFactory.CreateReader;
+            _logger = logger;
+            _options = options;
+        }
+
+        internal async Task ExecuteAsync(
+            ModelBindingContext bindingContext,
+            string modelBindingKey)
+        {
+            var allowEmptyInputInModelBinding = _options?.AllowEmptyInputInBodyModelBinding == true;
+            var httpContext = bindingContext.HttpContext;
+
+            var formatterContext = new InputFormatterContext(
+                httpContext,
+                modelBindingKey,
+                bindingContext.ModelState,
+                bindingContext.ModelMetadata,
+                _readerFactory,
+                allowEmptyInputInModelBinding);
+
+            var formatter = (IInputFormatter)null;
+            for (var i = 0; i < _formatters.Count; i++)
+            {
+                if (_formatters[i].CanRead(formatterContext))
+                {
+                    formatter = _formatters[i];
+                    _logger?.InputFormatterSelected(formatter, formatterContext);
+                    break;
+                }
+                else
+                {
+                    _logger?.InputFormatterRejected(_formatters[i], formatterContext);
+                }
+            }
+
+            if (formatter == null)
+            {
+                _logger?.NoInputFormatterSelected(formatterContext);
+
+                var message = Resources.FormatUnsupportedContentType(httpContext.Request.ContentType);
+                var exception = new UnsupportedContentTypeException(message);
+                bindingContext.ModelState.AddModelError(modelBindingKey, exception, bindingContext.ModelMetadata);
+                _logger?.DoneAttemptingToBindModel(bindingContext);
+                return;
+            }
+
+            try
+            {
+                var result = await formatter.ReadAsync(formatterContext);
+
+                if (result.HasError)
+                {
+                    // Formatter encountered an error. Do not use the model it returned.
+                    _logger?.DoneAttemptingToBindModel(bindingContext);
+                    return;
+                }
+
+                if (result.IsModelSet)
+                {
+                    var model = result.Model;
+                    bindingContext.Result = ModelBindingResult.Success(model);
+                }
+                else
+                {
+                    // If the input formatter gives a "no value" result, that's always a model state error,
+                    // because BodyModelBinder implicitly regards input as being required for model binding.
+                    // If instead the input formatter wants to treat the input as optional, it must do so by
+                    // returning InputFormatterResult.Success(defaultForModelType), because input formatters
+                    // are responsible for choosing a default value for the model type.
+                    var message = bindingContext
+                        .ModelMetadata
+                        .ModelBindingMessageProvider
+                        .MissingRequestBodyRequiredValueAccessor();
+                    bindingContext.ModelState.AddModelError(modelBindingKey, message);
+                }
+            }
+            catch (Exception exception) when (exception is InputFormatterException || ShouldHandleException(formatter))
+            {
+                bindingContext.ModelState.AddModelError(modelBindingKey, exception, bindingContext.ModelMetadata);
+            }
+
+            _logger?.DoneAttemptingToBindModel(bindingContext);
+        }
+
+        private static bool ShouldHandleException(IInputFormatter formatter)
+        {
+            // Any explicit policy on the formatters overrides the default.
+            var policy = (formatter as IInputFormatterExceptionPolicy)?.ExceptionPolicy ??
+                InputFormatterExceptionPolicy.MalformedInputExceptions;
+
+            return policy == InputFormatterExceptionPolicy.AllExceptions;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/MultipartSectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/MultipartSectionModelBinder.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="IInputFormatter"/>
+    /// when a model has the binding source <see cref="BindingSource.Body"/>.
+    /// </summary>
+    public sealed class MultipartSectionModelBinder : IModelBinder
+    {
+        private readonly BodyModelBinderWorker _worker;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates a new <see cref="BodyModelBinder"/>.
+        /// </summary>
+        /// <param name="formatters">The list of <see cref="IInputFormatter"/>.</param>
+        /// <param name="readerFactory">
+        /// The <see cref="IHttpRequestStreamReaderFactory"/>, used to create <see cref="System.IO.TextReader"/>
+        /// instances for reading the request body.
+        /// </param>
+        /// <param name="logger">The <see cref="ILogger"/>.</param>
+        /// <param name="options">The <see cref="MvcOptions"/>.</param>
+        public MultipartSectionModelBinder(
+            IList<IInputFormatter> formatters,
+            IHttpRequestStreamReaderFactory readerFactory,
+            ILogger<MultipartSectionModelBinder> logger,
+            MvcOptions options)
+        {
+            if (formatters == null)
+            {
+                throw new ArgumentNullException(nameof(formatters));
+            }
+
+            if (readerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(readerFactory));
+            }
+
+            _worker = new BodyModelBinderWorker(formatters, readerFactory, logger, options);
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var request = bindingContext.HttpContext.Request;
+            var requestContentType = request.ContentType;
+            if (!MediaTypeHeaderValue.TryParse(requestContentType, out var mediaType) || !mediaType.MediaType.Equals("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+            {
+                // log.debug("not multipart/form-data")
+                return;
+            }
+
+            var modelBindingKey = bindingContext.BinderModelName ?? bindingContext.ModelName;
+            var form = await request.ReadFormAsync();
+            if (!form.TryGetValue(modelBindingKey, out var values) || values.Count == 0)
+            {
+                // log.debug("no value found for '{modelBindingKey}'
+                return;
+            }
+
+
+            if (!form.TryGetContentType(modelBindingKey, out var multipartContentTypeString) ||
+                multipartContentTypeString.Count == 0 ||
+                !MediaTypeHeaderValue.TryParse(multipartContentTypeString[0], out var multipartContentType))
+            {
+                // log.debug("no content-type found for '{modelBindingKey}'
+                return;
+            }
+
+            _logger?.AttemptingToBindModel(bindingContext);
+
+            var originalBody = request.Body;
+            var value = values[0];
+
+            try
+            {
+                var bytes = Encoding.UTF8.GetBytes(value);
+                request.Body = new MemoryStream(bytes);
+                request.ContentType = multipartContentType.MediaType.Value;
+
+                await _worker.ExecuteAsync(bindingContext, modelBindingKey);
+            }
+            finally
+            {
+                request.Body = originalBody;
+                request.ContentType = requestContentType;
+            }
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/MultipartSectionModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/MultipartSectionModelBinderProvider.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinderProvider"/> for deserializing the request body using a formatter.
+    /// </summary>
+    public class MultipartSectionModelBinderProvider : IModelBinderProvider
+    {
+        private readonly IList<IInputFormatter> _formatters;
+        private readonly IHttpRequestStreamReaderFactory _readerFactory;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly MvcOptions _options;
+
+        /// <summary>
+        /// Creates a new <see cref="MultipartSectionModelBinderProvider"/>.
+        /// </summary>
+        /// <param name="formatters">The list of <see cref="IInputFormatter"/>.</param>
+        /// <param name="readerFactory">The <see cref="IHttpRequestStreamReaderFactory"/>.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        /// <param name="options">The <see cref="MvcOptions"/>.</param>
+        public MultipartSectionModelBinderProvider(
+            IList<IInputFormatter> formatters,
+            IHttpRequestStreamReaderFactory readerFactory,
+            ILoggerFactory loggerFactory,
+            MvcOptions options)
+        {
+            if (formatters == null)
+            {
+                throw new ArgumentNullException(nameof(formatters));
+            }
+
+            if (readerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(readerFactory));
+            }
+
+            _formatters = formatters;
+            _readerFactory = readerFactory;
+            _loggerFactory = loggerFactory;
+            _options = options;
+        }
+
+        /// <inheritdoc />
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.BindingInfo.BindingSource != null &&
+                context.BindingInfo.BindingSource.CanAcceptDataFrom(BindingSource.MultipartSection))
+            {
+                if (_formatters.Count == 0)
+                {
+                    throw new InvalidOperationException(Resources.FormatInputFormattersAreRequired(
+                        typeof(MvcOptions).FullName,
+                        nameof(MvcOptions.InputFormatters),
+                        typeof(IInputFormatter).FullName));
+                }
+
+                return new MultipartSectionModelBinder(_formatters, _readerFactory, _loggerFactory.CreateLogger<MultipartSectionModelBinder>(), _options);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Mvc/samples/MvcSandbox/Controllers/HomeController.cs
+++ b/src/Mvc/samples/MvcSandbox/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MvcSandbox.Controllers
@@ -10,9 +11,17 @@ namespace MvcSandbox.Controllers
         [ModelBinder]
         public string Id { get; set; }
 
-        public IActionResult Index()
+        [Consumes("multipart/form-data")]
+        public IActionResult Index([FromMultipartSection] Person person, IFormFileCollection forms)
         {
-            return View();
+            return Ok(person.Age + forms.Count);
         }
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+
+        public int Age { get; set; }
     }
 }

--- a/src/Mvc/samples/MvcSandbox/MvcSandbox.csproj
+++ b/src/Mvc/samples/MvcSandbox/MvcSandbox.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <Reference Include="Microsoft.AspNetCore.Components.Server" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />


### PR DESCRIPTION
POC for what this would look like. @davidfowl wasn't very happy about adding API to `IFormCollection`, but wanted to add something more full featured that `IFormCollection` could read from instead. Perhaps `IMultipartFormCollection`. Mvc's implementation for the multipart binder makes me a bit sad, at least it wasn't too difficult to get going.
