### PR TITLE
[Blazor] Add DebuggerDisplayAttribute to ComponentBase

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.Components
     /// Optional base class for components. Alternatively, components may
     /// implement <see cref="IComponent"/> directly.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayString()}")]
     public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRender
     {
         private readonly RenderFragment _renderFragment;
@@ -331,6 +333,18 @@ namespace Microsoft.AspNetCore.Components
             // reason we have OnAfterRenderAsync is so that the developer doesn't
             // have to use "async void" and do their own exception handling in
             // the case where they want to start an async task.
+        }
+
+        private string DebuggerDisplayString()
+        {
+            if (!_renderHandle.IsInitialized)
+            {
+                return "(uninitialized) " + ToString();
+            }
+            else
+            {
+                return $"({_renderHandle.ComponentId}) " + ToString();
+            }
         }
     }
 }

--- a/src/Components/Components/src/RenderHandle.cs
+++ b/src/Components/Components/src/RenderHandle.cs
@@ -44,6 +44,10 @@ namespace Microsoft.AspNetCore.Components
         public bool IsInitialized
             => _renderer != null;
 
+        // For debugging purposes, gives access to the component id from ComponentBase so
+        // that it can be displayed on DebuggerDisplayAttribute
+        internal int ComponentId => _componentId;
+
         /// <summary>
         /// Notifies the renderer that the component should be rendered.
         /// </summary>


### PR DESCRIPTION
Adds a private DebuggerDisplayString method for debugging purposes that preprends the component ID to the ToString() method of the component.

This allows developers to quickly detect when a component instance has been destroyed and recreated as a result of a re-rendering process.

![image](https://user-images.githubusercontent.com/6995051/85586867-2379f980-b5f6-11ea-8c41-b4b786f60cea.png)
![image](https://user-images.githubusercontent.com/6995051/85586970-37256000-b5f6-11ea-94b0-54c0f49f167c.png)

This is general goodness that helps troubleshoot weird behaviors on the renderer.