### PR TITLE
Remove unnecessary entries in LinkerWorkaround for WASM.

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/LinkerWorkaround.xml
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/LinkerWorkaround.xml
@@ -12,18 +12,4 @@
     <type fullname="System.ComponentModel.GuidConverter" />
     <type fullname="System.ComponentModel.TimeSpanConverter" />
   </assembly>
-
-  <assembly fullname="System.Text.Json">
-    <!-- S.T.J. uses Activator.CreateInstance to instantiate converters, so we need to preserve default constructors.
-    For safety, do this for all converter types, even though most of them are preserved anyway due to being referenced
-    statically. It's only JsonStringEnumConverter that currently isn't referenced statically.
-    The following is a workaround for https://github.com/dotnet/aspnetcore/issues/19086.
-    The underlying issue is reported in the runtime repo at https://github.com/dotnet/runtime/issues/34449 -->
-    <type fullname="System.Text.Json.Serialization.*Converter">
-      <method signature="System.Void .ctor()" />
-    </type>
-  </assembly>
-
-  <!-- Workaround for https://github.com/mono/linker/issues/1298 -->
-  <assembly fullname="System.Security.Cryptography.X509Certificates" />
 </linker>


### PR DESCRIPTION
* The underlying Json issue is fixed.
* The X509 issue is not an issue when TrimMode is set to link (which is it now by default).

Contributes to #23262
