### PR TITLE
Unquaratine blazor template tests 

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/build/net5.0/Microsoft.AspNetCore.Components.WebAssembly.props
+++ b/src/Components/WebAssembly/WebAssembly/src/build/net5.0/Microsoft.AspNetCore.Components.WebAssembly.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <BlazorWebAssemblyJSPath>$(MSBuildThisFileDirectory)blazor.webassembly.js</BlazorWebAssemblyJSPath>
+  </PropertyGroup>
+</Project>

--- a/src/ProjectTemplates/BlazorTemplates.Tests/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/AssemblyInfo.AssemblyFixtures.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.E2ETesting;
-using Microsoft.AspNetCore.Testing;
 using Templates.Test.Helpers;
 using Xunit;
 
@@ -11,4 +10,3 @@ using Xunit;
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(ProjectFactoryFixture))]
 [assembly: Microsoft.AspNetCore.E2ETesting.AssemblyFixture(typeof(SeleniumStandaloneServer))]
 
-[assembly: QuarantinedTest("Investigation pending in https://github.com/dotnet/aspnetcore/issues/20479")]

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -9,6 +9,7 @@
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''" >true</RunTemplateTests>
+    <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
     <!--Do not run this test project on Helix.-->
     <BuildHelixPayload>false</BuildHelixPayload>
     <SkipHelixArm>true</SkipHelixArm>

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
@@ -333,7 +333,7 @@ namespace Templates.Test
         public async Task BlazorWasmStandaloneTemplate_IndividualAuth_Works()
         {
             var project = await ProjectFactory.GetOrCreateProject("blazorstandaloneindividual", Output);
-            project.TargetFramework = "netstandard2.1";
+            project.RuntimeIdentifier = "browser-wasm";
 
             var createResult = await project.RunDotNetNewAsync("blazorwasm", args: new[] {
                 "-au",

--- a/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
+++ b/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
@@ -44,7 +44,7 @@ namespace Templates.Test.Helpers
                         DiagnosticsMessageSink = DiagnosticsMessageSink,
                         ProjectGuid = Path.GetRandomFileName().Replace(".", string.Empty)
                     };
-                    project.ProjectName = $"AspNet.{key}.{project.ProjectGuid}";
+                    project.ProjectName = project.ProjectGuid;
 
                     var assemblyPath = GetType().Assembly;
                     var basePath = GetTemplateFolderBasePath(assemblyPath);

--- a/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
+++ b/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
@@ -44,7 +44,7 @@ namespace Templates.Test.Helpers
                         DiagnosticsMessageSink = DiagnosticsMessageSink,
                         ProjectGuid = Path.GetRandomFileName().Replace(".", string.Empty)
                     };
-                    project.ProjectName = project.ProjectGuid;
+                    project.ProjectName = $"AspNet.{project.ProjectGuid}";
 
                     var assemblyPath = GetType().Assembly;
                     var basePath = GetTemplateFolderBasePath(assemblyPath);

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Components.Wasm.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Components.Wasm.targets
@@ -92,6 +92,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       Calculates the outputs and the paths for Blazor WASM. This target is invoked frequently and should perform minimal work.
     -->
+
     <ItemGroup>
       <_BlazorJSFile Include="$(BlazorWebAssemblyJSPath)" />
       <_BlazorJSFile Include="$(BlazorWebAssemblyJSMapPath)" Condition="Exists('$(BlazorWebAssemblyJSMapPath)')" />
@@ -140,7 +141,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="SatelliteAssembly" ItemName="_BlazorReadSatelliteAssembly" />
     </BlazorReadSatelliteAssemblyFile>
 
-    <ItemGroup >
+    <ItemGroup>
       <!-- We've imported a previously Cacheed file. Let's turn in to a _BlazorOutputWithTargetPath -->
       <_BlazorOutputWithTargetPath
         Include="@(_BlazorReadSatelliteAssembly)"
@@ -161,6 +162,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Retarget ReferenceCopyLocalPaths to copy to the wwwroot directory -->
       <ReferenceCopyLocalPaths DestinationSubDirectory="$(_BlazorOutputPath)%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
     </ItemGroup>
+
+    <!-- A missing blazor.webassembly.js is our packaging error. Produce an error so it's discovered early. -->
+    <Error
+      Text="Unable to find BlazorWebAssembly JS files. This usually indicates a packaging error."
+      Code="RAZORSDK1007"
+      Condition="'@(_BlazorJSFile->Count())' == '0'" />
 
     <!--
       When building with BuildingProject=false, satellite assemblies do not get resolved (the ones for the current project and the one for


### PR DESCRIPTION
* The failure issue #20479 was resolved, but the assembly level quarantine was
missed being removed.
* Use shorter project file names to avoid long path issues.
* Update blazorwasm template tests to react to net5 updates