### PR TITLE
Adds latin1 support to ANCM In-proc

### DIFF
--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)HttpSys\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\*.cs" LinkBase="ServerInfrastructure" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/IIS/IIS/ref/Microsoft.AspNetCore.Server.IIS.netcoreapp.cs
+++ b/src/Servers/IIS/IIS/ref/Microsoft.AspNetCore.Server.IIS.netcoreapp.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Builder
         public string AuthenticationDisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public bool AutomaticAuthentication { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public long? MaxRequestBodySize { get { throw null; } set { } }
+        public bool Latin1RequestHeaders { get { throw null; } set { } }
     }
 }
 namespace Microsoft.AspNetCore.Hosting

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -76,8 +76,8 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             IntPtr pInProcessHandler,
             IISServerOptions options,
             IISHttpServer server,
-            ILogger logger,)
-            : base((HttpApiTypes.HTTP_REQUEST*)NativeMethods.HttpGetRawRequest(pInProcessHandler), useLatin1: options.)
+            ILogger logger)
+            : base((HttpApiTypes.HTTP_REQUEST*)NativeMethods.HttpGetRawRequest(pInProcessHandler), useLatin1: options.Latin1RequestHeaders)
         {
             _memoryPool = memoryPool;
             _pInProcessHandler = pInProcessHandler;

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -76,8 +76,8 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             IntPtr pInProcessHandler,
             IISServerOptions options,
             IISHttpServer server,
-            ILogger logger)
-            : base((HttpApiTypes.HTTP_REQUEST*)NativeMethods.HttpGetRawRequest(pInProcessHandler))
+            ILogger logger,)
+            : base((HttpApiTypes.HTTP_REQUEST*)NativeMethods.HttpGetRawRequest(pInProcessHandler), useLatin1: options.)
         {
             _memoryPool = memoryPool;
             _pInProcessHandler = pInProcessHandler;

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -65,5 +65,10 @@ namespace Microsoft.AspNetCore.Builder
                 _maxRequestBodySize = value;
             }
         }
+
+        /// <summary>
+        /// Treat request headers as Latin-1 or ISO/IEC 8859-1 instead of UTF-8.
+        /// </summary>
+        public bool Latin1RequestHeaders { get; set; } = false;
     }
 }

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(SharedSourceRoot)StackTrace\**\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)RazorViews\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)ErrorPage\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\*.cs" LinkBase="Shared\" />
     <Compile Include="$(RepoRoot)src\Shared\TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/Latin1Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/Latin1Tests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -28,13 +29,13 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             var deploymentResult = await DeployAsync(deploymentParameters);
 
-            var client = new HttpClient(new LoggingHandler(new WinHttpHandler(), deploymentResult.Logger));
+            var client = new HttpClient(new LoggingHandler(new WinHttpHandler() { SendTimeout = TimeSpan.FromMinutes(3) }, deploymentResult.Logger));
 
-            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "/Latin1");
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"{deploymentResult.ApplicationBaseUri}Latin1");
             requestMessage.Headers.Add("foo", "£");
 
-            var result = await deploymentResult.HttpClient.SendAsync(requestMessage);
-            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, result.StatusCode);
+            var result = await client.SendAsync(requestMessage);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
     }
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/Latin1Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/Latin1Tests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
+{
+    [Collection(PublishedSitesCollection.Name)]
+    public class Latin1Tests : IISFunctionalTestBase
+    {
+        public Latin1Tests(PublishedSitesFixture fixture) : base(fixture)
+        {
+        }
+
+        [ConditionalFact]
+        [RequiresNewHandler]
+        public async Task Latin1Works()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+            deploymentParameters.TransformArguments((a, _) => $"{a} AddLatin1");
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var client = new HttpClient(new LoggingHandler(new WinHttpHandler(), deploymentResult.Logger));
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "/Latin1");
+            requestMessage.Headers.Add("foo", "£");
+
+            var result = await deploymentResult.HttpClient.SendAsync(requestMessage);
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, result.StatusCode);
+        }
+    }
+}

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -25,6 +25,7 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
+    <Reference Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -33,6 +33,7 @@
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
     <Reference Include="System.Net.WebSockets.WebSocketProtocol" />
