### PR TITLE
Set VaryByOrigin if CorsPolicy has non-default IsOriginAllowed function

### DIFF
--- a/src/Middleware/CORS/src/Infrastructure/CorsPolicy.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsPolicy.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
     /// </summary>
     public class CorsPolicy
     {
+        private Func<string, bool> _isOriginAllowed;
         private TimeSpan? _preflightMaxAge;
 
         /// <summary>
@@ -20,7 +21,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// </summary>
         public CorsPolicy()
         {
-            IsOriginAllowed = DefaultIsOriginAllowed;
+            _isOriginAllowed = DefaultIsOriginAllowed;
         }
 
         /// <summary>
@@ -72,9 +73,25 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         }
 
         /// <summary>
+        /// Gets a value indicating if <see cref="IsOriginAllowed"/> is the default function that is set in the CorsPolicy constructor.
+        /// </summary>
+        public bool HasDefaultIsOriginAllowed { get; private set; } = true;
+
+        /// <summary>
         /// Gets or sets a function which evaluates whether an origin is allowed.
         /// </summary>
-        public Func<string, bool> IsOriginAllowed { get; set; }
+        public Func<string, bool> IsOriginAllowed
+        {
+            get
+            {
+                return _isOriginAllowed;
+            }
+            set
+            {
+                _isOriginAllowed = value;
+                HasDefaultIsOriginAllowed = false;
+            }
+        }
 
         /// <summary>
         /// Gets the headers that the resource might use and can be exposed.

--- a/src/Middleware/CORS/src/Infrastructure/CorsService.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsService.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             {
                 var origin = headers[CorsConstants.Origin];
                 result.AllowedOrigin = origin;
-                result.VaryByOrigin = policy.Origins.Count > 1;
+                result.VaryByOrigin = policy.Origins.Count > 1 || !policy.HasDefaultIsOriginAllowed;
             }
 
             result.SupportsCredentials = policy.SupportsCredentials;

--- a/src/Middleware/CORS/test/UnitTests/CorsPolicyTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsPolicyTests.cs
@@ -25,6 +25,20 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.Empty(corsPolicy.Origins);
             Assert.Null(corsPolicy.PreflightMaxAge);
             Assert.NotNull(corsPolicy.IsOriginAllowed);
+            Assert.True(corsPolicy.HasDefaultIsOriginAllowed);
+        }
+
+        [Fact]
+        public void HasDefaultIsOriginAllowed_IsFalseAfterSettingIsOriginAllowed()
+        {
+            // Arrange
+            var policy = new CorsPolicy();
+
+            // Act
+            policy.IsOriginAllowed = origin => true;
+
+            // Assert
+            Assert.False(policy.HasDefaultIsOriginAllowed);
         }
 
         [Fact]

--- a/src/Middleware/CORS/test/UnitTests/CorsServiceTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsServiceTests.cs
@@ -224,6 +224,23 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         }
 
         [Fact]
+        public void EvaluatePolicy_SetIsOriginAllowed_VariesByOrigin()
+        {
+            // Arrange
+            var corsService = GetCorsService();
+            var requestContext = GetHttpContext(origin: "http://example.com");
+            var policy = new CorsPolicy();
+            policy.IsOriginAllowed = origin => true;
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.Equal("http://example.com", result.AllowedOrigin);
+            Assert.True(result.VaryByOrigin);
+        }
+
+        [Fact]
         public void EvaluatePolicy_NoExposedHeaders_NoAllowExposedHeaders()
         {
             // Arrange


### PR DESCRIPTION
Set `VaryByOrigin` in `CorsService.PopulateResult` when the `CorsPolicy` has a non-default `IsOriginAllowed` function.

Addresses #21988
