### PR TITLE
Add support for optional FromBody parameters

### DIFF
--- a/src/Mvc/Mvc.Abstractions/ref/Microsoft.AspNetCore.Mvc.Abstractions.netcoreapp.cs
+++ b/src/Mvc/Mvc.Abstractions/ref/Microsoft.AspNetCore.Mvc.Abstractions.netcoreapp.cs
@@ -160,6 +160,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
     public partial class ApiParameterDescription
     {
         public ApiParameterDescription() { }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo BindingInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public object DefaultValue { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public bool IsRequired { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.ModelMetadata ModelMetadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
@@ -459,6 +460,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     {
         public BindingInfo() { }
         public BindingInfo(Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo other) { }
+        public bool? AllowEmptyInputInBodyModelBinding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string BinderModelName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public System.Type BinderType { get { throw null; } set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }

--- a/src/Mvc/Mvc.Abstractions/ref/Microsoft.AspNetCore.Mvc.Abstractions.netcoreapp.cs
+++ b/src/Mvc/Mvc.Abstractions/ref/Microsoft.AspNetCore.Mvc.Abstractions.netcoreapp.cs
@@ -460,10 +460,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     {
         public BindingInfo() { }
         public BindingInfo(Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo other) { }
-        public bool? AllowEmptyInputInBodyModelBinding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string BinderModelName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public System.Type BinderType { get { throw null; } set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.EmptyBodyBehavior EmptyBodyBehavior { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.IPropertyFilterProvider PropertyFilterProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public System.Func<Microsoft.AspNetCore.Mvc.ActionContext, bool> RequestPredicate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public static Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo GetBindingInfo(System.Collections.Generic.IEnumerable<object> attributes) { throw null; }
@@ -501,6 +501,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource> BindingSources { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public override bool CanAcceptDataFrom(Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { throw null; }
         public static Microsoft.AspNetCore.Mvc.ModelBinding.CompositeBindingSource Create(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource> bindingSources, string displayName) { throw null; }
+    }
+    public enum EmptyBodyBehavior
+    {
+        Default = 0,
+        Allow = 1,
+        Disallow = 2,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EnumGroupAndName

--- a/src/Mvc/Mvc.Abstractions/src/ApiExplorer/ApiParameterDescription.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ApiExplorer/ApiParameterDescription.cs
@@ -33,6 +33,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         public BindingSource Source { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="BindingInfo"/>.
+        /// </summary>
+        public BindingInfo BindingInfo { get; set; }
+
+        /// <summary>
         /// Gets or sets the parameter type.
         /// </summary>
         public Type Type { get; set; }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingInfo.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingInfo.cs
@@ -38,6 +38,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             BinderType = other.BinderType;
             PropertyFilterProvider = other.PropertyFilterProvider;
             RequestPredicate = other.RequestPredicate;
+            AllowEmptyInputInBodyModelBinding = other.AllowEmptyInputInBodyModelBinding;
         }
 
         /// <summary>
@@ -86,6 +87,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// from the current request.
         /// </summary>
         public Func<ActionContext, bool> RequestPredicate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag which decides whether body model binding should treat empty
+        /// input as valid.
+        /// </summary>
+        public bool? AllowEmptyInputInBodyModelBinding { get; set; }
 
         /// <summary>
         /// Constructs a new instance of <see cref="BindingInfo"/> from the given <paramref name="attributes"/>.
@@ -156,6 +163,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 if (requestPredicateProvider.RequestPredicate != null)
                 {
                     bindingInfo.RequestPredicate = requestPredicateProvider.RequestPredicate;
+                    break;
+                }
+            }
+
+            foreach (var allowEmptyInputInModelBinding in attributes.OfType<IAllowEmptyInputInBodyModelBinding>())
+            {
+                isBindingInfoPresent = true;
+                if (allowEmptyInputInModelBinding.AllowEmptyInputInBodyModelBinding != null)
+                {
+                    bindingInfo.AllowEmptyInputInBodyModelBinding = allowEmptyInputInModelBinding.AllowEmptyInputInBodyModelBinding;
                     break;
                 }
             }
@@ -234,6 +251,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 isBindingInfoPresent = true;
                 PropertyFilterProvider = modelMetadata.PropertyFilterProvider;
             }
+
+            // There isn't a ModelMetadata feature to configure AllowEmptyInputInBodyModelBinding, 
+            // so nothing to infer from it.
 
             return isBindingInfoPresent;
         }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingInfo.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingInfo.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             BinderType = other.BinderType;
             PropertyFilterProvider = other.PropertyFilterProvider;
             RequestPredicate = other.RequestPredicate;
-            AllowEmptyInputInBodyModelBinding = other.AllowEmptyInputInBodyModelBinding;
+            EmptyBodyBehavior = other.EmptyBodyBehavior;
         }
 
         /// <summary>
@@ -89,10 +89,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public Func<ActionContext, bool> RequestPredicate { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag which decides whether body model binding should treat empty
-        /// input as valid.
+        /// Gets or sets the value which decides if empty bodies are treated as valid inputs.
         /// </summary>
-        public bool? AllowEmptyInputInBodyModelBinding { get; set; }
+        public EmptyBodyBehavior EmptyBodyBehavior { get; set; }
 
         /// <summary>
         /// Constructs a new instance of <see cref="BindingInfo"/> from the given <paramref name="attributes"/>.
@@ -167,14 +166,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 }
             }
 
-            foreach (var allowEmptyInputInModelBinding in attributes.OfType<IAllowEmptyInputInBodyModelBinding>())
+            foreach (var configureEmptyBodyBehavior in attributes.OfType<IConfigureEmptyBodyBehavior>())
             {
                 isBindingInfoPresent = true;
-                if (allowEmptyInputInModelBinding.AllowEmptyInputInBodyModelBinding != null)
-                {
-                    bindingInfo.AllowEmptyInputInBodyModelBinding = allowEmptyInputInModelBinding.AllowEmptyInputInBodyModelBinding;
-                    break;
-                }
+                bindingInfo.EmptyBodyBehavior = configureEmptyBodyBehavior.EmptyBodyBehavior;
+                break;
             }
 
             return isBindingInfoPresent ? bindingInfo : null;

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/EmptyBodyBehavior.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/EmptyBodyBehavior.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    /// <summary>
+    /// Determines the behavior for processing empty bodies during input formatting.
+    /// </summary>
+    public enum EmptyBodyBehavior
+    {
+        /// <summary>
+        /// Uses the framework default behavior for processing empty bodies.
+        /// This is typically configured using <c>MvcOptions.AllowEmptyInputInBodyModelBinding</c>
+        /// </summary>
+        Default,
+        
+        /// <summary>
+        /// Empty bodies are treated as valid inputs.
+        /// </summary>
+        Allow,
+
+        /// <summary>
+        /// Empty bodies are treated as invalid inputs.
+        /// </summary>
+        Disallow,
+    }
+}

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/IAllowEmptyInputInBodyModelBinding.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/IAllowEmptyInputInBodyModelBinding.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    internal interface IAllowEmptyInputInBodyModelBinding
+    {
+        public bool? AllowEmptyInputInBodyModelBinding { get; }
+    }
+}

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/IAllowEmptyInputInBodyModelBinding.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/IAllowEmptyInputInBodyModelBinding.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
-    internal interface IAllowEmptyInputInBodyModelBinding
+    internal interface IConfigureEmptyBodyBehavior
     {
-        public bool? AllowEmptyInputInBodyModelBinding { get; }
+        public EmptyBodyBehavior EmptyBodyBehavior { get; }
     }
 }

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             ProcessRouteParameters(context);
 
             // Set IsRequired=true
-            ProcessIsRequired(context);
+            ProcessIsRequired(context, _mvcOptions);
 
             // Set DefaultValue
             ProcessParameterDefaultValue(context);
@@ -273,13 +273,13 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             }
         }
 
