### PR TITLE
Use non-generic TaskCompletionSource in SignalR and Kestrel

### DIFF
--- a/eng/helix/content/RunTests/ProcessUtil.cs
+++ b/eng/helix/content/RunTests/ProcessUtil.cs
@@ -164,8 +164,8 @@ namespace RunTests
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            var canceledTcs = new TaskCompletionSource<object?>();
-            await using var _ = cancellationToken.Register(() => canceledTcs.TrySetResult(null));
+            var canceledTcs = new TaskCompletionSource();
+            await using var _ = cancellationToken.Register(() => canceledTcs.TrySetResult());
 
             var result = await Task.WhenAny(processLifetimeTask.Task, canceledTcs.Task);
 

--- a/eng/helix/content/RunTests/ProcessUtil.cs
+++ b/eng/helix/content/RunTests/ProcessUtil.cs
@@ -66,7 +66,7 @@ namespace RunTests
             string filename,
             string arguments,
             string? workingDirectory = null,
-            string dumpDirectoryPath = null,
+            string? dumpDirectoryPath = null,
             bool throwOnError = true,
             IDictionary<string, string?>? environmentVariables = null,
             Action<string>? outputDataReceived = null,
@@ -164,8 +164,8 @@ namespace RunTests
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            var canceledTcs = new TaskCompletionSource();
-            await using var _ = cancellationToken.Register(() => canceledTcs.TrySetResult());
+            var canceledTcs = new TaskCompletionSource<object?>();
+            await using var _ = cancellationToken.Register(() => canceledTcs.TrySetResult(null));
 
             var result = await Task.WhenAny(processLifetimeTask.Task, canceledTcs.Task);
 

--- a/src/Hosting/Hosting/src/WebHostExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostExtensions.cs
@@ -157,11 +157,11 @@ namespace Microsoft.AspNetCore.Hosting
             },
             applicationLifetime);
 
-            var waitForStop = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var waitForStop = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             applicationLifetime.ApplicationStopping.Register(obj =>
             {
-                var tcs = (TaskCompletionSource<object>)obj;
-                tcs.TrySetResult(null);
+                var tcs = (TaskCompletionSource)obj;
+                tcs.TrySetResult();
             }, waitForStop);
 
             await waitForStop.Task;

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/SelfHostDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/SelfHostDeployer.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 AddEnvironmentVariablesToProcess(startInfo, DeploymentParameters.EnvironmentVariables);
 
                 Uri actualUrl = null;
-                var started = new TaskCompletionSource<object>();
+                var started = new TaskCompletionSource();
 
                 HostProcess = new Process() { StartInfo = startInfo };
                 HostProcess.EnableRaisingEvents = true;
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 {
                     if (string.Equals(dataArgs.Data, ApplicationStartedMessage))
                     {
-                        started.TrySetResult(null);
+                        started.TrySetResult();
                     }
                     else if (!string.IsNullOrEmpty(dataArgs.Data))
                     {

--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         private readonly ServiceContext _serviceContext;
         private readonly Func<T, Task> _connectionDelegate;
         private readonly TransportConnectionManager _transportConnectionManager;
-        private readonly TaskCompletionSource<object> _acceptLoopTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _acceptLoopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public ConnectionDispatcher(ServiceContext serviceContext, Func<T, Task> connectionDelegate, TransportConnectionManager transportConnectionManager)
         {
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 }
                 finally
                 {
-                    _acceptLoopTcs.TrySetResult(null);
+                    _acceptLoopTcs.TrySetResult();
                 }
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -46,11 +46,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private readonly Http3Connection _http3Connection;
         private bool _receivedHeaders;
-        private TaskCompletionSource<object> _appCompleted;
+        private TaskCompletionSource _appCompleted;
 
         public Pipe RequestBodyPipe { get; }
 
-        public Http3Stream(Http3Connection http3Connection, Http3StreamContext context) 
+        public Http3Stream(Http3Connection http3Connection, Http3StreamContext context)
         {
             Initialize(context);
 
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
             Debug.Assert(_appCompleted != null);
 
-            _appCompleted.SetResult(new object());
+            _appCompleted.SetResult();
         }
 
         private bool TryClose()
@@ -457,7 +457,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _receivedHeaders = true;
             InputRemaining = HttpRequestHeaders.ContentLength;
 
-            _appCompleted = new TaskCompletionSource<object>();
+            _appCompleted = new TaskCompletionSource();
 
             ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private bool _completed;
 
         private readonly CancellationTokenSource _connectionClosingCts = new CancellationTokenSource();
-        private readonly TaskCompletionSource<object> _completionTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _completionTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         protected readonly long _id;
         protected readonly ServiceContext _serviceContext;
         protected readonly TransportConnectionManager _transportConnectionManager;
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public void Complete()
         {
-            _completionTcs.TrySetResult(null);
+            _completionTcs.TrySetResult();
 
             _connectionClosingCts.Dispose();
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportConnectionManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportConnectionManager.cs
@@ -95,8 +95,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 return Task.CompletedTask;
             }
 
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-            token.Register(() => tcs.SetResult(null));
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            token.Register(() => tcs.SetResult());
             return tcs.Task;
         }
     }

--- a/src/Servers/Kestrel/Core/src/KestrelServer.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         private bool _hasStarted;
         private int _stopping;
         private readonly CancellationTokenSource _stopCts = new CancellationTokenSource();
-        private readonly TaskCompletionSource<object> _stoppedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _stoppedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private IDisposable _configChangedRegistration;
 
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 _bindSemaphore.Release();
             }
 
-            _stoppedTcs.TrySetResult(null);
+            _stoppedTcs.TrySetResult();
         }
 
         // Ungraceful shutdown

--- a/src/Servers/Kestrel/Core/test/ConcurrentPipeWriterTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConcurrentPipeWriterTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.False(flushTask0.IsCompleted);
                 Assert.False(flushTask1.IsCompleted);
 
-                mockPipeWriter.FlushTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                mockPipeWriter.FlushTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 pipeWriterFlushTcsArray[0].SetResult(default);
 
                 await mockPipeWriter.FlushTcs.Task.DefaultTimeout();
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.False(flushTask0.IsCompleted);
                 Assert.False(flushTask1.IsCompleted);
 
-                mockPipeWriter.FlushTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                mockPipeWriter.FlushTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 pipeWriterFlushTcsArray[1].SetResult(default);
 
                 await mockPipeWriter.FlushTcs.Task.DefaultTimeout();
@@ -235,7 +235,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Equal(3, mockPipeWriter.AdvanceCallCount);
                 Assert.Equal(2, mockPipeWriter.FlushCallCount);
                 Assert.False(flushTask1.IsCompleted);
- 
+
                 pipeWriterFlushTcsArray[1].SetResult(default);
 
                 await flushTask1.DefaultTimeout();
@@ -426,14 +426,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public int FlushCallCount { get; set; }
             public int CancelPendingFlushCallCount { get; set; }
 
-            public TaskCompletionSource<object> FlushTcs { get; set; }
+            public TaskCompletionSource FlushTcs { get; set; }
 
             public Exception CompleteException { get; set; }
 
             public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
             {
                 FlushCallCount++;
-                FlushTcs?.TrySetResult(null);
+                FlushTcs?.TrySetResult();
                 return new ValueTask<FlushResult>(_flushResults[FlushCallCount - 1].Task);
             }
 

--- a/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var serviceContext = new TestServiceContext();
             // This needs to run inline
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
 
             var connection = new Mock<DefaultConnectionContext> { CallBase = true }.Object;
             connection.ConnectionClosed = new CancellationToken(canceled: true);
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(pairs.ContainsKey("ConnectionId"));
             Assert.Equal(connection.ConnectionId, pairs["ConnectionId"]);
 
-            tcs.TrySetResult(null);
+            tcs.TrySetResult();
 
             await task;
 

--- a/src/Servers/Kestrel/Core/test/HeartbeatTests.cs
+++ b/src/Servers/Kestrel/Core/test/HeartbeatTests.cs
@@ -29,12 +29,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var debugger = new Mock<IDebugger>();
             var kestrelTrace = new Mock<IKestrelTrace>();
             var handlerMre = new ManualResetEventSlim();
-            var handlerStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var now = systemClock.UtcNow;
 
             heartbeatHandler.Setup(h => h.OnHeartbeat(now)).Callback(() =>
             {
-                handlerStartedTcs.SetResult(null);
+                handlerStartedTcs.SetResult();
                 handlerMre.Wait();
             });
             debugger.Setup(d => d.IsAttached).Returns(false);
@@ -67,12 +67,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var debugger = new Mock<IDebugger>();
             var kestrelTrace = new Mock<IKestrelTrace>();
             var handlerMre = new ManualResetEventSlim();
-            var handlerStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var now = systemClock.UtcNow;
 
             heartbeatHandler.Setup(h => h.OnHeartbeat(now)).Callback(() =>
             {
-                handlerStartedTcs.SetResult(null);
+                handlerStartedTcs.SetResult();
                 handlerMre.Wait();
             });
 

--- a/src/Servers/Kestrel/Core/test/HttpConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO.Pipelines;
@@ -29,14 +29,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var httpConnection = new HttpConnection(httpConnectionContext);
 
-            var aborted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var aborted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var http1Connection = new Http1Connection(httpConnectionContext);
 
             httpConnection.Initialize(http1Connection);
             http1Connection.Reset();
             http1Connection.RequestAborted.Register(() =>
             {
-                aborted.SetResult(null);
+                aborted.SetResult();
             });
 
             httpConnection.OnTimeout(TimeoutReason.WriteDataRate);

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -373,7 +373,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 }
             };
 
-            var unbindTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var unbindTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockTransport = new Mock<IConnectionListener>();
             var mockTransportFactory = new Mock<IConnectionListenerFactory>();
@@ -411,7 +411,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 stopTask1.Wait();
             });
 
-            unbindTcs.SetResult(null);
+            unbindTcs.SetResult();
 
             // If stopTask2 is completed inline by the first call to StopAsync, stopTask1 will never complete.
             await stopTask1.DefaultTimeout();
@@ -467,16 +467,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             }).Build();
 
             Func<Task> changeCallback = null;
