### PR TITLE
Fix java pack on local builds

### DIFF
--- a/src/SignalR/clients/java/signalr/signalr.client.java.Tests.javaproj
+++ b/src/SignalR/clients/java/signalr/signalr.client.java.Tests.javaproj
@@ -78,7 +78,7 @@
 
   <PropertyGroup>
     <!-- Pass the Java Package Version down to Gradle -->
-    <GradleOptions Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(GradleOptions) -PpackageVersion="$(PackageVersion)"</GradleOptions>
+    <GradleOptions>$(GradleOptions) -PpackageVersion="$(PackageVersion)"</GradleOptions>
     <HelixCommand>chmod +x ./gradlew &amp;&amp; ./gradlew $(GradleOptions) test</HelixCommand>
     <HelixCommand Condition="'$(IsWindowsHelixQueue)' == 'true'">call gradlew $(GradleOptions) test</HelixCommand>
   </PropertyGroup>

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/Version.java
@@ -6,6 +6,6 @@ package com.microsoft.signalr;
 
 class Version {
     public static String getDetailedVersion() {
-        return "99.99.99-dev";
+        return "5.0.0-dev";
     }
 }


### PR DESCRIPTION
>error MSB3030: Could not copy the file "build\libs\signalr-5.0.0-dev.jar" because it was not found.

The version file will update every major/minor, but those aren't very often so it's fine.