### PR TITLE
Quarantining blazor tests

### DIFF
--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -6,6 +6,7 @@ using BasicTestApp;
 using BasicTestApp.HttpClientTest;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using TestServer;

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void CanSendAndReceiveBytes()
         {
             IssueRequest("/subdir/api/data");

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void CanSendAndReceiveBytes()
         {
             IssueRequest("/subdir/api/data");

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void CanRenderTextOnlyComponent()
         {
             var appElement = Browser.MountTestComponent<TextOnlyComponent>();

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -464,6 +464,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void CanRenderMarkupBlocks()
         {
             var appElement = Browser.MountTestComponent<MarkupBlockComponent>();

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
             Browser.FindElement(By.Id("button-without-onclick")).Click();

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
             Browser.FindElement(By.Id("button-without-onclick")).Click();

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BenchmarksRunWithoutError()
         {
             // In CI, we only verify that the benchmarks run without throwing any

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
     {
         public PerformanceTest(
             BrowserFixture browserFixture,
-            DevHostServerFixture<Wasm.Performance.TestApp.Program> serverFixture,
+            DevHostServerFixture<Wasm.Performance.TestApp.Program> servecrFixture,
             ITestOutputHelper output)
             : base(browserFixture, serverFixture, output)
         {
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest]
         public void BenchmarksRunWithoutError()
         {
             // In CI, we only verify that the benchmarks run without throwing any

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
     {
         public PerformanceTest(
             BrowserFixture browserFixture,
-            DevHostServerFixture<Wasm.Performance.TestApp.Program> servecrFixture,
+            DevHostServerFixture<Wasm.Performance.TestApp.Program> serverFixture,
             ITestOutputHelper output)
             : base(browserFixture, serverFixture, output)
         {

--- a/src/ProjectTemplates/BlazorTemplates.Tests/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/AssemblyInfo.AssemblyFixtures.cs
@@ -10,5 +10,3 @@ using Xunit;
 
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(ProjectFactoryFixture))]
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(SeleniumStandaloneServer))]
-
-[assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/20479")]

--- a/src/ProjectTemplates/BlazorTemplates.Tests/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/AssemblyInfo.AssemblyFixtures.cs
@@ -10,3 +10,5 @@ using Xunit;
 
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(ProjectFactoryFixture))]
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(SeleniumStandaloneServer))]
+
+[assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/20479")]


### PR DESCRIPTION
There were four blazor test failures in https://dev.azure.com/dnceng/public/_build/results?buildId=704666&view=ms.vss-test-web.build-test-results-tab&runId=21834978&resultId=100374&paneView=debug. All of them look fairly similar, seems more likely to be a general issue.

There was also a blanket quarantine on all blazor template tests, which is for an issue that has been resolved months ago.

Failure:
```
  | OpenQA.Selenium.BrowserAssertFailedException : Xunit.Sdk.TrueException: Assert.True() Failure\r\nExpected: True\r\nActual: False\r\n at Xunit.Assert.True(Nullable1 condition, String userMessage) in C:\\Dev\\xunit\\xunit\\src\\xunit.assert\\Asserts\\BooleanAsserts.cs:line 95\r\n at Xunit.Assert.True(Boolean condition) in C:\\Dev\\xunit\\xunit\\src\\xunit.assert\\Asserts\\BooleanAsserts.cs:line 62\r\n at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass5_0.<True>b__0() in /_/src/Shared/E2ETesting/WaitAssert.cs:line 30\r\n at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass16_0.<WaitAssertCore>b__0() in /_/src/Shared/E2ETesting/WaitAssert.cs:line 77\r\n at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass17_01.<WaitAssertCore>b__0(IWebDriver ) in //src/Shared/E2ETesting/WaitAssert.cs:line 103\r\nScreen shot captured at 'F:\workspace\_work\1\s\artifacts\TestResults\Release\Microsoft.AspNetCore.Components.E2ETests\802524f612c74cb3b73db104eeb550a3.png'\r\nEncountered browser errors\r\n[2020-06-25T18:18:26Z] [Debug] http://127.0.0.1:52317/_framework/dotnet.5.0.0-preview.6.20305.6.js 0:124605 "mono_wasm_runtime_ready" "fe00e07a-5519-4dfe-b35a-f867dbaf2e28"\r\n[2020-06-25T18:18:28Z] [Debug] http://127.0.0.1:52317/_framework/dotnet.5.0.0-preview.6.20305.6.js 0:124605 "mono_wasm_runtime_ready" "fe00e07a-5519-4dfe-b35a-f867dbaf2e28"\r\n[2020-06-25T18:18:32Z] [Debug] http://127.0.0.1:52317/_framework/dotnet.5.0.0-preview.6.20305.6.js 0:124605 "mono_wasm_runtime_ready" "fe00e07a-5519-4dfe-b35a-f867dbaf2e28"\r\n[2020-06-25T18:18:37Z] [Debug] http://127.0.0.1:52317/_framework/dotnet.5.0.0-preview.6.20305.6.js 0:124605 "mono_wasm_runtime_ready" "fe00e07a-5519-4dfe-b35a-f867dbaf2e28"\r\n[2020-06-25T18:18:42Z] [Debug] http://127.0.0.1:52317/_framework/dotnet.5.0.0-preview.6.20305.6.js 0:124605 "mono_wasm_runtime_ready" "fe00e07a-5519-4dfe-b35a-f867dbaf2e28"\r\n[2020-06-25T18:18:47Z] [Info] http://127.0.0.1:52317/_framework/blazor.webassembly.js 0:38153 "Refresh Time 63728705927218"\r\n[2020-06-25T18:18:48Z] [Info] http://127.0.0.1:52317/_framework/blazor.webassembly.js 0:38153 "Refresh Time 63728705928121"\r\n[2020-06-25T18:18:50Z] [Info] http://127.0.0.1:52317/_framework/blazor.webassembly.js 0:38153 "Refresh Time 63728705929998"\r\n[2020-06-25T18:19:01Z] [Info] http://127.0.0.1:52317/_framework/blazor.webassembly.js 0:38153 "Refresh Time 63728705941484.01"\r\n[2020-06-25T18:19:04Z] [Info] http://127.0.0.1:52317/_framework/blazor.webassembly.js 0:38153 "Refresh Time 63728705944285.01"\r\n[2020-06-25T18:19:08Z] [Info] http://127.0.0.1:52317/_framework/blazor.webassembly.js 0:38153 "Refresh Time 63728705948035.99"Page content:\r\n<head>\r\n <meta charset="utf-8">\r\n <title>E2EPerformance</title>\r\n <link href="benchmarks/lib/bootstrap.min.css" rel="stylesheet">\r\n <link href="benchmarks/lib/minibench/style.css" rel="stylesheet">\r\n</head>\r\n<body style="overflow: scroll;">\r\n <div class="container" id="display"><div class="d-flex align-items-center"><h2 class="mx-3 flex-grow-1">E2E Performance<label class="ml-auto mr-5"><input type="checkbox" class="mr-2">Verify only</label><button class="btn btn-success ml-auto px-4 run-button" id="runAll" style="display: block;">Run all</button><button class="btn btn-danger ml-auto px-4 stop-button" style="display: none;">Stop</button><div class="my-3 py-2 bg-white rounded shadow-sm"><div class="d-flex align-items-baseline px-4"><h5 class="py-2">App Startup<a class="ml-auto run-button" href="" style="display: block;">Run all<table class="table mb-0 benchmarks">
-- | --
Executions: 1 | Duration: 17300ms

 at Microsoft.AspNetCore.E2ETesting.WaitAssert.WaitAssertCore[TResult](IWebDriver driver, Func`1 assertion, TimeSpan timeout) in /_/src/Shared/E2ETesting/WaitAssert.cs:line 123
   at Microsoft.AspNetCore.E2ETesting.WaitAssert.WaitAssertCore(IWebDriver driver, Action assertion, TimeSpan timeout) in /_/src/Shared/E2ETesting/WaitAssert.cs:line 77
   at Microsoft.AspNetCore.E2ETesting.WaitAssert.True(IWebDriver driver, Func`1 actual, TimeSpan timeout) in /_/src/Shared/E2ETesting/WaitAssert.cs:line 30
   at Microsoft.AspNetCore.Components.E2ETest.Tests.PerformanceTest.BenchmarksRunWithoutError() in /_/src/Components/test/E2ETest/Tests/PerformanceTest.cs:line 51
----- Inner Stack Trace -----
   at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass5_0.<True>b__0() in /_/src/Shared/E2ETesting/WaitAssert.cs:line 30
   at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass16_0.<WaitAssertCore>b__0() in /_/src/Shared/E2ETesting/WaitAssert.cs:line 77
   at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass17_0`1.<WaitAssertCore>b__0(IWebDriver _) in /_/src/Shared/E2ETesting/WaitAssert.cs:line 103
```

