### PR TITLE
Avoid running restores for dotnet-watch run

### DIFF
--- a/src/Tools/dotnet-watch/README.md
+++ b/src/Tools/dotnet-watch/README.md
@@ -29,7 +29,7 @@ Some configuration options can be passed to `dotnet watch` through environment v
 | Variable                                       | Effect                                                   |
 | ---------------------------------------------- | -------------------------------------------------------- |
 | DOTNET_USE_POLLING_FILE_WATCHER                | If set to "1" or "true", `dotnet watch` will use a polling file watcher instead of CoreFx's `FileSystemWatcher`. Used when watching files on network shares or Docker mounted volumes.                       |
-| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizes the build by avoid certain operations such as running restore or re-evaluating the set on watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
+| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizes the build by avoid certain operations such as running restore or re-evaluating the set of watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
 
 ### MSBuild
 

--- a/src/Tools/dotnet-watch/README.md
+++ b/src/Tools/dotnet-watch/README.md
@@ -29,7 +29,7 @@ Some configuration options can be passed to `dotnet watch` through environment v
 | Variable                                       | Effect                                                   |
 | ---------------------------------------------- | -------------------------------------------------------- |
 | DOTNET_USE_POLLING_FILE_WATCHER                | If set to "1" or "true", `dotnet watch` will use a polling file watcher instead of CoreFx's `FileSystemWatcher`. Used when watching files on network shares or Docker mounted volumes.                       |
-| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizies the build by avoid certain operations such as running restore or re-evaluating the set on watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
+| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizes the build by avoid certain operations such as running restore or re-evaluating the set on watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
 
 ### MSBuild
 

--- a/src/Tools/dotnet-watch/README.md
+++ b/src/Tools/dotnet-watch/README.md
@@ -29,6 +29,7 @@ Some configuration options can be passed to `dotnet watch` through environment v
 | Variable                                       | Effect                                                   |
 | ---------------------------------------------- | -------------------------------------------------------- |
 | DOTNET_USE_POLLING_FILE_WATCHER                | If set to "1" or "true", `dotnet watch` will use a polling file watcher instead of CoreFx's `FileSystemWatcher`. Used when watching files on network shares or Docker mounted volumes.                       |
+| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizies the build by avoid certain operations such as running restore or re-evaluating the set on watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
 
 ### MSBuild
 

--- a/src/Tools/dotnet-watch/README.md
+++ b/src/Tools/dotnet-watch/README.md
@@ -29,7 +29,7 @@ Some configuration options can be passed to `dotnet watch` through environment v
 | Variable                                       | Effect                                                   |
 | ---------------------------------------------- | -------------------------------------------------------- |
 | DOTNET_USE_POLLING_FILE_WATCHER                | If set to "1" or "true", `dotnet watch` will use a polling file watcher instead of CoreFx's `FileSystemWatcher`. Used when watching files on network shares or Docker mounted volumes.                       |
-| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizes the build by avoid certain operations such as running restore or re-evaluating the set of watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
+| DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM   | By default, `dotnet watch` optimizes the build by avoiding certain operations such as running restore or re-evaluating the set of watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
 
 ### MSBuild
 

--- a/src/Tools/dotnet-watch/src/DotNetWatchContext.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatchContext.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class DotNetWatchContext
+    {
+        public IReporter Reporter { get; set; } = NullReporter.Singleton;
+
+        public ProcessSpec ProcessSpec { get; set; }
+
+        public IFileSet FileSet { get; set; }
+
+        public int Iteration { get; set; }
+
+        public string ChangedFile { get; set; }
+
+        public bool RequiresMSBuildRevaluation { get; set; }
+    }
+}

--- a/src/Tools/dotnet-watch/src/DotNetWatchContext.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatchContext.cs
@@ -18,5 +18,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         public string ChangedFile { get; set; }
 
         public bool RequiresMSBuildRevaluation { get; set; }
+
+        public bool SuppresMSBuildIncrementalism { get; set; }
     }
 }

--- a/src/Tools/dotnet-watch/src/DotNetWatchContext.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatchContext.cs
@@ -19,6 +19,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public bool RequiresMSBuildRevaluation { get; set; }
 
