### PR TITLE
Build native assets by default

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -398,10 +398,10 @@ if ($BinaryLog) {
     } else {
         # Use a different binary log path when running desktop msbuild if doing both builds.
         if ($performDesktopBuild -and $performDotnetBuild) {
-            $MSBuildArguments += [System.IO.Path]::ChangeExtension($bl, "native.binlog")
+            $MSBuildArguments += "/bl:" + [System.IO.Path]::ChangeExtension($bl, "native.binlog")
         }
 
-        $ToolsetBuildArguments += [System.IO.Path]::ChangeExtension($bl, "repotasks.binlog")
+        $ToolsetBuildArguments += "/bl:" + [System.IO.Path]::ChangeExtension($bl, "repotasks.binlog")
     }
 } elseif ($CI) {
     # Ensure the artifacts/log directory isn't empty to avoid warnings.

--- a/eng/scripts/GenerateReferenceAssemblies.ps1
+++ b/eng/scripts/GenerateReferenceAssemblies.ps1
@@ -10,9 +10,6 @@ try {
   & "$repoRoot\build.ps1"  -ci:$ci -nobl -noBuildRepoTasks -noRestore -buildNative -configuration Debug
 
   Remove-Item variable:global:_BuildTool -ErrorAction Ignore
-  Remove-Item variable:global:_DotNetInstallDir -ErrorAction Ignore
-  Remove-Item variable:global:_ToolsetBuildProj -ErrorAction Ignore
-  Remove-Item variable:global:_MSBuildExe -ErrorAction Ignore
 
   $excludeCIBinarylog = $true
   $msbuildEngine = 'dotnet'

--- a/src/Servers/IIS/build.cmd
+++ b/src/Servers/IIS/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..\..
-%RepoRoot%\build.cmd -BuildNative -projects %~dp0**\*.csproj %* 
+%RepoRoot%\build.cmd -projects %~dp0**\*.csproj %*

--- a/src/Servers/build.cmd
+++ b/src/Servers/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..
-%RepoRoot%\build.cmd -projects %~dp0**\*.*proj %*
+%RepoRoot%\build.cmd -projects %~dp0**\*.csproj %*

--- a/src/SiteExtensions/build.cmd
+++ b/src/SiteExtensions/build.cmd
@@ -3,14 +3,14 @@ SET RepoRoot=%~dp0..\..
 
 ECHO Building x64 Microsoft.AspNetCore.Runtime.SiteExtension
 CALL "%RepoRoot%\build.cmd" -arch x64 -projects "%~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj" ^
-    /bl:artifacts/log/SiteExtensions-Runtime-x86.binlog %*
+    "/bl:%RepoRoot%/artifacts/log/SiteExtensions-Runtime-x86.binlog" %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
 
 ECHO Building x86 Microsoft.AspNetCore.Runtime.SiteExtension
 CALL "%RepoRoot%\build.cmd" -arch x86 -projects "%~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj" ^
-    /bl:artifacts/log/SiteExtensions-Runtime-x86.binlog %*
+    "/bl:%RepoRoot%/artifacts/log/SiteExtensions-Runtime-x86.binlog" %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
@@ -19,14 +19,14 @@ ECHO Building x64 LoggingBranch
 REM /p:DisableTransitiveFrameworkReferences=true is needed to prevent SDK from picking up transitive references to
 REM Microsoft.AspNetCore.App as framework references https://github.com/dotnet/sdk/pull/3221
 CALL "%RepoRoot%\build.cmd" -arch x64 -projects "%~dp0LoggingBranch\LB.csproj" ^
-    /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x64.binlog %*
+    /p:DisableTransitiveFrameworkReferences=true "/bl:%RepoRoot%/artifacts/log/SiteExtensions-LoggingBranch-x64.binlog" %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
 
 ECHO Building x86 LoggingBranch
 CALL "%RepoRoot%\build.cmd" -arch x86 -projects "%~dp0LoggingBranch\LB.csproj" ^
-    /p:DisableTransitiveFrameworkReferences=true /bl:artifacts/log/SiteExtensions-LoggingBranch-x86.binlog %*
+    /p:DisableTransitiveFrameworkReferences=true "/bl:%RepoRoot%/artifacts/log/SiteExtensions-LoggingBranch-x86.binlog" %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )
@@ -34,7 +34,7 @@ IF %ERRORLEVEL% NEQ 0 (
 ECHO Building Microsoft.AspNetCore.AzureAppServices.SiteExtension
 CALL "%RepoRoot%\build.cmd" -projects ^
     "%~dp0LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj" ^
-    /bl:artifacts/log/SiteExtensions-LoggingAggregate.binlog %*
+    "/bl:%RepoRoot%/artifacts/log/SiteExtensions-LoggingAggregate.binlog" %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )


### PR DESCRIPTION
- #22556
- make `-BuildNative` primarily useful when you want _only_ native assets
- remove `-ForceCoreMsbuild` option

nit: extra `Remove-Item`s caused `MSBuild` function to do redundant work