### PR TITLE
Remove QueuePolicy locks

### DIFF
--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterMiddleware.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
                 LoggerMessage.Define<int>(LogLevel.Debug, new EventId(3, "RequestRunImmediately"), "Below MaxConcurrentRequests limit, running request immediately. Current active requests: {ActiveRequests}");
 
             private static readonly Action<ILogger, Exception> _requestRejectedQueueFull =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(4, "RequestRejectedQueueFull"), "Currently at the 'RequestQueueLimit', rejecting this request with a '503 server not availible' error");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(4, "RequestRejectedQueueFull"), "Currently at the 'RequestQueueLimit', rejecting this request with a '503 server not available' error");
 
             internal static void RequestEnqueued(ILogger logger, int activeRequests)
             {

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
         private readonly int _maxTotalRequest;
         private readonly SemaphoreSlim _serverSemaphore;
 
-        private object _totalRequestsLock = new object();
+        private readonly object _totalRequestsLock = new object();
 
         private int _totalRequests;
 

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
@@ -69,10 +69,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
         {
             _serverSemaphore.Release();
 
-            lock (_totalRequestsLock)
-            {
-                _totalRequests--;
-            }
+            Interlocked.Decrement(ref _totalRequests);
         }
 
         public void Dispose()

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicy.cs
@@ -15,7 +15,9 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 
         private object _totalRequestsLock = new object();
 
-        public int TotalRequests { get; private set; }
+        private int _totalRequests;
+
+        public int TotalRequests => _totalRequests;
 
         public QueuePolicy(IOptions<QueuePolicyOptions> options)
         {
@@ -46,12 +48,12 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 
             lock (_totalRequestsLock)
             {
-                if (TotalRequests >= _maxTotalRequest)
+                if (_totalRequests >= _maxTotalRequest)
                 {
                     return new ValueTask<bool>(false);
                 }
 
-                TotalRequests++;
+                _totalRequests++;
             }
 
             Task task = _serverSemaphore.WaitAsync();
@@ -69,7 +71,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
 
             lock (_totalRequestsLock)
             {
-                TotalRequests--;
+                _totalRequests--;
             }
         }
 

--- a/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicyOptions.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/QueuePolicies/QueuePolicyOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
         public int MaxConcurrentRequests { get; set; }
 
         /// <summary>
-        /// Maximum number of queued requests before the server starts rejecting connections with '503 Service Unavailible'.
+        /// Maximum number of queued requests before the server starts rejecting connections with '503 Service Unavailable'.
         /// This option is highly application dependant, and must be configured by the application.
         /// </summary>
         public int RequestQueueLimit { get; set; }

--- a/src/Middleware/ConcurrencyLimiter/test/PolicyTests/QueuePolicyTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/PolicyTests/QueuePolicyTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests.PolicyTests
     public class QueuePolicyTests
     {
         [Fact]
-        public void DoesNotWaitIfSpaceAvailible()
+        public void DoesNotWaitIfSpaceAvailable()
         {
             using var s = TestUtils.CreateQueuePolicy(2);
 
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests.PolicyTests
         }
 
         [Fact]
-        public async Task WaitsIfNoSpaceAvailible()
+        public async Task WaitsIfNoSpaceAvailable()
         {
             using var s = TestUtils.CreateQueuePolicy(1);
             Assert.True(await s.TryEnterAsync().OrTimeout());

--- a/src/Middleware/ConcurrencyLimiter/test/PolicyTests/QueuePolicyTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/PolicyTests/QueuePolicyTests.cs
@@ -37,6 +37,27 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests.PolicyTests
         }
 
         [Fact]
+        public void DoesNotWaitIfQueueFull()
+        {
+            using var s = TestUtils.CreateQueuePolicy(2, 1);
+
+            var t1 = s.TryEnterAsync();
+            Assert.True(t1.IsCompleted);
+            Assert.True(t1.Result);
+
+            var t2 = s.TryEnterAsync();
+            Assert.True(t2.IsCompleted);
+            Assert.True(t2.Result);
+
+            var t3 = s.TryEnterAsync();
+            Assert.False(t3.IsCompleted);
+
+            var t4 = s.TryEnterAsync();
+            Assert.True(t4.IsCompleted);
+            Assert.False(t4.Result);
+        }
+
+        [Fact]
         public async Task IsEncapsulated()
         {
             using var s1 = TestUtils.CreateQueuePolicy(1);


### PR DESCRIPTION
This PR removes the two locks from `QueuePolicy` and replaces them with calls to `Interlocked.Increment(ref int)`/`Interlocked.Decrement(ref int)` and changing the property to use a field.

In the case where the request queue is full, the benefit of the removal of the lock for normal operation is offset by the need to call `Interlocked.Decrement()` to revert the increment.

Also:
  * Fixes a few typos of _"availible"_ to _"available"_.
  * Adds a unit test to verify the Semaphore isn't awaited if the request queue is already full.

## Benchmarks

Running the microbenchmarks on my laptop gives the following results (full benchmarks below):

| Method | Mean Before | Mean After | Allocs Before | Allocs After |
|--:|--:|--:|--:|--:|
| `WithEmptyQueueOverhead_QueuePolicy(false)` | 86.603 ns | 65.841 ns | - | - |
| `WithEmptyQueueOverhead_QueuePolicy(true)` | 1,186.089 ns | 1,185.132 ns | 280 B | 279 B |
| `QueueingAll_QueuePolicy` | 1.218 μs | 1.133 μs | 276 B | 272 B |
| `RejectingRapidly_QueuePolicy` | 1.247 μs | 1.311 μs | 1079 B | 1080 B |

### Before

<details>

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.31802, CoreFX 5.0.20.31802), X64 RyuJIT
  Job-UOQSZQ : .NET Core 5.0.0 (CoreCLR 5.0.20.26401, CoreFX 5.0.20.26401), X64 RyuJIT

Server=True  Toolchain=.NET Core 5.0  RunStrategy=Throughput  

```
|                             Method | YieldsThreadInternally |         Mean |      Error |     StdDev |          Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |----------------------- |-------------:|-----------:|-----------:|--------------:|-------:|------:|------:|----------:|
|                           **Baseline** |                  **False** |     **2.954 ns** |  **0.0398 ns** |  **0.0353 ns** | **338,491,508.2** |      **-** |     **-** |     **-** |         **-** |
| WithEmptyQueueOverhead_QueuePolicy |                  False |    86.603 ns |  1.6849 ns |  2.0057 ns |  11,547,005.2 |      - |     - |     - |         - |
| WithEmptyQueueOverhead_StackPolicy |                  False |    50.556 ns |  0.6494 ns |  0.6074 ns |  19,780,105.0 |      - |     - |     - |         - |
|                           **Baseline** |                   **True** |   **987.124 ns** | **19.6590 ns** | **33.3825 ns** |   **1,013,043.7** |      **-** |     **-** |     **-** |     **112 B** |
| WithEmptyQueueOverhead_QueuePolicy |                   True | 1,186.089 ns | 13.3438 ns | 11.8289 ns |     843,107.4 | 0.0016 |     - |     - |     280 B |
| WithEmptyQueueOverhead_StackPolicy |                   True | 1,169.924 ns | 13.1807 ns | 12.3293 ns |     854,756.5 | 0.0016 |     - |     - |     279 B |

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.31802, CoreFX 5.0.20.31802), X64 RyuJIT
  Job-BIANII : .NET Core 5.0.0 (CoreCLR 5.0.20.26401, CoreFX 5.0.20.26401), X64 RyuJIT

Server=True  Toolchain=.NET Core 5.0  InvocationCount=1  
RunStrategy=Throughput  UnrollFactor=1  

```
|                  Method | MaxConcurrentRequests |     Mean |     Error |    StdDev |      Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------------------- |---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|                Baseline |                     8 | 1.019 μs | 0.0199 μs | 0.0278 μs | 980,978.1 |     - |     - |     - |     120 B |
| QueueingAll_QueuePolicy |                     8 | 1.218 μs | 0.0289 μs | 0.0837 μs | 821,029.0 |     - |     - |     - |     276 B |
| QueueingAll_StackPolicy |                     8 | 1.171 μs | 0.0280 μs | 0.0813 μs | 854,134.5 |     - |     - |     - |     275 B |

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.31802, CoreFX 5.0.20.31802), X64 RyuJIT
  Job-BIANII : .NET Core 5.0.0 (CoreCLR 5.0.20.26401, CoreFX 5.0.20.26401), X64 RyuJIT

Server=True  Toolchain=.NET Core 5.0  InvocationCount=1  
RunStrategy=Throughput  UnrollFactor=1  

```
|                       Method |     Mean |     Error |    StdDev |      Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|                     Baseline | 1.157 μs | 0.0260 μs | 0.0734 μs | 864,172.4 |     - |     - |     - |     916 B |
| RejectingRapidly_QueuePolicy | 1.247 μs | 0.0351 μs | 0.0948 μs | 802,155.8 |     - |     - |     - |    1079 B |
| RejectingRapidly_StackPolicy | 2.058 μs | 0.0410 μs | 0.0974 μs | 485,829.6 |     - |     - |     - |    1098 B |


</details>

### After

<details>

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.31802, CoreFX 5.0.20.31802), X64 RyuJIT
  Job-EDLYXQ : .NET Core 5.0.0 (CoreCLR 5.0.20.26401, CoreFX 5.0.20.26401), X64 RyuJIT

Server=True  Toolchain=.NET Core 5.0  RunStrategy=Throughput  

```
|                             Method | YieldsThreadInternally |         Mean |      Error |     StdDev |          Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |----------------------- |-------------:|-----------:|-----------:|--------------:|-------:|------:|------:|----------:|
|                           **Baseline** |                  **False** |     **2.696 ns** |  **0.0271 ns** |  **0.0241 ns** | **370,952,460.3** |      **-** |     **-** |     **-** |         **-** |
| WithEmptyQueueOverhead_QueuePolicy |                  False |    65.841 ns |  1.1905 ns |  1.1692 ns |  15,187,996.9 |      - |     - |     - |         - |
| WithEmptyQueueOverhead_StackPolicy |                  False |    49.974 ns |  0.2900 ns |  0.2571 ns |  20,010,247.2 |      - |     - |     - |         - |
|                           **Baseline** |                   **True** |   **907.282 ns** |  **7.4458 ns** |  **6.9648 ns** |   **1,102,193.6** |      **-** |     **-** |     **-** |     **112 B** |
| WithEmptyQueueOverhead_QueuePolicy |                   True | 1,185.132 ns | 23.5292 ns | 29.7569 ns |     843,787.6 | 0.0016 |     - |     - |     279 B |
| WithEmptyQueueOverhead_StackPolicy |                   True | 1,199.024 ns | 22.2960 ns | 42.9568 ns |     834,011.9 | 0.0016 |     - |     - |     279 B |

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.31802, CoreFX 5.0.20.31802), X64 RyuJIT
  Job-IQPHEX : .NET Core 5.0.0 (CoreCLR 5.0.20.26401, CoreFX 5.0.20.26401), X64 RyuJIT

