### PR TITLE
Ship the JSInterop package

### DIFF
--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -6,7 +6,7 @@
     <PackageTags>wasm;javascript;interop</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
+    <IsShipping>true</IsShipping>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
This was fixed in master, but also affects preview6: https://github.com/dotnet/aspnetcore/pull/22685