### PR TITLE
Improve XML docs for ActionResultObjectValueAttribute

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ActionResultObjectValueAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ActionResultObjectValueAttribute.cs
@@ -6,19 +6,33 @@ using System;
 namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
     /// <summary>
-    /// Attribute annoted on ActionResult constructor, helper method parameters, and properties to indicate
+    /// Attribute annotated on ActionResult constructor, helper method parameters, and properties to indicate
     /// that the parameter or property is used to set the "value" for ActionResult.
     /// <para>
     /// Analyzers match this parameter by type name. This allows users to annotate custom results \ custom helpers
-    /// with a user defined attribute without having to expose this type.
+    /// with a user-defined attribute without having to expose this type.
     /// </para>
     /// <para>
     /// This attribute is intentionally marked Inherited=false since the analyzer does not walk the inheritance graph.
     /// </para>
     /// </summary>
     /// <example>
-    /// BadObjectResult([ActionResultObjectValueAttribute] object value)
-    /// ObjectResult { [ActionResultObjectValueAttribute] public object Value { get; set; } }
+    /// Annotated constructor parameter:
+    /// <code>
+    /// public BadRequestObjectResult([ActionResultObjectValue] object error)
+    ///     :base(error)
+    /// {
+    ///     StatusCode = DefaultStatusCode;
+    /// }
+    /// </code>
+    /// Annotated property:
+    /// <code>
+    /// public class ObjectResult : ActionResult, IStatusCodeActionResult
+    /// {
+    ///     [ActionResultObjectValue]
+    ///     public object Value { get; set; }
+    /// }
+    /// </code>
     /// </example>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public sealed class ActionResultObjectValueAttribute : Attribute


### PR DESCRIPTION
Adds missing labels and `<code>` elements for the examples and fixes minor grammatical issues. Also provides more complete sample code.
