### PR TITLE
Keep building packages that are marked packable

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,7 +8,7 @@
 
     <!-- If the user has specified that they want to skip building any test related projects with SkipTestBuild,
      suppress all targets for TestProjects using ExcludeFromBuild. -->
-    <ExcludeFromBuild Condition="'$(IsPackable)' == 'false' and
+    <ExcludeFromBuild Condition="'$(IsPackable)' != 'true' and
         '$(SkipTestBuild)' == 'true' and
         ('$(IsTestProject)' == 'true' or
          '$(IsUnitTestProject)' == 'true' or

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,14 +5,15 @@
     <!-- Analyzer package are needed in source build for WebSDK -->
     <ExcludeFromSourceBuild
         Condition="'$(ExcludeFromSourceBuild)' == '' and '$(DotNetBuildFromSource)' == 'true' and '$(IsAspNetCoreApp)' != 'true' and '$(IsReferenceAssemblyProject)' != 'true' and '$(IsAnalyzersProject)' != 'true'">true</ExcludeFromSourceBuild>
-        
+
     <!-- If the user has specified that they want to skip building any test related projects with SkipTestBuild,
      suppress all targets for TestProjects using ExcludeFromBuild. -->
-    <ExcludeFromBuild Condition="'$(SkipTestBuild)' == 'true' and 
+    <ExcludeFromBuild Condition="'$(IsPackable)' == 'false' and
+        '$(SkipTestBuild)' == 'true' and
         ('$(IsTestProject)' == 'true' or
          '$(IsUnitTestProject)' == 'true' or
          '$(IsTestAssetProject)' == 'true' or
-         '$(IsBenchmarkProject)' == 'true' or 
+         '$(IsBenchmarkProject)' == 'true' or
          '$(IsSampleProject)' == 'true' or
          '$(IsSpecificationTestProject)' == 'true')">true</ExcludeFromBuild>
   </PropertyGroup>

--- a/src/Servers/IIS/IIS/test/testassets/TestTasks/TestTasks.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/TestTasks/TestTasks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SignalR/clients/java/signalr/signalr.client.java.Tests.javaproj
+++ b/src/SignalR/clients/java/signalr/signalr.client.java.Tests.javaproj
@@ -42,7 +42,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <!-- Define Target overrides after importing Directory.Build.targets so these don't get overridden -->
-  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Condition="'$(IsPackable)' == 'true' and '$(SkipTestBuild)' != 'true'">
+  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Condition="'$(IsPackable)' == 'true'">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Pack" />
     <Message Text="> gradlew $(GradleOptions) createPackage" Importance="high" />
     <Exec Command="./gradlew $(GradleOptions) createPackage" />
@@ -50,7 +50,7 @@
     <Copy SourceFiles="build\libs\%(JavaBuildFiles.Identity)" DestinationFolder="$(PackageOutputPath)" />
   </Target>
 
-  <Target Name="Build" Condition="'$(SkipTestBuild)' != 'true'">
+  <Target Name="Build">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Build" />
     <Exec Command="./gradlew $(GradleOptions) compileJava" />
   </Target>


### PR DESCRIPTION
The packages below stopped being in the shipping/non-shipping folder after https://github.com/dotnet/aspnetcore/pull/22362 which was an unintended side-effect:
* Microsoft.AspNetCore.SignalR.Specification.Tests
* signalr-x.y.z.jar
* Microsoft.AspNetCore.Server.IntegrationTesting
* Microsoft.AspNetCore.Server.IntegrationTesting.IIS