### PR TITLE
Remove the file extension in CreateBlazorTrimmerRootDescriptorFile

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/CreateBlazorTrimmerRootDescriptorFile.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/CreateBlazorTrimmerRootDescriptorFile.cs
@@ -32,7 +32,9 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             var roots = new XElement("linker");
             foreach (var assembly in Assemblies)
             {
-                var assemblyName = assembly.GetMetadata("FileName") + assembly.GetMetadata("Extension");
+                // NOTE: Descriptor files don't include the file extension
+                // in the assemblyName.
+                var assemblyName = assembly.GetMetadata("FileName");
                 var typePreserved = assembly.GetMetadata("Preserve");
                 var typeRequired = assembly.GetMetadata("Required");
 


### PR DESCRIPTION
The linker doesn't resolve assemblies correctly if the file extension (.dll) is included in the assembly name in the descriptor xml file.

See also https://github.com/mono/linker/issues/1294