### PR TITLE
Add support for the GeoJSON file type

### DIFF
--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -109,6 +109,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".fla", "application/octet-stream" },
                 { ".flr", "x-world/x-vrml" },
                 { ".flv", "video/x-flv" },
+                { ".geojson", "application/geo+json" },
                 { ".gif", "image/gif" },
                 { ".gtar", "application/x-gtar" },
                 { ".gz", "application/x-gzip" },


### PR DESCRIPTION
GeoJSON ( .geojson ) is a format for spatial data that is commonly used in web maps. 

It is defined in [IETF RFC 7946](https://tools.ietf.org/html/rfc7946)

Adding support for it in the static files middle would improve the experience of building web maps inside of ASP.NET Core projects.

Addresses #22477