### PR TITLE
Bump up the wasm template precedence

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -10,7 +10,7 @@
   "defaultName": "WebApplication",
   "description": "A project template for creating a Blazor app that runs on WebAssembly and is optionally hosted by an ASP.NET Core app. This template can be used for web apps with rich dynamic user interfaces (UIs).",
   "groupIdentity": "Microsoft.Web.Blazor.Wasm",
-  "precedence": "6001",
+  "precedence": "6002",
   "guids": [
     "4C26868E-5E7C-458D-82E3-040509D0C71F",
     "5990939C-7E7B-4CFA-86FF-44CA5756498A",


### PR DESCRIPTION
## Description

With a 3.1 SDK installed, the template engine prompts for a target framework to be specified when installing the template using the CLI. 

## Impact

Unable to run `dotnet new blazorwasm` unless the tfm is specified

## Regression

No, the templates are new to preview6.

## Risk

Low. 