### PR TITLE
Run full matrix on quarantined pipeline

### DIFF
--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -1,13 +1,10 @@
-# We want to run quarantined tests on master as well as on PRs
-trigger:
-  batch: true
-  branches:
-    include:
-    - master
+# We only want to run quarantined tests on master
+pr: none
+trigger: none
 
 schedules:
-- cron: "0 */4 * * *"
-  displayName: Every 4 hours test run
+- cron: "0 */12 * * *"
+  displayName: Every 12 hours test run
   branches:
     include:
     - master
@@ -36,7 +33,7 @@ jobs:
     - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
       displayName: Restore interop projects
     - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
-              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
+              -projects eng\helix\helix.proj /p:IsHelixDaily=true /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
               /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       continueOnError: true

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -3,7 +3,7 @@ pr: none
 trigger: none
 
 schedules:
-- cron: "0 23 * * *"
+- cron: "0 18 * * *"
   displayName: Run tests once a day at 11 PM
   branches:
     include:

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -25,7 +25,7 @@ jobs:
     jobName: Helix_quarantined_x64
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
-    timeoutInMinutes: 180
+    timeoutInMinutes: 480
     steps:
     # Build the shared framework
     - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
@@ -45,6 +45,30 @@ jobs:
       path: artifacts/log/
       publishOnError: true
 
+# Helix ARM64
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Helix_quarantined_arm64
+    jobDisplayName: "Tests: Helix ARM64"
+    agentOs: Linux
+    timeoutInMinutes: 480
+    steps:
+    - script: ./restore.sh -ci -nobl
+      displayName: Restore
+    - script: ./build.sh --ci --nobl --noBuildRepoTasks --arch arm64 -test --no-build-nodejs --all --projects
+              $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:RunQuarantinedTests=true
+              /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Run build.sh helix arm64 target
+      env:
+        HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+    installNodeJs: false
+    artifacts:
+    - name: Helix_arm64_logs
+      path: artifacts/log/
+      publishOnError: true
+      includeForks: true
+      
 - template: jobs/default-build.yml
   parameters:
     jobName: Windows_Quarantined_x64

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -3,8 +3,8 @@ pr: none
 trigger: none
 
 schedules:
-- cron: "0 */12 * * *"
-  displayName: Every 12 hours test run
+- cron: "0 23 * * *"
+  displayName: Run tests once a day at 11 PM
   branches:
     include:
     - master


### PR DESCRIPTION
@dougbu I can't remember exactly what we wanted to do for the schedule and which queues were super critical.  This PR just runs the full matrix every 12 hours.  I can add another pipeline if we need a different cron for just the arm queues if those were the special ones