### PR TITLE
Run quarantined tests on all helix queues

### DIFF
--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -37,7 +37,7 @@ jobs:
       displayName: Restore interop projects
     - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
-              /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:IsHelixDaily=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       continueOnError: true
       env:


### PR DESCRIPTION
Why weren't we doing this?