### PR TITLE
Create a new pipeline that runs PR queue tests more often

### DIFF
--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -28,7 +28,7 @@ jobs:
     jobName: Helix_quarantined_x64
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
-    timeoutInMinutes: 180
+    timeoutInMinutes: 240
     steps:
     # Build the shared framework
     - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
@@ -53,7 +53,7 @@ jobs:
     jobName: Windows_Quarantined_x64
     jobDisplayName: 'Tests: Windows x64'
     agentOs: Windows
-    timeoutInMinutes: 180
+    timeoutInMinutes: 240
     isTestingJob: true
     steps:
     - powershell: "& ./build.ps1 -CI -nobl -all -pack -NoBuildJava"
@@ -86,7 +86,7 @@ jobs:
     jobName: MacOS_Quarantined_Test
     jobDisplayName: "Tests: macOS 10.14"
     agentOs: macOS
-    timeoutInMinutes: 180
+    timeoutInMinutes: 240
     isTestingJob: true
     steps:
     - bash: ./build.sh --all --pack --ci --nobl --no-build-java
@@ -119,7 +119,7 @@ jobs:
     jobName: Linux_Quarantined_Test
     jobDisplayName: "Tests: Ubuntu 16.04 x64"
     agentOs: Linux
-    timeoutInMinutes: 180
+    timeoutInMinutes: 240
     isTestingJob: true
     useHostedUbuntu: false
     steps:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -1,0 +1,149 @@
+# We want to run quarantined tests on master as well as on PRs
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+
+schedules:
+- cron: "0 */4 * * *"
+  displayName: Every 4 hours test run
+  branches:
+    include:
+    - master
+  always: true
+
+variables:
+- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+  - name: _UseHelixOpenQueues
+    value: 'true'
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNet-HelixApi-Access
+  - name: _UseHelixOpenQueues
+    value: 'false'
+
+jobs:
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Helix_quarantined_x64
+    jobDisplayName: 'Tests: Helix'
+    agentOs: Windows
+    timeoutInMinutes: 180
+    steps:
+    # Build the shared framework
+    - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Build shared fx
+    - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
+      displayName: Restore interop projects
+    - script: ./build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
+              /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Run build.cmd helix target
+      continueOnError: true
+      env:
+        HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+    artifacts:
+    - name: Helix_logs
+      path: artifacts/log/
+      publishOnError: true
+
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Windows_Quarantined_x64
+    jobDisplayName: 'Tests: Windows x64'
+    agentOs: Windows
+    timeoutInMinutes: 180
+    isTestingJob: true
+    steps:
+    - powershell: "& ./build.ps1 -CI -nobl -all -pack -NoBuildJava"
+      displayName: Build
+    # The templates part can be removed when the Blazor Templates run on Helix
+    - script: ./src/ProjectTemplates/build.cmd -ci -nobl -pack -NoRestore -NoBuilddeps "/p:RunTemplateTests=true"
+      displayName: Pack Templates
+    - script: ./build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true"
+      displayName: Run Quarantined Tests
+      continueOnError: true
+    - task: PublishTestResults@2
+      displayName: Publish Quarantined Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+      condition: always()
+    artifacts:
+    - name: Windows_Quarantined_Test_Logs
+      path: artifacts/log/
+      publishOnError: true
+      includeForks: true
+    - name: Windows_Quarantined_Test_Results
+      path: artifacts/TestResults/
+      publishOnError: true
+      includeForks: true
+
+- template: jobs/default-build.yml
+  parameters:
+    jobName: MacOS_Quarantined_Test
+    jobDisplayName: "Tests: macOS 10.14"
+    agentOs: macOS
+    timeoutInMinutes: 180
+    isTestingJob: true
+    steps:
+    - bash: ./build.sh --all --pack --ci --nobl --no-build-java
+      displayName: Build
+    # The templates part can be removed when the Blazor Templates run on Helix
+    - bash: ./src/ProjectTemplates/build.sh --ci --nobl --pack --no-restore --no-build-deps
+      displayName: Pack Templates (for Template tests)
+    - bash: ./build.sh --no-build --ci --nobl --test -p:RunTemplateTests=true -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+      displayName: Run Quarantined Tests
+      continueOnError: true
+    - task: PublishTestResults@2
+      displayName: Publish Quarantined Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+      condition: always()
+    artifacts:
+    - name: MacOS_Quarantined_Test_Logs
+      path: artifacts/log/
+      publishOnError: true
+      includeForks: true
+    - name: MacOS_Quarantined_Test_Results
+      path: artifacts/TestResults/
+      publishOnError: true
+      includeForks: true
+
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Linux_Quarantined_Test
+    jobDisplayName: "Tests: Ubuntu 16.04 x64"
+    agentOs: Linux
+    timeoutInMinutes: 180
+    isTestingJob: true
+    useHostedUbuntu: false
+    steps:
+    - bash: ./build.sh --all --pack --ci --nobl --no-build-java
+      displayName: Build
+    # The templates part can be removed when the Blazor Templates run on Helix
+    - bash: ./src/ProjectTemplates/build.sh --ci --nobl --pack --no-restore --no-build-deps
+      displayName: Pack Templates (for Template tests)
+    - bash: ./build.sh --no-build --ci --nobl --test -p:RunTemplateTests=true -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+      displayName: Run Quarantined Tests
+      continueOnError: true
+    - task: PublishTestResults@2
+      displayName: Publish Quarantined Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+      condition: always()
+    artifacts:
+    - name: Linux_Quarantined_Test_Logs
+      path: artifacts/log/
+      publishOnError: true
+      includeForks: true
+    - name: Linux_Quarantined_Test_Results
+      path: artifacts/TestResults/
+      publishOnError: true
+      includeForks: true


### PR DESCRIPTION
Related to https://github.com/dotnet/aspnetcore/pull/23377 which converts existing quarantine to a once a day run.

Once 23377 is merged, I'll remove the non helix jobs from that pipeline assuming we still want those tests run more frequently as they are today