### PR TITLE
Add RazorLangVersion 5.0

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorLanguageVersion.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorLanguageVersion.cs
@@ -20,7 +20,9 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public static readonly RazorLanguageVersion Version_3_0 = new RazorLanguageVersion(3, 0);
 
-        public static readonly RazorLanguageVersion Latest = Version_3_0;
+        public static readonly RazorLanguageVersion Version_5_0 = new RazorLanguageVersion(5, 0);
+
+        public static readonly RazorLanguageVersion Latest = Version_5_0;
 
         public static readonly RazorLanguageVersion Experimental = new RazorLanguageVersion(1337, 1337);
 
@@ -41,6 +43,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 version = Experimental;
                 return true;
             }
+            else if (languageVersion == "5.0")
+            {
+                version = Version_5_0;
+                return true;
+            }
             else if (languageVersion == "3.0")
             {
                 version = Version_3_0;
@@ -49,7 +56,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             else if (languageVersion == "2.1")
             {
                 version = Version_2_1;
-                return true; 
+                return true;
             }
             else if (languageVersion == "2.0")
             {
@@ -84,7 +91,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
 
             throw new ArgumentException(
-                Resources.FormatRazorLanguageVersion_InvalidVersion(languageVersion), 
+                Resources.FormatRazorLanguageVersion_InvalidVersion(languageVersion),
                 nameof(languageVersion));
         }
 
@@ -131,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // We don't need to do anything special for our hash code since reference equality is what we're going for.
             return base.GetHashCode();
         }
-        
+
         public override string ToString() => $"{Major}.{Minor}";
 
         private string DebuggerToString() => $"Razor '{Major}.{Minor}'";

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorLanguageVersionTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorLanguageVersionTest.cs
@@ -93,6 +93,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
+        public void TryParse50()
+        {
+            // Arrange
+            var value = "5.0";
+
+            // Act
+            var result = RazorLanguageVersion.TryParse(value, out var version);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(RazorLanguageVersion.Version_5_0, version);
+        }
+
+        [Fact]
         public void TryParseLatest()
         {
             // Arrange
@@ -103,7 +117,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Assert
             Assert.True(result);
-            Assert.Same(RazorLanguageVersion.Version_3_0, version);
+            Assert.Same(RazorLanguageVersion.Version_5_0, version);
         }
 
         [Fact]

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntegrationTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntegrationTest.cs
@@ -625,13 +625,13 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:UseRazorBuildServer=false /p:RazorLangVersion=5.0",
+                "/p:UseRazorBuildServer=false /p:RazorLangVersion=6.0",
                 suppressBuildServer: true);
 
             Assert.BuildFailed(result);
             Assert.BuildOutputContainsLine(
                 result,
-                $"Invalid option 5.0 for Razor language version --version; must be Latest or a valid version in range 1.0 to 3.0.");
+                $"Invalid option 6.0 for Razor language version --version; must be Latest or a valid version in range 1.0 to 5.0.");
 
             // Compilation failed without creating the views assembly
             Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.dll");

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntegrationTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntegrationTest.cs
@@ -625,28 +625,26 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:UseRazorBuildServer=false /p:RazorLangVersion=6.0",
+                "/p:UseRazorBuildServer=false /p:RazorLangVersion=99.0",
                 suppressBuildServer: true);
 
             Assert.BuildFailed(result);
             Assert.BuildOutputContainsLine(
                 result,
-                $"Invalid option 6.0 for Razor language version --version; must be Latest or a valid version in range 1.0 to 5.0.");
+                $"Invalid option 99.0 for Razor language version --version; must be Latest or a valid version in range 1.0 to 5.0.");
 
             // Compilation failed without creating the views assembly
             Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.dll");
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.Views.dll");
         }
 
-        [Fact(Skip = "Default C# version is 7.3 for netcoreapp3.1 and later https://github.com/dotnet/aspnetcore/issues/13930")]
+        [Fact]
         [InitializeTestProject("SimpleMvc")]
         public async Task Build_ImplicitCSharp8_NullableEnforcement_WarningsDuringBuild_NoBuildServer()
         {
             var result = await DotnetMSBuild(
                 "Build",
-                // Remove /p:LangVersion=Default once we've picked up a compiler that supports .NET 5.0.
-                // Tracked by https://github.com/dotnet/aspnetcore/issues/13304
-                "/p:Nullable=enable /p:LangVersion=Default",
+                "/p:Nullable=enable",
                 suppressBuildServer: true);
             var indexFilePath = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cshtml.g.cs");
 

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntrospectionTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntrospectionTest.cs
@@ -88,13 +88,24 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         }
 
         [Fact]
