### PR TITLE
[Blazor] Fix manifest integrity computation

### DIFF
--- a/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
+++ b/src/Components/WebAssembly/Build/src/targets/ServiceWorkerAssetsManifest.targets
@@ -163,7 +163,7 @@
 
     <WriteLinesToFile
       File="$(_CombinedHashIntermediatePath)"
-      Lines="@(_ServiceWorkerAssetsManifestItemWithHash->'%(FileHash)')"
+      Lines="@(_ServiceWorkerAssetsManifestItemWithHash->'%(Integrity)')"
       WriteOnlyWhenDifferent="true"
       Overwrite="true" />
 

--- a/src/Components/WebAssembly/Build/test/BuildIntegrationTests/PwaManifestTests.cs
+++ b/src/Components/WebAssembly/Build/test/BuildIntegrationTests/PwaManifestTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -40,6 +41,78 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Build
 
             var entries = assets.EnumerateArray().Select(e => e.GetProperty("url").GetString()).OrderBy(e => e).ToArray();
             Assert.All(entries, e => expectedExtensions.Contains(Path.GetExtension(e)));
+        }
+
+        [Fact]
+        public async Task Publish_UpdatesServiceWorkerVersionHash_WhenSourcesChange()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone", additionalProjects: new[] { "razorclasslibrary" });
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish", args: "/bl:initial.binlog /p:ServiceWorkerAssetsManifest=service-worker-assets.js");
+
+            Assert.BuildPassed(result);
+
+            var publishOutputDirectory = project.PublishOutputDirectory;
+
+            var serviceWorkerFile = Assert.FileExists(result, publishOutputDirectory, "wwwroot", "serviceworkers", "my-service-worker.js");
+            var version = File.ReadAllLines(serviceWorkerFile).Last();
+            var match = Regex.Match(version, "\\/\\* Manifest version: (.{8}) \\*\\/");
+            Assert.True(match.Success);
+            Assert.Equal(2, match.Groups.Count);
+            Assert.NotNull(match.Groups[1].Value);
+            var capture = match.Groups[1].Value;
+
+            // Act
+            var cssFile = Path.Combine(project.DirectoryPath, "LinkToWebRoot", "css", "app.css");
+            File.WriteAllText(cssFile, ".updated { }");
+
+            // Assert
+            var updatedResult = await MSBuildProcessManager.DotnetMSBuild(project, "Publish", args: "/bl:updated.binlog /p:ServiceWorkerAssetsManifest=service-worker-assets.js");
+
+            Assert.BuildPassed(result);
+
+            var updatedVersion = File.ReadAllLines(serviceWorkerFile).Last();
+            var updatedMatch = Regex.Match(updatedVersion, "\\/\\* Manifest version: (.{8}) \\*\\/");
+            Assert.True(updatedMatch.Success);
+            Assert.Equal(2, updatedMatch.Groups.Count);
+            Assert.NotNull(updatedMatch.Groups[1].Value);
+            var updatedCapture = updatedMatch.Groups[1].Value;
+
+            Assert.NotEqual(capture, updatedCapture);
+        }
+
+        [Fact]
+        public async Task Publish_DeterministicAcrossBuilds_WhenNoSourcesChange()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("standalone", additionalProjects: new[] { "razorclasslibrary" });
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish", args: "/bl:initial.binlog /p:ServiceWorkerAssetsManifest=service-worker-assets.js");
+
+            Assert.BuildPassed(result);
+
+            var publishOutputDirectory = project.PublishOutputDirectory;
+
+            var serviceWorkerFile = Assert.FileExists(result, publishOutputDirectory, "wwwroot", "serviceworkers", "my-service-worker.js");
+            var version = File.ReadAllLines(serviceWorkerFile).Last();
+            var match = Regex.Match(version, "\\/\\* Manifest version: (.{8}) \\*\\/");
+            Assert.True(match.Success);
+            Assert.Equal(2, match.Groups.Count);
+            Assert.NotNull(match.Groups[1].Value);
+            var capture = match.Groups[1].Value;
+
+            // Act && Assert
+            var updatedResult = await MSBuildProcessManager.DotnetMSBuild(project, "Publish", args: "/bl:updated.binlog /p:ServiceWorkerAssetsManifest=service-worker-assets.js");
+
+            Assert.BuildPassed(result);
+
+            var updatedVersion = File.ReadAllLines(serviceWorkerFile).Last();
+            var updatedMatch = Regex.Match(updatedVersion, "\\/\\* Manifest version: (.{8}) \\*\\/");
+            Assert.True(updatedMatch.Success);
+            Assert.Equal(2, updatedMatch.Groups.Count);
+            Assert.NotNull(updatedMatch.Groups[1].Value);
+            var updatedCapture = updatedMatch.Groups[1].Value;
+
+            Assert.Equal(capture, updatedCapture);
         }
     }
 }


### PR DESCRIPTION
#### Description

A bug in our MSBuild pipeline prevents the manifest version for the service worker file of PWAs to be automatically updated when some of the sources change. 

The cause of this was that we were looking at the wrong metadata in an MSBuild itemgroup and as a result we were using empty strings to compute the manifest version which resulted in the manifest always having the same version.

The fix is to use the correct property that contains the data to compute the manifest version, with the effect that when some file updates it will be reflected on the manifest.

#### Customer Impact

Users PWA service workers don't get updated automatically when they publish new changes, so users load an older version and that breaks the app in production.

#### Regression?

No

#### Risk

The risk is low here, we were just looking at the wrong metadata item and we had a gap in our testing. We've added a couple of tests to make sure this doesn't regress in the future.

Fixes https://github.com/dotnet/aspnetcore/issues/22353