### PR TITLE
Enable Helix tests for Microsoft.AspNetCore.Mvc.Razor.Extensions.* projects.

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test.csproj
@@ -8,9 +8,6 @@
 
     <!-- Work around https://github.com/microsoft/msbuild/issues/4740 -->
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
-
-    <!-- Tests do not work on Helix yet -->
-    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +29,11 @@
     <MvcShim Condition="$(TargetFramework) != ''" Include="$(ArtifactsBinDir)\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.deps.json" />
   </ItemGroup>
 
-  <Target Name="CopyDepsFromShims" AfterTargets="Build">
+  <Target Name="CopyDepsFromShims_Build" AfterTargets="Build">
     <Copy SourceFiles="@(MvcShim)" DestinationFolder="$(OutputPath)" />
+  </Target>
+
+  <Target Name="CopyDepsFromShims_Publish" AfterTargets="Publish">
+    <Copy SourceFiles="@(MvcShim)" DestinationFolder="$(PublishDir)" Condition="Exists($(PublishDir))" />
   </Target>
 </Project>

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test.csproj
@@ -8,9 +8,6 @@
 
     <!-- Work around https://github.com/microsoft/msbuild/issues/4740 -->
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
-
-    <!-- Tests do not work on Helix yet -->
-    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,11 +25,19 @@
     <ProjectReference Include="..\..\test\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj" />
   </ItemGroup>
 
-  <Target Name="CopyDepsFromShims" AfterTargets="Build">
+  <Target Name="CopyDepsFromShims_Build" AfterTargets="Build">
     <ItemGroup>
       <MvcShim Condition="$(TargetFramework) != ''" Include="$(ArtifactsBinDir)\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.deps.json" />
     </ItemGroup>
 
     <Copy SourceFiles="@(MvcShim)" DestinationFolder="$(OutputPath)" />
+  </Target>
+
+  <Target Name="CopyDepsFromShims_Publish" AfterTargets="Publish">
+    <ItemGroup>
+      <MvcShim Condition="$(TargetFramework) != ''" Include="$(ArtifactsBinDir)\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.deps.json" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(MvcShim)"  DestinationFolder="$(PublishDir)" Condition="Exists($(PublishDir))" />
   </Target>
 </Project>

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/RazorPageDocumentClassifierPassTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/RazorPageDocumentClassifierPassTest.cs
@@ -51,10 +51,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
                 length: 5 + Environment.NewLine.Length);
 
             var expectedDiagnostic = RazorExtensionsDiagnosticFactory.CreatePageDirective_MustExistAtTheTopOfFile(sourceSpan);
-            var content = @"
-@somethingelse
-@page
-";
+            var content = Environment.NewLine +
+"@somethingelse" + Environment.NewLine +
+"@page" + Environment.NewLine;
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Test.cshtml"));
 
             var engine = CreateProjectEngine().Engine;

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj
@@ -8,9 +8,6 @@
 
     <!-- Work around https://github.com/microsoft/msbuild/issues/4740 -->
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
-
-    <!-- Tests do not work on Helix yet -->
-    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,11 +24,19 @@
     <ProjectReference Include="..\..\test\Microsoft.AspNetCore.Razor.Test.MvcShim\Microsoft.AspNetCore.Razor.Test.MvcShim.csproj" />
   </ItemGroup>
 
-  <Target Name="CopyDepsFromShims" AfterTargets="Build">
+  <Target Name="CopyDepsFromShims_Build" AfterTargets="Build">
     <ItemGroup>
       <MvcShim Condition="$(TargetFramework) != ''" Include="$(ArtifactsBinDir)\Microsoft.AspNetCore.Razor.Test.MvcShim\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Test.MvcShim.deps.json" />
     </ItemGroup>
 
     <Copy SourceFiles="@(MvcShim)" DestinationFolder="$(OutputPath)" />
+  </Target>
+
+  <Target Name="CopyDepsFromShims_Publish" AfterTargets="Publish">
+    <ItemGroup>
+      <MvcShim Condition="$(TargetFramework) != ''" Include="$(ArtifactsBinDir)\Microsoft.AspNetCore.Razor.Test.MvcShim\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Test.MvcShim.deps.json" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(MvcShim)"  DestinationFolder="$(PublishDir)" Condition="Exists($(PublishDir))" />
   </Target>
 </Project>

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/RazorPageDocumentClassifierPassTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/RazorPageDocumentClassifierPassTest.cs
@@ -51,10 +51,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 length: 5 + Environment.NewLine.Length);
 
             var expectedDiagnostic = RazorExtensionsDiagnosticFactory.CreatePageDirective_MustExistAtTheTopOfFile(sourceSpan);