Server=True  Toolchain=.NET Core 5.0  InvocationCount=1  
RunStrategy=Throughput  UnrollFactor=1  

```
|                  Method | MaxConcurrentRequests |     Mean |     Error |    StdDev |      Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------------------- |---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|                Baseline |                     8 | 1.012 μs | 0.0200 μs | 0.0371 μs | 988,543.2 |     - |     - |     - |     120 B |
| QueueingAll_QueuePolicy |                     8 | 1.133 μs | 0.0328 μs | 0.0956 μs | 882,494.5 |     - |     - |     - |     272 B |
| QueueingAll_StackPolicy |                     8 | 1.138 μs | 0.0226 μs | 0.0563 μs | 878,815.0 |     - |     - |     - |     274 B |

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.31802, CoreFX 5.0.20.31802), X64 RyuJIT
  Job-IQPHEX : .NET Core 5.0.0 (CoreCLR 5.0.20.26401, CoreFX 5.0.20.26401), X64 RyuJIT

Server=True  Toolchain=.NET Core 5.0  InvocationCount=1  
RunStrategy=Throughput  UnrollFactor=1  

```
|                       Method |     Mean |     Error |    StdDev |      Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|                     Baseline | 1.180 μs | 0.0319 μs | 0.0921 μs | 847,687.7 |     - |     - |     - |     916 B |
| RejectingRapidly_QueuePolicy | 1.311 μs | 0.0481 μs | 0.1380 μs | 762,637.8 |     - |     - |     - |    1080 B |
| RejectingRapidly_StackPolicy | 2.126 μs | 0.0375 μs | 0.0792 μs | 470,365.7 |     - |     - |     - |    1099 B |

</details>