### PR TITLE
Fixes NullRef exception in IIS in-proc

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp
@@ -112,7 +112,7 @@ IN_PROCESS_HANDLER::NotifyDisconnect()
 
     if (pManagedHttpContext != nullptr)
     {
-        m_pDisconnectHandler(m_pManagedHttpContext);
+        m_pDisconnectHandler(pManagedHttpContext);
     }
 }
 
@@ -139,14 +139,16 @@ IN_PROCESS_HANDLER::SetManagedHttpContext(
     PVOID pManagedHttpContext
 )
 {
+    bool disconnectFired = false;
     {
         SRWExclusiveLock lock(m_srwDisconnectLock);
         m_pManagedHttpContext = pManagedHttpContext;
+        disconnectFired = m_disconnectFired;
     }
 
-    if (m_disconnectFired && m_pManagedHttpContext != nullptr)
+    if (disconnectFired && pManagedHttpContext != nullptr)
     {
-        m_pDisconnectHandler(m_pManagedHttpContext);
+        m_pDisconnectHandler(pManagedHttpContext);
     }
 }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp
@@ -140,6 +140,7 @@ IN_PROCESS_HANDLER::SetManagedHttpContext(
 )
 {
     bool disconnectFired = false;
+
     {
         SRWExclusiveLock lock(m_srwDisconnectLock);
         m_pManagedHttpContext = pManagedHttpContext;

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -119,71 +119,77 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         protected void InitializeContext()
         {
-            _thisHandle = GCHandle.Alloc(this);
-
-            Method = GetVerb();
-
-            RawTarget = GetRawUrl();
-            // TODO version is slow.
-            HttpVersion = GetVersion();
-            Scheme = SslStatus != SslStatus.Insecure ? Constants.HttpsScheme : Constants.HttpScheme;
-            KnownMethod = VerbId;
-            StatusCode = 200;
-
-            var originalPath = GetOriginalPath();
-
-            if (KnownMethod == HttpApiTypes.HTTP_VERB.HttpVerbOPTIONS && string.Equals(RawTarget, "*", StringComparison.Ordinal))
+            // create a memory barrier between initialize and disconnect to prevent a possible
+            // NullRef with disconnect being called before these fields have been written
+            // disconnect aquires this lock as well
+            lock (_abortLock)
             {
-                PathBase = string.Empty;
-                Path = string.Empty;
-            }
-            else
-            {
-                // Path and pathbase are unescaped by RequestUriBuilder
-                // The UsePathBase middleware will modify the pathbase and path correctly
-                PathBase = string.Empty;
-                Path = originalPath;
-            }
+                _thisHandle = GCHandle.Alloc(this);
 
-            var cookedUrl = GetCookedUrl();
-            QueryString = cookedUrl.GetQueryString() ?? string.Empty;
+                Method = GetVerb();
 
-            RequestHeaders = new RequestHeaders(this);
-            HttpResponseHeaders = new HeaderCollection();
-            ResponseHeaders = HttpResponseHeaders;
+                RawTarget = GetRawUrl();
+                // TODO version is slow.
+                HttpVersion = GetVersion();
+                Scheme = SslStatus != SslStatus.Insecure ? Constants.HttpsScheme : Constants.HttpScheme;
+                KnownMethod = VerbId;
+                StatusCode = 200;
 
-            if (_options.ForwardWindowsAuthentication)
-            {
-                WindowsUser = GetWindowsPrincipal();
-                if (_options.AutomaticAuthentication)
+                var originalPath = GetOriginalPath();
+
+                if (KnownMethod == HttpApiTypes.HTTP_VERB.HttpVerbOPTIONS && string.Equals(RawTarget, "*", StringComparison.Ordinal))
                 {
-                    User = WindowsUser;
+                    PathBase = string.Empty;
+                    Path = string.Empty;
                 }
+                else
+                {
+                    // Path and pathbase are unescaped by RequestUriBuilder
+                    // The UsePathBase middleware will modify the pathbase and path correctly
+                    PathBase = string.Empty;
+                    Path = originalPath;
+                }
+
+                var cookedUrl = GetCookedUrl();
+                QueryString = cookedUrl.GetQueryString() ?? string.Empty;
+
+                RequestHeaders = new RequestHeaders(this);
+                HttpResponseHeaders = new HeaderCollection();
+                ResponseHeaders = HttpResponseHeaders;
+
+                if (_options.ForwardWindowsAuthentication)
+                {
+                    WindowsUser = GetWindowsPrincipal();
+                    if (_options.AutomaticAuthentication)
+                    {
+                        User = WindowsUser;
+                    }
+                }
+
+                MaxRequestBodySize = _options.MaxRequestBodySize;
+
+                ResetFeatureCollection();
+
+                if (!_server.IsWebSocketAvailable(_pInProcessHandler))
+                {
+                    _currentIHttpUpgradeFeature = null;
+                }
+
+                _streams = new Streams(this);
+
+                (RequestBody, ResponseBody) = _streams.Start();
+
+                var pipe = new Pipe(
+                    new PipeOptions(
+                        _memoryPool,
+                        readerScheduler: PipeScheduler.ThreadPool,
+                        pauseWriterThreshold: PauseWriterThreshold,
+                        resumeWriterThreshold: ResumeWriterTheshold,
+                        minimumSegmentSize: MinAllocBufferSize));
+                _bodyOutput = new OutputProducer(pipe);
+
+                NativeMethods.HttpSetManagedContext(_pInProcessHandler, (IntPtr)_thisHandle);
             }
-
-            MaxRequestBodySize = _options.MaxRequestBodySize;
-
-            ResetFeatureCollection();
-
-            if (!_server.IsWebSocketAvailable(_pInProcessHandler))
-            {
-                _currentIHttpUpgradeFeature = null;
-            }
-
-            _streams = new Streams(this);
-
-            (RequestBody, ResponseBody) = _streams.Start();
-
-            var pipe = new Pipe(
-                new PipeOptions(
-                    _memoryPool,
-                    readerScheduler: PipeScheduler.ThreadPool,
-                    pauseWriterThreshold: PauseWriterThreshold,
-                    resumeWriterThreshold: ResumeWriterTheshold,
-                    minimumSegmentSize: MinAllocBufferSize));
-            _bodyOutput = new OutputProducer(pipe);
-
-            NativeMethods.HttpSetManagedContext(_pInProcessHandler, (IntPtr)_thisHandle);
         }
 
         private string GetOriginalPath()

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -187,9 +187,9 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                         resumeWriterThreshold: ResumeWriterTheshold,
                         minimumSegmentSize: MinAllocBufferSize));
                 _bodyOutput = new OutputProducer(pipe);
