### PR TITLE
Expose TrySplitNamespaceAndType as internal static for use in tooling

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperBinderPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperBinderPhase.cs
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                     {
                         // If this is a child content tag helper, we want to add it if it's original type is in scope.
                         // E.g, if the type name is `Test.MyComponent.ChildContent`, we want to add it if `Test.MyComponent` is in scope.
-                        TrySplitNamespaceAndType(typeName, out var typeNameTextSpan, out var _);
+                        RazorCSharpUtilities.TrySplitNamespaceAndType(typeName, out var typeNameTextSpan, out var _);
                         typeName = GetTextSpanContent(typeNameTextSpan, typeName);
                     }
 
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                             {
                                 // If this is a child content tag helper, we want to add it if it's original type is in scope of the given namespace.
                                 // E.g, if the type name is `Test.MyComponent.ChildContent`, we want to add it if `Test.MyComponent` is in this namespace.
-                                TrySplitNamespaceAndType(typeName, out var typeNameTextSpan, out var _);
+                                RazorCSharpUtilities.TrySplitNamespaceAndType(typeName, out var typeNameTextSpan, out var _);
                                 typeName = GetTextSpanContent(typeNameTextSpan, typeName);
                             }
                             if (typeName != null && IsTypeInNamespace(typeName, @namespace))
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             internal static bool IsTypeInNamespace(string typeName, string @namespace)
             {
-                if (!TrySplitNamespaceAndType(typeName, out var typeNamespace, out var _) || typeNamespace.Length == 0)
+                if (!RazorCSharpUtilities.TrySplitNamespaceAndType(typeName, out var typeNamespace, out var _) || typeNamespace.Length == 0)
                 {
                     // Either the typeName is not the full type name or this type is at the top level.
                     return true;
@@ -368,7 +368,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Whereas `MyComponents.SomethingElse.OtherComponent` is not in scope.
             internal static bool IsTypeInScope(string typeName, string currentNamespace)
             {
-                if (!TrySplitNamespaceAndType(typeName, out var typeNamespaceTextSpan, out var _) || typeNamespaceTextSpan.Length == 0)
+                if (!RazorCSharpUtilities.TrySplitNamespaceAndType(typeName, out var typeNamespaceTextSpan, out var _) || typeNamespaceTextSpan.Length == 0)
                 {
                     // Either the typeName is not the full type name or this type is at the top level.
                     return true;
@@ -402,64 +402,16 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     // If this is a child content tag helper, we want to look at it's original type.
                     // E.g, if the type name is `Test.__generated__MyComponent.ChildContent`, we want to look at `Test.__generated__MyComponent`.
-                    TrySplitNamespaceAndType(typeName, out var typeNameTextSpan, out var _);
+                    RazorCSharpUtilities.TrySplitNamespaceAndType(typeName, out var typeNameTextSpan, out var _);
                     typeName = GetTextSpanContent(typeNameTextSpan, typeName);
                 }
-                if (!TrySplitNamespaceAndType(typeName, out var _, out var classNameTextSpan))
+                if (!RazorCSharpUtilities.TrySplitNamespaceAndType(typeName, out var _, out var classNameTextSpan))
                 {
                     return false;
                 }
                 var className = GetTextSpanContent(classNameTextSpan, typeName);
 
                 return ComponentMetadata.IsMangledClass(className);
-            }
-
-            // Internal for testing.
-            internal static bool TrySplitNamespaceAndType(string fullTypeName, out TextSpan @namespace, out TextSpan typeName)
-            {
-                @namespace = default;
-                typeName = default;
-
-                if (string.IsNullOrEmpty(fullTypeName))
-                {
-                    return false;
-                }
-
-                var nestingLevel = 0;
-                var splitLocation = -1;
-                for (var i = fullTypeName.Length - 1; i >= 0; i--)
-                {
-                    var c = fullTypeName[i];
-                    if (c == Type.Delimiter && nestingLevel == 0)
-                    {
-                        splitLocation = i;
-                        break;
-                    }
-                    else if (c == '>')
-                    {
-                        nestingLevel++;
-                    }
-                    else if (c == '<')
-                    {
-                        nestingLevel--;
-                    }
-                }
-
-                if (splitLocation == -1)
-                {
-                    typeName = new TextSpan(0, fullTypeName.Length);
-                    return true;
-                }
-
-                @namespace = new TextSpan(0, splitLocation);
-
-                var typeNameStartLocation = splitLocation + 1;
-                if (typeNameStartLocation < fullTypeName.Length)
-                {
-                    typeName = new TextSpan(typeNameStartLocation, fullTypeName.Length - typeNameStartLocation);
-                }
-
-                return true;
             }
 
             // Internal for testing.

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCSharpUtilities.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCSharpUtilities.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 
 namespace Microsoft.AspNetCore.Razor.Language

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCSharpUtilities.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCSharpUtilities.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal static class RazorCSharpUtilities
+    {
+        public static bool TrySplitNamespaceAndType(string fullTypeName, out TextSpan @namespace, out TextSpan typeName)
+        {
+            @namespace = default;
+            typeName = default;
+
+            if (string.IsNullOrEmpty(fullTypeName))
+            {
+                return false;
+            }
+
+            var nestingLevel = 0;
+            var splitLocation = -1;
+            for (var i = fullTypeName.Length - 1; i >= 0; i--)
+            {
+                var c = fullTypeName[i];
+                if (c == Type.Delimiter && nestingLevel == 0)
+                {
+                    splitLocation = i;
+                    break;
+                }
+                else if (c == '>')
+                {
+                    nestingLevel++;
+                }
+                else if (c == '<')
+                {
+                    nestingLevel--;
+                }
+            }
+
+            if (splitLocation == -1)
+            {
+                typeName = new TextSpan(0, fullTypeName.Length);
+                return true;
+            }
+
+            @namespace = new TextSpan(0, splitLocation);
+
+            var typeNameStartLocation = splitLocation + 1;
+            if (typeNameStartLocation < fullTypeName.Length)
+            {
+                typeName = new TextSpan(typeNameStartLocation, fullTypeName.Length - typeNameStartLocation);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -1342,26 +1342,6 @@ namespace Microsoft.AspNetCore.Razor.Language
             Assert.True(result);
         }
 
-        [Theory]
-        [InlineData("", false, "", "")]
-        [InlineData(".", true, "", "")]
-        [InlineData("Foo", true, "", "Foo")]
-        [InlineData("SomeProject.Foo", true, "SomeProject", "Foo")]
-        [InlineData("SomeProject.Foo<Bar>", true, "SomeProject", "Foo<Bar>")]
-        [InlineData("SomeProject.Foo<Bar.Baz>", true, "SomeProject", "Foo<Bar.Baz>")]
-        [InlineData("SomeProject.Foo<Bar.Baz>>", true, "", "SomeProject.Foo<Bar.Baz>>")]
-        [InlineData("SomeProject..Foo<Bar>", true, "SomeProject.", "Foo<Bar>")]
-        public void TrySplitNamespaceAndType_WorksAsExpected(string fullTypeName, bool expectedResult, string expectedNamespace, string expectedTypeName)
-        {
-            // Arrange & Act
-            var result = RazorCSharpUtilities.TrySplitNamespaceAndType(fullTypeName, out var @namespace, out var typeName);
-
-            // Assert
-            Assert.Equal(expectedResult, result);
-            Assert.Equal(expectedNamespace, DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(@namespace, fullTypeName));
-            Assert.Equal(expectedTypeName, DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(typeName, fullTypeName));
-        }
-
         private static RazorSourceDocument CreateComponentTestSourceDocument(string content, string filePath = null)
         {
             var sourceDocument = TestRazorSourceDocument.Create(content, filePath: filePath);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -1354,8 +1354,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void TrySplitNamespaceAndType_WorksAsExpected(string fullTypeName, bool expectedResult, string expectedNamespace, string expectedTypeName)
         {
             // Arrange & Act
-            var result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(
-                fullTypeName, out var @namespace, out var typeName);
+            var result = RazorCSharpUtilities.TrySplitNamespaceAndType(fullTypeName, out var @namespace, out var typeName);
 
             // Assert
             Assert.Equal(expectedResult, result);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorCSharpUtilitiesTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorCSharpUtilitiesTest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class RazorCSharpUtilitiesTest
+    {
+        [Theory]
+        [InlineData("", false, "", "")]
+        [InlineData(".", true, "", "")]
+        [InlineData("Foo", true, "", "Foo")]
+        [InlineData("SomeProject.Foo", true, "SomeProject", "Foo")]
+        [InlineData("SomeProject.Foo<Bar>", true, "SomeProject", "Foo<Bar>")]
+        [InlineData("SomeProject.Foo<Bar.Baz>", true, "SomeProject", "Foo<Bar.Baz>")]
+        [InlineData("SomeProject.Foo<Bar.Baz>>", true, "", "SomeProject.Foo<Bar.Baz>>")]
+        [InlineData("SomeProject..Foo<Bar>", true, "SomeProject.", "Foo<Bar>")]
+        public void TrySplitNamespaceAndType_WorksAsExpected(string fullTypeName, bool expectedResult, string expectedNamespace, string expectedTypeName)
+        {
+            // Arrange & Act
+            var result = RazorCSharpUtilities.TrySplitNamespaceAndType(fullTypeName, out var @namespace, out var typeName);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedNamespace, DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(@namespace, fullTypeName));
+            Assert.Equal(expectedTypeName, DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(typeName, fullTypeName));
+        }
+    }
+}


### PR DESCRIPTION
This moves `DefaultTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType` into a new `internal static RazorCSharpUtilities`.

This does not address a bug, but will allow us to correctly determine the namespace from a fully qualified component name. This functionality will guarantee correctness in the `add @using` code action for an out-of-scope component in `aspnetcore-tooling` .
