### PR TITLE
Fix AzureAd options validation

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOpenIdConnectOptionsConfiguration.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/AzureADOpenIdConnectOptionsConfiguration.cs
@@ -21,6 +21,11 @@ namespace Microsoft.AspNetCore.Authentication.AzureAD.UI
         public void Configure(string name, OpenIdConnectOptions options)
         {
             var azureADScheme = GetAzureADScheme(name);
+            if (azureADScheme is null)
+            {
+                return;
+            }
+
             var azureADOptions = _azureADOptions.Get(azureADScheme);
             if (name != azureADOptions.OpenIdConnectSchemeName)
             {

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/test/AzureADAuthenticationBuilderExtensionsTests.cs
@@ -485,5 +485,25 @@ namespace Microsoft.AspNetCore.Authentication
 
             Assert.NotNull(jwtOptions.Get("other"));
         }
+
+        [Fact]
+        public void AddAzureAD_SkipsOptionsValidationForNonAzureOpenIdConnect()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILoggerFactory>(new NullLoggerFactory());
+
+            services.AddAuthentication()
+                .AddAzureAD(o => { })
+                .AddOpenIdConnect("other", null, o =>
+                {
+                    o.ClientId = "ClientId";
+                    o.Authority = "https://authority.com";
+                });
+
+            var provider = services.BuildServiceProvider();
+            var openIdConnectOptions = provider.GetService<IOptionsMonitor<OpenIdConnectOptions>>();
+
+            Assert.NotNull(openIdConnectOptions.Get("other"));
+        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/20136

## Description
Originally #9967 added options validation for AzureAd auth options, but it introduced a regression where it would throw for other cookie or jwt auth providers.
https://github.com/dotnet/aspnetcore/pull/13480 fixed this for jwt and cookies auth but the issue also affects OIDC auth. This PR applies the same fix to OIDC auth.

## Customer Impact
Customers may not be able to use AzureAd auth combine with other kinds of auth in one app.

## Regression?
Yes this is a regression in 3.1

## Risk
Low, just adding a null check.