### PR TITLE
Unquarantine test that's not flaky anymore

### DIFF
--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -100,7 +100,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [ConditionalTheory]
         [MemberData(nameof(IPEndPointRegistrationDataDynamicPort))]
         [IPv6SupportedCondition]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore-internal/issues/2074")]
         public async Task RegisterIPEndPoint_DynamicPort_Success(IPEndPoint endPoint, string testUrl)
         {
             await RegisterIPEndPoint_Success(endPoint, testUrl);


### PR DESCRIPTION
This test has passed 100% of the time over the last 30 days

Though we don't have 30 days of unbroken data yet (due to the TFM change), the test history shows that the test was passing 100% of the time from 5/10-5/13 (pre-net5.0), and a separate entry shows it passing 100% of the time 5/14-today (post-net5.0)