### PR TITLE
Increase timeouts for full helix matrix runs

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -23,7 +23,7 @@ jobs:
     jobName: Helix_matrix_x64
     jobDisplayName: 'Tests: Helix full matrix x64'
     agentOs: Windows
-    timeoutInMinutes: 240
+    timeoutInMinutes: 480
     steps:
     # Build the shared framework
     - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
@@ -48,7 +48,7 @@ jobs:
     jobName: Helix_matrix_arm64
     jobDisplayName: "Tests: Helix ARM64 matrix"
     agentOs: Linux
-    timeoutInMinutes: 180
+    timeoutInMinutes: 480
     steps:
     - script: ./restore.sh -ci -nobl
       displayName: Restore


### PR DESCRIPTION
We only run these every 12 hours on master, and sometimes the queues take > 4 hours to run