-        public bool SuppresMSBuildIncrementalism { get; set; }
+        public bool SuppressMSBuildIncrementalism { get; set; }
     }
 }

--- a/src/Tools/dotnet-watch/src/DotNetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatcher.cs
@@ -49,10 +49,10 @@ namespace Microsoft.DotNet.Watcher
                 Iteration = -1,
                 ProcessSpec = processSpec,
                 Reporter = _reporter,
-                SuppresMSBuildIncrementalism = suppressMSBuildIncrementalism == "1" || suppressMSBuildIncrementalism == "true",
+                SuppressMSBuildIncrementalism = suppressMSBuildIncrementalism == "1" || suppressMSBuildIncrementalism == "true",
             };
 
-            if (context.SuppresMSBuildIncrementalism)
+            if (context.SuppressMSBuildIncrementalism)
             {
                 _reporter.Verbose("MSBuild incremental optimizations suppressed.");
             }

--- a/src/Tools/dotnet-watch/src/DotNetWatcher.cs
+++ b/src/Tools/dotnet-watch/src/DotNetWatcher.cs
@@ -43,12 +43,19 @@ namespace Microsoft.DotNet.Watcher
                 cancelledTaskSource);
 
             var initialArguments = processSpec.Arguments.ToArray();
+            var suppressMSBuildIncrementalism = Environment.GetEnvironmentVariable("DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM");
             var context = new DotNetWatchContext
             {
                 Iteration = -1,
                 ProcessSpec = processSpec,
                 Reporter = _reporter,
+                SuppresMSBuildIncrementalism = suppressMSBuildIncrementalism == "1" || suppressMSBuildIncrementalism == "true",
             };
