### PR TITLE
Turn off gRPC interop test console color logging

### DIFF
--- a/src/Grpc/test/testassets/InteropClient/InteropClient.cs
+++ b/src/Grpc/test/testassets/InteropClient/InteropClient.cs
@@ -97,7 +97,11 @@ namespace InteropTestsClient
             services.AddLogging(configure =>
             {
                 configure.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
-                configure.AddConsole(loggerOptions => loggerOptions.IncludeScopes = true);
+                configure.AddConsole(loggerOptions =>
+                {
+                    loggerOptions.IncludeScopes = true;
+                    loggerOptions.DisableColors = true;
+                });
             });
 
             serviceProvider = services.BuildServiceProvider();

--- a/src/Grpc/test/testassets/InteropWebsite/Program.cs
+++ b/src/Grpc/test/testassets/InteropWebsite/Program.cs
@@ -37,7 +37,7 @@ namespace InteropTestsWebsite
             Host.CreateDefaultBuilder(args)
                 .ConfigureLogging(builder =>
                 {
-                    builder.AddConsole();
+                    builder.AddConsole(o => o.DisableColors = true);
                     builder.SetMinimumLevel(LogLevel.Trace);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>


### PR DESCRIPTION
Stop color chars showing up in logs. See https://github.com/microsoft/azure-pipelines-agent/issues/1569
