### PR TITLE
Cache HtmlContentBuilder's Entries' count for loops

### DIFF
--- a/src/Html/Abstractions/src/HtmlContentBuilder.cs
+++ b/src/Html/Abstractions/src/HtmlContentBuilder.cs
@@ -111,7 +111,8 @@ namespace Microsoft.AspNetCore.Html
                 throw new ArgumentNullException(nameof(destination));
             }
 
-            for (var i = 0; i < Entries.Count; i++)
+            var count = Entries.Count;
+            for (var i = 0; i < count; i++)
             {
                 var entry = Entries[i];
 
@@ -140,7 +141,8 @@ namespace Microsoft.AspNetCore.Html
                 throw new ArgumentNullException(nameof(destination));
             }
 
-            for (var i = 0; i < Entries.Count; i++)
+            var count = Entries.Count;
+            for (var i = 0; i < count; i++)
             {
                 var entry = Entries[i];
 
@@ -176,7 +178,8 @@ namespace Microsoft.AspNetCore.Html
                 throw new ArgumentNullException(nameof(encoder));
             }
 
-            for (var i = 0; i < Entries.Count; i++)
+            var count = Entries.Count;
+            for (var i = 0; i < count; i++)
             {
                 var entry = Entries[i];
 


### PR DESCRIPTION
Cache the value of `Entries.Count `into a local when enumerating loops, rather than re-evaluating on each iteration.

I've seen this approach used elsewhere in the code base for performance, and as this type is used as part of MVC view rendering I figured it would be worth the tweak.

The type itself doesn't have any micro-benchmarks, so I wasn't sure what to use to get some concrete numbers on before/after.