### PR TITLE
Fix HTTP/2 stream output flow control abort error

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamOutputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamOutputFlowControl.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl
             if (_currentConnectionLevelAwaitable != null &&
                 _currentConnectionLevelAwaitable.Version == _currentConnectionLevelAwaitableVersion)
             {
-                _currentConnectionLevelAwaitable.SetResult(null);
+                _currentConnectionLevelAwaitable.TrySetResult(null);
             }
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1619,41 +1619,41 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 {
                     requestAbortedTcs.SetException(ex);
                 }
-            });
+            }).DefaultTimeout();
 
-            await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
+            await StartStreamAsync(1, _browserRequestHeaders, endStream: true).DefaultTimeout();
 
             await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 32,
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
-                withStreamId: 1);
+                withStreamId: 1).DefaultTimeout();
 
             await ExpectAsync(Http2FrameType.DATA,
                 withLength: 16384,
                 withFlags: (byte)(Http2DataFrameFlags.NONE),
-                withStreamId: 1);
+                withStreamId: 1).DefaultTimeout();
 
             await ExpectAsync(Http2FrameType.DATA,
                 withLength: 16384,
                 withFlags: (byte)(Http2DataFrameFlags.NONE),
-                withStreamId: 1);
+                withStreamId: 1).DefaultTimeout();
 
             await ExpectAsync(Http2FrameType.DATA,
                 withLength: 16384,
                 withFlags: (byte)(Http2DataFrameFlags.NONE),
-                withStreamId: 1);
+                withStreamId: 1).DefaultTimeout();
 
             await ExpectAsync(Http2FrameType.DATA,
                 withLength: 16383,
                 withFlags: (byte)(Http2DataFrameFlags.NONE),
-                withStreamId: 1);
+                withStreamId: 1).DefaultTimeout();
 
             _connection.HandleReadDataRateTimeout();
 
             connectionAbortedTcs.SetResult();
 
             // Task completing successfully means HttpContext.Abort didn't throw
-            await requestAbortedTcs.Task;
+            await requestAbortedTcs.Task.DefaultTimeout();
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1597,10 +1597,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task OutputFlowControl_ConnectionAndRequestAborted_NoException()
         {
-            // Zero-length data frames are allowed to be sent even if there is no space available in the flow control window.
-            // https://httpwg.org/specs/rfc7540.html#rfc.section.6.9.1
-
-            // This only affects the stream windows. The connection-level window is always initialized at 64KiB.
+            // Ensure the stream window size is bigger than the connection window size
             _clientSettings.InitialWindowSize = _clientSettings.InitialWindowSize * 2;
 
             var connectionAbortedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1652,6 +1652,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             connectionAbortedTcs.SetResult();
 
+            // Task completing successfully means HttpContext.Abort didn't throw
             await requestAbortedTcs.Task;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22060

You can recreate the original error if:
1. Stream is waiting on flow control
2. Connection is aborted
3. `HttpContext.Abort()` is called