### PR TITLE
Improve gRPC interop test failure logging

### DIFF
--- a/src/Grpc/test/InteropTests/Helpers/ClientProcess.cs
+++ b/src/Grpc/test/InteropTests/Helpers/ClientProcess.cs
@@ -44,6 +44,7 @@ namespace InteropTests.Helpers
         public Task WaitForReadyAsync() => _startTcs.Task;
         public Task WaitForExitAsync() => _processEx.Exited;
         public int ExitCode => _process.ExitCode;
+        public bool IsReady => _startTcs.Task.IsCompletedSuccessfully;
 
         public string GetOutput()
         {
@@ -77,7 +78,7 @@ namespace InteropTests.Helpers
             {
                 lock (_outputLock)
                 {
-                    _output.AppendLine(data);
+                    _output.AppendLine("ERROR: " + data);
                 }
             }
         }

--- a/src/Grpc/test/InteropTests/InteropTests.cs
+++ b/src/Grpc/test/InteropTests/InteropTests.cs
@@ -103,10 +103,20 @@ namespace InteropTests
                     }
                     catch (Exception ex)
                     {
-                        var clientOutput = clientProcess.GetOutput();
-                        var errorMessage = $@"Error while running client process. Process output:
+                        var errorMessage = $@"Error while running client process.
+
+Server ready: {serverProcess.IsReady}
+Client ready: {clientProcess.IsReady}
+
+Server process output:
 ======================================
-{clientOutput}";
+{serverProcess.GetOutput()}
+======================================
+
+Client process output:
+======================================
+{clientProcess.GetOutput()}
+======================================";
                         throw new InvalidOperationException(errorMessage, ex);
                     }
                 }

--- a/src/Grpc/test/testassets/InteropWebsite/Program.cs
+++ b/src/Grpc/test/testassets/InteropWebsite/Program.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace InteropTestsWebsite
 {
@@ -34,6 +35,11 @@ namespace InteropTestsWebsite
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureLogging(builder =>
+                {
+                    builder.AddConsole();
+                    builder.SetMinimumLevel(LogLevel.Trace);
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.ConfigureKestrel((context, options) =>


### PR DESCRIPTION
Some interop tests are consistently flaky. Improve logging to help diagnose.
