### PR TITLE
Correct build in aspnetcore-helix-matrix pipelines

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -30,7 +30,7 @@ jobs:
       displayName: Build shared fx
     - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
-    - script: .\build.cmd -ci -nobl -noBuildRepoTasks -NoRestore -test -all -projects eng\helix\helix.proj
+    - script: .\build.cmd -ci -nobl -noBuildRepoTasks -NoRestore -test -all -noBuildNative -projects eng\helix\helix.proj
               /p:IsHelixDaily=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true
               /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target


### PR DESCRIPTION
- should not use `-all` and `-projects` without `-noBuildNative`
- builds fail otherwise because build.ps1 attempts to build the specified projects in desktop `msbuild`