### PR TITLE
SpaProxy: Fix proxying of WebSocket protocol

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -209,6 +209,10 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
 
             using (var client = new ClientWebSocket())
             {
+                foreach (var protocol in context.WebSockets.WebSocketRequestedProtocols)
+                {
+                    client.Options.AddSubProtocol(protocol);
+                }
                 foreach (var headerEntry in context.Request.Headers)
                 {
                     if (!NotForwardedWebSocketHeaders.Contains(headerEntry.Key, StringComparer.OrdinalIgnoreCase))

--- a/src/Middleware/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
 
         // Don't forward User-Agent/Accept because of https://github.com/aspnet/JavaScriptServices/issues/1469
         // Others just aren't applicable in proxy scenarios
-        private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Version" };
+        private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
 
         public static HttpClient CreateHttpClientForProxy(TimeSpan requestTimeout)
         {


### PR DESCRIPTION
- Use `client.Options.AddSubProtocol` for setting the WebSocket protocol instead of `client.Options.SetRequestHeader`

Addresses #23207