### PR TITLE
Support SSO for Blazor WASM template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/vs-2017.3.host.json
@@ -28,6 +28,14 @@
       "auth": "Individual",
       "authenticationType": "IndividualAuth",
       "b2cAuthenticationOptions": "Local"
+    },
+    {
+      "auth": "SingleOrg",
+      "authenticationType": "OrgAuth",
+      "orgAuthenticationOptions": "SSO",
+      "provisionServerSymbol": "Hosted",
+      "callbackPath": "/authentication/login-callback",
+      "additionalReplyUriPorts": [ 5001 ]
     }
   ],
   "ports": [


### PR DESCRIPTION

This is the required additions to the host file to support SSO for the Blazor WebAssembly template.
