### PR TITLE
[HTTPS] Support exporting the dev-cert in PEM format and support importing an existing dev-cert in PFX

### DIFF
--- a/src/ProjectTemplates/Shared/DevelopmentCertificate.cs
+++ b/src/ProjectTemplates/Shared/DevelopmentCertificate.cs
@@ -35,7 +35,7 @@ namespace Templates.Test.Helpers
             var manager = CertificateManager.Instance;
             var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1));
             var certificateThumbprint = certificate.Thumbprint;
-            manager.ExportCertificate(certificate, path: certificatePath, includePrivateKey: true, certificatePassword);
+            manager.ExportCertificate(certificate, path: certificatePath, includePrivateKey: true, certificatePassword, CertificateKeyExportFormat.Pfx);
 
             return certificateThumbprint;
         }

--- a/src/Shared/CertificateGeneration/CertificateExportFormat.cs
+++ b/src/Shared/CertificateGeneration/CertificateExportFormat.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Certificates.Generation
+{
+    public enum CertificateKeyExportFormat
+    {
+        Pfx,
+        Pem,
+    }
+}

--- a/src/Shared/CertificateGeneration/CertificateExportFormat.cs
+++ b/src/Shared/CertificateGeneration/CertificateExportFormat.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Certificates.Generation
 {
-    public enum CertificateKeyExportFormat
+    internal enum CertificateKeyExportFormat
     {
         Pfx,
         Pem,

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -171,6 +171,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             certificates = filteredCertificates;
 
             X509Certificate2 certificate = null;
+            var isNewCertificate = false;
             if (certificates.Any())
             {
                 certificate = certificates.First();
@@ -217,6 +218,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 try
                 {
                     Log.CreateDevelopmentCertificateStart();
+                    isNewCertificate = true;
                     certificate = CreateAspNetCoreHttpsDevelopmentCertificate(notBefore, notAfter);
                 }
                 catch (Exception e)
@@ -292,6 +294,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                     return result;
                 }
             }
+
+            DisposeCertificates(!isNewCertificate ? certificates : certificates.Append(certificate));
 
             return result;
         }

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -402,7 +402,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                     switch (format)
                     {
                         case CertificateKeyExportFormat.Pfx:
-                            bytes = includePrivateKey ? certificate.Export(X509ContentType.Pkcs12, password) : certificate.Export(X509ContentType.Cert);
+                            bytes = certificate.Export(X509ContentType.Pkcs12, password);
                             break;
                         case CertificateKeyExportFormat.Pem:
                             var key = certificate.GetRSAPrivateKey();

--- a/src/Shared/CertificateGeneration/ImportCertificateResult.cs
+++ b/src/Shared/CertificateGeneration/ImportCertificateResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Certificates.Generation
+{
+    internal enum ImportCertificateResult
+    {
+        Succeeded = 1,
+        CertificateFileMissing,
+        InvalidCertificate,
+        NoDevelopmentHttpsCertificate,
+        ExistingCertificatesPresent,
+        ErrorSavingTheCertificateIntoTheCurrentUserPersonalStore,
+    }
+}
+

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             // Tries to use the certificate key to validate it can't access it
             try
             {
-                var rsa = candidate.GetRSAPrivateKey();
+                using var rsa = candidate.GetRSAPrivateKey();
                 if (rsa == null)
                 {
                     return new CheckCertificateStateResult(false, InvalidCertificateState);

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             var tmpFile = Path.GetTempFileName();
             try
             {
-                ExportCertificate(publicCertificate, tmpFile, includePrivateKey: false, password: null);
+                ExportCertificate(publicCertificate, tmpFile, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pfx);
                 Log.MacOSTrustCommandStart($"{MacOSTrustCertificateCommandLine} {MacOSTrustCertificateCommandLineArguments}{tmpFile}");
                 using (var process = Process.Start(MacOSTrustCertificateCommandLine, MacOSTrustCertificateCommandLineArguments + tmpFile))
                 {

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
         protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate)
         {
             var export = certificate.Export(X509ContentType.Pkcs12, "");
+            certificate.Dispose();
             certificate = new X509Certificate2(export, "", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             Array.Clear(export, 0, export.Length);
 

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -26,9 +26,10 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             // For the first run experience we don't need to know if the certificate can be exported.
             return true;
 #else
-            return (c.GetRSAPrivateKey() is RSACryptoServiceProvider rsaPrivateKey &&
+            using var key = c.GetRSAPrivateKey();
+            return (key is RSACryptoServiceProvider rsaPrivateKey &&
                     rsaPrivateKey.CspKeyContainerInfo.Exportable) ||
-                (c.GetRSAPrivateKey() is RSACng cngPrivateKey &&
+                (key is RSACng cngPrivateKey &&
                     cngPrivateKey.Key.ExportPolicy == CngExportPolicies.AllowExport);
 #endif
         }

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             // On non OSX systems we need to export the certificate and import it so that the transient
             // key that we generated gets persisted.
             var export = certificate.Export(X509ContentType.Pkcs12, "");
+            certificate.Dispose();
             certificate = new X509Certificate2(export, "", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             Array.Clear(export, 0, export.Length);
             certificate.FriendlyName = AspNetHttpsOidFriendlyName;
@@ -66,7 +67,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
 
         protected override void TrustCertificateCore(X509Certificate2 certificate)
         {
-            var publicCertificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
+            using var publicCertificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
 
             publicCertificate.FriendlyName = certificate.FriendlyName;
 


### PR DESCRIPTION
* Supports exporting the certificate in PEM format for use within tye, kubernetes, and other tools that don't support PFX.
* Supports importing an existing valid dev-certificate into a given environment.
  * Importing requires that no valid certificate is present.
  * The goal is to more easily share the dev-cert from the host with WSL.

### Open questions
- [ ] Confirm PBE parameters.
- [x]  Add additional tests
- [x] Validate UI