-        internal static void ProcessIsRequired(ApiParameterContext context)
+        internal static void ProcessIsRequired(ApiParameterContext context, MvcOptions mvcOptions)
         {
             foreach (var parameter in context.Results)
             {
                 if (parameter.Source == BindingSource.Body)
                 {
-                    parameter.IsRequired = true;
+                    parameter.IsRequired = !(parameter.BindingInfo?.AllowEmptyInputInBodyModelBinding ?? mvcOptions.AllowEmptyInputInBodyModelBinding);
                 }
 
                 if (parameter.ModelMetadata != null && parameter.ModelMetadata.IsBindingRequired)
@@ -466,6 +466,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
             public string PropertyName { get; set; }
 
+            public BindingInfo BindingInfo { get; set; }
+
             public static ApiParameterDescriptionContext GetContext(
                 ModelMetadata metadata,
                 BindingInfo bindingInfo,
@@ -478,6 +480,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     BinderModelName = bindingInfo?.BinderModelName,
                     BindingSource = bindingInfo?.BindingSource,
                     PropertyName = propertyName ?? metadata.Name,
+                    BindingInfo = bindingInfo,
                 };
             }
         }
@@ -607,6 +610,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     Source = source,
                     Type = bindingContext.ModelMetadata.ModelType,
                     ParameterDescriptor = Parameter,
