### PR TITLE
Do not cache 304 responses

### DIFF
--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -635,6 +635,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private static TimeSpan? GetCacheTtl(RequestContext requestContext)
         {
             var response = requestContext.Response;
+            // A 304 response is supposed to have the same headers as its associated 200 response, including Cache-Control, but the 304 response itself
+            // should not be cached. Otherwise Http.Sys will serve the 304 response to all requests without checking conditional headers like If-None-Match.
+            if (response.StatusCode == StatusCodes.Status304NotModified)
+            {
+                return null;
+            }
+
             // Only consider kernel-mode caching if the Cache-Control response header is present.
             var cacheControlHeader = response.Headers[HeaderNames.CacheControl];
             if (string.IsNullOrEmpty(cacheControlHeader))

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
@@ -80,6 +80,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 return httpContext.Response.Body.WriteAsync(new byte[10], 0, 10);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await SendRequestAsync(address));
                 Assert.Equal("2", await SendRequestAsync(address));
             }
@@ -126,6 +127,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 return httpContext.Response.Body.WriteAsync(new byte[10], 0, 10);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await SendRequestAsync(address));
                 Assert.Equal("1", await SendRequestAsync(address));
             }
@@ -165,6 +167,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 return httpContext.Response.Body.WriteAsync(new byte[10], 0, 10);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await SendRequestAsync(address));
                 Assert.Equal("1", await SendRequestAsync(address));
             }
@@ -335,6 +338,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 return httpContext.Response.Body.WriteAsync(new byte[10], 0, 10);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await SendRequestAsync(address));
                 Assert.Equal("2", await SendRequestAsync(address));
             }
@@ -356,6 +360,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 Assert.Null(httpContext.Response.ContentLength);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await SendRequestAsync(address));
                 Assert.Equal("1", await SendRequestAsync(address));
             }
@@ -374,6 +379,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 await httpContext.Response.SendFileAsync(_absoluteFilePath, 0, null, CancellationToken.None);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await GetFileAsync(address));
                 Assert.Equal("2", await GetFileAsync(address));
             }
@@ -393,6 +399,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                 await httpContext.Response.SendFileAsync(_absoluteFilePath, 0, null, CancellationToken.None);
             }))
             {
+                address += Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                 Assert.Equal("1", await GetFileAsync(address));
                 Assert.Equal("1", await GetFileAsync(address));
             }
@@ -421,13 +428,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     switch (status)
                     {
                         case 206: // 206 (Partial Content) is not cached
+                        case 304: // 304 (Not Modified) is not cached
                         case 407: // 407 (Proxy Authentication Required) makes CoreCLR's HttpClient throw
                             continue;
                     }
                     requestCount = 1;
+                    var query = "?" + Guid.NewGuid().ToString(); // Avoid cache collisions for failed tests.
                     try
                     {
-                        Assert.Equal("1", await SendRequestAsync(address + status, status));
+                        Assert.Equal("1", await SendRequestAsync(address + status + query, status));
                     }
                     catch (Exception ex)
                     {
@@ -435,7 +444,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     }
                     try
                     {
-                        Assert.Equal("1", await SendRequestAsync(address + status, status));
+                        Assert.Equal("1", await SendRequestAsync(address + status + query, status));
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Fixes #23345 A 304 response is supposed to have the same headers as its associated 200 response, including Cache-Control, but the 304 response itself should not be cached. Otherwise Http.Sys will serve the 304 response to all requests without checking conditional headers like If-None-Match.

@ricmrodrigues 