### PR TITLE
Fix Baseline.xml version updates

### DIFF
--- a/eng/tools/BaselineGenerator/Program.cs
+++ b/eng/tools/BaselineGenerator/Program.cs
@@ -177,7 +177,7 @@ namespace PackageBaselineGenerator
                 var versionAttribute = document.Root.Attribute("Version");
                 hasChanged = await TryUpdateVersionAsync(
                     versionAttribute,
-                    "Microsoft.AspNetCore.App",
+                    "Microsoft.AspNetCore.App.Runtime.win-x64",
                     packageMetadataResource,
                     logger,
                     cacheContext);


### PR DESCRIPTION
Use https://www.nuget.org/packages/Microsoft.AspNetCore.App.Runtime.win-x64/3.1.5 instead.