### PR TITLE
Fix xmldoc typo

### DIFF
--- a/src/Components/WebAssembly/Server/src/WebAssemblyNetDebugProxyAppBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/WebAssemblyNetDebugProxyAppBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Builder
     public static class WebAssemblyNetDebugProxyAppBuilderExtensions
     {
         /// <summary>
-        /// Adds middleware for needed for debugging Blazor WebAssembly applications
+        /// Adds middleware needed for debugging Blazor WebAssembly applications
         /// inside Chromium dev tools.
         /// </summary>
         public static void UseWebAssemblyDebugging(this IApplicationBuilder app)


### PR DESCRIPTION
Just removed 'for'  in

> Adds middleware _for_ needed for debugging Blazor WebAssembly applications