### PR TITLE
Two minor perf tweaks in CORS and Localization middleware

### DIFF
--- a/src/Middleware/CORS/src/Infrastructure/CorsPolicy.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsPolicy.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         {
             get
             {
-                if (Headers == null || Headers.Count != 1 || Headers.Count == 1 && Headers[0] != "*")
+                if (Headers == null || Headers.Count != 1 || Headers[0] != "*")
                 {
                     return false;
                 }
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         {
             get
             {
-                if (Methods == null || Methods.Count != 1 || Methods.Count == 1 && Methods[0] != "*")
+                if (Methods == null || Methods.Count != 1 || Methods[0] != "*")
                 {
                     return false;
                 }
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         {
             get
             {
-                if (Origins == null || Origins.Count != 1 || Origins.Count == 1 && Origins[0] != "*")
+                if (Origins == null || Origins.Count != 1 || Origins[0] != "*")
                 {
                     return false;
                 }

--- a/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
+++ b/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Localization
 {
@@ -13,7 +12,7 @@ namespace Microsoft.AspNetCore.Localization
     /// </summary>
     public class CookieRequestCultureProvider : RequestCultureProvider
     {
-        private static readonly char[] _cookieSeparator = new[] { '|' };
+        private static readonly char _cookieSeparator = '|';
         private static readonly string _culturePrefix = "c=";
         private static readonly string _uiCulturePrefix = "uic=";
 
@@ -60,9 +59,7 @@ namespace Microsoft.AspNetCore.Localization
                 throw new ArgumentNullException(nameof(requestCulture));
             }
 
-            var seperator = _cookieSeparator[0].ToString();
-
-            return string.Join(seperator,
+            return string.Join(_cookieSeparator,
                 $"{_culturePrefix}{requestCulture.Culture.Name}",
                 $"{_uiCulturePrefix}{requestCulture.UICulture.Name}");
         }


### PR DESCRIPTION
  * Use the newer overload for `string.Split()` that accepts a `char` instead of creating a `char[]`.
  * Remove redundant bounds checks for count of exactly 1 as they have already been checked.