-            TaskCompletionSource<object> changeCallbackRegisteredTcs = null;
+            TaskCompletionSource changeCallbackRegisteredTcs = null;
 
             var mockChangeToken = new Mock<IChangeToken>();
             mockChangeToken.Setup(t => t.RegisterChangeCallback(It.IsAny<Action<object>>(), It.IsAny<object>())).Returns<Action<object>, object>((callback, state) =>
             {
-                changeCallbackRegisteredTcs?.SetResult(null);
+                changeCallbackRegisteredTcs?.SetResult();
 
                 changeCallback = () =>
                 {
-                    changeCallbackRegisteredTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    changeCallbackRegisteredTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     callback(state);
                     return changeCallbackRegisteredTcs.Task;
                 };

--- a/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
+++ b/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
@@ -859,11 +859,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                var logEvent = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var logEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 var mockLogger = new Mock<IKestrelTrace>();
                 mockLogger
                     .Setup(logger => logger.RequestBodyDone("ConnectionId", "RequestId"))
-                    .Callback(() => logEvent.SetResult(null));
+                    .Callback(() => logEvent.SetResult());
                 mockLogger
                     .Setup(logger => logger.IsEnabled(Extensions.Logging.LogLevel.Debug))
                     .Returns(true);

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         private MemoryHandle _bufferHandle;
         private Task _processingTask;
-        private readonly TaskCompletionSource<object> _waitForConnectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _waitForConnectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private bool _connectionClosed;
 
         public LibuvConnection(UvStreamHandle socket,
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             {
                 state.CancelConnectionClosedToken();
 
-                state._waitForConnectionClosedTcs.TrySetResult(null);
+                state._waitForConnectionClosedTcs.TrySetResult();
             },
             this,
             preferLocal: false);

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvThread.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvThread.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         private readonly LibuvFunctions _libuv;
         private readonly IHostApplicationLifetime _appLifetime;
         private readonly Thread _thread;
-        private readonly TaskCompletionSource<object> _threadTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _threadTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly UvLoopHandle _loop;
         private readonly UvAsyncHandle _post;
         private Queue<Work> _workAdding = new Queue<Work>(1024);
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 return Task.CompletedTask;
             }
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var work = new Work
             {
                 CallbackAdapter = CallbackAdapter<T>.PostAsyncCallbackAdapter,
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                     _closeError = _closeError == null ? ex : new AggregateException(_closeError, ex);
                 }
                 WriteReqPool.Dispose();
-                _threadTcs.SetResult(null);
+                _threadTcs.SetResult();
 
 #if DEBUG && !INNER_LOOP
                 // Check for handle leaks after disposing everything
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 try
                 {
                     work.CallbackAdapter(work.Callback, work.State);
-                    work.Completion?.TrySetResult(null);
+                    work.Completion?.TrySetResult();
                 }
                 catch (Exception ex)
                 {
@@ -446,7 +446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             public Action<object, object> CallbackAdapter;
             public object Callback;
             public object State;
-            public TaskCompletionSource<object> Completion;
+            public TaskCompletionSource Completion;
         }
 
         private struct CloseHandle

--- a/src/Servers/Kestrel/Transport.Libuv/test/ListenerPrimaryTests.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/test/ListenerPrimaryTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             }
 
             // Create a pipe connection and keep it open without sending any data
-            var connectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var connectionTrace = new LibuvTrace(new TestApplicationErrorLogger());
             var pipe = new UvPipeHandle(connectionTrace);
 
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                         }
                         else
                         {
-                            connectTcs.SetResult(null);
+                            connectTcs.SetResult();
                         }
                     },
                     null);

--- a/src/Servers/Kestrel/Transport.Libuv/test/TestHelpers/MockLibuv.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/test/TestHelpers/MockLibuv.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
         private uv_async_cb _onPost;
 
         private readonly object _postLock = new object();
-        private TaskCompletionSource<object> _onPostTcs = new TaskCompletionSource<object>();
+        private TaskCompletionSource _onPostTcs = new TaskCompletionSource();
         private bool _completedOnPostTcs;
 
         private bool _stopLoop;
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
                 {
                     if (_completedOnPostTcs)
                     {
-                        _onPostTcs = new TaskCompletionSource<object>();
+                        _onPostTcs = new TaskCompletionSource();
                         _completedOnPostTcs = false;
                     }
 
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
                             // when the code attempts to call uv_async_send after awaiting
                             // OnPostTask. Task.Run so the run loop doesn't block either.
                             var onPostTcs = _onPostTcs;
-                            Task.Run(() => onPostTcs.TrySetResult(null));
+                            Task.Run(() => onPostTcs.TrySetResult());
                         }
                     }
                 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         private string _connectionId;
         private const int MinAllocBufferSize = 4096;
         private volatile Exception _shutdownReason;
-        private readonly TaskCompletionSource<object> _waitForConnectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _waitForConnectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly object _shutdownLock = new object();
 
         public QuicStreamContext(QuicStream stream, QuicConnectionContext connection, QuicTransportContext context)
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             {
                 state.CancelConnectionClosedToken();
 
-                state._waitForConnectionClosedTcs.TrySetResult(null);
+                state._waitForConnectionClosedTcs.TrySetResult();
             },
             this,
             preferLocal: false);

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private volatile bool _socketDisposed;
         private volatile Exception _shutdownReason;
         private Task _processingTask;
-        private readonly TaskCompletionSource<object> _waitForConnectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _waitForConnectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private bool _connectionClosed;
         private readonly bool _waitForData;
 
@@ -317,7 +317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             {
                 state.CancelConnectionClosedToken();
 
-                state._waitForConnectionClosedTcs.TrySetResult(null);
+                state._waitForConnectionClosedTcs.TrySetResult();
             },
             this,
             preferLocal: false);

--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -118,8 +118,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var bytesWrittenPollingInterval = TimeSpan.FromMilliseconds(bytesWrittenTimeout.TotalMilliseconds / 10);
             var maxSendSize = 4096;
 
-            var startReadingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startReadingRequestBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientFinishedSendingRequestBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var lastBytesWritten = DateTime.MaxValue;
 
             var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         }
 
                         Assert.Equal(data.Length, bytesWritten);
-                        clientFinishedSendingRequestBody.TrySetResult(null);
+                        clientFinishedSendingRequestBody.TrySetResult();
                     };
 
                     var sendTask = sendFunc();
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         Assert.InRange(bytesWritten, minimumExpectedBytesWritten, maximumExpectedBytesWritten);
 
                         // Tell server to start reading request body
-                        startReadingRequestBody.TrySetResult(null);
+                        startReadingRequestBody.TrySetResult();
 
                         // Wait for sendTask to finish sending the remaining bytes
                         await sendTask;
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         await sendTask;
 
                         // Tell server to start reading request body
-                        startReadingRequestBody.TrySetResult(null);
+                        startReadingRequestBody.TrySetResult();
                     }
 
                     await AssertStreamContains(stream, $"bytesRead: {data.Length}");
@@ -211,8 +211,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var bytesWrittenPollingInterval = TimeSpan.FromMilliseconds(bytesWrittenTimeout.TotalMilliseconds / 10);
             var maxSendSize = 4096;
 
-            var startReadingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startReadingRequestBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientFinishedSendingRequestBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var lastBytesWritten = DateTime.MaxValue;
 
             var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                             lastBytesWritten = DateTime.Now;
                         }
 
-                        clientFinishedSendingRequestBody.TrySetResult(null);
+                        clientFinishedSendingRequestBody.TrySetResult();
                     };
 
                     var ignore = sendFunc();
@@ -276,16 +276,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 }
             }
             // Allow appfunc to unblock
-            startReadingRequestBody.SetResult(null);
-            clientFinishedSendingRequestBody.SetResult(null);
+            startReadingRequestBody.SetResult();
+            clientFinishedSendingRequestBody.SetResult();
             await memoryPoolFactory.WhenAllBlocksReturned(TestConstants.DefaultTimeout);
         }
 
         private async Task<IWebHost> StartWebHost(long? maxRequestBufferSize,
             byte[] expectedBody,
             bool useConnectionAdapter,
-            TaskCompletionSource<object> startReadingRequestBody,
-            TaskCompletionSource<object> clientFinishedSendingRequestBody,
+            TaskCompletionSource startReadingRequestBody,
+            TaskCompletionSource clientFinishedSendingRequestBody,
             Func<MemoryPool<byte>> memoryPoolFactory = null)
         {
             var host = TransportSelector.GetWebHostBuilder(memoryPoolFactory, maxRequestBufferSize)

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task CanHandleMultipleConcurrentRequests()
         {
             var requestNumber = 0;
-            var ensureConcurrentRequestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var ensureConcurrentRequestTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(async context =>
             {
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 }
                 else
                 {
-                    ensureConcurrentRequestTcs.SetResult(null);
+                    ensureConcurrentRequestTcs.SetResult();
                 }
             }, new TestServiceContext(LoggerFactory)))
             {
@@ -504,15 +504,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task ConnectionClosedTokenFiresOnClientFIN(ListenOptions listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var appStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(context =>
             {
-                appStartedTcs.SetResult(null);
+                appStartedTcs.SetResult();
 
                 var connectionLifetimeFeature = context.Features.Get<IConnectionLifetimeFeature>();
-                connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult(null));
+                connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 return Task.CompletedTask;
             }, testContext, listenOptions))
@@ -540,12 +540,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task ConnectionClosedTokenFiresOnServerFIN(ListenOptions listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(context =>
             {
                 var connectionLifetimeFeature = context.Features.Get<IConnectionLifetimeFeature>();
-                connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult(null));
+                connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 return Task.CompletedTask;
             }, testContext, listenOptions))
@@ -577,12 +577,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task ConnectionClosedTokenFiresOnServerAbort(ListenOptions listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(context =>
             {
                 var connectionLifetimeFeature = context.Features.Get<IConnectionLifetimeFeature>();
-                connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult(null));
+                connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 context.Abort();
 
@@ -623,7 +623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var testContext = new TestServiceContext(LoggerFactory);
 
-            var readTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var registrationTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             var requestId = 0;
 
@@ -713,10 +713,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const int connectionFinSentEventId = 7;
             const int maxRequestBufferSize = 4096;
 
-            var readCallbackUnwired = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var clientClosedConnection = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var serverClosedConnection = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readCallbackUnwired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientClosedConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serverClosedConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appFuncCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             TestSink.MessageLogged += context =>
             {
@@ -728,11 +728,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 if (context.EventId.Id == connectionPausedEventId)
                 {
-                    readCallbackUnwired.TrySetResult(null);
+                    readCallbackUnwired.TrySetResult();
                 }
                 else if (context.EventId == connectionFinSentEventId)
                 {
-                    serverClosedConnection.SetResult(null);
+                    serverClosedConnection.SetResult();
                 }
             };
 
@@ -760,7 +760,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 await serverClosedConnection.Task;
 
-                appFuncCompleted.SetResult(null);
+                appFuncCompleted.SetResult();
             }, testContext, listenOptions))
             {
                 using (var connection = server.CreateConnection())
@@ -778,7 +778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     await readCallbackUnwired.Task.DefaultTimeout();
                 }
 
-                clientClosedConnection.SetResult(null);
+                clientClosedConnection.SetResult();
 
                 await appFuncCompleted.Task.DefaultTimeout();
                 await server.StopAsync();
