### PR TITLE
Enable Kestrel config reload in ConfigureWebHostDefaults

### DIFF
--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore
             });
             builder.UseKestrel((builderContext, options) =>
             {
-                options.Configure(builderContext.Configuration.GetSection("Kestrel"));
+                options.Configure(builderContext.Configuration.GetSection("Kestrel"), reloadOnChange: true);
             })
             .ConfigureServices((hostingContext, services) =>
             {


### PR DESCRIPTION
The PR to enable reloadable Kestrel config (#21072) originally changed the behavior of the existing `KestrelServerOptions.Configure(IConfiguration)` method to support reloading config and added a new overload to opt out. We decided that was too breaking, so we switched it to opt in.

I think that changing the behavior of ConfigureWebHostDefaults is worth the break though. ConfigureWebHostDefaults already calls AddJsonFile with reloadOnChange set to true, so having Kestrel reloadOnChange is more consistent. I also find it unlikely that it's common to change Kestrel config and expect Kestrel not to react to it.

I'm targeting preview6 so we can get feedback on this change earlier.