+
+            if (context.SuppresMSBuildIncrementalism)
+            {
+                _reporter.Verbose("MSBuild incremental optimizations suppressed.");
+            }
 
             while (true)
             {

--- a/src/Tools/dotnet-watch/src/IWatchFilter.cs
+++ b/src/Tools/dotnet-watch/src/IWatchFilter.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public interface IWatchFilter
+    {
+        ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/dotnet-watch/src/Internal/FileSet.cs
+++ b/src/Tools/dotnet-watch/src/Internal/FileSet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,6 +19,8 @@ namespace Microsoft.DotNet.Watcher.Internal
         public bool Contains(string filePath) => _files.Contains(filePath);
 
         public int Count => _files.Count;
+
+        public static IFileSet Empty = new FileSet(Array.Empty<string>());
 
         public IEnumerator<string> GetEnumerator() => _files.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => _files.GetEnumerator();

--- a/src/Tools/dotnet-watch/src/MSBuildEvaluationFilter.cs
+++ b/src/Tools/dotnet-watch/src/MSBuildEvaluationFilter.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class MSBuildEvaluationFilter : IWatchFilter
+    {
+        // File types that require an MSBuild re-evaluation
+        private static readonly HashSet<string> _msBuildFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".props", ".targets", ".csproj", ".fsproj", ".vbproj",
+        };
+        private readonly IFileSetFactory _factory;
+
+        public MSBuildEvaluationFilter(IFileSetFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
+        {
+            if (context.Iteration == 0 || RequiresMSBuildRevaluation(context.ChangedFile))
+            {
+                context.RequiresMSBuildRevaluation = true;
+            }
+
+            if (context.RequiresMSBuildRevaluation)
+            {
+                context.Reporter.Verbose("Evaluating dotnet-watch file set.");
+                context.FileSet = await _factory.CreateAsync(cancellationToken);
+            }
+        }
+
+        private static bool RequiresMSBuildRevaluation(string changedFile)
+        {
+            if (string.IsNullOrEmpty(changedFile))
+            {
+                return false;
+            }
+
+            var extension = Path.GetExtension(changedFile);
+            return !string.IsNullOrEmpty(extension) && _msBuildFileExtensions.Contains(extension);
+        }
+    }
+}

--- a/src/Tools/dotnet-watch/src/MSBuildEvaluationFilter.cs
+++ b/src/Tools/dotnet-watch/src/MSBuildEvaluationFilter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
-            if (context.SuppresMSBuildIncrementalism)
+            if (context.SuppressMSBuildIncrementalism)
             {
                 context.RequiresMSBuildRevaluation = true;
                 context.FileSet = await _factory.CreateAsync(cancellationToken);

--- a/src/Tools/dotnet-watch/src/NoRestoreFilter.cs
+++ b/src/Tools/dotnet-watch/src/NoRestoreFilter.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public sealed class NoRestoreFilter : IWatchFilter
+    {
+        private bool _canUseNoRestore;
+        private string[] _noRestoreArguments;
+
+        public ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
+        {
+            if (context.Iteration == 0)
+            {
+                var arguments = context.ProcessSpec.Arguments;
+                _canUseNoRestore = CanUseNoRestore(arguments, context.Reporter);
+                if (_canUseNoRestore)
+                {
+                    // Create run --no-restore <other args>
+                    _noRestoreArguments = arguments.Take(1).Append("--no-restore").Concat(arguments.Skip(1)).ToArray();
+                    context.Reporter.Verbose($"No restore arguments: {string.Join(" ", _noRestoreArguments)}");
+                }
+            }
+            else if (_canUseNoRestore)
+            {
+                if (context.RequiresMSBuildRevaluation)
+                {
+                    context.Reporter.Verbose("Cannot use --no-restore since msbuild project files have changed.");
+                }
+                else
+                {
+
+                    context.Reporter.Verbose("Modifying command to use --no-restore");
+                    context.ProcessSpec.Arguments = _noRestoreArguments;
+                }
+            }
+
+            return default;
+        }
+
+        private static bool CanUseNoRestore(IEnumerable<string> arguments, IReporter reporter)
+        {
+            // For some well-known dotnet commands, we can pass in the --no-restore switch to avoid unnecessary restores between iterations.
+            // For now we'll support the "run" and "test" commands.
+            if (arguments.Any(a => string.Equals(a, "--no-restore", StringComparison.Ordinal)))
+            {
+                // Did the user already configure a --no-restore?
+                return false;
+            }
+
+            var dotnetCommand = arguments.FirstOrDefault();
+            if (string.Equals(dotnetCommand, "run", StringComparison.Ordinal) || string.Equals(dotnetCommand, "test", StringComparison.Ordinal))
+            {
+                reporter.Verbose("Watch command can be configured to use --no-restore.");
+                return true;
+            }
+            else
+            {
+                reporter.Verbose($"Watch command will not use --no-restore. Unsupport dotnet-command '{dotnetCommand}'.");
+                return false;
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-watch/src/NoRestoreFilter.cs
+++ b/src/Tools/dotnet-watch/src/NoRestoreFilter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
-            if (context.SuppresMSBuildIncrementalism)
+            if (context.SuppressMSBuildIncrementalism)
             {
                 return default;
             }

--- a/src/Tools/dotnet-watch/src/NoRestoreFilter.cs
+++ b/src/Tools/dotnet-watch/src/NoRestoreFilter.cs
@@ -17,6 +17,11 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public ValueTask ProcessAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            if (context.SuppresMSBuildIncrementalism)
+            {
+                return default;
+            }
+
             if (context.Iteration == 0)
             {
                 var arguments = context.ProcessSpec.Arguments;
@@ -36,7 +41,6 @@ namespace Microsoft.DotNet.Watcher.Tools
                 }
                 else
                 {
-
                     context.Reporter.Verbose("Modifying command to use --no-restore");
                     context.ProcessSpec.Arguments = _noRestoreArguments;
                 }

--- a/src/Tools/dotnet-watch/src/Program.cs
+++ b/src/Tools/dotnet-watch/src/Program.cs
@@ -162,8 +162,8 @@ namespace Microsoft.DotNet.Watcher
                 _reporter.Output("Polling file watcher is enabled");
             }
 
-            await new DotNetWatcher(reporter)
-                .WatchAsync(processInfo, fileSetFactory, cancellationToken);
+            await new DotNetWatcher(reporter, fileSetFactory)
+                .WatchAsync(processInfo, cancellationToken);
 
             return 0;
         }

--- a/src/Tools/dotnet-watch/test/MSBuildEvaluationFilterTest.cs
+++ b/src/Tools/dotnet-watch/test/MSBuildEvaluationFilterTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class MSBuildEvaluationFilterTest
+    {
+        private readonly IFileSetFactory _fileSetFactory = Mock.Of<IFileSetFactory>(f => f.CreateAsync(It.IsAny<CancellationToken>()) == Task.FromResult(Mock.Of<IFileSet>()));
+
+        [Fact]
+        public async Task ProcessAsync_EvaluatesFileSetIfProjFileChanges()
+        {
+            // Arrange
+            var filter = new MSBuildEvaluationFilter(_fileSetFactory);
+            var fileSet = Mock.Of<IFileSet>();
+            var context = new DotNetWatchContext
+            {
+                Iteration = 4,
+                ChangedFile = "Test.csproj",
+                FileSet = fileSet,
+            };
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.True(context.RequiresMSBuildRevaluation);
+            Assert.NotSame(fileSet, context.FileSet);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_DoesNotEvaluateFileSetIfNonProjFileChanges()
+        {
+            // Arrange
+            var filter = new MSBuildEvaluationFilter(_fileSetFactory);
+            var fileSet = Mock.Of<IFileSet>();
+            var context = new DotNetWatchContext
+            {
+                Iteration = 5,
+                ChangedFile = "Controller.cs",
+                FileSet = fileSet,
+            };
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.False(context.RequiresMSBuildRevaluation);
+            Assert.Same(fileSet, context.FileSet);
+        }
+    }
+}

--- a/src/Tools/dotnet-watch/test/MSBuildEvaluationFilterTest.cs
+++ b/src/Tools/dotnet-watch/test/MSBuildEvaluationFilterTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             var context = new DotNetWatchContext
             {
                 Iteration = 0,
-                SuppresMSBuildIncrementalism = true,
+                SuppressMSBuildIncrementalism = true,
             };
 
             await filter.ProcessAsync(context, default);

--- a/src/Tools/dotnet-watch/test/MSBuildEvaluationFilterTest.cs
+++ b/src/Tools/dotnet-watch/test/MSBuildEvaluationFilterTest.cs
@@ -1,8 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Watcher.Internal;
 using Moq;
 using Xunit;
 
@@ -10,27 +15,30 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public class MSBuildEvaluationFilterTest
     {
-        private readonly IFileSetFactory _fileSetFactory = Mock.Of<IFileSetFactory>(f => f.CreateAsync(It.IsAny<CancellationToken>()) == Task.FromResult(Mock.Of<IFileSet>()));
+        private readonly IFileSetFactory _fileSetFactory = Mock.Of<IFileSetFactory>(
+            f => f.CreateAsync(It.IsAny<CancellationToken>()) == Task.FromResult<IFileSet>(new FileSet(Enumerable.Empty<string>())));
 
         [Fact]
         public async Task ProcessAsync_EvaluatesFileSetIfProjFileChanges()
         {
             // Arrange
             var filter = new MSBuildEvaluationFilter(_fileSetFactory);
-            var fileSet = Mock.Of<IFileSet>();
             var context = new DotNetWatchContext
             {
-                Iteration = 4,
-                ChangedFile = "Test.csproj",
-                FileSet = fileSet,
+                Iteration = 0,
             };
+
+            await filter.ProcessAsync(context, default);
+
+            context.Iteration++;
+            context.ChangedFile = "Test.csproj";
+            context.RequiresMSBuildRevaluation = false;
 
             // Act
             await filter.ProcessAsync(context, default);
 
             // Assert
             Assert.True(context.RequiresMSBuildRevaluation);
-            Assert.NotSame(fileSet, context.FileSet);
         }
 
         [Fact]
@@ -38,20 +46,97 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             // Arrange
             var filter = new MSBuildEvaluationFilter(_fileSetFactory);
-            var fileSet = Mock.Of<IFileSet>();
             var context = new DotNetWatchContext
             {
-                Iteration = 5,
-                ChangedFile = "Controller.cs",
-                FileSet = fileSet,
+                Iteration = 0,
             };
+
+            await filter.ProcessAsync(context, default);
+
+            context.Iteration++;
+            context.ChangedFile = "Controller.cs";
+            context.RequiresMSBuildRevaluation = false;
 
             // Act
             await filter.ProcessAsync(context, default);
 
             // Assert
             Assert.False(context.RequiresMSBuildRevaluation);
-            Assert.Same(fileSet, context.FileSet);
+            Mock.Get(_fileSetFactory).Verify(v => v.CreateAsync(It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task ProcessAsync_EvaluateFileSetOnEveryChangeIfOptimizationIsSuppressed()
+        {
+            // Arrange
+            var filter = new MSBuildEvaluationFilter(_fileSetFactory);
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                SuppresMSBuildIncrementalism = true,
+            };
+
+            await filter.ProcessAsync(context, default);
+
+            context.Iteration++;
+            context.ChangedFile = "Controller.cs";
+            context.RequiresMSBuildRevaluation = false;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.True(context.RequiresMSBuildRevaluation);
+            Mock.Get(_fileSetFactory).Verify(v => v.CreateAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+
+        }
+
+        [Fact]
+        public async Task ProcessAsync_SetsEvaluationRequired_IfMSBuildFileChanges_ButIsNotChangedFile()
+        {
+            // There's a chance that the watcher does not correctly report edits to msbuild files on
+            // concurrent edits. MSBuildEvaluationFilter uses timestamps to additionally track changes to these files.
+
+            // Arrange
+            var fileSet = new FileSet(new[] { "Controlller.cs", "Proj.csproj" });
+            var fileSetFactory = Mock.Of<IFileSetFactory>(f => f.CreateAsync(It.IsAny<CancellationToken>()) == Task.FromResult<IFileSet>(fileSet));
+
+            var filter = new TestableMSBuildEvaluationFilter(fileSetFactory)
+            {
+                Timestamps =
+                {
+                    ["Controller.cs"] = new DateTime(1000),
+                    ["Proj.csproj"] = new DateTime(1000),
+                }
+            };
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+            };
+
+            await filter.ProcessAsync(context, default);
+            context.RequiresMSBuildRevaluation = false;
+            context.ChangedFile = "Controller.cs";
+            context.Iteration++;
+            filter.Timestamps["Proj.csproj"] = new DateTime(1007);
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.True(context.RequiresMSBuildRevaluation);
+        }
+
+        public class TestableMSBuildEvaluationFilter : MSBuildEvaluationFilter
+        {
+            public TestableMSBuildEvaluationFilter(IFileSetFactory factory)
+                : base(factory)
+            {
+            }
+
+            public Dictionary<string, DateTime> Timestamps { get; } = new Dictionary<string, DateTime>();
+
+            protected override DateTime GetLastWriteTimeUtcSafely(string file) => Timestamps[file];
         }
     }
 }

--- a/src/Tools/dotnet-watch/test/NoRestoreFilterTest.cs
+++ b/src/Tools/dotnet-watch/test/NoRestoreFilterTest.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class NoRestoreFilterTest
+    {
+        private readonly string[] _arguments = new[] { "run" };
+
+        [Fact]
+        public async Task ProcessAsync_LeavesArgumentsUnchangedOnFirstRun()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+
+            var context = new DotNetWatchContext
+            {
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = _arguments,
+                }
+            };
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Same(_arguments, context.ProcessSpec.Arguments);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_LeavesArgumentsUnchangedIfMsBuildRevaluationIsRequired()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = _arguments,
+                }
+            };
+            await filter.ProcessAsync(context, default);
+
+            context.ChangedFile = "Test.proj";
+            context.RequiresMSBuildRevaluation = true;
+            context.Iteration++;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Same(_arguments, context.ProcessSpec.Arguments);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_AddsNoRestoreSwitch()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = _arguments,
+                }
+            };
+            await filter.ProcessAsync(context, default);
+
+            context.ChangedFile = "Program.cs";
+            context.Iteration++;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Equal(new[] { "run", "--no-restore" }, context.ProcessSpec.Arguments);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_AddsNoRestoreSwitch_WithAdditionalArguments()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = new[] { "run", "-f", "net5.0", "--", "foo=bar" },
+                }
+            };
+            await filter.ProcessAsync(context, default);
+
+            context.ChangedFile = "Program.cs";
+            context.Iteration++;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Equal(new[] { "run", "--no-restore", "-f", "net5.0", "--", "foo=bar" }, context.ProcessSpec.Arguments);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_AddsNoRestoreSwitch_ForTestCommand()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = new[] { "test", "--filter SomeFilter" },
+                }
+            };
+            await filter.ProcessAsync(context, default);
+
+            context.ChangedFile = "Program.cs";
+            context.Iteration++;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Equal(new[] { "test", "--no-restore", "--filter SomeFilter" }, context.ProcessSpec.Arguments);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_DoesNotModifyArgumentsForUnknownCommands()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+            var arguments = new[] { "ef", "database", "update" };
+
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = arguments,
+                }
+            };
+            await filter.ProcessAsync(context, default);
+
+            context.ChangedFile = "Program.cs";
+            context.Iteration++;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Same(arguments, context.ProcessSpec.Arguments);
+        }
+    }
+}

