### PR TITLE
Improve XML docs for ActionResultStatusCodeAttribute

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ActionResultStatusCodeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ActionResultStatusCodeAttribute.cs
@@ -6,18 +6,24 @@ using System;
 namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
     /// <summary>
-    /// Attribute annoted on ActionResult constructor and helper method parameters to indicate
+    /// Attribute annotated on ActionResult constructor and helper method parameters to indicate
     /// that the parameter is used to set the "statusCode" for the ActionResult.
     /// <para>
     /// Analyzers match this parameter by type name. This allows users to annotate custom results \ custom helpers
-    /// with a user defined attribute without having to expose this type.
+    /// with a user-defined attribute without having to expose this type.
     /// </para>
     /// <para>
     /// This attribute is intentionally marked Inherited=false since the analyzer does not walk the inheritance graph.
     /// </para>
     /// </summary>
     /// <example>
-    /// StatusCodeResult([ActionResultStatusCodeParameter] int statusCode)
+    /// Annotated constructor parameter:
+    /// <code>
+    /// public StatusCodeResult([ActionResultStatusCode] int statusCode)
+    /// {
+    ///     StatusCode = statusCode;
+    /// }
+    /// </code>
     /// </example>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     public sealed class ActionResultStatusCodeAttribute : Attribute


### PR DESCRIPTION
Adds missing label and `<code>` elements for the example and fixes minor grammatical issues. Also provides more complete sample code and fixes the attribute name used in the sample.