+    <Reference Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -27,6 +27,8 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
+    <Reference Include="System.Net.Http.WinHttpHandler" />
+
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../FunctionalTest.props" />
 
@@ -29,6 +29,7 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
+    <Reference Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -145,9 +145,9 @@ namespace TestSite
                     }
 
                     return 0;
+#if !FORWARDCOMPAT
                 case "ThrowInStartupGenericHost":
                     {
-#if !FORWARDCOMPAT
                         var host = new HostBuilder().ConfigureWebHost((c) =>
                         {
                             c.ConfigureLogging((_, factory) =>
@@ -158,12 +158,32 @@ namespace TestSite
                             .UseIIS()
                             .UseStartup<ThrowingStartup>();
                         });
-                                   
+
 
                         host.Build().Run();
-#endif
                     }
                     return 0;
+                case "AddLatin1":
+                    {
+                        var host = new HostBuilder().ConfigureWebHost((c) =>
+                        {
+                            c.ConfigureLogging((_, factory) =>
+                            {
+                                factory.AddConsole();
+                                factory.AddFilter("Console", level => level >= LogLevel.Information);
+                            })
+                            .ConfigureServices(services =>
+                            {
+                                services.Configure<IISServerOptions>(options => options.Latin1RequestHeaders = true);
+                            })
+                            .UseIIS()
+                            .UseStartup<Startup>();
+                        });
+
+                        host.Build().Run();
+                        return 0;
+                    }
+#endif
                 default:
                     return StartServer();
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -199,9 +199,7 @@ namespace TestSite
                     factory.AddConsole();
                     factory.AddFilter("Console", level => level >= LogLevel.Information);
                 })
-                .UseKestrel()
                 .UseIIS()
-                .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1016,5 +1016,12 @@ namespace TestSite
 
             await context.Response.WriteAsync(httpsPort.HasValue ? httpsPort.Value.ToString() : "NOVALUE");
         }
+
+        public Task Latin1(HttpContext context)
+        {
+            var value = context.Request.Headers["foo"];
+            Assert.Equal("£", value);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Shared/HttpSys/RequestProcessing/HeaderEncoding.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderEncoding.cs
@@ -3,24 +3,87 @@
 
 using System;
 using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.HttpSys.Internal
 {
     internal static class HeaderEncoding
     {
-        // It should just be ASCII or ANSI, but they break badly with un-expected values. We use UTF-8 because it's the same for
-        // ASCII, and because some old client would send UTF8 Host headers and expect UTF8 Location responses
-        // (e.g. IE and HttpWebRequest on intranets).
-        private static Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+        private static Encoding DefaultEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
-        internal static unsafe string GetString(byte* pBytes, int byteCount)
+        internal static unsafe string GetString(byte* pBytes, int byteCount, bool useLatin1)
         {
-            return Encoding.GetString(new ReadOnlySpan<byte>(pBytes, byteCount));
+            if (useLatin1)
+            {
+                return GetLatin1StringNonNullCharacters(new Span<byte>(pBytes, byteCount));
+            }
+            else
+            {
+                return GetAsciiOrUTF8StringNonNullCharacters(new Span<byte>(pBytes, byteCount));
+            }
+        }
+
+        private static unsafe string GetLatin1StringNonNullCharacters(this Span<byte> span)
+        {
+            if (span.IsEmpty)
+            {
+                return string.Empty;
+            }
+
+            var resultString = new string('\0', span.Length);
+
+            fixed (char* output = resultString)
+            fixed (byte* buffer = span)
+            {
+                // This returns false if there are any null (0 byte) characters in the string.
+                if (!StringUtilities.TryGetLatin1String(buffer, output, span.Length))
+                {
+                    // null characters are considered invalid
+                    throw new InvalidOperationException();
+                }
+            }
+
+            return resultString;
+        }
+
+        private static unsafe string GetAsciiOrUTF8StringNonNullCharacters(this Span<byte> span)
+        {
+            if (span.IsEmpty)
+            {
+                return string.Empty;
+            }
+
+            var resultString = new string('\0', span.Length);
+            fixed (char* output = resultString)
+            fixed (byte* buffer = span)
+            {
+                // This version if AsciiUtilities returns null if there are any null (0 byte) characters
+                // StringUtilities.TryGetAsciiString returns null if there are any null (0 byte) characters
+                // in the string
+                if (!StringUtilities.TryGetAsciiString(buffer, output, span.Length))
+                {
+                    // null characters are considered invalid
+                    if (span.IndexOf((byte)0) != -1)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                    try
+                    {
+                        resultString = DefaultEncoding.GetString(buffer, span.Length);
+                    }
+                    catch (DecoderFallbackException)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                }
+            }
+
+            return resultString;
         }
 
         internal static byte[] GetBytes(string myString)
         {
-            return Encoding.GetBytes(myString);
+            return DefaultEncoding.GetBytes(myString);
         }
     }
 }

--- a/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
+++ b/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         private const int AlignmentPadding = 8;
         private const int DefaultBufferSize = 4096 - AlignmentPadding;
         private IntPtr _originalBufferAddress;
+        private bool _useLatin1;
         private HttpApiTypes.HTTP_REQUEST* _nativeRequest;
         private IMemoryOwner<byte> _backingBuffer;
         private MemoryHandle _memoryHandle;
@@ -61,8 +62,9 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         }
 
         // To be used by IIS Integration.
