### PR TITLE
Fix the blazorwasm benchmark app

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -40,13 +40,12 @@ namespace Wasm.Performance.Driver
                     return 1;
                 }
 
-                if (stressRunSeconds < 1)
+                if (stressRunSeconds < 0)
                 {
                     Console.Error.WriteLine("Stress run duration must be a positive integer.");
                     return 1;
                 }
-
-                if (stressRunSeconds > 0)
+                else if (stressRunSeconds > 0)
                 {
                     isStressRun = true;
 

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Selenium.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Selenium.cs
@@ -15,7 +15,13 @@ namespace Wasm.Performance.Driver
     {
         const int SeleniumPort = 4444;
         static bool RunHeadlessBrowser = true;
-        static bool PoolForBrowserLogs = false;
+
+        static bool PoolForBrowserLogs =
+#if DEBUG
+            true;
+#else
+            false;
+#endif
 
         private static async ValueTask<Uri> WaitForServerAsync(int port, CancellationToken cancellationToken)
         {

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
@@ -8,6 +8,8 @@
     <!-- WebDriver is not strong-named, so this test project cannot be strong named either. -->
     <SignAssembly>false</SignAssembly>
     <IsTestAssetProject>true</IsTestAssetProject>
+    <!-- We are unable to specify a RID via the commandline. Workaround by assuming linux-x64 when building in release. -->
+    <RuntimeIdentifier Condition="'$(Configuration)' == 'Release'">linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/benchmarkapps/Wasm.Performance/README.md
+++ b/src/Components/benchmarkapps/Wasm.Performance/README.md
@@ -9,7 +9,7 @@ The TestApp is a regular BlazorWASM project and can be run using `dotnet run`. T
 
 Here are the commands you would need to run it locally inside docker:
 
-1. `dotnet publish -c Release -r linux-x64 Driver/Wasm.Performance.Driver.csproj`
+1. `dotnet publish -c Release Driver/Wasm.Performance.Driver.csproj`
 2. `docker build -t blazor-local -f ./local.dockerfile . `
 3. `docker run -it blazor-local`
 

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -20,10 +20,11 @@ ADD https://api.github.com/repos/dotnet/aspnetcore/git/ref/heads/${gitBranch} /a
 RUN git init \
     && git fetch https://github.com/aspnet/aspnetcore ${gitBranch} \
     && git reset --hard FETCH_HEAD \
-    && git submodule update --init
+    && git submodule update --init \
+    && git remote add origin https://github.com/aspnet/aspnetcore
 
 RUN ./restore.sh
-RUN .dotnet/dotnet publish -c Release -r linux-x64 -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app

--- a/src/Components/benchmarkapps/Wasm.Performance/local.dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/local.dockerfile
@@ -3,7 +3,7 @@ FROM selenium/standalone-chrome:3.141.59-mercury as final
 ENV StressRunDuration=0
 
 WORKDIR /app
-COPY ./Driver/bin/Release/netcoreapp3.1/linux-x64/publish ./
+COPY ./Driver/bin/Release/net5.0/linux-x64/publish ./
 COPY ./exec.sh ./
 
 ENTRYPOINT [ "bash", "./exec.sh" ]

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/Microsoft.AspNetCore.Razor.Tools.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/Microsoft.AspNetCore.Razor.Tools.csproj
@@ -20,6 +20,7 @@
 
     <!-- Don't produce rzc.exe -->
     <UseAppHost>false</UseAppHost>
+    <RuntimeIdentifier />
 
     <!-- Need to build this project in source build -->
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/Microsoft.NET.Sdk.Razor.csproj
@@ -30,7 +30,7 @@
       ReferenceOutputAssembly="false"
       IsImplicityDefined="false"
       SkipGetTargetFrameworkProperties="true"
-      UndefineProperties="TargetFramework;TargetFrameworks" />
+      UndefineProperties="TargetFramework;TargetFrameworks;RuntimeIdentifier;PublishDir" />
 
     <ProjectReference
       Include="..\..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj"
@@ -78,11 +78,11 @@
     </ItemGroup>
 
     <Error
-      Message="rzc outputs were not found in $(ArtifactsBinDir)Microsoft.AspNetCore.Razor.Tools\$(Configuration)\netcoreapp3.0\publish"
+      Text="rzc outputs were not found in $(ArtifactsBinDir)Microsoft.AspNetCore.Razor.Tools\$(Configuration)\netcoreapp3.0\publish"
       Condition="'@(RazorToolsOutput->Count())' == '0'" />
 
     <Error
-      Message="Mvc extensions outputs were not found in $(ArtifactsBinDir)Microsoft.AspNetCore.Mvc.Razor.Extensions\$(Configuration)\netstandard2.0"
+      Text="Mvc extensions outputs were not found in $(ArtifactsBinDir)Microsoft.AspNetCore.Mvc.Razor.Extensions\$(Configuration)\netstandard2.0"
       Condition="'@(MvcRazorExtensionOutput->Count())' == '0'" />
 
     <Copy SourceFiles="@(RazorToolsOutput)" DestinationFolder="$(SdkOutputPath)tools\netcoreapp3.0\" SkipUnchangedFiles="true" Retries="$(_Retries)" ContinueOnError="$(_ContinueOnError)" />


### PR DESCRIPTION
Specifying the RID and PublishDir when publishing the driver app causes all sorts of
build issues. This change moves specifying the RID in to the driver app and ensures PublishDir
does not flow to the referenced RazorSDK project.

* Fix docker build
* Update readme typos