+                    BindingInfo = bindingContext.BindingInfo
                 };
             }
 

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -279,7 +279,14 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             {
                 if (parameter.Source == BindingSource.Body)
                 {
-                    parameter.IsRequired = !(parameter.BindingInfo?.AllowEmptyInputInBodyModelBinding ?? mvcOptions.AllowEmptyInputInBodyModelBinding);
+                    if (parameter.BindingInfo == null || parameter.BindingInfo.EmptyBodyBehavior == EmptyBodyBehavior.Default)
+                    {
+                        parameter.IsRequired = !mvcOptions.AllowEmptyInputInBodyModelBinding;
+                    }
+                    else
+                    {
+                        parameter.IsRequired = !(parameter.BindingInfo.EmptyBodyBehavior == EmptyBodyBehavior.Allow);
+                    }
                 }
 
                 if (parameter.ModelMetadata != null && parameter.ModelMetadata.IsBindingRequired)

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1725,10 +1725,45 @@ namespace Microsoft.AspNetCore.Mvc.Description
             var context = GetApiParameterContext(description);
 
             // Act
-            DefaultApiDescriptionProvider.ProcessIsRequired(context);
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions());
 
             // Assert
             Assert.True(description.IsRequired);
+        }
+
+        [Fact]
+        public void ProcessIsRequired_SetsFalse_IfAllowEmptyInputInBodyModelBinding_IsSetInMvcOptions()
+        {
+            // Arrange
+            var description = new ApiParameterDescription { Source = BindingSource.Body, };
+            var context = GetApiParameterContext(description);
+
+            // Act
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions { AllowEmptyInputInBodyModelBinding = true });
+
+            // Assert
+            Assert.False(description.IsRequired);
+        }
+
+        [Fact]
+        public void ProcessIsRequired_SetsFalse_IfAllowEmptyInputInBodyModelBinding_IsSetInBindingInfo()
+        {
+            // Arrange
+            var description = new ApiParameterDescription 
+            { 
+                Source = BindingSource.Body, 
+                BindingInfo = new BindingInfo
+                {
+                    AllowEmptyInputInBodyModelBinding = true,
+                }
+            };
+            var context = GetApiParameterContext(description);
+
+            // Act
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions());
+
+            // Assert
+            Assert.False(description.IsRequired);
         }
 
         [Fact]
@@ -1747,7 +1782,7 @@ namespace Microsoft.AspNetCore.Mvc.Description
             description.ModelMetadata = modelMetadataProvider.GetMetadataForProperty(typeof(Person), nameof(Person.Name));
 
             // Act
