### PR TITLE
Right-size Lists when created

### DIFF
--- a/src/FileProviders/Embedded/src/Manifest/ManifestDirectory.cs
+++ b/src/FileProviders/Embedded/src/Manifest/ManifestDirectory.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Manifest
 
         private ManifestEntry[] CopyChildren()
         {
-            var list = new List<ManifestEntry>();
+            var list = new List<ManifestEntry>(Children.Count);
             for (int i = 0; i < Children.Count; i++)
             {
                 var child = Children[i];

--- a/src/Http/Http/src/Features/RequestCookiesFeature.cs
+++ b/src/Http/Http/src/Features/RequestCookiesFeature.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Http.Features
                     }
                     else
                     {
-                        var headers = new List<string>();
+                        var headers = new List<string>(_parsedValues.Count);
                         foreach (var pair in _parsedValues)
                         {
                             headers.Add(new CookieHeaderValue(pair.Key, pair.Value).ToString());

--- a/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
@@ -497,7 +497,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                         updatedParameterPolicies = new Dictionary<string, List<RoutePatternParameterPolicyReference>>(StringComparer.OrdinalIgnoreCase);
                     }
 
-                    parameterConstraints = new List<RoutePatternParameterPolicyReference>();
+                    parameterConstraints = new List<RoutePatternParameterPolicyReference>(parameter.ParameterPolicies.Count);
                     updatedParameterPolicies.Add(parameter.Name, parameterConstraints);
                 }
 

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -169,16 +169,22 @@ namespace Microsoft.AspNetCore.Identity
         public virtual async Task RefreshSignInAsync(TUser user)
         {
             var auth = await Context.AuthenticateAsync(IdentityConstants.ApplicationScheme);
-            var claims = new List<Claim>();
+            IList<Claim> claims = Array.Empty<Claim>();
+
             var authenticationMethod = auth?.Principal?.FindFirst(ClaimTypes.AuthenticationMethod);
-            if (authenticationMethod != null)
-            {
-                claims.Add(authenticationMethod);
-            }
             var amr = auth?.Principal?.FindFirst("amr");
-            if (amr != null)
+
+            if (authenticationMethod != null || amr != null)
             {
-                claims.Add(amr);
+                claims = new List<Claim>();
+                if (authenticationMethod != null)
+                {
+                    claims.Add(authenticationMethod);
+                }
+                if (amr != null)
+                {
+                    claims.Add(amr);
+                }
             }
 
             await SignInWithClaimsAsync(user, auth?.Properties, claims);
@@ -203,9 +209,10 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>The task object representing the asynchronous operation.</returns>
         public virtual Task SignInAsync(TUser user, AuthenticationProperties authenticationProperties, string authenticationMethod = null)
         {
-            var additionalClaims = new List<Claim>();
+            IList<Claim> additionalClaims = Array.Empty<Claim>();
             if (authenticationMethod != null)
             {
+                additionalClaims = new List<Claim>();
                 additionalClaims.Add(new Claim(ClaimTypes.AuthenticationMethod, authenticationMethod));
             }
             return SignInWithClaimsAsync(user, authenticationProperties, additionalClaims);

--- a/src/Middleware/Localization/src/RequestLocalizationOptions.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationOptions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The <see cref="RequestLocalizationOptions"/>.</returns>
         public RequestLocalizationOptions AddSupportedCultures(params string[] cultures)
         {
-            var supportedCultures = new List<CultureInfo>();
+            var supportedCultures = new List<CultureInfo>(cultures.Length);
 
             foreach (var culture in cultures)
             {
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The <see cref="RequestLocalizationOptions"/>.</returns>
         public RequestLocalizationOptions AddSupportedUICultures(params string[] uiCultures)
         {
-            var supportedUICultures = new List<CultureInfo>();
+            var supportedUICultures = new List<CultureInfo>(uiCultures.Length);
             foreach (var culture in uiCultures)
             {
                 supportedUICultures.Add(new CultureInfo(culture));

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/ApplicationModelFactory.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/ApplicationModelFactory.cs
@@ -309,7 +309,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             // Text to show as the attribute route template for conventionally routed actions.
             var nullTemplate = Resources.AttributeRoute_NullTemplateRepresentation;
 
-            var actionDescriptions = new List<string>();
+            var actionDescriptions = new List<string>(actions.Count);
             for (var i = 0; i < actions.Count; i++)
             {
                 var (action, selector) = actions[i];

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/ControllerActionDescriptorBuilder.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/ControllerActionDescriptorBuilder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
         private static void AddParameterDescriptors(ActionDescriptor actionDescriptor, ActionModel action)
         {
-            var parameterDescriptors = new List<ParameterDescriptor>();
+            var parameterDescriptors = new List<ParameterDescriptor>(action.Parameters.Count);
             foreach (var parameter in action.Parameters)
             {
                 var parameterDescriptor = CreateParameterDescriptor(parameter);

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
             // This is fairly complicated so that we maintain referential equality between items in
             // ActionModel.Attributes and ActionModel.Attributes[*].Attribute.
-            var applicableAttributes = new List<object>();
+            var applicableAttributes = new List<object>(routeAttributes.Length);
             foreach (var attribute in attributes)
             {
                 if (attribute is IRouteTemplateProvider)

--- a/src/Mvc/Mvc.Core/src/BindAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/BindAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="include">Names of parameters to include in binding.</param>
         public BindAttribute(params string[] include)
         {
-            var items = new List<string>();
+            var items = new List<string>(include.Length);
             foreach (var item in include)
             {
                 items.AddRange(SplitString(item));

--- a/src/Mvc/Mvc.Core/src/ConsumesAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ConsumesAttribute.cs
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.Mvc
 
         private MediaTypeCollection GetContentTypes(string firstArg, string[] args)
         {
-            var completeArgs = new List<string>();
+            var completeArgs = new List<string>(args.Length + 1);
             completeArgs.Add(firstArg);
             completeArgs.AddRange(args);
             var contentTypes = new MediaTypeCollection();

--- a/src/Mvc/Mvc.Core/src/Formatters/InputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/InputFormatter.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     {
                         if (mediaTypes == null)
                         {
-                            mediaTypes = new List<string>();
+                            mediaTypes = new List<string>(SupportedMediaTypes.Count);
                         }
 
                         mediaTypes.Add(mediaType);

--- a/src/Mvc/Mvc.Core/src/Formatters/OutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/OutputFormatter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     {
                         if (mediaTypes == null)
                         {
-                            mediaTypes = new List<string>();
+                            mediaTypes = new List<string>(SupportedMediaTypes.Count);
                         }
 
                         mediaTypes.Add(contentType);
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     {
                         if (mediaTypes == null)
                         {
-                            mediaTypes = new List<string>();
+                            mediaTypes = new List<string>(SupportedMediaTypes.Count);
                         }
 
                         mediaTypes.Add(mediaType);

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ActionSelector.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ActionSelector.cs
@@ -135,10 +135,11 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             RouteContext context,
             IReadOnlyList<ActionDescriptor> actions)
         {
-            var candidates = new List<ActionSelectorCandidate>();
+            var actionsCount = actions.Count;
+            var candidates = new List<ActionSelectorCandidate>(actionsCount);
 
             // Perf: Avoid allocations
-            for (var i = 0; i < actions.Count; i++)
+            for (var i = 0; i < actionsCount; i++)
             {
                 var action = actions[i];
                 var constraints = _actionConstraintCache.GetActionConstraints(context.HttpContext, action);
@@ -150,9 +151,10 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             List<ActionDescriptor> results = null;
             if (matches != null)
             {
-                results = new List<ActionDescriptor>(matches.Count);
+                var matchesCount = matches.Count;
+                results = new List<ActionDescriptor>(matchesCount);
                 // Perf: Avoid allocations
-                for (var i = 0; i < matches.Count; i++)
+                for (var i = 0; i < matchesCount; i++)
                 {
                     var candidate = matches[i];
                     results.Add(candidate.Action);

--- a/src/Mvc/Mvc.Core/src/ProducesAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesAttribute.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Mvc
 
         private MediaTypeCollection GetContentTypes(string firstArg, string[] args)
         {
-            var completeArgs = new List<string>();
+            var completeArgs = new List<string>(args.Length + 1);
             completeArgs.Add(firstArg);
             completeArgs.AddRange(args);
             var contentTypes = new MediaTypeCollection();

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorReferenceManager.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorReferenceManager.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
         // For unit testing
         internal IEnumerable<string> GetReferencePaths()
         {
-            var referencePaths = new List<string>();
+            var referencePaths = new List<string>(_options.AdditionalReferencePaths.Count);
 
             foreach (var part in _partManager.ApplicationParts)
             {

--- a/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/DefaultTempDataSerializer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Infrastructure/DefaultTempDataSerializer.cs
@@ -83,7 +83,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
 
         private static object DeserializeArray(in JsonElement arrayElement)
         {
-            if (arrayElement.GetArrayLength() == 0)
+            int arrayLength = arrayElement.GetArrayLength();
+            if (arrayLength == 0)
             {
                 // We have to infer the type of the array by inspecting it's elements.
                 // If there's nothing to inspect, return a null value since we do not know
@@ -93,7 +94,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
 
             if (arrayElement[0].ValueKind == JsonValueKind.String)
             {
-                var array = new List<string>();
+                var array = new List<string>(arrayLength);
 
                 foreach (var item in arrayElement.EnumerateArray())
                 {
@@ -104,7 +105,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure
             }
             else if (arrayElement[0].ValueKind == JsonValueKind.Number)
             {
-                var array = new List<int>();
+                var array = new List<int>(arrayLength);
 
                 foreach (var item in arrayElement.EnumerateArray())
                 {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentEventHandlerLoweringPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentEventHandlerLoweringPass.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             // This method is overloaded on string and T, which means that it will put the code in the
             // correct context for intellisense when typing in the attribute.
             var eventArgsType = node.TagHelper.GetEventArgsType();
-            var tokens = new List<IntermediateToken>()
+            var tokens = new List<IntermediateToken>(original.Count + 2)
             {
                 new IntermediateToken()
                 {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/Application.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/Application.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
         private static string[] ExpandResponseFiles(string[] args)
         {
-            var expandedArgs = new List<string>();
+            var expandedArgs = new List<string>(args.Length);
             foreach (var arg in args)
             {
                 if (!arg.StartsWith("@", StringComparison.Ordinal))

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/DefaultRequestDispatcher.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/DefaultRequestDispatcher.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
         /// </summary>
         private void WaitForAnyCompletion(CancellationToken cancellationToken)
         {
-            var all = new List<Task>();
+            var all = new List<Task>(_connections.Count + 3);
             all.AddRange(_connections);
             all.Add(_timeoutTask);
             all.Add(_listenTask);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/MetadataReaderExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/MetadataReaderExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
         
         internal static AssemblyIdentity[] GetReferencedAssembliesOrThrow(this MetadataReader reader)
         {
-            var references = new List<AssemblyIdentity>();
+            var references = new List<AssemblyIdentity>(reader.AssemblyReferences.Count);
 
             foreach (var referenceHandle in reader.AssemblyReferences)
             {

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/FindAssembliesWithReferencesTo.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/FindAssembliesWithReferencesTo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public override bool Execute()
         {
-            var referenceItems = new List<AssemblyItem>();
+            var referenceItems = new List<AssemblyItem>(Assemblies.Length);
             foreach (var item in Assemblies)
             {
                 const string FusionNameKey = "FusionName";

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/ReferenceResolver.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/ReferenceResolver.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
                 var metadataReader = peReader.GetMetadataReader();
 
-                var references = new List<AssemblyItem>();
+                var references = new List<AssemblyItem>(metadataReader.AssemblyReferences.Count);
                 foreach (var handle in metadataReader.AssemblyReferences)
                 {
                     var reference = metadataReader.GetAssemblyReference(handle);

--- a/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                     matchedAttributes.Add(attribute);
                 }
             }
-            attributes = matchedAttributes ?? Array.Empty<TagHelperAttribute>() as IReadOnlyList<TagHelperAttribute>;
+            attributes = matchedAttributes ?? (IReadOnlyList<TagHelperAttribute>)Array.Empty<TagHelperAttribute>();
 
             return matchedAttributes != null;
         }

--- a/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -12,8 +12,6 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
     /// </summary>
     public abstract class ReadOnlyTagHelperAttributeList : ReadOnlyCollection<TagHelperAttribute>
     {
-        private static readonly IReadOnlyList<TagHelperAttribute> EmptyList = new TagHelperAttribute[0];
-
         /// <summary>
         /// Instantiates a new instance of <see cref="ReadOnlyTagHelperAttributeList"/> with an empty
         /// collection.
@@ -146,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                     matchedAttributes.Add(attribute);
                 }
             }
-            attributes = matchedAttributes ?? EmptyList;
+            attributes = matchedAttributes ?? Array.Empty<TagHelperAttribute>() as IReadOnlyList<TagHelperAttribute>;
 
             return matchedAttributes != null;
         }

--- a/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// collection.
         /// </summary>
         protected ReadOnlyTagHelperAttributeList()
-            : base(new List<TagHelperAttribute>())
+            : base(Array.Empty<TagHelperAttribute>())
         {
         }
 

--- a/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Razor/Razor/src/TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// collection.
         /// </summary>
         protected ReadOnlyTagHelperAttributeList()
-            : base(Array.Empty<TagHelperAttribute>())
+            : base(new List<TagHelperAttribute>())
         {
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -12,14 +12,12 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
     /// </summary>
     public abstract class ReadOnlyTagHelperAttributeList : ReadOnlyCollection<TagHelperAttribute>
     {
-        private static readonly IReadOnlyList<TagHelperAttribute> EmptyList = new TagHelperAttribute[0];
-
         /// <summary>
         /// Instantiates a new instance of <see cref="ReadOnlyTagHelperAttributeList"/> with an empty
         /// collection.
         /// </summary>
         protected ReadOnlyTagHelperAttributeList()
-            : base(new List<TagHelperAttribute>())
+            : base(Array.Empty<TagHelperAttribute>())
         {
         }
 
@@ -138,7 +136,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                     matchedAttributes.Add(Items[i]);
                 }
             }
-            attributes = matchedAttributes ?? EmptyList;
+            attributes = matchedAttributes ?? Array.Empty<TagHelperAttribute>() as IReadOnlyList<TagHelperAttribute>;
 
             return matchedAttributes != null;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// collection.
         /// </summary>
         protected ReadOnlyTagHelperAttributeList()
-            : base(Array.Empty<TagHelperAttribute>())
+            : base(new List<TagHelperAttribute>())
         {
         }
 

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate
             var certificateIsValid = chain.Build(clientCertificate);
             if (!certificateIsValid)
             {
-                var chainErrors = new List<string>();
+                var chainErrors = new List<string>(chain.ChainStatus.Length);
                 foreach (var validationFailure in chain.ChainStatus)
                 {
                     chainErrors.Add($"{validationFailure.Status} {validationFailure.StatusInformation}");

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
@@ -274,7 +274,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         
         private static string CreateErrorDescription(Exception authFailure)
         {
-            IEnumerable<Exception> exceptions;
+            IReadOnlyCollection<Exception> exceptions;
             if (authFailure is AggregateException agEx)
             {
                 exceptions = agEx.InnerExceptions;
@@ -284,7 +284,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                 exceptions = new[] { authFailure };
             }
 
-            var messages = new List<string>();
+            var messages = new List<string>(exceptions.Count);
 
             foreach (var ex in exceptions)
             {

--- a/src/Servers/HttpSys/src/AuthenticationManager.cs
+++ b/src/Servers/HttpSys/src/AuthenticationManager.cs
@@ -107,12 +107,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal static IList<string> GenerateChallenges(AuthenticationSchemes authSchemes)
         {
-            IList<string> challenges = new List<string>();
-
             if (authSchemes == AuthenticationSchemes.None)
             {
-                return challenges;
+                return Array.Empty<string>();
             }
+
+            IList<string> challenges = new List<string>();
 
             // Order by strength.
             if ((authSchemes & AuthenticationSchemes.Kerberos) == AuthenticationSchemes.Kerberos)

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 // Copied from the multi-value headers section of SerializeHeaders
                 if (authChallenges != null && authChallenges.Count > 0)
                 {
-                    pinnedHeaders = new List<GCHandle>();
+                    pinnedHeaders = new List<GCHandle>(authChallenges.Count + 3);
 
                     HttpApiTypes.HTTP_RESPONSE_INFO[] knownHeaderInfo = null;
                     knownHeaderInfo = new HttpApiTypes.HTTP_RESPONSE_INFO[1];

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
             if (_bufferList == null)
             {
-                _bufferList = new List<ArraySegment<byte>>((int)buffer.Length);
+                _bufferList = new List<ArraySegment<byte>>();
             }
             else
             {

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSender.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
             if (_bufferList == null)
             {
-                _bufferList = new List<ArraySegment<byte>>();
+                _bufferList = new List<ArraySegment<byte>>((int)buffer.Length);
             }
             else
             {

--- a/src/Shared/Buffers.Testing/ReadOnlySequenceFactory.cs
+++ b/src/Shared/Buffers.Testing/ReadOnlySequenceFactory.cs
@@ -92,7 +92,7 @@ namespace System.Buffers
 
             public override ReadOnlySequence<byte> CreateWithContent(byte[] data)
             {
-                var segments = new List<byte[]>();
+                var segments = new List<byte[]>((data.Length * 2) + 1);
 
                 segments.Add(Array.Empty<byte>());
                 foreach (var b in data)

--- a/src/Shared/ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Shared/ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -155,8 +155,8 @@ namespace Microsoft.Extensions.Internal
             var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
 
             // Build parameter list
-            var parameters = new List<Expression>();
             var paramInfos = methodInfo.GetParameters();
+            var parameters = new List<Expression>(paramInfos.Length);
             for (int i = 0; i < paramInfos.Length; i++)
             {
                 var paramInfo = paramInfos[i];
@@ -207,8 +207,8 @@ namespace Microsoft.Extensions.Internal
             var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
 
             // Build parameter list
-            var parameters = new List<Expression>();
             var paramInfos = methodInfo.GetParameters();
+            var parameters = new List<Expression>(paramInfos.Length);
             for (int i = 0; i < paramInfos.Length; i++)
             {
                 var paramInfo = paramInfos[i];

--- a/src/Shared/StackTrace/StackFrame/StackTraceHelper.cs
+++ b/src/Shared/StackTrace/StackFrame/StackTraceHelper.cs
@@ -18,12 +18,10 @@ namespace Microsoft.Extensions.StackTrace.Sources
     {
         public static IList<StackFrameInfo> GetFrames(Exception exception, out AggregateException? error)
         {
-            var frames = new List<StackFrameInfo>();
-
             if (exception == null)
             {
                 error = default;
-                return frames;
+                return Array.Empty<StackFrameInfo>();
             }
 
             var needFileInfo = true;
@@ -33,8 +31,10 @@ namespace Microsoft.Extensions.StackTrace.Sources
             if (stackFrames == null)
             {
                 error = default;
-                return frames;
+                return Array.Empty<StackFrameInfo>();
             }
+
+            var frames = new List<StackFrameInfo>(stackFrames.Length);
 
             List<Exception>? exceptions = null;
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             // Stop firing the timer
             _nextHeartbeat.Stop();
 
-            var tasks = new List<Task>();
+            var tasks = new List<Task>(_connections.Count);
 
             // REVIEW: In the future we can consider a hybrid where we first try to wait for shutdown
             // for a certain time frame then after some grace period we shutdown more aggressively

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
             if (streamIdCount > 0)
             {
-                streams = new List<string>((int)streamIdCount);
+                streams = new List<string>();
                 for (var i = 0; i < streamIdCount; i++)
                 {
                     streams.Add(reader.ReadString());

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
             if (streamIdCount > 0)
             {
-                streams = new List<string>();
+                streams = new List<string>((int)streamIdCount);
                 for (var i = 0; i < streamIdCount; i++)
                 {
                     streams.Add(reader.ReadString());

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -73,8 +73,7 @@ namespace Microsoft.AspNetCore.SignalR
 
                 if (_hubOptions.HubFilters != null)
                 {
-                    hubFilters = new List<IHubFilter>();
-                    hubFilters.AddRange(_hubOptions.HubFilters);
+                    hubFilters = new List<IHubFilter>(_hubOptions.HubFilters);
                 }
             }
             else
@@ -84,8 +83,7 @@ namespace Microsoft.AspNetCore.SignalR
 
                 if (_globalHubOptions.HubFilters != null)
                 {
-                    hubFilters = new List<IHubFilter>();
-                    hubFilters.AddRange(_globalHubOptions.HubFilters);
+                    hubFilters = new List<IHubFilter>(_globalHubOptions.HubFilters);
                 }
             }
 

--- a/src/SignalR/server/Core/src/HubOptionsSetup.cs
+++ b/src/SignalR/server/Core/src/HubOptionsSetup.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             if (options.SupportedProtocols == null)
             {
-                options.SupportedProtocols = new List<string>();
+                options.SupportedProtocols = new List<string>(_defaultProtocols.Count);
             }
 
             if (options.StreamBufferCapacity == null)

--- a/src/SignalR/server/StackExchangeRedis/src/Internal/DefaultHubMessageSerializer.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/DefaultHubMessageSerializer.cs
@@ -10,11 +10,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 {
     internal class DefaultHubMessageSerializer
     {
-        private readonly List<IHubProtocol> _hubProtocols = new List<IHubProtocol>();
+        private readonly List<IHubProtocol> _hubProtocols;
 
         public DefaultHubMessageSerializer(IHubProtocolResolver hubProtocolResolver, IList<string> globalSupportedProtocols, IList<string> hubSupportedProtocols)
         {
             var supportedProtocols = hubSupportedProtocols ?? globalSupportedProtocols ?? Array.Empty<string>();
+            _hubProtocols = new List<IHubProtocol>(supportedProtocols.Count);
             foreach (var protocolName in supportedProtocols)
             {
                 var protocol = hubProtocolResolver.GetProtocol(protocolName, (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList());

--- a/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
@@ -465,7 +465,7 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis
                     {
                         var invocation = _protocol.ReadInvocation((byte[])channelMessage.Message);
 
-                        var tasks = new List<Task>();
+                        var tasks = new List<Task>(subscriptions.Count);
                         foreach (var userConnection in subscriptions)
                         {
                             tasks.Add(userConnection.WriteAsync(invocation.Message).AsTask());
@@ -491,7 +491,7 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis
                 {
                     var invocation = _protocol.ReadInvocation((byte[])channelMessage.Message);
 
-                    var tasks = new List<Task>();
+                    var tasks = new List<Task>(groupConnections.Count);
                     foreach (var groupConnection in groupConnections)
                     {
                         if (invocation.ExcludedConnectionIds?.Contains(groupConnection.ConnectionId) == true)


### PR DESCRIPTION
## Changes

  * Create new instances of `List<T>` with an appropriate capacity for the items that will be added.
  * Use `Array.Empty<T>()` where appropriate, rather than create an empty list and then return it.
  * ~Create lists with the default capacity for a list containing only a small number of items, [which is 4](https://github.com/dotnet/runtime/blob/ac8fe0d787ece0ad0cc4db767393d55361924623/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs#L24), so that a resize is not immediately required when the first item is added.~

## Rationale

I noticed there were a few places where lists were created and then immediately added to, so thought that the capacity could be specified instead. In many cases the lists have the potential to be added to again later after the method creating them returns, so I've used the default capacity the `List`s would have had before the change once members were added by the code, rather than the _exact_ number of items, as otherwise any resizes that may have happened would then happen sooner than before. Similarly this might also have changed when the resizes caused the arrays to double in size, so increasing the memory footprint.

I've separate this PR into two commits as the second commit uses `4` as a magic number quite a lot. I've put a comment on each instance of its use explaining why, but if the change is wanted there might be a better way to do it than sprinkling `4` everywhere.

I used the following micro-benchmarks to guide the use of 4, rather than say 1, as the default capacity.

As you can see from the `*ThenAddOnce` benchmarks, adding 1 item to an empty list allocates the same memory as adding 1 item to a list with a capacity of 4, but it does so ~37% faster due to there being no need to resize the internal array from 0 to 4 when the first item is added.

While only setting a capacity of 1 saves 8 bytes compared to initial capacities of 0 and 4, it doubles the time required to add a second item later, as well as requiring an allocation of an extra 24 bytes, as can be seen by the `*ThenAddTwice` benchmarks.

Overall, `CreateWithFour*` with `new List<T>(4)` seems the best option as it uses the same memory as `new List<T>()`, while being faster for adding 1 and 2 items using `Add()`.

## Benchmarks

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.301
  [Host]     : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
|                     Method |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|     CreateEmptyThenAddOnce | 23.92 ns | 0.874 ns | 2.521 ns | 23.18 ns |  1.00 |    0.00 | 0.0229 |     - |     - |      72 B |
|   CreateWithOneThenAddOnce | 13.99 ns | 0.450 ns | 1.276 ns | 13.77 ns |  0.59 |    0.08 | 0.0204 |     - |     - |      64 B |
|  CreateWithFourThenAddOnce | 14.95 ns | 0.665 ns | 1.949 ns | 14.31 ns |  0.63 |    0.11 | 0.0229 |     - |     - |      72 B |
|    CreateEmptyThenAddTwice | 24.28 ns | 0.788 ns | 2.237 ns | 23.85 ns |  1.02 |    0.13 | 0.0229 |     - |     - |      72 B |
|  CreateWithOneThenAddTwice | 44.18 ns | 1.267 ns | 3.511 ns | 43.88 ns |  1.87 |    0.25 | 0.0306 |     - |     - |      96 B |
| CreateWithFourThenAddTwice | 16.94 ns | 0.612 ns | 1.796 ns | 16.68 ns |  0.71 |    0.10 | 0.0229 |     - |     - |      72 B |

```csharp
using System.Collections.Generic;
using BenchmarkDotNet.Attributes;

namespace ListBenchmark
{
    [MemoryDiagnoser]
    public class CreateListBenchmarks
    {
        [Benchmark(Baseline = true)]
        public List<int> CreateEmptyThenAddOnce()
        {
            var list = new List<int>();
            list.Add(1);
            return list;
        }

        [Benchmark]
        public List<int> CreateWithOneThenAddOnce()
        {
            var list = new List<int>(1);
            list.Add(1);
            return list;
        }

        [Benchmark]
        public List<int> CreateWithFourThenAddOnce()
        {
            var list = new List<int>(4);
            list.Add(1);
            return list;
        }

        [Benchmark]
        public List<int> CreateEmptyThenAddTwice()
        {
            var list = new List<int>();
            list.Add(1);
            list.Add(2);
            return list;
        }

        [Benchmark]
        public List<int> CreateWithOneThenAddTwice()
        {
            var list = new List<int>(1);
            list.Add(1);
            list.Add(2);
            return list;
        }

        [Benchmark]
        public List<int> CreateWithFourThenAddTwice()
        {
            var list = new List<int>(4);
            list.Add(1);
            list.Add(2);
            return list;
        }
    }
}
```