-
-                NativeMethods.HttpSetManagedContext(_pInProcessHandler, (IntPtr)_thisHandle);
             }
+
+            NativeMethods.HttpSetManagedContext(_pInProcessHandler, (IntPtr)_thisHandle);
         }
 
         private string GetOriginalPath()

--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             try
             {
                 context = (IISHttpContext)GCHandle.FromIntPtr(pvManagedHttpContext).Target;
-                context.AbortIO(clientDisconnect: true);
+                context?.AbortIO(clientDisconnect: true);
             }
             catch (Exception ex)
             {
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             try
             {
                 context = (IISHttpContext)GCHandle.FromIntPtr(pvManagedHttpContext).Target;
-                context.OnAsyncCompletion(hr, bytes);
+                context?.OnAsyncCompletion(hr, bytes);
                 return NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_PENDING;
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/17516

#### Description

Customers are hitting a null ref exception occasionally on requests closing. The fix is to fix a couple race conditions in the IIS in-proc code.

#### Customer Impact

Customers reported the issue in https://github.com/dotnet/aspnetcore/issues/17516 and there have been many comments on it about hitting the same issue (+11 on one comment).

Exceptions show up in debugger. And this has increased in frequency with VS 16.5

No workarounds besides ignoring the exception.

#### Regression?

No, this has been there since in-proc was released.

#### Risk

Low, mostly just extra null checks.