### PR TITLE
Ensure DevServer has the AspNetCore.App runtime in runtimeconfig.json

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -38,4 +38,19 @@
     <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 
+  <Target Name="_FixupRuntimeConfig" BeforeTargets="_GenerateRuntimeConfigurationFilesInputCache">
+    <ItemGroup>
+      <_RuntimeFramework Include="@(RuntimeFramework)" />
+      <RuntimeFramework Remove="@(RuntimeFramework)" />
+      <RuntimeFramework Include="Microsoft.AspNetCore.App" FrameworkName="Microsoft.AspNetCore.App" Version="5.0.0-preview" />
+    </ItemGroup>
+  </Target>
+
+   <Target Name="_UndoRuntimeConfigWorkarounds" AfterTargets="GenerateBuildRuntimeConfigurationFiles">
+    <ItemGroup>
+      <RuntimeFramework Remove="@(RuntimeFramework)" />
+      <RuntimeFramework Include="@(_RuntimeFramework)" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Decription
We've discovered that the Microsoft.AspNetCore.Components.WebAssembly.DevServer package didn't reference AspNetCore.App reference after migration to 5.0.

## User impact
As a result of this, when trying to run the app in VS using IIS Express, the user will end up seeing the below error and won't get the app to load:
![image](https://user-images.githubusercontent.com/34246760/87088236-4b1db400-c1e9-11ea-965e-dab2c1bd7854.png)

## Risk
Low. The change is related only to how we structure the dependencies, and doesn't include any code change. We have also manually validated this fix.