### PR TITLE
Quarantine flaky tests

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/IntegrationTests/StaticWebAssetsIntegrationTest.cs
@@ -105,6 +105,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         }
 
         [Fact]
+        [QuarantinedTest]
         [InitializeTestProject("AppWithPackageAndP2PReference", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Publish_WithBuildReferencesDisabled_CopiesStaticWebAssetsToDestinationFolder()
         {

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -499,6 +499,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
+        [QuarantinedTest]
         [MemberData(nameof(ConnectionMiddlewareData))]
         public async Task ConnectionClosedTokenFiresOnClientFIN(ListenOptions listenOptions)
         {


### PR DESCRIPTION
ConnectionClosedTokenFiresOnClientFIN: https://github.com/dotnet/aspnetcore/issues/20163

Publish_WithBuildReferencesDisabled_CopiesStaticWebAssetsToDestinationFolder: https://github.com/dotnet/aspnetcore/issues/22451