@@ -792,8 +792,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [QuarantinedTest]
         public async Task AppCanHandleClientAbortingConnectionMidRequest(ListenOptions listenOptions)
         {
-            var readTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var appStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockKestrelTrace = new Mock<IKestrelTrace>();
             var testContext = new TestServiceContext(LoggerFactory, mockKestrelTrace.Object);
@@ -802,7 +802,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var server = new TestServer(async context =>
             {
-                appStartedTcs.SetResult(null);
+                appStartedTcs.SetResult();
 
                 try
                 {

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             try
             {
-                var serverConnectionCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var serverConnectionCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 async Task EchoServer(ConnectionContext connection)
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     }
                     finally
                     {
-                        serverConnectionCompletedTcs.TrySetResult(null);
+                        serverConnectionCompletedTcs.TrySetResult();
                     }
                 }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -842,7 +842,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task ClosingConnectionMidChunkPrefixThrows()
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var readStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 #pragma warning disable CS0618 // Type or member is obsolete
             var exTcs = new TaskCompletionSource<BadHttpRequestException>(TaskCreationOptions.RunContinuationsAsynchronously);
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -850,7 +850,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             await using (var server = new TestServer(async httpContext =>
             {
                 var readTask = httpContext.Request.Body.CopyToAsync(Stream.Null);
-                readStartedTcs.SetResult(null);
+                readStartedTcs.SetResult();
 
                 try
                 {
@@ -892,7 +892,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ChunkedRequestCallCancelPendingReadWorks()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             var testContext = new TestServiceContext(LoggerFactory);
 
             await using (var server = new TestServer(async httpContext =>
@@ -911,7 +911,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 Assert.True((await requestTask).IsCanceled);
 
-                tcs.SetResult(null);
+                tcs.SetResult();
 
                 response.Headers["Content-Length"] = new[] { "11" };
 
@@ -1056,7 +1056,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ChunkedRequestCallCompleteWithExceptionCauses500()
         {
-            var tcs = new TaskCompletionSource<object>();
             var testContext = new TestServiceContext(LoggerFactory);
 
             using (var server = new TestServer(async httpContext =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
                         "",
-                        length.ToString("x"), 
+                        length.ToString("x"),
                         new string('a', length),
                         "0",
                         "",
@@ -485,7 +485,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var testContext = new TestServiceContext(LoggerFactory);
 
-            var flushWh = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var flushWh = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -514,7 +514,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Hello ",
                         "");
 
-                    flushWh.SetResult(null);
+                    flushWh.SetResult();
 
                     await connection.Receive(
                         "6",

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
@@ -23,12 +23,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ResetsCountWhenConnectionClosed()
         {
-            var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var releasedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var requestTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releasedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var lockedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var counter = new EventRaisingResourceCounter(ResourceCounter.Quota(1));
             counter.OnLock += (s, e) => lockedTcs.TrySetResult(e);
-            counter.OnRelease += (s, e) => releasedTcs.TrySetResult(null);
+            counter.OnRelease += (s, e) => releasedTcs.TrySetResult();
 
             await using (var server = CreateServerWithMaxConnections(async context =>
             {
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     await connection.SendEmptyGetAsKeepAlive(); ;
                     await connection.Receive("HTTP/1.1 200 OK");
                     Assert.True(await lockedTcs.Task.DefaultTimeout());
-                    requestTcs.TrySetResult(null);
+                    requestTcs.TrySetResult();
                 }
             }
 
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task RejectsConnectionsWhenLimitReached()
         {
             const int max = 10;
-            var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var requestTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = CreateServerWithMaxConnections(async context =>
             {
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         }
                     }
 
-                    requestTcs.TrySetResult(null);
+                    requestTcs.TrySetResult();
                 }
             }
         }
@@ -148,8 +148,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             const int count = 100;
             var opened = 0;
             var closed = 0;
-            var openedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var closedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var openedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var closedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var counter = new EventRaisingResourceCounter(ResourceCounter.Quota(uint.MaxValue));
 
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 if (e && Interlocked.Increment(ref opened) >= count)
                 {
-                    openedTcs.TrySetResult(null);
+                    openedTcs.TrySetResult();
                 }
             };
 
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 if (Interlocked.Increment(ref closed) >= count)
                 {
-                    closedTcs.TrySetResult(null);
+                    closedTcs.TrySetResult();
                 }
             };
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ImmediateShutdownDuringOnConnectionAsyncDoesNotCrash()
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0));
             listenOptions.Use(next =>
             {
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     stopTask = server.StopAsync();
 
-                    tcs.TrySetResult(null);
+                    tcs.TrySetResult();
                 }
 
                 await stopTask;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -715,7 +715,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task ContentLength_Received_MultipleDataFrame_ReadViaPipeAndStream_Verified()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             var headers = new[]
             {
                 new KeyValuePair<string, string>(HeaderNames.Method, "POST"),
@@ -729,7 +729,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Equal(1, readResult.Buffer.Length);
                 context.Request.BodyReader.AdvanceTo(readResult.Buffer.End);
 
-                tcs.SetResult(null);
+                tcs.SetResult();
 
                 var buffer = new byte[100];
 
@@ -1257,7 +1257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task StartAsync_WithoutFinalFlushDoesNotFlushUntilResponseEnd()
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var headers = new[]
             {
@@ -1286,7 +1286,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
-            tcs.SetResult(null);
+            tcs.SetResult();
 
             await ExpectAsync(Http2FrameType.DATA,
                 withLength: 0,
@@ -2336,7 +2336,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 
-                _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                _runningStreams[streamIdFeature.StreamId].TrySetResult();
             });
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
@@ -2371,7 +2371,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 context.Response.BodyWriter.Advance(10);
                 await context.Response.BodyWriter.FlushAsync();
 
-                _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                _runningStreams[streamIdFeature.StreamId].TrySetResult();
             });
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
@@ -2407,7 +2407,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                         _abortedStreamIds.Add(streamIdFeature.StreamId);
                     }
 
-                    _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                    _runningStreams[streamIdFeature.StreamId].TrySetResult();
                 }
                 catch (Exception ex)
                 {
@@ -2450,7 +2450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                         _abortedStreamIds.Add(streamIdFeature.StreamId);
                     }
 
-                    _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                    _runningStreams[streamIdFeature.StreamId].TrySetResult();
                 }
                 catch (Exception ex)
                 {
@@ -2484,7 +2484,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                             _abortedStreamIds.Add(streamIdFeature.StreamId);
                         }
 
-                        _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                        _runningStreams[streamIdFeature.StreamId].TrySetResult();
                     });
 
                     context.Abort();
@@ -2524,7 +2524,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                             _abortedStreamIds.Add(streamIdFeature.StreamId);
                         }
 
-                        _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                        _runningStreams[streamIdFeature.StreamId].TrySetResult();
                     });
 
                     await context.Response.Body.WriteAsync(new byte[10], 0, 10);
@@ -3927,7 +3927,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task CompleteAsync_AdvanceAfterComplete_AdvanceThrows()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             var headers = new[]
             {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -3944,7 +3944,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 }
                 catch (InvalidOperationException)
                 {
-                    tcs.SetResult(null);
+                    tcs.SetResult();
                     return;
                 }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -130,14 +130,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         internal readonly Mock<ITimeoutHandler> _mockTimeoutHandler = new Mock<ITimeoutHandler>();
         internal readonly Mock<MockTimeoutControlBase> _mockTimeoutControl;
 
-        protected readonly ConcurrentDictionary<int, TaskCompletionSource<object>> _runningStreams = new ConcurrentDictionary<int, TaskCompletionSource<object>>();
+        protected readonly ConcurrentDictionary<int, TaskCompletionSource> _runningStreams = new ConcurrentDictionary<int, TaskCompletionSource>();
         protected readonly Dictionary<string, string> _receivedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         protected readonly Dictionary<string, string> _receivedTrailers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         protected readonly Dictionary<string, string> _decodedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         protected readonly HashSet<int> _abortedStreamIds = new HashSet<int>();
         protected readonly object _abortedStreamIdsLock = new object();
-        protected readonly TaskCompletionSource<object> _closingStateReached = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        protected readonly TaskCompletionSource<object> _closedStateReached = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        protected readonly TaskCompletionSource _closingStateReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        protected readonly TaskCompletionSource _closedStateReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         protected readonly RequestDelegate _noopApplication;
         protected readonly RequestDelegate _readHeadersApplication;
@@ -174,10 +174,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _mockKestrelTrace
                 .Setup(m => m.Http2ConnectionClosing(It.IsAny<string>()))
-                .Callback(() => _closingStateReached.SetResult(null));
+                .Callback(() => _closingStateReached.SetResult());
             _mockKestrelTrace
                 .Setup(m => m.Http2ConnectionClosed(It.IsAny<string>(), It.IsAny<int>()))
-                .Callback(() => _closedStateReached.SetResult(null));
+                .Callback(() => _closedStateReached.SetResult());
 
             _mockConnectionContext.Setup(c => c.Abort(It.IsAny<ConnectionAbortedException>())).Callback<ConnectionAbortedException>(ex =>
             {
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 await sem.WaitAsync().DefaultTimeout();
 
-                _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                _runningStreams[streamIdFeature.StreamId].TrySetResult();
             };
 
             _waitForAbortFlushingApplication = async context =>
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 await context.Response.Body.FlushAsync();
 
-                _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+                _runningStreams[streamIdFeature.StreamId].TrySetResult();
             };
 
             _readRateApplication = async context =>
@@ -500,7 +500,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected Task StartStreamAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _runningStreams[streamId] = tcs;
 
             writableBuffer.WriteStartStream(streamId, _hpackEncoder, GetHeadersEnumerator(headers), _headerEncodingBuffer, endStream);
