### PR TITLE
Use Range instead of Slice()

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -628,7 +628,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentMemoryPrefixBytes = ChunkWriter.GetPrefixBytesForChunk(_currentChunkMemory.Length, out var sliceOne);
             if (sliceOne)
             {
-                _currentChunkMemory = _currentChunkMemory.Slice(0, _currentChunkMemory.Length - 1);
+                _currentChunkMemory = _currentChunkMemory[..^1];
             }
             _currentChunkMemoryUpdated = true;
         }


### PR DESCRIPTION
Use a Range to remove the last byte, rather than `Slice()`.

I wondered if it was a perf thing, rather than just cosmetic, so I tried out a quick benchmark and the range ended up coming out the fastest consistently on my laptop so I figured it was worth pushing up.

I didn't try investigating whether any other changes of `Slice()` to use a Range would be beneficial elsewhere, I only spotted this one because Visual Studio suggested it when I had the file open.

Also, if I'm honest, I don't know _why_ it's seemingly faster.

## Benchmark

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.301
  [Host]     : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
|               Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|  RemoveLastWithSlice | 11.93 ns | 0.314 ns | 0.541 ns |  1.00 |    0.00 | 0.0102 |     - |     - |      32 B |
|  RemoveLastWithRange | 11.41 ns | 0.328 ns | 0.936 ns |  0.94 |    0.10 | 0.0102 |     - |     - |      32 B |
| RemoveLastWithRange2 | 10.34 ns | 0.303 ns | 0.665 ns |  0.88 |    0.07 | 0.0102 |     - |     - |      32 B |

```csharp
using System;
using System.Collections.Generic;
using BenchmarkDotNet.Attributes;

namespace SlicingBenchmark
{
    [MemoryDiagnoser]
    public class SliceBenchmarks
    {
        private static readonly byte[] Source = new[] { (byte)1, (byte)2, (byte)3, (byte)4 };

        [Benchmark(Baseline = true)]
        public byte[] RemoveLastWithSlice()
        {
            var memory = new Memory<byte>(Source);
            memory = memory.Slice(0, memory.Length - 1);
            return memory.ToArray();
        }

        [Benchmark]
        public byte[] RemoveLastWithRange()
        {
            var memory = new Memory<byte>(Source);
            memory = memory[0..^1];
            return memory.ToArray();
        }

        [Benchmark]
        public byte[] RemoveLastWithRange2()
        {
            var memory = new Memory<byte>(Source);
            memory = memory[..^1];
            return memory.ToArray();
        }
    }
}
```