### PR TITLE
React to regression in Http.Sys 

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -20,6 +20,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
 {
     public class Http2Tests
     {
+        // TODO: Remove when the regression is fixed.
+        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+        private static readonly Version Win10_Regressed_DataFrame = new Version(10, 0, 20145, 0);
+
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
         public async Task EmptyResponse_200()
@@ -45,11 +49,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     });
 
                     var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    // TODO: Why are we receiving a blank data frame after headers?
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
 
-                    dataFrame = await h2Connection.ReceiveFrameAsync();
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
                     Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
@@ -166,11 +173,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     });
 
                     var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    // TODO: Why the extra data frame?
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
 
-                    dataFrame = await h2Connection.ReceiveFrameAsync();
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
                     Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
 
                     // Http.Sys doesn't send a final GoAway unless we ignore the first one and send 200 additional streams.
@@ -211,11 +221,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     });
 
                     var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    // TODO: Why the empty data frame?
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: false, length: 0);
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
 
-                    dataFrame = await h2Connection.ReceiveFrameAsync();
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
                     Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: true, length: 0);
 
                     // Http.Sys doesn't send a final GoAway unless we ignore the first one and send 200 additional streams.
@@ -233,11 +246,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                         });
 
                         dataFrame = await h2Connection.ReceiveFrameAsync();
-                        // TODO: Why the empty data frame?
-                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                        Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: false, length: 0);
+                        if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                        {
+                            // TODO: Remove when the regression is fixed.
+                            // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                            Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: false, length: 0);
 
-                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                            dataFrame = await h2Connection.ReceiveFrameAsync();
+                        }
                         Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: true, length: 0);
                     }
 
@@ -257,11 +273,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     });
 
                     dataFrame = await h2Connection.ReceiveFrameAsync();
-                    // TODO: Why the empty data frame?
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: false, length: 0);
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: false, length: 0);
 
-                    dataFrame = await h2Connection.ReceiveFrameAsync();
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
                     Http2Utilities.VerifyDataFrame(dataFrame, streamId, endOfStream: true, length: 0);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
@@ -293,11 +312,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     });
 
                     var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    // TODO: Why are we receiving a blank data frame after headers?
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
 
-                    dataFrame = await h2Connection.ReceiveFrameAsync();
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
                     Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
@@ -362,13 +384,16 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                         Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
                     });
 
-                    // TODO: Why does flushing the headers produce an empty data frame? Seems to be coming from Http.Sys.
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    Http2Utilities.VerifyDataFrame(dataFrame, expectedStreamId: 1, endOfStream: false, length: 0);
+                    var frame = await h2Connection.ReceiveFrameAsync();
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(frame, 1, endOfStream: false, length: 0);
 
-                    var resetFrame = await h2Connection.ReceiveFrameAsync();
-                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, Http2ErrorCode.INTERNAL_ERROR);
+                        frame = await h2Connection.ReceiveFrameAsync();
+                    }
+                    Http2Utilities.VerifyResetFrame(frame, expectedStreamId: 1, Http2ErrorCode.INTERNAL_ERROR);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
                 })
@@ -752,11 +777,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
                     });
 
                     var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    // TODO: Why the extra data frame?
-                    // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
 
-                    dataFrame = await h2Connection.ReceiveFrameAsync();
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
                     Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
 
                     var resetFrame = await h2Connection.ReceiveFrameAsync();


### PR DESCRIPTION
Fixes #23164
All of these tests fail because Http.Sys sends an empty data frame after the headers if there is no data. It's a regression and they plan to fix it. This is a temporary mitigation until then.