### PR TITLE
Fix issue with updating user email address - token string doesn't match

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ConfirmEmailChange.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ConfirmEmailChange.cshtml.cs
@@ -57,7 +57,6 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
                 return NotFound($"Unable to load user with ID '{userId}'.");
             }
 
-            code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
             var result = await _userManager.ChangeEmailAsync(user, email, code);
             if (!result.Succeeded)
             {


### PR DESCRIPTION
Removed decoding/encoding of the variable "code" (token). The variable "code", which is a string that represents the token generated when a user changes their email address, doesn't match with the current decoding/encoding and ends up throwing an Invalid Token error. Removing this line allows the strings match.