-        [InitializeTestProject("SimpleMvc")]
+        [InitializeTestProject("SimpleMvc31")]
         public async Task RazorSdk_ResolvesRazorLangVersionTo30ForNetCoreApp30Projects()
         {
             var result = await DotnetMSBuild("ResolveRazorConfiguration", "/t:_IntrospectResolvedConfiguration");
 
             Assert.BuildPassed(result);
             Assert.BuildOutputContainsLine(result, "RazorLangVersion: 3.0");
+            Assert.BuildOutputContainsLine(result, "ResolvedRazorConfiguration: MVC-3.0");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task RazorSdk_ResolvesRazorLangVersionTo50ForNetCoreApp50Projects()
+        {
+            var result = await DotnetMSBuild("ResolveRazorConfiguration", "/t:_IntrospectResolvedConfiguration");
+
+            Assert.BuildPassed(result);
+            Assert.BuildOutputContainsLine(result, "RazorLangVersion: 5.0");
             Assert.BuildOutputContainsLine(result, "ResolvedRazorConfiguration: MVC-3.0");
         }
 
@@ -142,7 +153,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var result = await DotnetMSBuild("ResolveRazorConfiguration", "/t:_IntrospectResolvedConfiguration");
 
             Assert.BuildPassed(result);
-            Assert.BuildOutputContainsLine(result, "RazorLangVersion: 3.0");
+            Assert.BuildOutputContainsLine(result, "RazorLangVersion: 5.0");
             Assert.BuildOutputContainsLine(result, "ResolvedRazorConfiguration: MVC-3.0");
         }
 

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildServerIntegrationTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildServerIntegrationTest.cs
@@ -100,12 +100,12 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             var result = await DotnetMSBuild(
                 "Build",
-                "/p:_RazorForceBuildServer=true /p:RazorLangVersion=5.0");
+                "/p:_RazorForceBuildServer=true /p:RazorLangVersion=99.0");
 
             Assert.BuildFailed(result);
             Assert.BuildOutputContainsLine(
                 result,
-                $"Invalid option 5.0 for Razor language version --version; must be Latest or a valid version in range 1.0 to 3.0.");
+                $"Invalid option 99.0 for Razor language version --version; must be Latest or a valid version in range 1.0 to 5.0.");
 
             // Compilation failed without creating the views assembly
             Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.dll");

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/ConfigurationMetadataIntegrationTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/ConfigurationMetadataIntegrationTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileContainsLine(
                 result,
                 razorAssemblyInfo,
-                "[assembly: Microsoft.AspNetCore.Razor.Hosting.RazorLanguageVersionAttribute(\"3.0\")]");
+                "[assembly: Microsoft.AspNetCore.Razor.Hosting.RazorLanguageVersionAttribute(\"5.0\")]");
             Assert.FileContainsLine(
                 result,
                 razorAssemblyInfo,

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/MvcBuildIntegrationTest31.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/MvcBuildIntegrationTest31.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
 namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 {
     public class MvcBuildIntegrationTest31 : MvcBuildIntegrationTestLegacy
@@ -12,5 +16,33 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         public override string TestProjectName => "SimpleMvc31";
         public override string TargetFramework => "netcoreapp3.1";
+
+        [Fact]
+        public async Task Build_WithGenerateRazorHostingAssemblyInfo_AddsConfigurationMetadata()
+        {
+            using var project = CreateTestProject();
+
+            var razorAssemblyInfo = Path.Combine(IntermediateOutputPath, "SimpleMvc31.RazorAssemblyInfo.cs");
+            var result = await DotnetMSBuild("Build", "/p:GenerateRazorHostingAssemblyInfo=true");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc31.Views.dll");
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc31.Views.pdb");
+
+            Assert.FileExists(result, razorAssemblyInfo);
+            Assert.FileContainsLine(
+                result,
+                razorAssemblyInfo,
+                "[assembly: Microsoft.AspNetCore.Razor.Hosting.RazorLanguageVersionAttribute(\"3.0\")]");
+            Assert.FileContainsLine(
+                result,
+                razorAssemblyInfo,
+                "[assembly: Microsoft.AspNetCore.Razor.Hosting.RazorConfigurationNameAttribute(\"MVC-3.0\")]");
+            Assert.FileContainsLine(
+                result,
+                razorAssemblyInfo,
+                "[assembly: Microsoft.AspNetCore.Razor.Hosting.RazorExtensionAssemblyNameAttribute(\"MVC-3.0\", \"Microsoft.AspNetCore.Mvc.Razor.Extensions\")]");
+        }
     }
 }

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Configuration.targets
@@ -69,6 +69,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Determine the default Razor configuration
   -->
   <PropertyGroup Condition="'$(RazorDefaultConfiguration)'==''">
+    <!-- For 5.0, we're not introducing any new language features for MVC. We can continue using the 3.0 configuration \ extension for MVC support. -->
     <RazorDefaultConfiguration Condition="'$(AddRazorSupportForMvc)'=='true'">MVC-3.0</RazorDefaultConfiguration>
     <RazorDefaultConfiguration Condition="'$(RazorDefaultConfiguration)'==''">Default</RazorDefaultConfiguration>
   </PropertyGroup>
@@ -80,7 +81,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       the project's runtime.
     -->
     <RazorConfiguration Include="Default" />
-    <RazorConfiguration Include="MVC-3.0" >
+    <RazorConfiguration Include="MVC-3.0">
       <Extensions>MVC-3.0;$(CustomRazorExtension)</Extensions>
     </RazorConfiguration>
   </ItemGroup>

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -45,6 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       Infer the RazorLangVersion if no value was specified. When adding support for newer target frameworks, list newer language versions first.
     -->
+    <RazorLangVersion Condition="'$(RazorLangVersion)' == '' AND '$(_TargetingNET50OrLater)' == 'true'">5.0</RazorLangVersion>
     <RazorLangVersion Condition="'$(RazorLangVersion)' == '' AND '$(_TargetingNETCoreApp30OrLater)' == 'true'">3.0</RazorLangVersion>
 
     <!--


### PR DESCRIPTION
I spoke to Taylor offline and it looks like we can get away without creating a new RazorConfiguration or extension for MVC. I did some testing with MVC 5.0 and 3.1 apps, and tooling appears to work correctly. 