### PR TITLE
Remove used-once field

### DIFF
--- a/src/Hosting/Abstractions/src/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -13,8 +13,6 @@ namespace Microsoft.AspNetCore.Hosting
 {
     public static class HostingAbstractionsWebHostBuilderExtensions
     {
-        private static readonly string ServerUrlsSeparator = ";";
-
         /// <summary>
         /// Use the given configuration settings on the web host.
         /// </summary>
@@ -144,7 +142,7 @@ namespace Microsoft.AspNetCore.Hosting
                 throw new ArgumentNullException(nameof(urls));
             }
 
-            return hostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, string.Join(ServerUrlsSeparator, urls));
+            return hostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, string.Join(';', urls));
         }
 
         /// <summary>


### PR DESCRIPTION
Remove a field that's only used in one place, and just pass the char directly to `string.Join()` on use.
