### PR TITLE
Remove 'absolute' from documentation of Action

### DIFF
--- a/src/Mvc/Mvc.Core/src/UrlHelperExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/UrlHelperExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc
     public static class UrlHelperExtensions
     {
         /// <summary>
-        /// Generates a URL with an absolute path for an action method.
+        /// Generates a URL with a path for an action method.
         /// </summary>
         /// <param name="helper">The <see cref="IUrlHelper"/>.</param>
         /// <returns>The generated URL.</returns>
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> name.
         /// </summary>
         /// <param name="helper">The <see cref="IUrlHelper"/>.</param>
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> name and route <paramref name="values"/>.
         /// </summary>
         /// <param name="helper">The <see cref="IUrlHelper"/>.</param>
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> and <paramref name="controller"/> names.
         /// </summary>
         /// <param name="helper">The <see cref="IUrlHelper"/>.</param>
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> name, <paramref name="controller"/> name, and route <paramref name="values"/>.
         /// </summary>
         /// <param name="helper">The <see cref="IUrlHelper"/>.</param>
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> name, <paramref name="controller"/> name, route <paramref name="values"/>, and
         /// <paramref name="protocol"/> to use. See the remarks section for important security information.
         /// </summary>
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> name, <paramref name="controller"/> name, route <paramref name="values"/>,
         /// <paramref name="protocol"/> to use, and <paramref name="host"/> name.
         /// Generates an absolute URL if the <paramref name="protocol"/> and <paramref name="host"/> are
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// Generates a URL with a path for an action method, which contains the specified
         /// <paramref name="action"/> name, <paramref name="controller"/> name, route <paramref name="values"/>,
         /// <paramref name="protocol"/> to use, <paramref name="host"/> name, and <paramref name="fragment"/>.
         /// Generates an absolute URL if the <paramref name="protocol"/> and <paramref name="host"/> are


### PR DESCRIPTION
It cost me a couple of hours of yak shaving to figure out that, despite
the documentation, the URL returned by the 'smaller' overloads of the
`Action` method don't return absolute URLs.

As the documentation for the larger overloads of the `Action` method states:

> Generates an absolute URL if the `protocol` and `host` are non-null.

Even those overloads only generate absolute URLs when `protocol` and
`host` are supplied.

I hope that this documentation update can save some other programmer
some time.