-            DefaultApiDescriptionProvider.ProcessIsRequired(context);
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions());
 
             // Assert
             Assert.True(description.IsRequired);
@@ -1765,7 +1800,7 @@ namespace Microsoft.AspNetCore.Mvc.Description
             var context = GetApiParameterContext(description);
 
             // Act
-            DefaultApiDescriptionProvider.ProcessIsRequired(context);
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions());
 
             // Assert
             Assert.True(description.IsRequired);
@@ -1779,7 +1814,7 @@ namespace Microsoft.AspNetCore.Mvc.Description
             var context = GetApiParameterContext(description);
 
             // Act
-            DefaultApiDescriptionProvider.ProcessIsRequired(context);
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions());
 
             // Assert
             Assert.False(description.IsRequired);
@@ -1798,7 +1833,7 @@ namespace Microsoft.AspNetCore.Mvc.Description
             description.ModelMetadata = modelMetadataProvider.GetMetadataForProperty(typeof(Person), nameof(Person.Name));
 
             // Act
-            DefaultApiDescriptionProvider.ProcessIsRequired(context);
+            DefaultApiDescriptionProvider.ProcessIsRequired(context, new MvcOptions());
 
             // Assert
             Assert.False(description.IsRequired);

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1746,7 +1746,7 @@ namespace Microsoft.AspNetCore.Mvc.Description
         }
 
         [Fact]
-        public void ProcessIsRequired_SetsFalse_IfAllowEmptyInputInBodyModelBinding_IsSetInBindingInfo()
+        public void ProcessIsRequired_SetsFalse_IfEmptyBodyBehaviorIsAllowedInBindingInfo()
         {
             // Arrange
             var description = new ApiParameterDescription 
@@ -1754,7 +1754,7 @@ namespace Microsoft.AspNetCore.Mvc.Description
                 Source = BindingSource.Body, 
                 BindingInfo = new BindingInfo
                 {
-                    AllowEmptyInputInBodyModelBinding = true,
+                    EmptyBodyBehavior = EmptyBodyBehavior.Allow,
                 }
             };
             var context = GetApiParameterContext(description);

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
@@ -2795,8 +2795,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     {
         public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory) { }
         public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
