### PR TITLE
Remove tests from official builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -246,7 +246,7 @@ stages:
   - template: jobs/default-build.yml
     parameters:
       codeSign: true
-      jobName: Windows_64_build
+      jobName: Windows_arm64_build
       jobDisplayName: "Build: Windows ARM64"
       agentOs: Windows
       buildArgs:
@@ -676,7 +676,7 @@ stages:
         dependsOn:
           - Windows_build
           - Windows_arm_build
-          - Windows_64_build
+          - Windows_arm64_build
           - CodeSign_Xplat_MacOS_x64
           - CodeSign_Xplat_Linux_x64
           - CodeSign_Xplat_Linux_arm

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -492,132 +492,133 @@ stages:
     parameters:
       inputName: Linux_musl_arm64
 
-  # Test jobs
-  - template: jobs/default-build.yml
-    parameters:
-      condition: ne(variables['SkipTests'], 'true')
-      jobName: Windows_Test
-      jobDisplayName: "Test: Windows Server 2016 x64"
-      agentOs: Windows
-      isTestingJob: true
-      buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
-                 /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
-                 $(_InternalRuntimeDownloadArgs)
-      beforeBuild:
-      - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
-        displayName: Setup IISExpress test certificates and schema
-      artifacts:
-      - name: Windows_Test_Dumps
-        path: artifacts/dumps/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_Test_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_Test_Results
-        path: artifacts/TestResults/
-        publishOnError: true
-        includeForks: true
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+    # Test jobs
+    - template: jobs/default-build.yml
+      parameters:
+        condition: ne(variables['SkipTests'], 'true')
+        jobName: Windows_Test
+        jobDisplayName: "Test: Windows Server 2016 x64"
+        agentOs: Windows
+        isTestingJob: true
+        buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
+                   /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
+                   $(_InternalRuntimeDownloadArgs)
+        beforeBuild:
+        - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
+          displayName: Setup IISExpress test certificates and schema
+        artifacts:
+        - name: Windows_Test_Dumps
+          path: artifacts/dumps/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Test_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Test_Results
+          path: artifacts/TestResults/
+          publishOnError: true
+          includeForks: true
 
-  - template: jobs/default-build.yml
-    parameters:
-      condition: ne(variables['SkipTests'], 'true')
-      jobName: Windows_Templates_Test
-      jobDisplayName: "Test: Templates - Windows Server 2016 x64"
-      agentOs: Windows
-      isTestingJob: true
-      steps:
-      - script: ./build.cmd -ci -nobl -all -pack $(_InternalRuntimeDownloadArgs)
-        displayName: Build Repo
-      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -pack -NoRestore -noBuildNative -NoBuilddeps "/p:RunTemplateTests=true"
-        displayName: Pack Templates
-      - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
-        displayName: Test Templates
-      artifacts:
-      - name: Windows_Test_Templates_Dumps
-        path: artifacts/dumps/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_Test_Templates_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_Test_Templates_Results
-        path: artifacts/TestResults/
-        publishOnError: true
-        includeForks: true
+    - template: jobs/default-build.yml
+      parameters:
+        condition: ne(variables['SkipTests'], 'true')
+        jobName: Windows_Templates_Test
+        jobDisplayName: "Test: Templates - Windows Server 2016 x64"
+        agentOs: Windows
+        isTestingJob: true
+        steps:
+        - script: ./build.cmd -ci -nobl -all -pack $(_InternalRuntimeDownloadArgs)
+          displayName: Build Repo
+        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -pack -NoRestore -noBuildNative -NoBuilddeps "/p:RunTemplateTests=true"
+          displayName: Pack Templates
+        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
+          displayName: Test Templates
+        artifacts:
+        - name: Windows_Test_Templates_Dumps
+          path: artifacts/dumps/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Test_Templates_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Test_Templates_Results
+          path: artifacts/TestResults/
+          publishOnError: true
+          includeForks: true
 