--- a/src/Tools/dotnet-watch/test/NoRestoreFilterTest.cs
+++ b/src/Tools/dotnet-watch/test/NoRestoreFilterTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 {
                     Arguments = _arguments,
                 },
-                SuppresMSBuildIncrementalism = true,
+                SuppressMSBuildIncrementalism = true,
             };
             await filter.ProcessAsync(context, default);
 

--- a/src/Tools/dotnet-watch/test/NoRestoreFilterTest.cs
+++ b/src/Tools/dotnet-watch/test/NoRestoreFilterTest.cs
@@ -59,6 +59,33 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Fact]
+        public async Task ProcessAsync_LeavesArgumentsUnchangedIfOptimizationIsSuppressed()
+        {
+            // Arrange
+            var filter = new NoRestoreFilter();
+
+            var context = new DotNetWatchContext
+            {
+                Iteration = 0,
+                ProcessSpec = new ProcessSpec
+                {
+                    Arguments = _arguments,
+                },
+                SuppresMSBuildIncrementalism = true,
+            };
+            await filter.ProcessAsync(context, default);
+
+            context.ChangedFile = "Program.cs";
+            context.Iteration++;
+
+            // Act
+            await filter.ProcessAsync(context, default);
+
+            // Assert
+            Assert.Same(_arguments, context.ProcessSpec.Arguments);
+        }
+
+        [Fact]
         public async Task ProcessAsync_AddsNoRestoreSwitch()
         {
             // Arrange

--- a/src/Tools/dotnet-watch/test/Scenario/WatchableApp.cs
+++ b/src/Tools/dotnet-watch/test/Scenario/WatchableApp.cs
@@ -39,6 +39,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public AwaitableProcess Process { get; protected set; }
 
+        public List<string> DotnetWatchArgs { get; } = new List<string>();
+
         public string SourceDirectory { get; }
 
         public Task HasRestarted()
@@ -86,6 +88,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             {
                 Scenario.DotNetWatchPath,
             };
+            args.AddRange(DotnetWatchArgs);
             args.AddRange(arguments);
 
             var dotnetPath = "dotnet";

--- a/src/Tools/dotnet-watch/test/TestProjects/KitchenSink/Program.cs
+++ b/src/Tools/dotnet-watch/test/TestProjects/KitchenSink/Program.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace KitchenSink
 {
@@ -15,6 +16,12 @@ namespace KitchenSink
             Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
             Console.WriteLine("DOTNET_WATCH = " + Environment.GetEnvironmentVariable("DOTNET_WATCH"));
             Console.WriteLine("DOTNET_WATCH_ITERATION = " + Environment.GetEnvironmentVariable("DOTNET_WATCH_ITERATION"));
+
+            if (args.Length > 0 && args[0] == "wait")
+            {
+                Console.WriteLine("Waiting for process to be terminated.");
+                Thread.Sleep(Timeout.Infinite);
+            }
         }
     }
 }


### PR DESCRIPTION
* Use --no-restore if a non-MSBuild file changed
* Avoid evaluation watched file if non-MSBuild file changed.

Contributes to https://github.com/dotnet/aspnetcore/issues/23073

Some numbers: https://gist.github.com/pranavkm/21d0f197f8fbb0383752b8fb51b602e9