### PR TITLE
Stop remaining auto-injected component detection runs

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -242,6 +242,7 @@ jobs:
         continueOnError: true
         condition: always()
 
+    # Run component detection after all successful Build:* jobs unless overridden e.g. for Alpine build.
     - ${{ if and(startsWith(parameters.jobDisplayName, 'Build:'), ne(variables['skipComponentGovernanceDetection'], 'true'), ne(parameters.skipComponentGovernanceDetection, 'true'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
         condition: and(succeeded(), ne(variables['CG_RAN'], 'true'))
@@ -253,6 +254,11 @@ jobs:
             ignoreDirectories: '.dotnet,.packages,artifacts/log,artifacts/symbols,artifacts/tmp'
           sourceScanPath: $(Build.SourcesDirectory)
           verbosity: Verbose
+    # Make sure auto-injected component detection does _not_ execute in other jobs nor when overridden.
+    # No need to recheck variables or build reason because auto-injected component detection honors those values.
+    - ${{ if or(not(startsWith(parameters.jobDisplayName, 'Build:')), eq(parameters.skipComponentGovernanceDetection, 'true')) }}:
+      - script:  echo "##vso[task.setvariable variable=CG_RAN]true"
+        displayName: 'Skip Component Detection'
 
     - ${{ each artifact in parameters.artifacts }}:
       - task: PublishBuildArtifacts@1


### PR DESCRIPTION
  - was still running in every job where explicit CD build step did not execute
    - caused consistent errors in Linux MUSL x64 (Alpine) jobs
      - error was ignored but made build failure diagnosis more difficult
    - totally redundant in test jobs