-  - template: jobs/default-build.yml
-    parameters:
-      condition: ne(variables['SkipTests'], 'true')
-      jobName: MacOS_Test
-      jobDisplayName: "Test: macOS 10.14"
-      agentOs: macOS
-      isTestingJob: true
-      buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
-      beforeBuild:
-      - bash: "./eng/scripts/install-nginx-mac.sh"
-        displayName: Installing Nginx
-      artifacts:
-      - name: MacOS_Test_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: MacOS_Test_Results
-        path: artifacts/TestResults/
-        publishOnError: true
-        includeForks: true
+    - template: jobs/default-build.yml
+      parameters:
+        condition: ne(variables['SkipTests'], 'true')
+        jobName: MacOS_Test
+        jobDisplayName: "Test: macOS 10.14"
+        agentOs: macOS
+        isTestingJob: true
+        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+        beforeBuild:
+        - bash: "./eng/scripts/install-nginx-mac.sh"
+          displayName: Installing Nginx
+        artifacts:
+        - name: MacOS_Test_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: MacOS_Test_Results
+          path: artifacts/TestResults/
+          publishOnError: true
+          includeForks: true
 
-  - template: jobs/default-build.yml
-    parameters:
-      condition: ne(variables['SkipTests'], 'true')
-      jobName: Linux_Test
-      jobDisplayName: "Test: Ubuntu 16.04 x64"
-      agentOs: Linux
-      isTestingJob: true
-      useHostedUbuntu: false
-      buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
-      beforeBuild:
-      - bash: "./eng/scripts/install-nginx-linux.sh"
-        displayName: Installing Nginx
-      - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
-        displayName: Increase inotify limit
-      artifacts:
-      - name: Linux_Test_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_Test_Results
-        path: artifacts/TestResults/
-        publishOnError: true
-        includeForks: true
+    - template: jobs/default-build.yml
+      parameters:
+        condition: ne(variables['SkipTests'], 'true')
+        jobName: Linux_Test
+        jobDisplayName: "Test: Ubuntu 16.04 x64"
+        agentOs: Linux
+        isTestingJob: true
+        useHostedUbuntu: false
+        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+        beforeBuild:
+        - bash: "./eng/scripts/install-nginx-linux.sh"
+          displayName: Installing Nginx
+        - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
+          displayName: Increase inotify limit
+        artifacts:
+        - name: Linux_Test_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_Test_Results
+          path: artifacts/TestResults/
+          publishOnError: true
+          includeForks: true
 
-  # Helix x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Helix_x64
-      jobDisplayName: 'Tests: Helix x64'
-      agentOs: Windows
-      timeoutInMinutes: 180
-      steps:
-      # Build the shared framework
-      - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-        displayName: Build shared fx
-      - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
-        displayName: Restore interop projects
-      - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
-                /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
-                /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-        displayName: Run build.cmd helix target
-        env:
-          HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-      artifacts:
-      - name: Helix_logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
+    # Helix x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Helix_x64
+        jobDisplayName: 'Tests: Helix x64'
+        agentOs: Windows
+        timeoutInMinutes: 180
+        steps:
+        # Build the shared framework
+        - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+          displayName: Build shared fx
+        - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
+          displayName: Restore interop projects
+        - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
+                  /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
+                  /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+          displayName: Run build.cmd helix target
+          env:
+            HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+        artifacts:
+        - name: Helix_logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
 
   # Source build
   - job: Source_Build
@@ -675,6 +676,7 @@ stages:
         dependsOn:
           - Windows_build
           - Windows_arm_build
+          - Windows_64_build
           - CodeSign_Xplat_MacOS_x64
           - CodeSign_Xplat_Linux_x64
           - CodeSign_Xplat_Linux_arm
@@ -682,11 +684,7 @@ stages:
           - CodeSign_Xplat_Linux_musl_x64
           - CodeSign_Xplat_Linux_musl_arm64
           # In addition to the dependencies above, ensure the build was successful overall.
-          - Linux_Test
-          - MacOS_Test
           - Source_Build
-          - Windows_Templates_Test
-          - Windows_Test
         pool:
           vmImage: vs2017-win2016
         publishUsingPipelines: ${{ variables._PublishUsingPipelines }}


### PR DESCRIPTION
- #22787

nit: _add_ dependency on Windows ARM64 build when publishing to the BAR
    - not a major problem because this particular build rarely if ever fails
    - the existence of the correct manifests is much more important