### PR TITLE
Fix HeaderSegmentCollection when value has a trailing space (#21556)

### DIFF
--- a/src/Http/Http.Abstractions/src/Internal/HeaderSegmentCollection.cs
+++ b/src/Http/Http.Abstractions/src/Internal/HeaderSegmentCollection.cs
@@ -254,6 +254,11 @@ namespace Microsoft.AspNetCore.Http
                                 switch (attr)
                                 {
                                     case Attr.Delimiter:
+                                        if (ch == (char)0)
+                                        {
+                                            _valueEnd = _offset;
+                                            _trailingStart = _offset;
+                                        }
                                         _mode = Mode.Produce;
                                         break;
                                     case Attr.Quote:

--- a/src/Http/Http/test/HeaderDictionaryTests.cs
+++ b/src/Http/Http/test/HeaderDictionaryTests.cs
@@ -103,5 +103,18 @@ namespace Microsoft.AspNetCore.Http
             Assert.Throws<InvalidOperationException>(() => headers.Remove(new KeyValuePair<string, StringValues>("header1", "value1")));
             Assert.Throws<InvalidOperationException>(() => headers.Remove("header1"));
         }
+
+        [Fact]
+        public void GetCommaSeparatedValues_WorksForUnquotedHeaderValuesEndingWithSpace()
+        {
+            var headers = new HeaderDictionary
+            {
+                { "Via", "value " },
+            };
+
+            var result = headers.GetCommaSeparatedValues("Via");
+
+            Assert.Equal(new[]{"value "}, result);
+        }
     }
 }


### PR DESCRIPTION
Fixes #21556 