### PR TITLE
[3.1] Enable control flow guard for IIS dlls

### DIFF
--- a/src/Servers/IIS/build/Build.Settings
+++ b/src/Servers/IIS/build/Build.Settings
@@ -26,6 +26,7 @@
        <PrecompiledHeader>Use</PrecompiledHeader>
        <TreatWarningAsError Condition="'$(TreatWarningsAsErrors)' != ''">true</TreatWarningAsError>
        <SDLCheck>true</SDLCheck>
+       <ControlFlowGuard>Guard</ControlFlowGuard>
        <StringPooling>true</StringPooling>
      </ClCompile>
      <Link>


### PR DESCRIPTION
Backporting https://github.com/dotnet/aspnetcore/pull/22480 to 3.1.