### PR TITLE
Include aspnet-blazor-eng team as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,14 +9,16 @@
 /eng/common/                    @dotnet-maestro-bot
 /eng/Versions.props             @dotnet-maestro-bot @dougbu
 /eng/Version.Details.xml        @dotnet-maestro-bot @dougbu
-/src/Components/                @SteveSandersonMS
+/src/Components/                @SteveSandersonMS @aspnet-blazor-eng
 /src/DefaultBuilder/            @tratcher
 /src/Hosting/                   @tratcher
 /src/Http/                      @tratcher @jkotalik
 /src/Middleware/                @tratcher
 /src/Middleware/HttpsPolicy/    @jkotalik
 /src/Middleware/Rewrite/        @jkotalik
-# /src/ProjectTemplates/          @ryanbrandenburg
+# /src/ProjectTemplates/        @ryanbrandenburg
+/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/  @aspnet-blazor-eng
+/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/  @aspnet-blazor-eng
 /src/Security/                  @tratcher
 /src/Servers/                   @tratcher @jkotalik @halter73
 /src/Shared/runtime/            @dotnet/http


### PR DESCRIPTION
Making sure that the @dotnet/aspnet-blazor-eng team is automatically assigned to all PRs related to Blazor.
This was already setup in the `blazor-wasm` branch, but got removed during merge.