### PR TITLE
Grab some binary logs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -64,11 +64,11 @@ variables:
     value: '/p:SkipTestBuild=true'
   - name: _PublishArgs
     value: ''
-  # Write binary logs for all main Windows build steps in public and PR builds.
+  # Write binary logs for all main Windows build steps except the x86 one in public and PR builds.
   - name: Windows64LogArgs
     value: /bl:artifacts/log/Release/Build.x64.binlog
   - name: Windows86LogArgs
-    value: /bl:artifacts/log/Release/Build.x86.binlog
+    value: -ExcludeCIBinaryLog
   - name: WindowsSignLogArgs
     value: /bl:artifacts/log/Release/Build.CodeSign.binlog
   - name: WindowsInstallersLogArgs

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -184,6 +184,7 @@ stages:
       - script: ./build.cmd
                 -ci
                 -noBuildRepoTasks
+                -noBuildNative
                 -noBuild
                 -noRestore
                 -sign

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -32,13 +32,50 @@ variables:
   value: .NETCORE
 - name: _DotNetValidationArtifactsCategory
   value: .NETCORE
-- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - name: _UseHelixOpenQueues
-    value: 'true'
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _BuildArgs
+    value: /p:TeamName=$(_TeamName)
+           /p:OfficialBuildId=$(Build.BuildNumber)
+           /p:SkipTestBuild=true
+  # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
+  # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+  - group: DotNet-Blob-Feed
+  - group: Publish-Build-Assets
+  # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
+  - name: _PublishArgs
+    value: /p:Publish=true
+           /p:GenerateChecksums=true
+           /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+           /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+           /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+           /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+           /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+  # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
+  - name: Windows64LogArgs
+    value: -ExcludeCIBinaryLog
+  - name: Windows86LogArgs
+    value: -ExcludeCIBinaryLog
+  - name: WindowsSignLogArgs
+    value: -ExcludeCIBinaryLog
+  - name: WindowsInstallersLogArgs
+    value: -ExcludeCIBinaryLog
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: '/p:SkipTestBuild=true'
   - name: _PublishArgs
     value: ''
+  # Write binary logs for all main Windows build steps in public and PR builds.
+  - name: Windows64LogArgs
+    value: /bl:artifacts/log/Release/Build.x64.binlog
+  - name: Windows86LogArgs
+    value: /bl:artifacts/log/Release/Build.x86.binlog
+  - name: WindowsSignLogArgs
+    value: /bl:artifacts/log/Release/Build.CodeSign.binlog
+  - name: WindowsInstallersLogArgs
+    value: /bl:artifacts/log/Release/Build.Installers.binlog
+- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+  - name: _UseHelixOpenQueues
+    value: 'true'
   - name: _SignType
     value: ''
   - name: _InternalRuntimeDownloadArgs
@@ -59,35 +96,11 @@ variables:
   - name: _UseHelixOpenQueues
     value: 'false'
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-    # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-    - group: DotNet-Blob-Feed
-    - group: Publish-Build-Assets
-
-    - name: _BuildArgs
-      value: /p:TeamName=$(_TeamName)
-             /p:OfficialBuildId=$(Build.BuildNumber)
-             /p:SkipTestBuild=true
     - name: _SignType
       value: real
-
-    # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
-    - name: _PublishArgs
-      value: /p:Publish=true
-             /p:GenerateChecksums=true
-             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-             /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-             /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-             /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-    - name: _BuildArgs
-      value: '/p:SkipTestBuild=true'
     - name: _SignType
       value: test
-    - name: _PublishArgs
-      value: ''
 
 stages:
 - stage: build
@@ -130,19 +143,18 @@ stages:
       # The sign settings have been configured to
       - script: ./build.cmd
                 -ci
-                -nobl
                 -arch x64
                 -pack
                 -all
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
+                $(Windows64LogArgs)
         displayName: Build x64
 
       # Build the x86 shared framework
       # This is going to actually build x86 native assets.
       - script: ./build.cmd
                 -ci
-                -nobl
                 -noBuildRepoTasks
                 -arch x86
                 -pack
@@ -152,11 +164,11 @@ stages:
                 /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
+                $(Windows86LogArgs)
         displayName: Build x86
 
       - script: .\src\SiteExtensions\build.cmd
                 -ci
-                -nobl
                 -noBuildRepoTasks
                 -pack
                 -noBuildDeps
@@ -171,19 +183,18 @@ stages:
       # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
       - script: ./build.cmd
                 -ci
-                -nobl
                 -noBuildRepoTasks
                 -noBuild
                 -noRestore
                 -sign
                 /p:DotNetSignType=$(_SignType)
                 $(_BuildArgs)
+                $(WindowsSignLogArgs)
         displayName: Code sign packages
 
       # Windows installers bundle both x86 and x64 assets
       - script: ./build.cmd
                 -ci
-                -nobl
                 -noBuildRepoTasks
                 -sign
                 -buildInstallers
@@ -194,6 +205,7 @@ stages:
                 $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
                 /p:PublishInstallerBaseVersion=true
+                $(WindowsInstallersLogArgs)
         displayName: Build Installers
 
       # A few files must also go to the VS package feed.
@@ -313,7 +325,6 @@ stages:
       steps:
       - script: ./build.sh
             --ci
-            --nobl
             --arch x64
             --pack
             --all

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,7 +29,7 @@
     <FileExtensionSignInfo Include=".msi" CertificateName="None" />
 
     <!--
-      Use the PublicKeyToken of .NET assemblies to determine with authenticode cert to use.
+      Use the PublicKeyToken of .NET assemblies to determine which authenticode cert to use.
       'None' is required to ensure code signing does not attempt to re-sign them or submit
       to ESPR for strong-naming signing. We don't delay sign, so we only need to authenticode sign.
       See https://github.com/dotnet/arcade/issues/1911 for context.


### PR DESCRIPTION
Grab binary logs for main Windows and Linux jobs
- in the Windows case, do not do this in official builds (logging slows build down)