### PR TITLE
Skip gRPC template test on Windows 8.1

### DIFF
--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -26,7 +26,7 @@ namespace Templates.Test
         public ITestOutputHelper Output { get; }
 
         [ConditionalFact]
-        [SkipOnHelix("Not supported queues", Queues = "Windows.7.Amd64;Windows.7.Amd64.Open;OSX.1014.Amd64;OSX.1014.Amd64.Open")]
+        [SkipOnHelix("Not supported queues", Queues = "Windows.7.Amd64;Windows.7.Amd64.Open;Windows.81.Amd64.Open;OSX.1014.Amd64;OSX.1014.Amd64.Open")]
         public async Task GrpcTemplate()
         {
             // Setup AssemblyTestLog


### PR DESCRIPTION
Fix the Windows 8.1 failure in https://dev.azure.com/dnceng/public/_build/results?buildId=722486&view=ms.vss-test-web.build-test-results-tab