### PR TITLE
[HTTPS] Export the certificate in PEM format too

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                             Array.Clear(keyBytes, 0, keyBytes.Length);
                             Array.Clear(pem, 0, pem.Length);
 
-                            bytes = certificate.Export(X509ContentType.Cert);
+                            bytes = Encoding.ASCII.GetBytes(PemEncoding.Write("CERTIFICATE", certificate.Export(X509ContentType.Cert)));
                             break;
                         default:
                             throw new InvalidOperationException("Unknown format.");

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
         {
             // Arrange
             var message = "plaintext";
-            const string CertificateName = nameof(EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates) + ".pfx";
+            const string CertificateName = nameof(EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates) + ".pem";
             var certificatePassword = Guid.NewGuid().ToString();
 
             _fixture.CleanupCertificates();
@@ -183,10 +183,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Equal(EnsureCertificateResult.ValidCertificatePresent, result);
             Assert.True(File.Exists(CertificateName));
 
-            var key = RSA.Create();
-            key.ImportFromEncryptedPem(File.ReadAllText(Path.ChangeExtension(CertificateName, "key")), certificatePassword);
-            var exportedCertificate = new X509Certificate2(File.ReadAllBytes(CertificateName));
-            exportedCertificate = exportedCertificate.CopyWithPrivateKey(key);
+            var exportedCertificate = X509Certificate2.CreateFromEncryptedPemFile(CertificateName, certificatePassword, Path.ChangeExtension(CertificateName, "key"));
             Assert.NotNull(exportedCertificate);
             Assert.True(exportedCertificate.HasPrivateKey);
 
@@ -260,7 +257,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
         {
             // Arrange
             var message = "plaintext";
-            const string CertificateName = nameof(EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates) + ".pfx";
+            const string CertificateName = nameof(EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates) + ".pem";
             _fixture.CleanupCertificates();
 
             var now = DateTimeOffset.UtcNow;
@@ -277,10 +274,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             Assert.Equal(EnsureCertificateResult.ValidCertificatePresent, result);
             Assert.True(File.Exists(CertificateName));
 
-            var key = RSA.Create();
-            key.ImportFromPem(File.ReadAllText(Path.ChangeExtension(CertificateName, "key")));
-            var exportedCertificate = new X509Certificate2(File.ReadAllBytes(CertificateName));
-            exportedCertificate = exportedCertificate.CopyWithPrivateKey(key);
+            var exportedCertificate = X509Certificate2.CreateFromPemFile(CertificateName, Path.ChangeExtension(CertificateName, "key"));
             Assert.NotNull(exportedCertificate);
             Assert.True(exportedCertificate.HasPrivateKey);
 

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -92,9 +92,9 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                         "Imports the provided HTTPS development certificate into the machine. All other HTTPS developer certificates will be cleared out",
                         CommandOptionType.SingleValue);
 
-                    var keyFormat = c.Option(
-                        "--key-format",
-                        "Export the certificate key in the given format. Valid values are Pfx and Pem. Pfx is the default.",
+                    var format = c.Option(
+                        "--format",
+                        "Export the certificate in the given format. Valid values are Pfx and Pem. Pfx is the default.",
                         CommandOptionType.SingleValue);
 
                     CommandOption trust = null;
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 
                         if (clean.HasValue())
                         {
-                            if (exportPath.HasValue() || trust?.HasValue() == true || keyFormat.HasValue() || noPassword.HasValue() || check.HasValue() ||
+                            if (exportPath.HasValue() || trust?.HasValue() == true || format.HasValue() || noPassword.HasValue() || check.HasValue() ||
                                (!import.HasValue() && password.HasValue()) ||
                                (import.HasValue() && !password.HasValue()))
                             {
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 
                         if (check.HasValue())
                         {
-                            if (exportPath.HasValue() || password.HasValue() || noPassword.HasValue() || clean.HasValue() || keyFormat.HasValue() || import.HasValue())
+                            if (exportPath.HasValue() || password.HasValue() || noPassword.HasValue() || clean.HasValue() || format.HasValue() || import.HasValue())
                             {
                                 reporter.Error(InvalidUsageErrorMessage);
                                 return CriticalError;
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                                 return CriticalError;
                             }
 
-                            if (noPassword.HasValue() && !(keyFormat.HasValue() && string.Equals(keyFormat.Value(), "PEM", StringComparison.OrdinalIgnoreCase)))
+                            if (noPassword.HasValue() && !(format.HasValue() && string.Equals(format.Value(), "PEM", StringComparison.OrdinalIgnoreCase)))
                             {
                                 reporter.Error(InvalidUsageErrorMessage);
                                 return CriticalError;
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                             return ImportCertificate(import, password, reporter);
                         }
 
-                        return EnsureHttpsCertificate(exportPath, password, noPassword, trust, keyFormat, reporter);
+                        return EnsureHttpsCertificate(exportPath, password, noPassword, trust, format, reporter);
                     });
                 });
 


### PR DESCRIPTION
* Tweaked dev certs to export the certificate in PEM format as well as the key.
* Turns out that I was wrong and I also needed the certificate to be in PEM format for usage with the angular spa proxy.
* This change better aligns that expectation.
* It is still possible to export the certificate in DER format, it just requires one additional command.
