### PR TITLE
[5.0-preview6] Enable control flow guard for IIS dlls

### DIFF
--- a/src/Servers/IIS/build/Build.Settings
+++ b/src/Servers/IIS/build/Build.Settings
@@ -26,6 +26,7 @@
        <PrecompiledHeader>Use</PrecompiledHeader>
        <TreatWarningAsError Condition="'$(TreatWarningsAsErrors)' != ''">true</TreatWarningAsError>
        <SDLCheck>true</SDLCheck>
+       <ControlFlowGuard>Guard</ControlFlowGuard>
        <StringPooling>true</StringPooling>
      </ClCompile>
      <Link>


### PR DESCRIPTION
Backporting #22480 to 5.0-preview6.