@@ -510,7 +510,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected Task StartStreamAsync(int streamId, Span<byte> headerData, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _runningStreams[streamId] = tcs;
 
             writableBuffer.WriteStartStream(streamId, headerData, endStream);
@@ -529,7 +529,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected Task SendHeadersWithPaddingAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, byte padLength, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _runningStreams[streamId] = tcs;
 
             var frame = new Http2Frame();
@@ -571,7 +571,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected Task SendHeadersWithPriorityAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, byte priority, int streamDependency, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _runningStreams[streamId] = tcs;
 
             var frame = new Http2Frame();
@@ -616,7 +616,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected Task SendHeadersWithPaddingAndPriorityAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, byte padLength, byte priority, int streamDependency, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _runningStreams[streamId] = tcs;
 
             var frame = new Http2Frame();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -87,11 +87,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             // The KeepAlive timeout is set when the stream completes processing on a background thread, so we need to hook the
             // keep-alive set afterwards to make a reliable test.
-            var setTimeoutTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var setTimeoutTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _mockTimeoutControl.Setup(c => c.SetTimeout(It.IsAny<long>(), TimeoutReason.KeepAlive)).Callback<long, TimeoutReason>((t, r) =>
             {
                 _timeoutControl.SetTimeout(t, r);
-                setTimeoutTcs.SetResult(null);
+                setTimeoutTcs.SetResult();
             });
 
             // Send continuation frame to verify intermediate request header timeout doesn't interfere with keep-alive timeout.
@@ -851,7 +851,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var initialConnectionWindowSize = _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize;
             var framesConnectionInWindow = initialConnectionWindowSize / Http2PeerSettings.DefaultMaxFrameSize;
 
-            var backpressureTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var backpressureTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockSystemClock = _serviceContext.MockSystemClock;
             var limits = _serviceContext.ServerOptions.Limits;
@@ -900,7 +900,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockTimeoutHandler.Verify(h => h.OnTimeout(It.IsAny<TimeoutReason>()), Times.Never);
 
             // Opening the connection window starts the read rate timeout enforcement after that point.
-            backpressureTcs.SetResult(null);
+            backpressureTcs.SetResult();
 
             await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 6,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpConnectionManagerTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpConnectionManagerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             await using (var server = new TestServer(context =>
                 {
                     appStartedWh.Release();
-                    var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     return tcs.Task;
                 },
                 testContext))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [QuarantinedTest]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var loggerProvider = new HandshakeErrorLoggerProvider();
             LoggerFactory.AddProvider(loggerProvider);
 
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     try
                     {
                         await httpContext.Response.WriteAsync($"hello, world");
-                        tcs.SetResult(null);
+                        tcs.SetResult();
                     }
                     catch (Exception ex)
                     {
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var testContext = new TestServiceContext(LoggerFactory);
             var heartbeatManager = new HeartbeatManager(testContext.ConnectionManager);
 
-            var handshakeStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handshakeStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             TimeSpan handshakeTimeout = default;
 
             await using (var server = new TestServer(context => Task.CompletedTask,
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         o.ServerCertificate = new X509Certificate2(TestResources.GetTestCertificate());
                         o.OnAuthenticate = (_, __) =>
                         {
-                            handshakeStartedTcs.SetResult(null);
+                            handshakeStartedTcs.SetResult();
                         };
 
                         handshakeTimeout = o.HandshakeTimeout;
@@ -489,13 +489,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             public LogLevel LastLogLevel { get; set; }
             public EventId LastEventId { get; set; }
-            public TaskCompletionSource<object> LogTcs { get; } = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource LogTcs { get; } = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             {
                 LastLogLevel = logLevel;
                 LastEventId = eventId;
-                LogTcs.SetResult(null);
+                LogTcs.SetResult();
             }
 
             public bool IsEnabled(LogLevel logLevel)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         private static readonly TimeSpan _longDelay = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan _shortDelay = TimeSpan.FromSeconds(_longDelay.TotalSeconds / 10);
 
-        private readonly TaskCompletionSource<object> _firstRequestReceived = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _firstRequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         [Fact]
         public async Task ConnectionClosedWhenKeepAliveTimeoutExpires()
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var responseStream = httpContext.Response.Body;
             var responseBytes = Encoding.ASCII.GetBytes("hello, world");
 
-            _firstRequestReceived.TrySetResult(null);
+            _firstRequestReceived.TrySetResult();
 
             if (httpContext.Request.Path == "/longrunning")
             {
@@ -285,8 +285,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 return Task.CompletedTask;
             }
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            token.Register(() => tcs.SetResult(null));
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            token.Register(() => tcs.SetResult());
             return tcs.Task;
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestBodyTimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestBodyTimeoutTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var serviceContext = new TestServiceContext(LoggerFactory);
             var heartbeatManager = new HeartbeatManager(serviceContext.ConnectionManager);
 
-            var appRunningEvent = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appRunningEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(context =>
             {
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 //     return context.Request.Body.ReadAsync(new byte[1], 0, 1);
 
                 var readTask = context.Request.Body.ReadAsync(new byte[1], 0, 1);
-                appRunningEvent.SetResult(null);
+                appRunningEvent.SetResult();
                 return readTask;
             }, serviceContext))
             {
@@ -104,13 +104,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             date.OnHeartbeat(clock.UtcNow);
             serviceContext.DateHeaderValueManager = date;
 
-            var appRunningEvent = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appRunningEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(context =>
             {
                 context.Features.Get<IHttpMinRequestBodyDataRateFeature>().MinDataRate = null;
 
-                appRunningEvent.SetResult(null);
+                appRunningEvent.SetResult();
                 return Task.CompletedTask;
             }, serviceContext))
             {
@@ -146,8 +146,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var serviceContext = new TestServiceContext(LoggerFactory);
             var heartbeatManager = new HeartbeatManager(serviceContext.ConnectionManager);
 
-            var appRunningTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var exceptionSwallowedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appRunningTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var exceptionSwallowedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async context =>
             {
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 // See comment in RequestTimesOutWhenRequestBodyNotReceivedAtSpecifiedMinimumRate for
                 // why we call ReadAsync before setting the appRunningEvent.
                 var readTask = context.Request.Body.ReadAsync(new byte[1], 0, 1);
-                appRunningTcs.SetResult(null);
+                appRunningTcs.SetResult();
 
                 try
                 {
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
                 catch (Microsoft.AspNetCore.Http.BadHttpRequestException ex) when (ex.StatusCode == 408)
                 {
-                    exceptionSwallowedTcs.SetResult(null);
+                    exceptionSwallowedTcs.SetResult();
                 }
                 catch (Exception ex)
                 {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -84,8 +84,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task RequestBodyReadAsyncCanBeCancelled()
         {
-            var helloTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var readTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var helloTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var cts = new CancellationTokenSource();
 
             await using (var server = new TestServer(async context =>
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                     Assert.Equal("Hello ", Encoding.ASCII.GetString(buffer, 0, 6));
 
-                    helloTcs.TrySetResult(null);
+                    helloTcs.TrySetResult();
                 }
                 catch (Exception ex)
                 {
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 try
                 {
                     var task = context.Request.Body.ReadAsync(buffer, 0, buffer.Length, cts.Token);
-                    readTcs.TrySetResult(null);
+                    readTcs.TrySetResult();
                     await task;
 
                     context.Response.ContentLength = 12;
@@ -1053,19 +1053,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task ContentLengthReadAsyncSingleBytesAtATime()
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var tcs = new TaskCompletionSource<object>();
-            var tcs2 = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
+            var tcs2 = new TaskCompletionSource();
             await using (var server = new TestServer(async httpContext =>
             {
                 var readResult = await httpContext.Request.BodyReader.ReadAsync();
                 Assert.Equal(3, readResult.Buffer.Length);
-                tcs.SetResult(null);
+                tcs.SetResult();
 
                 httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
 
                 readResult = await httpContext.Request.BodyReader.ReadAsync();
                 httpContext.Request.BodyReader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
-                tcs2.SetResult(null);
+                tcs2.SetResult();
 
                 readResult = await httpContext.Request.BodyReader.ReadAsync();
                 Assert.Equal(5, readResult.Buffer.Length);
@@ -1495,8 +1495,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task DoesNotEnforceRequestBodyMinimumDataRateOnUpgradedRequest()
         {
-            var appEvent = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var delayEvent = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var delayEvent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var serviceContext = new TestServiceContext(LoggerFactory);
             var heartbeatManager = new HeartbeatManager(serviceContext.ConnectionManager);
 
@@ -1507,7 +1507,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 using (var stream = await context.Features.Get<IHttpUpgradeFeature>().UpgradeAsync())
                 {
-                    appEvent.SetResult(null);
+                    appEvent.SetResult();
 
                     // Read once to go through one set of TryPauseTimingReads()/TryResumeTimingReads() calls
                     await stream.ReadAsync(new byte[1], 0, 1);
@@ -1537,7 +1537,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     serviceContext.MockSystemClock.UtcNow += TimeSpan.FromSeconds(5);
                     heartbeatManager.OnHeartbeat(serviceContext.SystemClock.UtcNow);
 
-                    delayEvent.SetResult(null);
+                    delayEvent.SetResult();
 
                     await connection.Send("b");
 
@@ -1767,7 +1767,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ContentLengthRequestCallCancelPendingReadWorks()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             var testContext = new TestServiceContext(LoggerFactory);
 
             await using (var server = new TestServer(async httpContext =>
@@ -1786,7 +1786,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 Assert.True((await requestTask).IsCanceled);
 
-                tcs.SetResult(null);
+                tcs.SetResult();
 
                 response.Headers["Content-Length"] = new[] { "11" };
 
@@ -1864,7 +1864,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var testContext = new TestServiceContext(LoggerFactory);
 
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             await using (var server = new TestServer(async httpContext =>
             {
                 var request = httpContext.Request;
@@ -1874,7 +1874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                 httpContext.Request.BodyReader.Complete();
 
-                tcs.SetResult(null);
+                tcs.SetResult();
 
             }, testContext))
             {
@@ -1903,7 +1903,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ContentLengthCallCompleteWithExceptionCauses500()
         {
-            var tcs = new TaskCompletionSource<object>();
             var testContext = new TestServiceContext(LoggerFactory);
 
             await using (var server = new TestServer(async httpContext =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 {
                     var transportConnection = connection.TransportConnection;
 
-                    var outputBufferedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var outputBufferedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 #pragma warning disable 0618 // TODO: Repalce OnWriterCompleted
                     transportConnection.Output.OnWriterCompleted((ex, state) =>
                     {
-                        ((TaskCompletionSource<object>)state).SetResult(null);
+                        ((TaskCompletionSource)state).SetResult();
                     },
                     outputBufferedTcs);
 #pragma warning restore

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -34,14 +34,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task OnCompleteCalledEvenWhenOnStartingNotCalled()
         {
             var onStartingCalled = false;
-            TaskCompletionSource<object> onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource onCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(context =>
             {
                 context.Response.OnStarting(() => Task.Run(() => onStartingCalled = true));
                 context.Response.OnCompleted(() => Task.Run(() =>
                 {
-                    onCompletedTcs.SetResult(null);
+                    onCompletedTcs.SetResult();
                 }));
 
                 // Prevent OnStarting call (see HttpProtocol.ProcessRequestsAsync()).
@@ -141,8 +141,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var serviceContext = new TestServiceContext(LoggerFactory);
             var cts = new CancellationTokenSource();
-            var appTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var writeBlockedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var writeBlockedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async context =>
             {
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         completedTask = await Task.WhenAny(writeTask, timerTask);
                     }
 
-                    writeBlockedTcs.TrySetResult(null);
+                    writeBlockedTcs.TrySetResult();
 
                     await writeTask;
                 }
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
                 finally
                 {
-                    appTcs.TrySetResult(null);
+                    appTcs.TrySetResult();
                 }
             }, serviceContext))
             {
@@ -331,7 +331,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task OnCompletedShouldNotBlockAResponse()
         {
-            var delayTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var delayTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async context =>
             {
@@ -361,20 +361,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "");
                 }
 
-                delayTcs.SetResult(null);
+                delayTcs.SetResult();
             }
         }
 
         [Fact]
         public async Task InvalidChunkedEncodingInRequestShouldNotBlockOnCompleted()
         {
-            var onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var onCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(httpContext =>
             {
                 httpContext.Response.OnCompleted(() => Task.Run(() =>
                 {
-                    onCompletedTcs.SetResult(null);
+                    onCompletedTcs.SetResult();
                 }));
                 return Task.CompletedTask;
             }, new TestServiceContext(LoggerFactory)))
@@ -644,11 +644,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             const string response = "hello, world";
 
-            var logTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var logTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockKestrelTrace = new Mock<IKestrelTrace>();
             mockKestrelTrace
                 .Setup(trace => trace.ConnectionHeadResponseBodyWrite(It.IsAny<string>(), response.Length))
-                .Callback<string, long>((connectionId, count) => logTcs.SetResult(null));
+                .Callback<string, long>((connectionId, count) => logTcs.SetResult());
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -831,13 +831,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task WhenAppWritesLessThanContentLengthErrorLogged()
         {
-            var logTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var logTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockTrace = new Mock<IKestrelTrace>();
             mockTrace
                 .Setup(trace => trace.ApplicationError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<InvalidOperationException>()))
                 .Callback<string, string, Exception>((connectionId, requestId, ex) =>
                 {
-                    logTcs.SetResult(null);
+                    logTcs.SetResult();
                 });
 
             await using (var server = new TestServer(async httpContext =>
@@ -886,13 +886,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             InvalidOperationException completeEx = null;
 
-            var logTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var logTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockTrace = new Mock<IKestrelTrace>();
             mockTrace
                 .Setup(trace => trace.ApplicationError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<InvalidOperationException>()))
                 .Callback<string, string, Exception>((connectionId, requestId, ex) =>
                 {
-                    logTcs.SetResult(null);
+                    logTcs.SetResult();
                 });
 
             await using (var server = new TestServer(async httpContext =>
@@ -944,14 +944,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task WhenAppWritesLessThanContentLengthButRequestIsAbortedErrorNotLogged()
         {
-            var requestAborted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var requestAborted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockTrace = new Mock<IKestrelTrace>();
 
             await using (var server = new TestServer(async httpContext =>
             {
                 httpContext.RequestAborted.Register(() =>
                 {
-                    requestAborted.SetResult(null);
+                    requestAborted.SetResult();
                 });
 
                 httpContext.Response.ContentLength = 12;
@@ -1165,7 +1165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task HeadResponseBodyNotWrittenWithAsyncWrite()
         {
-            var flushed = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var flushed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -1188,7 +1188,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    flushed.SetResult(null);
+                    flushed.SetResult();
                 }
             }
         }
@@ -1196,7 +1196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task HeadResponseBodyNotWrittenWithSyncWrite()
         {
-            var flushed = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var flushed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
 
@@ -1221,7 +1221,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    flushed.SetResult(null);
+                    flushed.SetResult();
                 }
             }
         }
@@ -1229,7 +1229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task ZeroLengthWritesFlushHeaders()
         {
-            var flushed = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var flushed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -1253,7 +1253,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    flushed.SetResult(null);
+                    flushed.SetResult();
 
                     await connection.Receive("hello, world");
                 }
@@ -1264,7 +1264,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task AppCanWriteOwnBadRequestResponse()
         {
             var expectedResponse = string.Empty;
-            var responseWritten = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var responseWritten = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -1278,7 +1278,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
                     httpContext.Response.ContentLength = ex.Message.Length;
                     await httpContext.Response.WriteAsync(ex.Message);
-                    responseWritten.SetResult(null);
+                    responseWritten.SetResult();
                 }
             }, new TestServiceContext(LoggerFactory)))
             {
@@ -2257,7 +2257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task OnStartingThrowsInsideOnStartingCallbacksRuns()
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -2266,7 +2266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     response.OnStarting(state2 =>
                     {
-                        tcs.TrySetResult(null);
+                        tcs.TrySetResult();
                         return Task.CompletedTask;
                     },
                     null);
@@ -2301,7 +2301,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task OnCompletedThrowsInsideOnCompletedCallbackRuns()
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -2310,7 +2310,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 {
                     response.OnCompleted(state2 =>
                     {
-                        tcs.TrySetResult(null);
+                        tcs.TrySetResult();
 
                         return Task.CompletedTask;
                     },
@@ -2565,8 +2565,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 feature.Abort();
 
                 // Ensure the response doesn't get flush before the abort is observed.
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                feature.ConnectionClosed.Register(() => tcs.TrySetResult(null));
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                feature.ConnectionClosed.Register(() => tcs.TrySetResult());
 
                 return tcs.Task;
             }, testContext))
@@ -2846,7 +2846,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var testContext = new TestServiceContext(LoggerFactory);
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async httpContext =>
             {
@@ -2874,7 +2874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
                     // If we reach this point before the app exits, this means the flush finished early.
-                    tcs.SetResult(null);
+                    tcs.SetResult();
                 }
             }
         }
@@ -3027,14 +3027,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var testContext = new TestServiceContext(LoggerFactory);
 
             var callOrder = new Stack<int>();
-            var onStartingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var onStartingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async context =>
             {
                 context.Response.OnStarting(_ =>
                 {
                     callOrder.Push(1);
-                    onStartingTcs.SetResult(null);
+                    onStartingTcs.SetResult();
                     return Task.CompletedTask;
                 }, null);
                 context.Response.OnStarting(_ =>
@@ -3078,14 +3078,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             var testContext = new TestServiceContext(LoggerFactory);
 
             var callOrder = new Stack<int>();
-            var onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var onCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async context =>
             {
                 context.Response.OnCompleted(_ =>
                 {
                     callOrder.Push(1);
-                    onCompletedTcs.SetResult(null);
+                    onCompletedTcs.SetResult();
                     return Task.CompletedTask;
                 }, null);
                 context.Response.OnCompleted(_ =>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
 
         private readonly ILogger _logger;
         private bool _isClosed;
-        private readonly TaskCompletionSource<object> _waitForCloseTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _waitForCloseTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public InMemoryTransportConnection(MemoryPool<byte> memoryPool, ILogger logger, PipeScheduler scheduler = null)
         {
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
             {
                 state._connectionClosedTokenSource.Cancel();
 
-                state._waitForCloseTcs.TrySetResult(null);
+                state._waitForCloseTcs.TrySetResult();
             },
             this,
             preferLocal: false);
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
             private class ObservablePipeReader : PipeReader
             {
                 private readonly PipeReader _reader;
-                private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                private readonly TaskCompletionSource _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 public Task WaitForReadTask => _tcs.Task;
 
@@ -164,9 +164,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
                 private class ObservableValueTask<T> : IValueTaskSource<T>
                 {
                     private readonly ValueTask<T> _task;
-                    private readonly TaskCompletionSource<object> _tcs;
+                    private readonly TaskCompletionSource _tcs;
 
-                    public ObservableValueTask(ValueTask<T> task, TaskCompletionSource<object> tcs)
+                    public ObservableValueTask(ValueTask<T> task, TaskCompletionSource tcs)
                     {
                         _task = task;
                         _tcs = tcs;
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
                     {
                         _task.GetAwaiter().UnsafeOnCompleted(() => continuation(state));
 
-                        _tcs.TrySetResult(null);
+                        _tcs.TrySetResult();
                     }
                 }
             }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task UpgradeCannotBeCalledMultipleTimes()
         {
-            var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var upgradeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             await using (var server = new TestServer(async context =>
             {
                 var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         public async Task RejectsUpgradeWhenLimitReached()
         {
             const int limit = 10;
-            var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var upgradeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var serviceContext = new TestServiceContext(LoggerFactory);
             serviceContext.ConnectionManager = new ConnectionManager(serviceContext.Log, ResourceCounter.Quota(limit));
 
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public async Task DoesNotThrowOnFin()
         {
-            var appCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using (var server = new TestServer(async context =>
             {
@@ -320,7 +320,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 try
                 {
                     await duplexStream.CopyToAsync(Stream.Null);
-                    appCompletedTcs.SetResult(null);
+                    appCompletedTcs.SetResult();
                 }
                 catch (Exception ex)
                 {

--- a/src/Shared/Buffers.MemoryPool/DiagnosticMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/DiagnosticMemoryPool.cs
@@ -24,7 +24,7 @@ namespace System.Buffers
 
         private readonly List<Exception> _blockAccessExceptions;
 
-        private readonly TaskCompletionSource<object> _allBlocksReturned;
+        private readonly TaskCompletionSource _allBlocksReturned;
 
         private int _totalBlocks;
 
@@ -40,7 +40,7 @@ namespace System.Buffers
             _rentTracking = rentTracking;
             _blocks = new HashSet<DiagnosticPoolBlock>();
             _syncObj = new object();
-            _allBlocksReturned = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _allBlocksReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _blockAccessExceptions = new List<Exception>();
         }
 
@@ -142,7 +142,7 @@ namespace System.Buffers
             }
             else
             {
-                _allBlocksReturned.SetResult(null);
+                _allBlocksReturned.SetResult();
             }
         }
 

--- a/src/Shared/Http2cat/Http2Utilities.cs
+++ b/src/Shared/Http2cat/Http2Utilities.cs
@@ -229,7 +229,6 @@ namespace Microsoft.AspNetCore.Http2Cat
         public Task StartStreamAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var frame = new Http2Frame();
             frame.PrepareHeaders(Http2HeadersFrameFlags.NONE, streamId);
@@ -328,7 +327,6 @@ namespace Microsoft.AspNetCore.Http2Cat
         public Task SendHeadersWithPaddingAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, byte padLength, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var frame = new Http2Frame();
 
@@ -369,7 +367,6 @@ namespace Microsoft.AspNetCore.Http2Cat
         public Task SendHeadersWithPriorityAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, byte priority, int streamDependency, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var frame = new Http2Frame();
             frame.PrepareHeaders(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.PRIORITY, streamId);
@@ -413,7 +410,6 @@ namespace Microsoft.AspNetCore.Http2Cat
         public Task SendHeadersWithPaddingAndPriorityAsync(int streamId, IEnumerable<KeyValuePair<string, string>> headers, byte padLength, byte priority, int streamDependency, bool endStream)
         {
             var writableBuffer = _pair.Application.Output;
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var frame = new Http2Frame();
             frame.PrepareHeaders(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.PADDED | Http2HeadersFrameFlags.PRIORITY, streamId);

--- a/src/Shared/SyncPoint/SyncPoint.cs
+++ b/src/Shared/SyncPoint/SyncPoint.cs
@@ -8,8 +8,8 @@ namespace Microsoft.AspNetCore.Internal
 {
     public class SyncPoint
     {
-        private readonly TaskCompletionSource<object> _atSyncPoint = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource<object> _continueFromSyncPoint = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _atSyncPoint = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _continueFromSyncPoint = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         /// <summary>
         /// Waits for the code-under-test to reach <see cref="WaitToContinue"/>.
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Internal
         /// <summary>
         /// Releases the code-under-test to continue past where it waited for <see cref="WaitToContinue"/>.
         /// </summary>
-        public void Continue() => _continueFromSyncPoint.TrySetResult(null);
+        public void Continue() => _continueFromSyncPoint.TrySetResult();
 
         /// <summary>
         /// Used by the code-under-test to wait for the test code to sync up.
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Internal
         /// <returns></returns>
         public Task WaitToContinue()
         {
-            _atSyncPoint.TrySetResult(null);
+            _atSyncPoint.TrySetResult();
             return _continueFromSyncPoint.Task;
         }
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 const string originalMessage = "SignalR";
 
                 var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory);
-                var restartTcs = new TaskCompletionSource<object>();
+                var restartTcs = new TaskCompletionSource();
                 connection.Closed += async e =>
                 {
                     try
@@ -327,7 +327,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                             logger.LogInformation("Restarting connection");
                             await connection.StartAsync().OrTimeout();
                             logger.LogInformation("Restarted connection");
-                            restartTcs.SetResult(null);
+                            restartTcs.SetResult();
                         }
                     }
                     catch (Exception ex)
@@ -716,7 +716,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var server = await StartServer<Startup>())
             {
                 var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory);
-                var closeTcs = new TaskCompletionSource<object>();
+                var closeTcs = new TaskCompletionSource();
                 connection.Closed += e =>
                 {
                     if (e != null)
@@ -725,7 +725,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     }
                     else
                     {
-                        closeTcs.SetResult(null);
+                        closeTcs.SetResult();
                     }
                     return Task.CompletedTask;
                 };
@@ -1881,12 +1881,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 try
                 {
                     var echoMessage = "test";
-                    var reconnectingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var reconnectingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var reconnectedTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     connection.Reconnecting += _ =>
                     {
-                        reconnectingTcs.SetResult(null);
+                        reconnectingTcs.SetResult();
                         return Task.CompletedTask;
                     };
 
@@ -1942,12 +1942,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 try
                 {
                     var echoMessage = "test";
-                    var reconnectingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var reconnectingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var reconnectedTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     connection.Reconnecting += _ =>
                     {
-                        reconnectingTcs.SetResult(null);
+                        reconnectingTcs.SetResult();
                         return Task.CompletedTask;
                     };
 
@@ -2008,12 +2008,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 try
                 {
                     var echoMessage = "test";
-                    var reconnectingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var reconnectingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var reconnectedTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     connection.Reconnecting += _ =>
                     {
-                        reconnectingTcs.SetResult(null);
+                        reconnectingTcs.SetResult();
                         return Task.CompletedTask;
                     };
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubProtocolVersionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubProtocolVersionTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                         DefaultTransferFormat = TransferFormat.Text
                     }),
                     LoggerFactory);
-                var tcs = new TaskCompletionSource<object>();
+                var tcs = new TaskCompletionSource();
 
                 var proxyConnectionFactory = new ProxyConnectionFactory(httpConnectionFactory);
 
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var connection = connectionBuilder.Build();
                 connection.On("NewProtocolMethodClient", () =>
                 {
-                    tcs.SetResult(null);
+                    tcs.SetResult();
                 });
 
                 try

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -358,7 +358,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 {
                     var httpHandler = new TestHttpMessageHandler();
 
-                    var connectResponseTcs = new TaskCompletionSource<object>();
+                    var connectResponseTcs = new TaskCompletionSource();
                     httpHandler.OnGet("/?id=00000000-0000-0000-0000-000000000000", async (_, __) =>
                     {
                         await connectResponseTcs.Task;
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             var startTask = connection.StartAsync();
                             Assert.False(connectResponseTcs.Task.IsCompleted);
                             Assert.False(startTask.IsCompleted);
-                            connectResponseTcs.TrySetResult(null);
+                            connectResponseTcs.TrySetResult();
                             await startTask.OrTimeout();
                         });
                 }

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.ConnectionLifecycle.cs
@@ -266,10 +266,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var testConnection = new TestConnection();
                 await AsyncUsing(CreateHubConnection(testConnection), async connection =>
                 {
-                    var closed = new TaskCompletionSource<object>();
+                    var closed = new TaskCompletionSource();
                     connection.Closed += exception =>
                     {
-                        closed.TrySetResult(null);
+                        closed.TrySetResult();
                         Assert.Equal(HubConnectionState.Disconnected, connection.State);
                         return Task.CompletedTask;
                     };
@@ -358,12 +358,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             public async Task CompletingTheTransportSideMarksConnectionAsClosed()
             {
                 var testConnection = new TestConnection();
-                var closed = new TaskCompletionSource<object>();
+                var closed = new TaskCompletionSource();
                 await AsyncUsing(CreateHubConnection(testConnection), async connection =>
                 {
                     connection.Closed += (e) =>
                     {
-                        closed.TrySetResult(null);
+                        closed.TrySetResult();
                         return Task.CompletedTask;
                     };
                     await connection.StartAsync().OrTimeout();
@@ -383,13 +383,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             public async Task TransportCompletionWhileShuttingDownIsNoOp()
             {
                 var testConnection = new TestConnection();
-                var testConnectionClosed = new TaskCompletionSource<object>();
-                var connectionClosed = new TaskCompletionSource<object>();
+                var connectionClosed = new TaskCompletionSource();
                 await AsyncUsing(CreateHubConnection(testConnection), async connection =>
                 {
                     connection.Closed += (e) =>
                     {
-                        connectionClosed.TrySetResult(null);
+                        connectionClosed.TrySetResult();
                         return Task.CompletedTask;
                     };
 
@@ -423,12 +422,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             public async Task StopAsyncDuringUnderlyingConnectionCloseWaitsAndNoOps()
             {
                 var testConnection = new TestConnection();
-                var connectionClosed = new TaskCompletionSource<object>();
+                var connectionClosed = new TaskCompletionSource();
                 await AsyncUsing(CreateHubConnection(testConnection), async connection =>
                 {
                     connection.Closed += (e) =>
                     {
-                        connectionClosed.TrySetResult(null);
+                        connectionClosed.TrySetResult();
                         return Task.CompletedTask;
                     };
 

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             writeContext.EventId.Name == "ReconnectingWithError");
                 }
 
-                var failReconnectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var failReconnectTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 using (StartVerifiableLog(ExpectedErrors))
                 {
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             writeContext.EventId.Name == "ReconnectingWithError");
                 }
 
-                var failReconnectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var failReconnectTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 using (StartVerifiableLog(ExpectedErrors))
                 {
@@ -378,13 +378,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             writeContext.EventId.Name == "ReconnectingWithError");
                 }
 
-                var failReconnectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-
                 using (StartVerifiableLog(ExpectedErrors))
                 {
                     var builder = new HubConnectionBuilder().WithLoggerFactory(LoggerFactory).WithUrl("http://example.com");
                     var testConnectionFactory = default(ReconnectingConnectionFactory);
-       
+
                     testConnectionFactory = new ReconnectingConnectionFactory(() => new TestConnection());
                     builder.Services.AddSingleton<IConnectionFactory>(testConnectionFactory);
 
@@ -464,13 +462,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             writeContext.EventId.Name == "ShutdownWithError");
                 }
 
-                var failReconnectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-
                 using (StartVerifiableLog(ExpectedErrors))
                 {
                     var builder = new HubConnectionBuilder().WithLoggerFactory(LoggerFactory).WithUrl("http://example.com");
                     var testConnectionFactory = default(ReconnectingConnectionFactory);
-       
+
                     testConnectionFactory = new ReconnectingConnectionFactory(() => new TestConnection());
                     builder.Services.AddSingleton<IConnectionFactory>(testConnectionFactory);
 
@@ -647,7 +643,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     builder.Services.AddSingleton<IConnectionFactory>(testConnectionFactory);
 
                     var retryContexts = new List<RetryContext>();
-                    var secondRetryDelayTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var secondRetryDelayTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var mockReconnectPolicy = new Mock<IRetryPolicy>();
                     mockReconnectPolicy.Setup(p => p.NextRetryDelay(It.IsAny<RetryContext>())).Returns<RetryContext>(context =>
                     {
@@ -655,7 +651,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                         if (retryContexts.Count == 2)
                         {
-                            secondRetryDelayTcs.SetResult(null);
+                            secondRetryDelayTcs.SetResult();
                         }
 
                         return TimeSpan.Zero;
@@ -754,7 +750,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     builder.Services.AddSingleton<IConnectionFactory>(testConnectionFactory);
 
                     var retryContexts = new List<RetryContext>();
-                    var secondRetryDelayTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var secondRetryDelayTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var mockReconnectPolicy = new Mock<IRetryPolicy>();
                     mockReconnectPolicy.Setup(p => p.NextRetryDelay(It.IsAny<RetryContext>())).Returns<RetryContext>(context =>
                     {
@@ -762,7 +758,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                         if (retryContexts.Count == 2)
                         {
-                            secondRetryDelayTcs.SetResult(null);
+                            secondRetryDelayTcs.SetResult();
                         }
 
                         return TimeSpan.Zero;
@@ -869,7 +865,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 using (StartVerifiableLog(ExpectedErrors))
                 {
                     var builder = new HubConnectionBuilder().WithLoggerFactory(LoggerFactory).WithUrl("http://example.com");
-                    var connectionStartTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var connectionStartTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     async Task OnTestConnectionStart()
                     {
@@ -879,7 +875,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         }
                         finally
                         {
-                            connectionStartTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                            connectionStartTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                         }
                     }
 
@@ -921,7 +917,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     };
 
                     // Allow the first connection to start successfully.
-                    connectionStartTcs.SetResult(null);
+                    connectionStartTcs.SetResult();
                     await hubConnection.StartAsync().OrTimeout();
 
                     var firstException = new Exception();
@@ -935,7 +931,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                     var secondException = new Exception();
                     var stopTask = hubConnection.StopAsync();
-                    connectionStartTcs.SetResult(null);
+                    connectionStartTcs.SetResult();
 
                     Assert.IsType<OperationCanceledException>(await closedErrorTcs.Task.OrTimeout());
                     Assert.Single(retryContexts);

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.cs
@@ -84,18 +84,18 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             var connection = new TestConnection();
             var hubConnection = CreateHubConnection(connection, loggerFactory: LoggerFactory);
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             hubConnection.On("method", async () =>
             {
                 await hubConnection.StopAsync().OrTimeout();
-                tcs.SetResult(null);
+                tcs.SetResult();
             });
 
             await hubConnection.StartAsync().OrTimeout();
 
             await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.InvocationMessageType, target= "method", arguments = new object[] { } }).OrTimeout();
 
-            Assert.Null(await tcs.Task.OrTimeout());
+            await tcs.Task.OrTimeout();
         }
 
         [Fact]
@@ -104,11 +104,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             var connection = new TestConnection();
             var hubConnection = CreateHubConnection(connection, loggerFactory: LoggerFactory);
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var methodCalledTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var methodCalledTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             hubConnection.On("method", async () =>
             {
-                methodCalledTcs.SetResult(null);
+                methodCalledTcs.SetResult();
                 await tcs.Task;
             });
 
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             await methodCalledTcs.Task.OrTimeout();
             await hubConnection.StopAsync().OrTimeout();
 
-            tcs.SetResult(null);
+            tcs.SetResult();
         }
 
         [Fact]
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var hubConnection = CreateHubConnection(connection, loggerFactory: LoggerFactory);
                 await hubConnection.StartAsync().OrTimeout();
 
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 hubConnection.On<string>("Echo", async msg =>
                 {
                     try
@@ -573,13 +573,13 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         return;
                     }
 
-                    tcs.SetResult(null);
+                    tcs.SetResult();
                 });
 
-                var closedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var closedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 hubConnection.Closed += _ =>
                 {
-                    closedTcs.SetResult(null);
+                    closedTcs.SetResult();
 
                     return Task.CompletedTask;
                 };

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/LongPollingTransportTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/LongPollingTransportTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task StopTransportWhenConnectionAlreadyStoppedOnServer()
         {
-            var pollRequestTcs = new TaskCompletionSource<object>();
+            var pollRequestTcs = new TaskCompletionSource();
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             var firstPoll = true;
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                     var stopTask = longPollingTransport.StopAsync();
 
-                    pollRequestTcs.SetResult(null);
+                    pollRequestTcs.SetResult();
 
                     await stopTask.OrTimeout();
                 }
@@ -520,7 +520,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             var sentRequests = new List<byte[]>();
             var pollTcs = new TaskCompletionSource<HttpResponseMessage>();
-            var deleteTcs = new TaskCompletionSource<object>();
+            var deleteTcs = new TaskCompletionSource();
             var firstPoll = true;
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -552,7 +552,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         // The poll task should have been completed
                         Assert.True(pollTcs.Task.IsCompleted);
 
-                        deleteTcs.TrySetResult(null);
+                        deleteTcs.TrySetResult();
 
                         return ResponseUtils.CreateResponse(HttpStatusCode.Accepted);
                     }
@@ -632,7 +632,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task LongPollingTransportRePollsIfRequestCanceled()
         {
             var numPolls = 0;
-            var completionTcs = new TaskCompletionSource<object>();
+            var completionTcs = new TaskCompletionSource();
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()
@@ -652,7 +652,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         throw new OperationCanceledException();
                     }
 
-                    completionTcs.SetResult(null);
+                    completionTcs.SetResult();
                     return ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
 

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/ServerSentEventsTransportTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/ServerSentEventsTransportTests.cs
@@ -25,8 +25,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task CanStartStopSSETransport()
         {
-            var eventStreamTcs = new TaskCompletionSource<object>();
-            var copyToAsyncTcs = new TaskCompletionSource<int>();
+            var eventStreamTcs = new TaskCompletionSource();
+            var copyToAsyncTcs = new TaskCompletionSource();
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 {
                     await Task.Yield();
                     // Receive loop started - allow stopping the transport
-                    eventStreamTcs.SetResult(null);
+                    eventStreamTcs.SetResult();
 
                     // returns unfinished task to block pipelines
                     var mockStream = new Mock<Stream>();
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
             finally
             {
-                copyToAsyncTcs.SetResult(0);
+                copyToAsyncTcs.SetResult();
             }
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                        writeContext.EventId.Name == "ErrorSending";
             }
 
-            var eventStreamTcs = new TaskCompletionSource<object>();
+            var eventStreamTcs = new TaskCompletionSource();
             var readTcs = new TaskCompletionSource<int>();
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     if (request.Headers.Accept?.Contains(new MediaTypeWithQualityHeaderValue("text/event-stream")) == true)
                     {
                         // Receive loop started - allow stopping the transport
-                        eventStreamTcs.SetResult(null);
+                        eventStreamTcs.SetResult();
 
                         // returns unfinished task to block pipelines
                         var mockStream = new Mock<Stream>();
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task SSETransportStopsIfChannelClosed()
         {
-            var eventStreamTcs = new TaskCompletionSource<object>();
+            var eventStreamTcs = new TaskCompletionSource();
             var readTcs = new TaskCompletionSource<int>();
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     await Task.Yield();
 
                     // Receive loop started - allow stopping the transport
-                    eventStreamTcs.SetResult(null);
+                    eventStreamTcs.SetResult();
 
                     // returns unfinished task to block pipelines
                     var mockStream = new Mock<Stream>();
@@ -299,8 +299,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task SSETransportCancelsSendOnStop()
         {
-            var eventStreamTcs = new TaskCompletionSource<object>();
-            var readTcs = new TaskCompletionSource<object>();
+            var eventStreamTcs = new TaskCompletionSource();
+            var readTcs = new TaskCompletionSource();
             var sendSyncPoint = new SyncPoint();
 
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     if (request.Headers.Accept?.Contains(new MediaTypeWithQualityHeaderValue("text/event-stream")) == true)
                     {
                         // Receive loop started - allow stopping the transport
-                        eventStreamTcs.SetResult(null);
+                        eventStreamTcs.SetResult();
 
                         // returns unfinished task to block pipelines
                         var mockStream = new Mock<Stream>();
@@ -351,7 +351,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                 var stopTask = sseTransport.StopAsync();
 
-                readTcs.SetResult(null);
+                readTcs.SetResult();
                 sendSyncPoint.Continue();
 
                 await stopTask;

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestConnection.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestConnection.cs
@@ -22,8 +22,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
     internal class TestConnection : ConnectionContext, IConnectionInherentKeepAliveFeature
     {
         private readonly bool _autoHandshake;
-        private readonly TaskCompletionSource<object> _started = new TaskCompletionSource<object>();
-        private readonly TaskCompletionSource<object> _disposed = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource _started = new TaskCompletionSource();
+        private readonly TaskCompletionSource _disposed = new TaskCompletionSource();
 
         private int _disposeCount = 0;
         public Task Started => _started.Task;
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
         public async ValueTask<ConnectionContext> StartAsync()
         {
-            _started.TrySetResult(null);
+            _started.TrySetResult();
 
             await _onStart();
 
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         private async ValueTask DisposeCoreAsync(Exception ex = null)
         {
             Interlocked.Increment(ref _disposeCount);
-            _disposed.TrySetResult(null);
+            _disposed.TrySetResult();
             await _onDispose();
 
             // Simulate HttpConnection's behavior by Completing the Transport pipe.

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestHttpMessageHandler.cs
@@ -111,8 +111,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deleteCts.Token);
 
                 // Just block until canceled
-                var tcs = new TaskCompletionSource<object>();
-                using (cts.Token.Register(() => tcs.TrySetResult(null)))
+                var tcs = new TaskCompletionSource();
+                using (cts.Token.Register(() => tcs.TrySetResult()))
                 {
                     await tcs.Task;
                 }

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TimerAwaitableTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [QuarantinedTest]
         public async Task FinalizerRunsIfTimerAwaitableReferencesObject()
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             UseTimerAwaitableAndUnref(tcs);
 
             GC.Collect();
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void UseTimerAwaitableAndUnref(TaskCompletionSource<object> tcs)
+        private void UseTimerAwaitableAndUnref(TaskCompletionSource tcs)
         {
             _ = new ObjectWithTimerAwaitable(tcs).Start();
         }
@@ -38,9 +38,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
     public class ObjectWithTimerAwaitable
     {
         private readonly TimerAwaitable _timer;
-        private readonly TaskCompletionSource<object> _tcs;
+        private readonly TaskCompletionSource _tcs;
 
-        public ObjectWithTimerAwaitable(TaskCompletionSource<object> tcs)
+        public ObjectWithTimerAwaitable(TaskCompletionSource tcs)
         {
             _tcs = tcs;
             _timer = new TimerAwaitable(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
         ~ObjectWithTimerAwaitable()
         {
-            _tcs.TrySetResult(null);
+            _tcs.TrySetResult();
         }
     }
 }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         // This tcs exists so that multiple calls to DisposeAsync all wait asynchronously
         // on the same task
-        private readonly TaskCompletionSource<object> _disposeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _disposeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         /// <summary>
         /// Creates the DefaultConnectionContext without Pipes to avoid upfront allocations.
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 }
 
                 // Notify all waiters that we're done disposing
-                _disposeTcs.TrySetResult(null);
+                _disposeTcs.TrySetResult();
             }
             catch (OperationCanceledException)
             {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 }
 
                 // Create a new Tcs every poll to keep track of the poll finishing, so we can properly wait on previous polls
-                var currentRequestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var currentRequestTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 if (!connection.TryActivateLongPollingConnection(
                         connectionDelegate, context, options.LongPolling.PollTimeout,
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 {
                     // Artificial task queue
                     // This will cause incoming polls to wait until the previous poll has finished updating internal state info
-                    currentRequestTcs.TrySetResult(null);
+                    currentRequestTcs.TrySetResult();
                 }
             }
         }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -94,11 +94,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     connection.TransportTask = Task.CompletedTask;
                 }
 
-                var applicationInputTcs = new TaskCompletionSource<object>();
-                var applicationOutputTcs = new TaskCompletionSource<object>();
-                var transportInputTcs = new TaskCompletionSource<object>();
-                var transportOutputTcs = new TaskCompletionSource<object>();
-
                 try
                 {
                     await connection.DisposeAsync(closeGracefully).OrTimeout();
@@ -269,7 +264,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
                 var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 connection.ApplicationTask = tcs.Task;
                 connection.TransportTask = tcs.Task;
@@ -279,7 +274,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 Assert.False(firstTask.IsCompleted);
                 Assert.False(secondTask.IsCompleted);
 
-                tcs.TrySetResult(null);
+                tcs.TrySetResult();
 
                 await Task.WhenAll(firstTask, secondTask).OrTimeout();
             }
@@ -292,7 +287,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
                 var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 connection.ApplicationTask = tcs.Task;
                 connection.TransportTask = tcs.Task;
@@ -319,7 +314,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
                 var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 connection.ApplicationTask = tcs.Task;
                 connection.TransportTask = tcs.Task;
@@ -376,7 +371,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var appLifetime = new TestApplicationLifetime();
                 var connectionManager = CreateConnectionManager(LoggerFactory, appLifetime);
-                var tcs = new TaskCompletionSource<object>();
 
                 appLifetime.Start();
 
@@ -398,7 +392,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 appLifetime.Start();
 
                 var connectionManager = CreateConnectionManager(LoggerFactory, appLifetime);
-                var tcs = new TaskCompletionSource<object>();
 
                 var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
 

--- a/src/SignalR/common/Http.Connections/test/TestWebSocketConnectionFeature.cs
+++ b/src/SignalR/common/Http.Connections/test/TestWebSocketConnectionFeature.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         private readonly SyncPoint _sync;
-        private readonly TaskCompletionSource<object> _accepted = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource _accepted = new TaskCompletionSource();
 
         public bool IsWebSocketRequest => true;
 
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             Client = clientSocket;
             SubProtocol = context.SubProtocol;
 
-            _accepted.TrySetResult(null);
+            _accepted.TrySetResult();
             return Task.FromResult<WebSocket>(serverSocket);
         }
 

--- a/src/SignalR/common/testassets/Tests.Utils/CancellationTokenExtensions.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/CancellationTokenExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
@@ -10,10 +10,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public static Task WaitForCancellationAsync(this CancellationToken token)
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             token.Register((t) =>
             {
-                ((TaskCompletionSource<object>)t).SetResult(null);
+                ((TaskCompletionSource)t).SetResult();
             }, tcs);
             return tcs.Task;
         }

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
 
         public class NoErrorHubConnectionContext : HubConnectionContext
         {
-            public TaskCompletionSource<object> ReceivedCompleted = new TaskCompletionSource<object>();
+            public TaskCompletionSource ReceivedCompleted = new TaskCompletionSource();
 
             public NoErrorHubConnectionContext(ConnectionContext connectionContext, HubConnectionContextOptions contextOptions, ILoggerFactory loggerFactory)
                 : base(connectionContext, contextOptions, loggerFactory)
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
                 if (message is CompletionMessage completionMessage)
                 {
-                    ReceivedCompleted.TrySetResult(null);
+                    ReceivedCompleted.TrySetResult();
 
                     if (!string.IsNullOrEmpty(completionMessage.Error))
                     {
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamChannelReaderCount", new object[] { 0 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamIAsyncEnumerableCount", new object[] { 0 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamIAsyncEnumerableCountCompletedTask", new object[] { 0 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamChannelReaderCount", new object[] { 1 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamIAsyncEnumerableCount", new object[] { 1 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -309,7 +309,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamIAsyncEnumerableCountCompletedTask", new object[] { 1 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamChannelReaderCount", new object[] { 1000 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -327,7 +327,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamIAsyncEnumerableCount", new object[] { 1000 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, new StreamInvocationMessage("123", "StreamIAsyncEnumerableCountCompletedTask", new object[] { 1000 }));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, CompletionMessage.Empty("1"));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -358,7 +358,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, CompletionMessage.Empty("1"));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, CompletionMessage.Empty("1"));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
 
         [Benchmark]
@@ -386,7 +386,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             await _dispatcher.DispatchMessageAsync(_connectionContext, CompletionMessage.Empty("1"));
 
             await (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted.Task;
-            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource<object>();
+            (_connectionContext as NoErrorHubConnectionContext).ReceivedCompleted = new TaskCompletionSource();
         }
     }
 }

--- a/src/SignalR/samples/JwtClientSample/Program.cs
+++ b/src/SignalR/samples/JwtClientSample/Program.cs
@@ -39,10 +39,10 @@ namespace JwtClientSample
                 })
                 .Build();
 
-            var closedTcs = new TaskCompletionSource<object>();
+            var closedTcs = new TaskCompletionSource();
             hubConnection.Closed += e =>
             {
-                closedTcs.SetResult(null);
+                closedTcs.SetResult();
                 return Task.CompletedTask;
             };
 

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.SignalR
         private readonly ConnectionContext _connectionContext;
         private readonly ILogger _logger;
         private readonly CancellationTokenSource _connectionAbortedTokenSource = new CancellationTokenSource();
-        private readonly TaskCompletionSource<object> _abortCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _abortCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly long _keepAliveInterval;
         private readonly long _clientTimeoutInterval;
         private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1);
@@ -640,7 +640,7 @@ namespace Microsoft.AspNetCore.SignalR
                 {
                     // Communicate the fact that we're finished triggering abort callbacks
                     // HubOnDisconnectedAsync is waiting on this to complete the Pipe
-                    connection._abortCompletedTcs.TrySetResult(null);
+                    connection._abortCompletedTcs.TrySetResult();
                 }
                 finally
                 {

--- a/src/SignalR/server/SignalR/test/DefaultHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/SignalR/test/DefaultHubLifetimeManagerTests.cs
@@ -39,10 +39,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.Equal("Hello", message.Target);
                 Assert.Single(message.Arguments);
                 Assert.Equal("World", (string)message.Arguments[0]);
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection2.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
                 Assert.False(connection1.ConnectionAborted.IsCancellationRequested);
@@ -65,10 +65,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.False(sendTask.IsCompleted);
                 cts.Cancel();
                 await sendTask.OrTimeout();
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection2.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
                 Assert.False(connection1.ConnectionAborted.IsCancellationRequested);
@@ -89,10 +89,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.False(sendTask.IsCompleted);
                 cts.Cancel();
                 await sendTask.OrTimeout();
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection1.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
             }
@@ -111,10 +111,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.False(sendTask.IsCompleted);
                 cts.Cancel();
                 await sendTask.OrTimeout();
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection1.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
             }
@@ -134,10 +134,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.False(sendTask.IsCompleted);
                 cts.Cancel();
                 await sendTask.OrTimeout();
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection1.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
             }
@@ -161,10 +161,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.False(sendTask.IsCompleted);
                 cts.Cancel();
                 await sendTask.OrTimeout();
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection2.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
                 Assert.False(connection1.ConnectionAborted.IsCancellationRequested);
@@ -186,10 +186,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.False(sendTask.IsCompleted);
                 cts.Cancel();
                 await sendTask.OrTimeout();
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection1.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
             }
@@ -215,10 +215,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.Equal("Hello", message.Target);
                 Assert.Single(message.Arguments);
                 Assert.Equal("World", (string)message.Arguments[0]);
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection2.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
                 Assert.False(connection1.ConnectionAborted.IsCancellationRequested);
@@ -245,10 +245,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 Assert.Equal("Hello", message.Target);
                 Assert.Single(message.Arguments);
                 Assert.Equal("World", (string)message.Arguments[0]);
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 connection2.ConnectionAborted.Register(t =>
                 {
-                    ((TaskCompletionSource<object>)t).SetResult(null);
+                    ((TaskCompletionSource)t).SetResult();
                 }, tcs);
                 await tcs.Task.OrTimeout();
                 Assert.False(connection1.ConnectionAborted.IsCancellationRequested);

--- a/src/SignalR/server/SignalR/test/EndToEndTests.cs
+++ b/src/SignalR/server/SignalR/test/EndToEndTests.cs
@@ -550,7 +550,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                         .Build();
                 try
                 {
-                    var closeTcs = new TaskCompletionSource<object>();
+                    var closeTcs = new TaskCompletionSource();
                     connection.Closed += e =>
                     {
                         if (e != null)
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                         }
                         else
                         {
-                            closeTcs.SetResult(null);
+                            closeTcs.SetResult();
                         }
                         return Task.CompletedTask;
                     };

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -510,7 +510,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public override Task OnConnectedAsync()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             tcs.SetException(new InvalidOperationException("Hub OnConnected failed."));
             return tcs.Task;
         }
@@ -520,7 +520,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public override Task OnDisconnectedAsync(Exception exception)
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             tcs.SetException(new InvalidOperationException("Hub OnDisconnected failed."));
             return tcs.Task;
         }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2823,13 +2823,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         internal class PipeReaderWrapper : PipeReader
         {
             private readonly PipeReader _originalPipeReader;
-            private TaskCompletionSource<object> _waitForRead;
+            private TaskCompletionSource _waitForRead;
             private object _lock = new object();
 
             public PipeReaderWrapper(PipeReader pipeReader)
             {
                 _originalPipeReader = pipeReader;
-                _waitForRead = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waitForRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
             public override void AdvanceTo(SequencePosition consumed) =>
@@ -2848,7 +2848,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 lock (_lock)
                 {
-                    _waitForRead.SetResult(null);
+                    _waitForRead.SetResult();
                 }
 
                 try
@@ -2859,7 +2859,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 {
                     lock (_lock)
                     {
-                        _waitForRead = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        _waitForRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     }
                 }
             }
@@ -4011,8 +4011,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             public int ReleaseCount;
             private IServiceProvider _serviceProvider;
-            public TaskCompletionSource<object> ReleaseTask = new TaskCompletionSource<object>();
-            public TaskCompletionSource<object> CreateTask = new TaskCompletionSource<object>();
+            public TaskCompletionSource ReleaseTask = new TaskCompletionSource();
+            public TaskCompletionSource CreateTask = new TaskCompletionSource();
 
             public CustomHubActivator(IServiceProvider serviceProvider)
             {
@@ -4021,9 +4021,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             public THub Create()
             {
-                ReleaseTask = new TaskCompletionSource<object>();
+                ReleaseTask = new TaskCompletionSource();
                 var hub = new DefaultHubActivator<THub>(_serviceProvider).Create();
-                CreateTask.TrySetResult(null);
+                CreateTask.TrySetResult();
                 return hub;
             }
 
@@ -4031,8 +4031,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 ReleaseCount++;
                 hub.Dispose();
-                ReleaseTask.TrySetResult(null);
-                CreateTask = new TaskCompletionSource<object>();
+                ReleaseTask.TrySetResult();
+                CreateTask = new TaskCompletionSource();
             }
         }
 

--- a/src/SignalR/server/SignalR/test/Internal/TypedClientBuilderTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/TypedClientBuilderTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Internal
 
             public Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken)
             {
-                var tcs = new TaskCompletionSource<object>();
+                var tcs = new TaskCompletionSource();
 
                 Sends.Add(new SendContext(method, args, cancellationToken, tcs));
 
@@ -246,13 +246,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Internal
 
         private struct SendContext
         {
-            private TaskCompletionSource<object> _tcs;
+            private TaskCompletionSource _tcs;
 
             public string Method { get; }
             public object[] Arguments { get; }
             public CancellationToken CancellationToken { get; }
 
-            public SendContext(string method, object[] arguments, CancellationToken cancellationToken, TaskCompletionSource<object> tcs) : this()
+            public SendContext(string method, object[] arguments, CancellationToken cancellationToken, TaskCompletionSource tcs) : this()
             {
                 Method = method;
                 Arguments = arguments;
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Internal
 
             public void Complete()
             {
-                _tcs.TrySetResult(null);
+                _tcs.TrySetResult();
             }
         }
     }

--- a/src/SignalR/server/StackExchangeRedis/src/Internal/AckHandler.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/AckHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal
         {
             if (_acks.TryRemove(id, out var ack))
             {
-                ack.Tcs.TrySetResult(null);
+                ack.Tcs.TrySetResult();
             }
         }
 
@@ -104,13 +104,13 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal
 
         private class AckInfo
         {
-            public TaskCompletionSource<object> Tcs { get; private set; }
+            public TaskCompletionSource Tcs { get; private set; }
             public DateTime Created { get; private set; }
 
             public AckInfo()
             {
                 Created = DateTime.UtcNow;
-                Tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                Tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }
     }


### PR DESCRIPTION
Yay new type 😄 
