### PR TITLE
No build native in site extension

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -159,6 +159,7 @@ stages:
                 -noBuildRepoTasks
                 -pack
                 -noBuildDeps
+                -noBuildNative
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
         condition: ne(variables['Build.Reason'], 'PullRequest')

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -162,7 +162,6 @@ stages:
                 -noBuildNative
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
-        condition: ne(variables['Build.Reason'], 'PullRequest')
         displayName: Build SiteExtension
 
       # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -162,6 +162,7 @@ stages:
                 -noBuildNative
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
+        condition: ne(variables['Build.Reason'], 'PullRequest')
         displayName: Build SiteExtension
 
       # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If


### PR DESCRIPTION
Currently Site Extension builds are failing occasionally due to trying to build native in the site extension. Disable it in that build step.