### PR TITLE
Quarantine failing E2E circuit test

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.E2ETesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
@@ -77,6 +78,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23015")]
         public async Task ClosingTheBrowserWindow_GracefullyDisconnects_WhenNavigatingAwayFromThePage()
         {
             // Arrange & Act


### PR DESCRIPTION
Test failure occurred in https://github.com/dotnet/aspnetcore/pull/23011/checks?check_run_id=777676515.