-        public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Mvc.MvcOptions? options) { }
-        public Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder? GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext context) { throw null; }
+        public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Mvc.MvcOptions options) { }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext context) { throw null; }
     }
     public partial class ByteArrayModelBinder : Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder
     {

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
@@ -744,6 +744,7 @@ namespace Microsoft.AspNetCore.Mvc
     public partial class FromBodyAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.ModelBinding.IBindingSourceMetadata
     {
         public FromBodyAttribute() { }
+        public bool AllowEmptyInputInBodyModelBinding { get { throw null; } set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
@@ -2794,8 +2795,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     {
         public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory) { }
         public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
-        public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Mvc.MvcOptions options) { }
-        public Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext context) { throw null; }
+        public BodyModelBinderProvider(System.Collections.Generic.IList<Microsoft.AspNetCore.Mvc.Formatters.IInputFormatter> formatters, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpRequestStreamReaderFactory readerFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Mvc.MvcOptions? options) { }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder? GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext context) { throw null; }
     }
     public partial class ByteArrayModelBinder : Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder
     {

--- a/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
+++ b/src/Mvc/Mvc.Core/ref/Microsoft.AspNetCore.Mvc.Core.netcoreapp.cs
@@ -744,8 +744,8 @@ namespace Microsoft.AspNetCore.Mvc
     public partial class FromBodyAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.ModelBinding.IBindingSourceMetadata
     {
         public FromBodyAttribute() { }
-        public bool AllowEmptyInputInBodyModelBinding { get { throw null; } set { } }
         public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { get { throw null; } }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.EmptyBodyBehavior EmptyBodyBehavior { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public partial class FromFormAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.ModelBinding.IBindingSourceMetadata, Microsoft.AspNetCore.Mvc.ModelBinding.IModelNameProvider

--- a/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
@@ -10,9 +10,27 @@ namespace Microsoft.AspNetCore.Mvc
     /// Specifies that a parameter or property should be bound using the request body.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class FromBodyAttribute : Attribute, IBindingSourceMetadata
+    public class FromBodyAttribute : Attribute, IBindingSourceMetadata, IAllowEmptyInputInBodyModelBinding
     {
+        private bool? _allowEmptyInputInBodyModelBinding;
+
         /// <inheritdoc />
         public BindingSource BindingSource => BindingSource.Body;
+
+        /// <summary>
+        /// Gets or sets the flag which decides whether body model binding (for example, on an
+        /// action method parameter with <see cref="FromBodyAttribute"/>) should treat empty
+        /// input as valid. <see langword="null"/> by default.
+        /// </summary>
+        /// <remarks>
+        /// When configured, takes precedence over <see cref="MvcOptions.AllowEmptyInputInBodyModelBinding"/>.
+        /// </remarks>
+        public bool AllowEmptyInputInBodyModelBinding
+        {
+            get => _allowEmptyInputInBodyModelBinding ?? false;
+            set => _allowEmptyInputInBodyModelBinding = value;
+        }
+
+        bool? IAllowEmptyInputInBodyModelBinding.AllowEmptyInputInBodyModelBinding => _allowEmptyInputInBodyModelBinding;
     }
 }

--- a/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
@@ -10,27 +10,19 @@ namespace Microsoft.AspNetCore.Mvc
     /// Specifies that a parameter or property should be bound using the request body.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class FromBodyAttribute : Attribute, IBindingSourceMetadata, IAllowEmptyInputInBodyModelBinding
+    public class FromBodyAttribute : Attribute, IBindingSourceMetadata, IConfigureEmptyBodyBehavior
     {
-        private bool? _allowEmptyInputInBodyModelBinding;
-
         /// <inheritdoc />
         public BindingSource BindingSource => BindingSource.Body;
 
         /// <summary>
-        /// Gets or sets the flag which decides whether body model binding (for example, on an
-        /// action method parameter with <see cref="FromBodyAttribute"/>) should treat empty
-        /// input as valid. <see langword="null"/> by default.
+        /// Gets or sets a value which decides whether body model binding should treat empty
+        /// input as valid.
         /// </summary>
         /// <remarks>
-        /// When configured, takes precedence over <see cref="MvcOptions.AllowEmptyInputInBodyModelBinding"/>.
+        /// The default behavior is to use framework defaults as configured by <see cref="MvcOptions.AllowEmptyInputInBodyModelBinding"/>.
+        /// Specifying <see cref="EmptyBodyBehavior.Allow"/> or <see cref="EmptyBodyBehavior.Disallow" /> will override the framework defaults.
         /// </remarks>
-        public bool AllowEmptyInputInBodyModelBinding
-        {
-            get => _allowEmptyInputInBodyModelBinding ?? false;
-            set => _allowEmptyInputInBodyModelBinding = value;
-        }
-
-        bool? IAllowEmptyInputInBodyModelBinding.AllowEmptyInputInBodyModelBinding => _allowEmptyInputInBodyModelBinding;
+        public EmptyBodyBehavior EmptyBodyBehavior { get; set; }
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinder.cs
@@ -80,16 +80,17 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(readerFactory));
             }
 
-            _formatters = formatters;
-            _readerFactory = readerFactory.CreateReader;
-
             if (loggerFactory != null)
             {
-                _logger = loggerFactory.CreateLogger<BodyModelBinder>();
+                _logger = loggerFactory?.CreateLogger<BodyModelBinder>();
             }
 
             _options = options;
+            _formatters = formatters;
+            _readerFactory = readerFactory.CreateReader;
         }
