### PR TITLE
Use Array.Empty in WebEncoders

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Hosting
             }
             else
             {
-                model.ErrorDetails = new ExceptionDetails[0];
+                model.ErrorDetails = Array.Empty<ExceptionDetails>();
             }
 
             var errorPage = new ErrorPage(model);

--- a/src/Shared/WebEncoders/WebEncoders.cs
+++ b/src/Shared/WebEncoders/WebEncoders.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Internal
 #endif
     static class WebEncoders
     {
-        private static readonly byte[] EmptyBytes = new byte[0];
+        private static readonly byte[] EmptyBytes = Array.Empty<byte>();
 
         /// <summary>
         /// Decodes a base64url-encoded string.

--- a/src/Shared/WebEncoders/WebEncoders.cs
+++ b/src/Shared/WebEncoders/WebEncoders.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Extensions.Internal
 #endif
     static class WebEncoders
     {
-        private static readonly byte[] EmptyBytes = Array.Empty<byte>();
-
         /// <summary>
         /// Decodes a base64url-encoded string.
         /// </summary>
@@ -70,7 +68,7 @@ namespace Microsoft.Extensions.Internal
             // Special-case empty input
             if (count == 0)
             {
-                return EmptyBytes;
+                return Array.Empty<byte>();
             }
 
             // Create array large enough for the Base64 characters, not just shorter Base64-URL-encoded form.
@@ -117,7 +115,7 @@ namespace Microsoft.Extensions.Internal
 
             if (count == 0)
             {
-                return EmptyBytes;
+                return Array.Empty<byte>();
             }
 
             // Assumption: input is base64url encoded without padding and contains no whitespace.


### PR DESCRIPTION
Use `Array.Empty<byte>()` instead of allocating a new empty byte array.
