### PR TITLE
Update `StaticWebAssetsFileProvider NormalizePath`

### DIFF
--- a/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsFileProvider.cs
+++ b/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsFileProvider.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
         private static string NormalizePath(string path)
         {
             path = path.Replace('\\', '/');
-            return path != "" && path.StartsWith("/") ? path : "/" + path;
+            return path.StartsWith("/") ? path : "/" + path;
         }
 
         private bool StartsWithBasePath(string subpath, out PathString rest)

--- a/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsFileProvider.cs
+++ b/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsFileProvider.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
         private static string NormalizePath(string path)
         {
             path = path.Replace('\\', '/');
-            return path != null && path.StartsWith("/") ? path : "/" + path;
+            return path != "" && path.StartsWith("/") ? path : "/" + path;
         }
 
         private bool StartsWithBasePath(string subpath, out PathString rest)

--- a/src/Hosting/Hosting/test/StaticWebAssets/StaticWebAssetsFileProviderTests.cs
+++ b/src/Hosting/Hosting/test/StaticWebAssets/StaticWebAssetsFileProviderTests.cs
@@ -87,6 +87,20 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
             // Assert
             Assert.Empty(directory);
         }
+        
+        [Fact]
+        public void GetDirectoryContents_HandlersEmptyPath()
+        {
+            // Arrange
+            var provider = new StaticWebAssetsFileProvider("/_content",
+                Path.Combine(AppContext.BaseDirectory, "testroot", "wwwroot"));
+
+            // Act
+            var directory = provider.GetDirectoryContents("");
+
+            // Assert
+            Assert.True(directory.Exists);
+        }
 
         [Fact]
         public void GetDirectoryContents_HandlesWhitespaceInBase()


### PR DESCRIPTION
`path` is never `null`, so it should be judged as `" "`