+
+        internal bool AllowEmptyInputInBodyModelBinding { get; set; }
 
         /// <inheritdoc />
         public async Task BindModelAsync(ModelBindingContext bindingContext)
@@ -116,15 +117,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             var httpContext = bindingContext.HttpContext;
 
-            var allowEmptyInputInModelBinding = _options?.AllowEmptyInputInBodyModelBinding == true;
-
             var formatterContext = new InputFormatterContext(
                 httpContext,
                 modelBindingKey,
                 bindingContext.ModelState,
                 bindingContext.ModelMetadata,
                 _readerFactory,
-                allowEmptyInputInModelBinding);
+                AllowEmptyInputInBodyModelBinding);
 
             var formatter = (IInputFormatter)null;
             for (var i = 0; i < _formatters.Count; i++)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinder.cs
@@ -80,17 +80,18 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(readerFactory));
             }
 
+            _formatters = formatters;
+            _readerFactory = readerFactory.CreateReader;
+
             if (loggerFactory != null)
             {
-                _logger = loggerFactory?.CreateLogger<BodyModelBinder>();
+                _logger = loggerFactory.CreateLogger<BodyModelBinder>();
             }
 
             _options = options;
-            _formatters = formatters;
-            _readerFactory = readerFactory.CreateReader;
         }
 
-        internal bool AllowEmptyInputInBodyModelBinding { get; set; }
+        internal bool AllowEmptyBody { get; set; }
 
         /// <inheritdoc />
         public async Task BindModelAsync(ModelBindingContext bindingContext)
@@ -123,7 +124,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 bindingContext.ModelState,
                 bindingContext.ModelMetadata,
                 _readerFactory,
-                AllowEmptyInputInBodyModelBinding);
+                AllowEmptyBody);
 
             var formatter = (IInputFormatter)null;
             for (var i = 0; i < _formatters.Count; i++)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -21,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         private readonly IList<IInputFormatter> _formatters;
         private readonly IHttpRequestStreamReaderFactory _readerFactory;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly MvcOptions? _options;
+        private readonly MvcOptions _options;
 
         /// <summary>
         /// Creates a new <see cref="BodyModelBinderProvider"/>.
@@ -55,7 +53,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             IList<IInputFormatter> formatters,
             IHttpRequestStreamReaderFactory readerFactory,
             ILoggerFactory loggerFactory,
-            MvcOptions? options)
+            MvcOptions options)
         {
             if (formatters == null)
             {
@@ -74,7 +72,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         }
 
         /// <inheritdoc />
-        public IModelBinder? GetBinder(ModelBinderProviderContext context)
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
         {
             if (context == null)
             {
@@ -93,9 +91,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 }
 
                 var allowEmptyInputInBodyModelBinding =
-                    context?.BindingInfo.AllowEmptyInputInBodyModelBinding
-                    ?? _options?.AllowEmptyInputInBodyModelBinding
-                    ?? false;
+                    context?.BindingInfo.AllowEmptyInputInBodyModelBinding ??
+                    _options?.AllowEmptyInputInBodyModelBinding ??
+                    false;
 
                 return new BodyModelBinder(_formatters, _readerFactory, _loggerFactory, _options)
                 {

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderProvider.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 {
@@ -18,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         private readonly IList<IInputFormatter> _formatters;
         private readonly IHttpRequestStreamReaderFactory _readerFactory;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly MvcOptions _options;
+        private readonly MvcOptions? _options;
 
         /// <summary>
         /// Creates a new <see cref="BodyModelBinderProvider"/>.
@@ -26,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         /// <param name="formatters">The list of <see cref="IInputFormatter"/>.</param>
         /// <param name="readerFactory">The <see cref="IHttpRequestStreamReaderFactory"/>.</param>
         public BodyModelBinderProvider(IList<IInputFormatter> formatters, IHttpRequestStreamReaderFactory readerFactory)
-            : this(formatters, readerFactory, loggerFactory: null)
+            : this(formatters, readerFactory, loggerFactory: NullLoggerFactory.Instance)
         {
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             IList<IInputFormatter> formatters,
             IHttpRequestStreamReaderFactory readerFactory,
             ILoggerFactory loggerFactory,
-            MvcOptions options)
+            MvcOptions? options)
         {
             if (formatters == null)
             {
@@ -71,7 +74,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         }
 
         /// <inheritdoc />
-        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        public IModelBinder? GetBinder(ModelBinderProviderContext context)
         {
             if (context == null)
             {
@@ -89,7 +92,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                         typeof(IInputFormatter).FullName));
                 }
 
-                return new BodyModelBinder(_formatters, _readerFactory, _loggerFactory, _options);
+                var allowEmptyInputInBodyModelBinding =
+                    context?.BindingInfo.AllowEmptyInputInBodyModelBinding
+                    ?? _options?.AllowEmptyInputInBodyModelBinding
+                    ?? false;
+
+                return new BodyModelBinder(_formatters, _readerFactory, _loggerFactory, _options)
+                {
+                    AllowEmptyInputInBodyModelBinding = allowEmptyInputInBodyModelBinding,
+                };
             }
 
             return null;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinderProvider.cs
@@ -90,18 +90,25 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                         typeof(IInputFormatter).FullName));
                 }
 
