### PR TITLE
Fix: 'https://' is also supported as scheme.

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -268,7 +268,7 @@
     <value>Overriding endpoints defined in UseKestrel() because {settingName} is set to true. Binding to address(es) '{addresses}' instead.</value>
   </data>
   <data name="UnsupportedAddressScheme" xml:space="preserve">
-    <value>Unrecognized scheme in server address '{address}'. Only 'http://' is supported.</value>
+    <value>Unrecognized scheme in server address '{address}'. Only 'http://' and 'https://' are supported.</value>
   </data>
   <data name="HeadersAreReadOnly" xml:space="preserve">
     <value>Headers are read-only, response has already started.</value>


### PR DESCRIPTION
 - Fix documentation, https is also a valid scheme

https://github.com/dotnet/aspnetcore/blob/100823af0d50333b6ee10147a20b35196fcbbc7d/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs#L102-L116
