### PR TITLE
Enable manual github action runs

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -1,7 +1,7 @@
 name: AspNetCore-Runtime Code Sync
 on:
-  # Test this script using on: push
-  # push:
+  # Manual run
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
@@ -11,7 +11,7 @@ on:
 jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
-    if: github.repository == 'dotnet/aspnetcore'
+    # if: github.repository == 'dotnet/aspnetcore'
     name: Compare the shared code in the AspNetCore and Runtime repos and notify if they're out of sync.
     runs-on: windows-latest
     steps:
@@ -51,7 +51,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Test this script using an issue in the local forked repo
-        $issue = 'https://api.github.com/repos/dotnet/aspnetcore/issues/18943'
+        $issue = 'https://github.com/Tratcher/aspnetcore/issues/1'
+        # $issue = 'https://api.github.com/repos/dotnet/aspnetcore/issues/18943'
         $changed = .\aspnetcore\.github\workflows\ReportDiff.ps1
         echo "::set-output name=changed::$changed"
     - name: Send PR

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
-    # if: github.repository == 'dotnet/aspnetcore'
+    if: github.repository == 'dotnet/aspnetcore'
     name: Compare the shared code in the AspNetCore and Runtime repos and notify if they're out of sync.
     runs-on: windows-latest
     steps:
@@ -51,8 +51,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Test this script using an issue in the local forked repo
-        $issue = 'https://github.com/Tratcher/aspnetcore/issues/1'
-        # $issue = 'https://api.github.com/repos/dotnet/aspnetcore/issues/18943'
+        $issue = 'https://api.github.com/repos/dotnet/aspnetcore/issues/18943'
         $changed = .\aspnetcore\.github\workflows\ReportDiff.ps1
         echo "::set-output name=changed::$changed"
     - name: Send PR


### PR DESCRIPTION
Github actions has a new feature that lets you trigger actions manually. I'm enabling this for the code sync action to make it easier to test, as well as allowing us to trigger it without waiting for the scheduled run.
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/