### PR TITLE
Fix build issues in Blazor WASM template tests

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -39,6 +39,9 @@
     <ProjectReference Include="$(RepoRoot)src\Hosting\Server.IntegrationTesting\src\Microsoft.AspNetCore.Server.IntegrationTesting.csproj" />
     <ProjectReference Include="../testassets/DotNetToolsInstaller/DotNetToolsInstaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(RepoRoot)src\Razor\Microsoft.NET.Sdk.Razor\src\Microsoft.NET.Sdk.Razor.csproj"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -42,6 +42,9 @@
     <ProjectReference Include="../Web.ItemTemplates/Microsoft.DotNet.Web.ItemTemplates.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../Web.Spa.ProjectTemplates/Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(RepoRoot)src\Razor\Microsoft.NET.Sdk.Razor\src\Microsoft.NET.Sdk.Razor.csproj"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Currently, all the Blazor WASM template tests are failing because they are unable to find tasks in assemblies that do not exist.

```
F:\workspace\_work\1\s\.dotnet\sdk\5.0.100-preview.6.20266.3\MSBuild.dll -maxcpucount -property:Configuration=Release -target:Publish -verbosity:m /bl .\AspNet.blazorserverindividual.sbmuheoguk4.csproj
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
F:\workspace\_work\1\s\src\Razor\Microsoft.NET.Sdk.Razor\src\build\netstandard2.0\Microsoft.NET.Sdk.Razor.MvcApplicationPartsDiscovery.targets(54,5): error MSB4062: The "Microsoft.AspNetCore.Razor.Tasks.FindAssembliesWithReferencesTo" task could not be loaded from the assembly F:\workspace\_work\1\s\src\Razor\Microsoft.NET.Sdk.Razor\src\build\netstandard2.0\..\..\tasks\net5.0\Microsoft.NET.Sdk.Razor.Tasks.dll. Could not load file or assembly 'F:\workspace\_work\1\s\src\Razor\Microsoft.NET.Sdk.Razor\src\tasks\net5.0\Microsoft.NET.Sdk.Razor.Tasks.dll'. The system cannot find the path specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. [F:\workspace\_work\1\s\src\ProjectTemplates\BlazorTemplates.Tests\bin\Release\net5.0\TestTemplates\AspNet.blazorserverindividual.sbmuheoguk4\AspNet.blazorserverindividual.sbmuheoguk4.csproj]
```

This is an attempt to fix this by adding a project reference to the Razor SDK so we ensure the assemblies are built before they are referenced.
