### PR TITLE
Enable control flow guard for IIS dlls

### DIFF
--- a/src/Servers/IIS/build/Build.Settings
+++ b/src/Servers/IIS/build/Build.Settings
@@ -26,6 +26,7 @@
        <PrecompiledHeader>Use</PrecompiledHeader>
        <TreatWarningAsError Condition="'$(TreatWarningsAsErrors)' != ''">true</TreatWarningAsError>
        <SDLCheck>true</SDLCheck>
+       <ControlFlowGuard>Guard</ControlFlowGuard>
        <StringPooling>true</StringPooling>
      </ClCompile>
      <Link>


### PR DESCRIPTION
Enables control flow guards for IIS native dlls.

Will backport to 2.1 and 3.1 if this succeeds in master.