### PR TITLE
Fix Kestrel HTTP/2 debug assert failure

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -39,13 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        protected override void OnDataRead(long bytesRead)
-        {
-            // The HTTP/2 flow control window cannot be larger than 2^31-1 which limits bytesRead.
-            _context.OnDataRead((int)bytesRead);
-            AddAndCheckConsumedBytes(bytesRead);
-        }
-
         public override void Reset()
         {
             base.Reset();
@@ -59,9 +52,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
         {
+            var newlyExaminedBytes = TrackConsumedAndExaminedBytes(_readResult, consumed, examined);
+
             // Ensure we consume data from the RequestBodyPipe before sending WINDOW_UPDATES to the client.
             _context.RequestBodyPipe.Reader.AdvanceTo(consumed, examined);
-            OnAdvance(_readResult, consumed, examined);
+
+            // The HTTP/2 flow control window cannot be larger than 2^31-1 which limits bytesRead.
+            _context.OnDataRead((int)newlyExaminedBytes);
+            AddAndCheckObservedBytes(newlyExaminedBytes);
         }
 
         public override bool TryRead(out ReadResult readResult)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -59,8 +59,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
         {
-            OnAdvance(_readResult, consumed, examined);
+            // Ensure we consume data from the RequestBodyPipe before sending WINDOW_UPDATES to the client.
             _context.RequestBodyPipe.Reader.AdvanceTo(consumed, examined);
+            OnAdvance(_readResult, consumed, examined);
         }
 
         public override bool TryRead(out ReadResult readResult)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -446,7 +446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                             var flushTask = RequestBodyPipe.Writer.FlushAsync();
                             // It shouldn't be possible for the RequestBodyPipe to fill up an return an incomplete task if
                             // _inputFlowControl.Advance() didn't throw.
-                            Debug.Assert(flushTask.IsCompleted);
+                            Debug.Assert(flushTask.IsCompletedSuccessfully);
                         }
                     }
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
@@ -33,11 +33,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
         }
 
-        protected override void OnDataRead(long bytesRead)
-        {
-            AddAndCheckConsumedBytes(bytesRead);
-        }
-
         public static MessageBody For(Http3Stream context)
         {
             return new Http3MessageBody(context);
@@ -50,8 +45,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
         {
-            OnAdvance(_readResult, consumed, examined);
+            var newlyExaminedBytes = TrackConsumedAndExaminedBytes(_readResult, consumed, examined);
+
             _context.RequestBodyPipe.Reader.AdvanceTo(consumed, examined);
+
+            AddAndCheckObservedBytes(newlyExaminedBytes);
         }
 
         public override bool TryRead(out ReadResult readResult)


### PR DESCRIPTION
- Due to flow control, here should always be "room" in the HTTP/2
  RequestBodyPipe to flush without back pressure.
- We have an assert verifying this, but it's failing.
- My assumption is this assert is failing becausue we are triggering a
  WINDOW_UPDATE before advancing RequestBodyPipe.Reader.

Addresses #23058