### PR TITLE
Fix path for artifacts in SignalR tests

### DIFF
--- a/.azure/pipelines/signalr-daily-tests.yml
+++ b/.azure/pipelines/signalr-daily-tests.yml
@@ -16,5 +16,5 @@ jobs:
     jobDisplayName: "SignalR Daily Tests"
     artifacts:
     - name: Windows_Logs
-      path: ./artifacts/log/
+      path: artifacts/log/
       publishOnError: true

--- a/.azure/pipelines/signalr-daily-tests.yml
+++ b/.azure/pipelines/signalr-daily-tests.yml
@@ -16,5 +16,5 @@ jobs:
     jobDisplayName: "SignalR Daily Tests"
     artifacts:
     - name: Windows_Logs
-      path: ../../artifacts/log/
+      path: ./artifacts/log/
       publishOnError: true


### PR DESCRIPTION
During the publishing phase of the SignalR tests, the build looks for the published artifacts in the incorrect directory.

**Ref:** https://dev.azure.com/dnceng/internal/_build/results?buildId=691106&view=logs&j=a7124730-cbd2-5a4d-e6a2-4b7337d9a2cd&t=aa0e6a39-56c7-5d46-3f11-aa51ba6d291c