-                var allowEmptyInputInBodyModelBinding =
-                    context?.BindingInfo.AllowEmptyInputInBodyModelBinding ??
-                    _options?.AllowEmptyInputInBodyModelBinding ??
-                    false;
+                var treatEmptyInputAsDefaultValue = CalculateAllowEmptyBody(context.BindingInfo.EmptyBodyBehavior, _options);
 
                 return new BodyModelBinder(_formatters, _readerFactory, _loggerFactory, _options)
                 {
-                    AllowEmptyInputInBodyModelBinding = allowEmptyInputInBodyModelBinding,
+                    AllowEmptyBody = treatEmptyInputAsDefaultValue,
                 };
             }
 
             return null;
+        }
+
+        internal static bool CalculateAllowEmptyBody(EmptyBodyBehavior emptyBodyBehavior, MvcOptions options)
+        {
+            if (emptyBodyBehavior == EmptyBodyBehavior.Default)
+            {
+                return options?.AllowEmptyInputInBodyModelBinding ?? false;
+            }
+
+            return emptyBodyBehavior == EmptyBodyBehavior.Allow;
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/BodyModelBinderProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/BodyModelBinderProviderTest.cs
@@ -86,6 +86,53 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             provider.GetBinder(context);
         }
 
+        [Fact]
+        public void CalculateAllowEmptyBody_EmptyBodyBehaviorIsDefaultValue_UsesMvcOptions()
+        {
+            // Arrange
+            var options = new MvcOptions { AllowEmptyInputInBodyModelBinding = true };
+
+            // Act
+            var allowEmpty = BodyModelBinderProvider.CalculateAllowEmptyBody(EmptyBodyBehavior.Default, options);
+
+            // Assert
+            Assert.True(allowEmpty);
+        }
+
+        [Fact]
+        public void CalculateAllowEmptyBody_EmptyBodyBehaviorIsDefaultValue_DefaultsToFalseWhenOptionsIsUnavailable()
+        {
+            // Act
+            var allowEmpty = BodyModelBinderProvider.CalculateAllowEmptyBody(EmptyBodyBehavior.Default, options: null);
+
+            // Assert
+            Assert.False(allowEmpty);
+        }
+
+        [Fact]
+        public void CalculateAllowEmptyBody_EmptyBodyBehaviorIsAllow()
+        {
+            // Act
+            var allowEmpty = BodyModelBinderProvider.CalculateAllowEmptyBody(EmptyBodyBehavior.Allow, options: new MvcOptions());
+
+            // Assert
+            Assert.True(allowEmpty);
+        }
+
+        [Fact]
+        public void CalculateAllowEmptyBody_EmptyBodyBehaviorIsDisallowed()
+        {
+            // Arrange
+            // MvcOptions.AllowEmptyInputInBodyModelBinding should be ignored if EmptyBodyBehavior disallows it
+            var options = new MvcOptions { AllowEmptyInputInBodyModelBinding = true };
+
+            // Act
+            var allowEmpty = BodyModelBinderProvider.CalculateAllowEmptyBody(EmptyBodyBehavior.Disallow, options);
+
+            // Assert
+            Assert.False(allowEmpty);
+        }
+
         private static BodyModelBinderProvider CreateProvider(params IInputFormatter[] formatters)
         {
             var sink = new TestSink();

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/BodyModelBinderTests.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/BodyModelBinderTests.cs
@@ -657,8 +657,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
         private static BodyModelBinder CreateBinder(IList<IInputFormatter> formatters, bool treatEmptyInputAsDefaultValueOption = false)
         {
-            var options = new MvcOptions { AllowEmptyInputInBodyModelBinding = treatEmptyInputAsDefaultValueOption };
-            return CreateBinder(formatters, options);
+            var options = new MvcOptions();
+            var binder = CreateBinder(formatters, options);
+            binder.AllowEmptyInputInBodyModelBinding = treatEmptyInputAsDefaultValueOption;
+
+            return binder;
         }
 
         private static BodyModelBinder CreateBinder(IList<IInputFormatter> formatters, MvcOptions mvcOptions)

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/BodyModelBinderTests.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/BodyModelBinderTests.cs
@@ -659,7 +659,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             var options = new MvcOptions();
             var binder = CreateBinder(formatters, options);
-            binder.AllowEmptyInputInBodyModelBinding = treatEmptyInputAsDefaultValueOption;
+            binder.AllowEmptyBody = treatEmptyInputAsDefaultValueOption;
 
             return binder;
         }

