### PR TITLE
Add detail to InvalidOperationException in Exception Handler Middleware

### DIFF
--- a/src/Middleware/Diagnostics/src/Resources.resx
+++ b/src/Middleware/Diagnostics/src/Resources.resx
@@ -248,7 +248,7 @@
     <value>Environment:</value>
   </data>
   <data name="ExceptionHandlerOptions_NotConfiguredCorrectly" xml:space="preserve">
-    <value>An error occurred when configuring the exception handler middleware. Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' property must be set in 'UseExceptionHandler()'. Alternatively, set one of the aforementioned properties in 'Startup.ConfigureServices' as follows: 'services.Configure<ExceptionHandlerOptions>(options => { ... });'.</value>
+    <value>An error occurred when configuring the exception handler middleware. Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' property must be set in 'UseExceptionHandler()'. Alternatively, set one of the aforementioned properties in 'Startup.ConfigureServices' as follows: 'services.Configure&lt;ExceptionHandlerOptions&gt;(options =&gt; { ... });'.</value>
   </data>
   <data name="ErrorPageHtml_NoRouteValues" xml:space="preserve">
     <value>No route values.</value>

--- a/src/Middleware/Diagnostics/src/Resources.resx
+++ b/src/Middleware/Diagnostics/src/Resources.resx
@@ -248,7 +248,7 @@
     <value>Environment:</value>
   </data>
   <data name="ExceptionHandlerOptions_NotConfiguredCorrectly" xml:space="preserve">
-    <value>An error occurred when configuring the exception handler middleware. Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' option must be set in 'UseExceptionHandler()'.</value>
+    <value>An error occurred when configuring the exception handler middleware. Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' property must be set in 'UseExceptionHandler()'. Alternatively, set one of the aforementioned properties in 'Startup.ConfigureServices' as follows: 'services.Configure<ExceptionHandlerOptions>(options => { ... });'.</value>
   </data>
   <data name="ErrorPageHtml_NoRouteValues" xml:space="preserve">
     <value>No route values.</value>

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -410,7 +410,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             // Assert
             Assert.Equal("An error occurred when configuring the exception handler middleware. " +
                 "Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' property must be set in 'UseExceptionHandler()'. " +
-                @"Alternatively, set one of the aforementioned properties in 'Startup.ConfigureServices' as follows: 'services.Configure&lt;ExceptionHandlerOptions&gt;(options =&gt; { ... });'.",
+                "Alternatively, set one of the aforementioned properties in 'Startup.ConfigureServices' as follows: 'services.Configure<ExceptionHandlerOptions>(options => { ... });'.",
                 exception.Message);
         }
     }

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -408,8 +408,9 @@ namespace Microsoft.AspNetCore.Diagnostics
             var exception = Assert.Throws<InvalidOperationException>(() => new TestServer(builder));
 
             // Assert
-            Assert.Equal($"An error occurred when configuring the exception handler middleware. " +
-                $"Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' option must be set in 'UseExceptionHandler()'.",
+            Assert.Equal("An error occurred when configuring the exception handler middleware. " +
+                "Either the 'ExceptionHandlingPath' or the 'ExceptionHandler' property must be set in 'UseExceptionHandler()'. " +
+                @"Alternatively, set one of the aforementioned properties in 'Startup.ConfigureServices' as follows: 'services.Configure&lt;ExceptionHandlerOptions&gt;(options =&gt; { ... });'.",
                 exception.Message);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21893

Add more detail to the `InvalidOperationException` that can be thrown in the middleware when invoking `app.UseExceptionHandler();` in `Startup.Configure`. The extra detail explains that the following is another valid configuration strategy:

```csharp
services.Configure<ExceptionHandlerOptions>(options => options.ExceptionHandlingPath = "/Error");
```