### PR TITLE
Fix urls of @microsoft/dotnet-js-interop package

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
@@ -18,9 +18,9 @@
   "author": "Microsoft",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/dotnet/extensions/issues"
+    "url": "https://github.com/dotnet/aspnetcore/issues"
   },
-  "homepage": "https://github.com/dotnet/extensions/tree/master/src/JSInterop#readme",
+  "homepage": "https://github.com/dotnet/aspnetcore/tree/master/src/JSInterop",
   "files": [
     "dist/**"
   ],


### PR DESCRIPTION
Updates urls in `@microsoft/dotnet-js-interop` package to point to `aspnetcore` repository, seems like it was missed when migrating from https://github.com/dotnet/extensions.

https://www.npmjs.com/package/@microsoft/dotnet-js-interop