--- a/src/Mvc/test/WebSites/FormatterWebSite/Controllers/HomeController.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Controllers/HomeController.cs
@@ -34,5 +34,13 @@ namespace FormatterWebSite.Controllers
                 SampleIntInDerived = 50
             };
         }
+
+        [HttpPost]
+        public IActionResult DefaultBody([FromBody] DummyClass dummy) 
+            => ModelState.IsValid ? Ok() : ValidationProblem();
+
+        [HttpPost]
+        public IActionResult OptionalBody([FromBody(AllowEmptyInputInBodyModelBinding = true)] DummyClass dummy)
+            => ModelState.IsValid ? Ok() : ValidationProblem();
     }
 }

--- a/src/Mvc/test/WebSites/FormatterWebSite/Controllers/HomeController.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace FormatterWebSite.Controllers
 {
@@ -40,7 +41,7 @@ namespace FormatterWebSite.Controllers
             => ModelState.IsValid ? Ok() : ValidationProblem();
 
         [HttpPost]
-        public IActionResult OptionalBody([FromBody(AllowEmptyInputInBodyModelBinding = true)] DummyClass dummy)
+        public IActionResult OptionalBody([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] DummyClass dummy)
             => ModelState.IsValid ? Ok() : ValidationProblem();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/6878

-----

```diff
public enum EmptyBodyBehavior
{
    Default = 0,
    Allow = 1,
    Disallow = 2,
}

public partial class FromBodyAttribute : System.Attribute, Microsoft.AspNetCore.Mvc.ModelBinding.IBindingSourceMetadata
{
      public FromBodyAttribute() { }
+     public EmptyBodyBehavior EmptyBodyBehavior { get { throw null; } set { } }
}

public partial class BindingInfo
{
    public BindingInfo() { }
    public BindingInfo(Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo other) { }
+   public EmptyBodyBehavior EmptyBodyBehavior { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
}

public partial class ApiParameterDescription
{
    public ApiParameterDescription() { }
+    public Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo BindingInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
```