### PR TITLE
[Blazor] Bump Mono.Cecil to use embedded portable pdb

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -221,7 +221,7 @@
     <IdentityServer4EntityFrameworkStoragePackageVersion>3.0.0</IdentityServer4EntityFrameworkStoragePackageVersion>
     <MessagePackPackageVersion>2.1.90</MessagePackPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
-    <MonoCecilPackageVersion>0.10.1</MonoCecilPackageVersion>
+    <MonoCecilPackageVersion>0.11.2</MonoCecilPackageVersion>
     <NewtonsoftJsonBsonPackageVersion>1.0.2</NewtonsoftJsonBsonPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <!-- Begin: STOP!!! Razor need to reference the version of JSON that our HOSTS support. -->


### PR DESCRIPTION
- Bump Mono.Cecil to use embedded portable pdb.
- I was investigating why it was not possible to debug Vb.Net sources as was described in this issue: https://developercommunity.visualstudio.com/idea/468570/support-vbnet-in-aspnet-core-30-and-blazor.html?childToView=1075184#comment-1075184, but yes it's working, unless it's using an embedded portable pdb, in this case it doesn't work neither for C# nor for VB.Net. 


