### PR TITLE
[Blazor] Register HttpClient as a scoped instance

### DIFF
--- a/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs
+++ b/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs
@@ -25,13 +25,13 @@ namespace ComponentsWebAssembly_CSharp
             builder.RootComponents.Add<App>("app");
 
 #if (!Hosted || NoAuth)
-            builder.Services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+            builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 #else
             builder.Services.AddHttpClient("ComponentsWebAssembly_CSharp.ServerAPI", client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress))
                 .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>();
 
             // Supply HttpClient instances that include access tokens when making requests to the server project
-            builder.Services.AddTransient(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("ComponentsWebAssembly_CSharp.ServerAPI"));
+            builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("ComponentsWebAssembly_CSharp.ServerAPI"));
 #endif
 #if(!NoAuth)
 


### PR DESCRIPTION
#### Description

We register HttpClient in the dependency injector container as transient. Given that it implements IDisposable the container will keep a reference to it in memory for the lifetime of the app. This can cause a memory leak and for the app to consume more memory. 

The fix is to register the HttpClient instance in the container as Scoped instead, which in the context of Blazor WebAssembly is equivalent to Singleton, ensuring that only one instance is used across the app.

#### Customer Impact

After a very long time the app might crash due to a memory leak. We don't want customers to get the idea that registering HttpClient as transient is ok.

#### Regression?

No

#### Risk

Minimal. It is a change in the template (doesn't affect existing apps) and we have tests that validate the new (more correct) behavior.

Fixes https://github.com/dotnet/aspnetcore/issues/21655