### PR TITLE
Continue on error for helix arm64 on quarantined-tests

### DIFF
--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -59,6 +59,7 @@ jobs:
               $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:RunQuarantinedTests=true
               /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target
+      continueOnError: true
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
         SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops


### PR DESCRIPTION
This will make the pipeline not always be red