### PR TITLE
BDN workaround for netcoreapp5.0->net5.0 moniker rebranding

### DIFF
--- a/src/Shared/BenchmarkRunner/Program.cs
+++ b/src/Shared/BenchmarkRunner/Program.cs
@@ -9,7 +9,10 @@ using System.Reflection;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.CsProj;
+using BenchmarkDotNet.Toolchains.DotNetCli;
 
 namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
 {
@@ -26,7 +29,7 @@ namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
 
             AssignConfiguration(ref args);
             var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly)
-                .Run(args, ManualConfig.CreateEmpty());
+                .Run(args, GetConfig());
 
             foreach (var summary in summaries)
             {
@@ -55,6 +58,24 @@ namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
             }
 
             return 0;
+        }
+
+        private static IConfig GetConfig()
+        {
+#if NET5_0 || NETCOREAPP5_0
+            return ManualConfig.CreateEmpty()
+                .AddJob(Job.Default
+                    .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings
+                    (
+                        // not using "net5.0", a workaround for https://github.com/dotnet/BenchmarkDotNet/pull/1479
+                        targetFrameworkMoniker: "netcoreapp5.0",
+                        runtimeFrameworkVersion: default,
+                        name: ".NET Core 5.0"
+                    )))
+                    .AsDefault());
+#else
+            return ManualConfig.CreateEmpty();
+#endif
         }
 
         private static int Fail(object o, string message)


### PR DESCRIPTION
A workaround for BDN bug caused by netcoreapp5.0->net5.0 moniker rebranding

The proper fix is available at: https://github.com/dotnet/BenchmarkDotNet/pull/1479 but before we ship new BDN version to NuGet.org (most probably a matter of months) you can use this workaround.

@JamesNK 

Fixes https://github.com/dotnet/aspnetcore/issues/22915