### PR TITLE
Use new string.Split() overloads

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     serverAddressesFeature.PreferHostingUrls = WebHostUtilities.ParseBool(Configuration, WebHostDefaults.PreferHostingUrlsKey);
 
-                    foreach (var value in urls.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (var value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))
                     {
                         addresses.Add(value);
                     }

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Hosting
                     {
                         serverAddressesFeature.PreferHostingUrls = WebHostUtilities.ParseBool(_config, WebHostDefaults.PreferHostingUrlsKey);
 
-                        foreach (var value in urls.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                        foreach (var value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))
                         {
                             addresses.Add(value);
                         }

--- a/src/Hosting/Hosting/src/Internal/WebHostOptions.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHostOptions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Hosting
             }
 
             var list = new List<string>();
-            foreach (var part in value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var part in value.Split(';', StringSplitOptions.RemoveEmptyEntries))
             {
                 var trimmedPart = part;
                 if (!string.IsNullOrEmpty(trimmedPart))

--- a/src/Shared/RazorViews/BaseView.cs
+++ b/src/Shared/RazorViews/BaseView.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.RazorViews
     internal abstract class BaseView
     {
         private static readonly Encoding UTF8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+        private static readonly char[] NewLineChars = new[] { '\r', '\n' };
         private readonly Stack<TextWriter> _textWriterStack = new Stack<TextWriter>();
 
         /// <summary>
@@ -292,8 +293,8 @@ namespace Microsoft.Extensions.RazorViews
 
             // Split on line breaks before passing it through the encoder.
             return string.Join("<br />" + Environment.NewLine,
-                input.Split(new[] { "\r\n" }, StringSplitOptions.None)
-                .SelectMany(s => s.Split(new[] { '\r', '\n' }, StringSplitOptions.None))
+                input.Split("\r\n", StringSplitOptions.None)
+                .SelectMany(s => s.Split(NewLineChars, StringSplitOptions.None))
                 .Select(HtmlEncoder.Encode));
         }
     }


### PR DESCRIPTION
  * Use new `string.Split()` overloads to remove need to allocate arrays.
  * Use static array for new line characters in `HtmlEncodeAndReplaceLineBreaks()` instead of allocating a new one each time.
