### PR TITLE
Set the correct tfm in Wasm template.json

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -20,6 +20,7 @@
     "53bc9b9d-9d6a-45d4-8429-2a2761773502" // Client ID
   ],
   "identity": "Microsoft.Web.Blazor.Wasm.CSharp.5.0",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/5.0-third-party-notices",
   "preferNameDirectory": true,
   "primaryOutputs": [
     {
@@ -221,12 +222,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "HostIdentifier": {
       "type": "bind",


### PR DESCRIPTION
#### Description

The Blazor WebAssembly templates have incorrect metadata in the template.json

#### Customer Impact

If a preview6 SDK is installed, Blazor WebAssembly no longer appears in VS. Installing via CLI also fails. This is particularly problematic since the 3.2 WASM templates are also unavailable to be installed once the preview6 is installed.

#### Regression?

The WASM templates are new to 5.0

#### Risk

Low. The template.json config accurately represents the actual contents of the template. 
