### PR TITLE
Add test for root domains not included in CORS subdomain wildcards

### DIFF
--- a/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsPolicyBuilderTests.cs
@@ -206,6 +206,20 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         }
 
         [Fact]
+        public void SetIsOriginAllowedToAllowWildcardSubdomains_DoesNotAllowRootDomain()
+        {
+            // Arrange
+            var builder = new CorsPolicyBuilder("http://*.example.com");
+
+            // Act
+            builder.SetIsOriginAllowedToAllowWildcardSubdomains();
+
+            // Assert
+            var corsPolicy = builder.Build();
+            Assert.False(corsPolicy.IsOriginAllowed("http://example.com"));
+        }
+
+        [Fact]
         public void WithMethods_AddsMethods()
         {
             // Arrange


### PR DESCRIPTION
This test makes it clear root domains are not included in CORS subdomain wildcards.