-            var content = @"
-@somethingelse
-@page
-";
+            var content = Environment.NewLine +
+"@somethingelse" + Environment.NewLine +
+"@page" + Environment.NewLine;
             var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Test.cshtml"));
 
             var engine = CreateRuntimeEngine();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
@@ -11,18 +11,16 @@ namespace Microsoft.AspNetCore.Razor.Language
         public static string GetProjectDirectory(string directoryHint)
         {
             var repoRoot = SearchUp(AppContext.BaseDirectory, "global.json");
+            if (repoRoot == null)
+            {
+                repoRoot = AppContext.BaseDirectory;
+            }
+            
             var projectDirectory = Path.Combine(repoRoot, "src", "Razor", directoryHint, "test");
 
-            if (!Directory.Exists(projectDirectory) &&
-                string.Equals(directoryHint, "Microsoft.AspNetCore.Razor.Language.Test", StringComparison.Ordinal))
+            if (string.Equals(directoryHint, "Microsoft.AspNetCore.Razor.Language.Test", StringComparison.Ordinal))
             {
                 projectDirectory = Path.Combine(repoRoot, "src", "Razor", "Microsoft.AspNetCore.Razor.Language", "test");
-            }
-
-            if (!Directory.Exists(projectDirectory))
-            {
-                throw new InvalidOperationException(
-                    $@"Could not locate project directory for directory hint {directoryHint}. Directory probe path: {projectDirectory}.");
             }
 
             return projectDirectory;
@@ -31,18 +29,16 @@ namespace Microsoft.AspNetCore.Razor.Language
         public static string GetProjectDirectory(Type type)
         {
             var repoRoot = SearchUp(AppContext.BaseDirectory, "global.json");
-            var assemblyName = type.Assembly.GetName().Name;
-            var projectDirectory = Path.Combine(repoRoot, "src", "Razor", assemblyName, "test");
-            if (!Directory.Exists(projectDirectory) &&
-                string.Equals(assemblyName, "Microsoft.AspNetCore.Razor.Language.Test", StringComparison.Ordinal))
+            if (repoRoot == null)
             {
-                projectDirectory = Path.Combine(repoRoot, "src", "Razor", "Microsoft.AspNetCore.Razor.Language", "test");
+                repoRoot = AppContext.BaseDirectory;
             }
 
-            if (!Directory.Exists(projectDirectory))
+            var assemblyName = type.Assembly.GetName().Name;
+            var projectDirectory = Path.Combine(repoRoot, "src", "Razor", assemblyName, "test");
+            if (string.Equals(assemblyName, "Microsoft.AspNetCore.Razor.Language.Test", StringComparison.Ordinal))
             {
-                throw new InvalidOperationException(
-                    $@"Could not locate project directory for type {type.FullName}. Directory probe path: {projectDirectory}.");
+                projectDirectory = Path.Combine(repoRoot, "src", "Razor", "Microsoft.AspNetCore.Razor.Language", "test");
             }
 
             return projectDirectory;
@@ -62,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
             while (directoryInfo.Parent != null);
 
-            throw new Exception($"File {fileName} could not be found in {baseDirectory} or its parent directories.");
+            return null;
         }
     }
 }


### PR DESCRIPTION
- Enabled Helix for:
    - `Microsoft.AspNetCore.Mvc.Razor.Extensions.Test`
    - `Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test`
    - `Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Test`
- These tests depended on our MVC shim project's deps.json's to exist in the test bin directory during publish. Therefore added an additional target copy over those assets at publish time.
- There were some tests that were relying on source positions from a string to match a runtime generated source position. In Helix dll's are built on Windows (string's get compiled with \r\n) and then deployed to potentially non-Windows boxes resulting in mismatches of expectations. To address this I changed the test that had this dependency to dynamically generate the input string.
- Our common language test project used to rely on test files being on disk. At some point in the past those test files started being embedded in the assembly but we maintained directory checking logic to ensure various directories existed on disk (no longe required). Changed the logic to not enforce directories to be on disk (they aren't in Helix) and instead only rely on the embedded TestFiles.

dotnet/aspnetcore#22100