-        internal NativeRequestContext(HttpApiTypes.HTTP_REQUEST* request)
+        internal NativeRequestContext(HttpApiTypes.HTTP_REQUEST* request, bool useLatin1)
         {
+            _useLatin1 = useLatin1;
             _nativeRequest = request;
             _bufferAlignment = 0;
             _permanentlyPinned = true;
@@ -155,7 +157,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             }
             else if (verb == HttpApiTypes.HTTP_VERB.HttpVerbUnknown && NativeRequest->pUnknownVerb != null)
             {
-                return HeaderEncoding.GetString(NativeRequest->pUnknownVerb, NativeRequest->UnknownVerbLength);
+                return HeaderEncoding.GetString(NativeRequest->pUnknownVerb, NativeRequest->UnknownVerbLength, _useLatin1);
             }
 
             return null;
@@ -321,7 +323,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             // pRawValue will point to empty string ("\0")
             if (pKnownHeader->RawValueLength > 0)
             {
-                value = HeaderEncoding.GetString(pKnownHeader->pRawValue + fixup, pKnownHeader->RawValueLength);
+                value = HeaderEncoding.GetString(pKnownHeader->pRawValue + fixup, pKnownHeader->RawValueLength, _useLatin1);
             }
 
             return value;
@@ -359,11 +361,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     // pRawValue will be null.
                     if (pUnknownHeader->pName != null && pUnknownHeader->NameLength > 0)
                     {
-                        var headerName = HeaderEncoding.GetString(pUnknownHeader->pName + fixup, pUnknownHeader->NameLength);
+                        var headerName = HeaderEncoding.GetString(pUnknownHeader->pName + fixup, pUnknownHeader->NameLength, _useLatin1);
                         string headerValue;
                         if (pUnknownHeader->pRawValue != null && pUnknownHeader->RawValueLength > 0)
                         {
-                            headerValue = HeaderEncoding.GetString(pUnknownHeader->pRawValue + fixup, pUnknownHeader->RawValueLength);
+                            headerValue = HeaderEncoding.GetString(pUnknownHeader->pRawValue + fixup, pUnknownHeader->RawValueLength, _useLatin1);
                         }
                         else
                         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22675.

Few notes:
- I could add support for latin1 for HttpSys in this PR as well.
- This PR is for master, for 3.1 I'll add an app context switch for latin1
