### PR TITLE
Reuse model binders

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CancellationTokenModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CancellationTokenModelBinderProvider.cs
@@ -11,7 +11,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     /// </summary>
     public class CancellationTokenModelBinderProvider : IModelBinderProvider
     {
-        private CancellationTokenModelBinder _modelBinder;
+        // CancellationTokenModelBinder does not have any state. Re-use the same instance for binding.
+
+        private readonly CancellationTokenModelBinder _modelBinder = new CancellationTokenModelBinder();
 
         /// <inheritdoc />
         public IModelBinder GetBinder(ModelBinderProviderContext context)
@@ -23,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             if (context.Metadata.ModelType == typeof(CancellationToken))
             {
-                return _modelBinder ??= new CancellationTokenModelBinder();
+                return _modelBinder;
             }
 
             return null;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CancellationTokenModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CancellationTokenModelBinderProvider.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     /// </summary>
     public class CancellationTokenModelBinderProvider : IModelBinderProvider
     {
+        private CancellationTokenModelBinder _modelBinder;
+
         /// <inheritdoc />
         public IModelBinder GetBinder(ModelBinderProviderContext context)
         {
@@ -21,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             if (context.Metadata.ModelType == typeof(CancellationToken))
             {
-                return new CancellationTokenModelBinder();
+                return _modelBinder ??= new CancellationTokenModelBinder();
             }
 
             return null;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ServicesModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ServicesModelBinderProvider.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     /// </summary>
     public class ServicesModelBinderProvider : IModelBinderProvider
     {
+        private ServicesModelBinder _modelBinder;
+
         /// <inheritdoc />
         public IModelBinder GetBinder(ModelBinderProviderContext context)
         {
@@ -21,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             if (context.BindingInfo.BindingSource != null &&
                 context.BindingInfo.BindingSource.CanAcceptDataFrom(BindingSource.Services))
             {
-                return new ServicesModelBinder();
+                return _modelBinder ??= new ServicesModelBinder();
             }
 
             return null;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ServicesModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ServicesModelBinderProvider.cs
@@ -10,7 +10,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     /// </summary>
     public class ServicesModelBinderProvider : IModelBinderProvider
     {
-        private ServicesModelBinder _modelBinder;
+        // ServicesModelBinder does not have any state. Re-use the same instance for binding.
+
+        private readonly ServicesModelBinder _modelBinder = new ServicesModelBinder();
 
         /// <inheritdoc />
         public IModelBinder GetBinder(ModelBinderProviderContext context)
@@ -23,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             if (context.BindingInfo.BindingSource != null &&
                 context.BindingInfo.BindingSource.CanAcceptDataFrom(BindingSource.Services))
             {
-                return _modelBinder ??= new ServicesModelBinder();
+                return _modelBinder;
             }
 
             return null;


### PR DESCRIPTION
Reuse the same model binders for `CancellationToken`s and services, rather than allocating a new one for every request with such a parameter.

Both `CancellationTokenModelBinder` and `ServicesModelBinder` don't have any state, so it seems that reusing the same instance within the model binder providers ~(created lazily)~ would reduce the number of allocations for an application with a controller method similar to the example below:

```csharp
public async Task<IActionResult> GetForecast(
    string location,
    [FromServices] WeatherClient client,
    CancellationToken cancellationToken)
{
    var forecast = await client.GetForecastAsync(location, cancellationToken);
    return Json(forecast);
}
```