### PR TITLE
Fix startvs.cmd  for Components solution

### DIFF
--- a/src/Components/startvs.cmd
+++ b/src/Components/startvs.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 
-%~dp0..\..\startvs.cmd %~dp0Blazor.sln
+%~dp0..\..\startvs.cmd %~dp0Components.sln


### PR DESCRIPTION
The startvs still references the old solution name so I've updated it here.