### PR TITLE
 Use TryGetValue() in TokenExtensions

### DIFF
--- a/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
+++ b/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNetCore.Authentication
     /// </summary>
     public static class AuthenticationTokenExtensions
     {
-        private static string TokenNamesKey = ".TokenNames";
-        private static string TokenKeyPrefix = ".Token.";
+        private const string TokenNamesKey = ".TokenNames";
+        private const string TokenKeyPrefix = ".Token.";
 
         /// <summary>
         /// Stores a set of authentication tokens, after removing any old tokens.

--- a/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
+++ b/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
@@ -76,9 +76,13 @@ namespace Microsoft.AspNetCore.Authentication
             }
 
             var tokenKey = TokenKeyPrefix + tokenName;
-            return properties.Items.ContainsKey(tokenKey)
-                ? properties.Items[tokenKey]
-                : null;
+
+            if (!properties.Items.TryGetValue(tokenKey, out var value))
+            {
+                value = null;
+            }
+
+            return value;
         }
 
         public static bool UpdateTokenValue(this AuthenticationProperties properties, string tokenName, string tokenValue)

--- a/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
+++ b/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
@@ -77,12 +77,7 @@ namespace Microsoft.AspNetCore.Authentication
 
             var tokenKey = TokenKeyPrefix + tokenName;
 
-            if (!properties.Items.TryGetValue(tokenKey, out var value))
-            {
-                value = null;
-            }
-
-            return value;
+            return properties.Items.TryGetValue(tokenKey, out var value) ? value : null;
         }
 
         public static bool UpdateTokenValue(this AuthenticationProperties properties, string tokenName, string tokenValue)


### PR DESCRIPTION
  * Use `TryGetValue()` instead of `ContainsKey()` + indexer.
  * Make two fields constants as they aren't ever modified or used outside the class.
