### PR TITLE
Make Kestrel config case-insensitive for certificates

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private IDictionary<string, CertificateConfig> ReadCertificates()
         {
-            var certificates = new Dictionary<string, CertificateConfig>(0);
+            var certificates = new Dictionary<string, CertificateConfig>(0, StringComparer.OrdinalIgnoreCase);
 
             var certificatesConfig = _configuration.GetSection(CertificatesKey).GetChildren();
             foreach (var certificateConfig in certificatesConfig)

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -254,38 +254,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         }
 
         [Fact]
-        public void ConfigureEndpointDevelopmentCertificateIsCaseInsensitive()
-        {
-            try
-            {
-                var serverOptions = CreateServerOptions();
-                var certificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
-                var bytes = certificate.Export(X509ContentType.Pkcs12, "1234");
-                var path = GetCertificatePath();
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
-                File.WriteAllBytes(path, bytes);
-
-                var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
-                {
-                    new KeyValuePair<string, string>("Certificates:DEVELOPMENT:Password", "1234"),
-                }).Build();
-
-                serverOptions
-                    .Configure(config)
-                    .Load();
-
-                Assert.NotNull(serverOptions.DefaultCertificate);
-            }
-            finally
-            {
-                if (File.Exists(GetCertificatePath()))
-                {
-                    File.Delete(GetCertificatePath());
-                }
-            }
-        }
-
-        [Fact]
         public void ConfigureEndpointDevelopmentCertificateGetsIgnoredIfPasswordIsNotCorrect()
         {
             try

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -254,6 +254,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Tests
         }
 
         [Fact]
+        public void ConfigureEndpointDevelopmentCertificateIsCaseInsensitive()
+        {
+            try
+            {
+                var serverOptions = CreateServerOptions();
+                var certificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
+                var bytes = certificate.Export(X509ContentType.Pkcs12, "1234");
+                var path = GetCertificatePath();
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllBytes(path, bytes);
+
+                var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
+                {
+                    new KeyValuePair<string, string>("Certificates:DEVELOPMENT:Password", "1234"),
+                }).Build();
+
+                serverOptions
+                    .Configure(config)
+                    .Load();
+
+                Assert.NotNull(serverOptions.DefaultCertificate);
+            }
+            finally
+            {
+                if (File.Exists(GetCertificatePath()))
+                {
+                    File.Delete(GetCertificatePath());
+                }
+            }
+        }
+
+        [Fact]
         public void ConfigureEndpointDevelopmentCertificateGetsIgnoredIfPasswordIsNotCorrect()
         {
             try


### PR DESCRIPTION
Attempts to resolve https://github.com/dotnet/aspnetcore/issues/21494

