### PR TITLE
Quarantine flaky test

### DIFF
--- a/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
+++ b/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
@@ -9,6 +9,7 @@ using HostedInAspNet.Server;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
@@ -38,6 +39,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void CachesResourcesAfterFirstLoad()
         {
             // On the first load, we have to fetch everything


### PR DESCRIPTION
Failed here: https://dev.azure.com/dnceng/internal/_build/results?buildId=676432&view=ms.vss-test-web.build-test-results-tab&runId=20961872&resultId=100366&paneView=debug

> Assert.NotEmpty() Failure

> at Microsoft.AspNetCore.Components.E2ETest.Tests.BootResourceCachingTest.CachesResourcesAfterFirstLoad() in /_/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs:line 49

