### PR TITLE
Add an option to configure the NewtonsoftJson buffer size

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/MvcNewtonsoftJsonOptions.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/MvcNewtonsoftJsonOptions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Mvc
         public JsonSerializerSettings SerializerSettings { get; } = JsonSerializerSettingsProvider.CreateSerializerSettings();
 
         /// <summary>
-        /// Gets the maximum size to buffer in memory when <see cref="MvcOptions.SuppressInputFormatterBuffering"/> is not reset.
+        /// Gets the maximum size to buffer in memory when <see cref="MvcOptions.SuppressInputFormatterBuffering"/> is not set.
         /// <para>
         /// <see cref="NewtonsoftJsonInputFormatter"/> buffers the input stream by default, buffering up to a certain amount in memory, before buffering to disk.
         /// This option configures the size in bytes that MVC will buffer in memory, before switching to disk.

--- a/src/Mvc/Mvc.NewtonsoftJson/src/MvcNewtonsoftJsonOptions.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/MvcNewtonsoftJsonOptions.cs
@@ -39,6 +39,16 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         public JsonSerializerSettings SerializerSettings { get; } = JsonSerializerSettingsProvider.CreateSerializerSettings();
 
+        /// <summary>
+        /// Gets the maximum size to buffer in memory when <see cref="MvcOptions.SuppressInputFormatterBuffering"/> is not reset.
+        /// <para>
+        /// <see cref="NewtonsoftJsonInputFormatter"/> buffers the input stream by default, buffering up to a certain amount in memory, before buffering to disk.
+        /// This option configures the size in bytes that MVC will buffer in memory, before switching to disk.
+        /// </para>
+        /// </summary>
+        /// <value>Defaults to 30Kb.</value>
+        public int InputFormatterMemoryBufferThreshold { get; set; } = 1024 * 30;
+
         IEnumerator<ICompatibilitySwitch> IEnumerable<ICompatibilitySwitch>.GetEnumerator() => _switches.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => _switches.GetEnumerator();

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     /// </summary>
     public class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFormatterExceptionPolicy
     {
-        private const int DefaultMemoryThreshold = 1024 * 30;
         private readonly IArrayPool<char> _charPool;
         private readonly ILogger _logger;
         private readonly ObjectPoolProvider _objectPoolProvider;
@@ -144,7 +143,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 // JSON.Net does synchronous reads. In order to avoid blocking on the stream, we asynchronously
                 // read everything into a buffer, and then seek back to the beginning.
-                var memoryThreshold = DefaultMemoryThreshold;
+                var memoryThreshold = _jsonOptions.InputFormatterMemoryBufferThreshold;
                 var contentLength = request.ContentLength.GetValueOrDefault();
                 if (contentLength > 0 && contentLength < memoryThreshold)
                 {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/21245

```diff
public class MvcNewtonsoftJsonOptions
{
+  public int InputFormatterMemoryBufferThreshold { get; set; }
}
```