### PR TITLE
Increase timeout for SignalR functional tests

### DIFF
--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -1427,6 +1427,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Compon
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Components.Web.Extensions.Tests", "src\Components\Web.Extensions\test\Microsoft.AspNetCore.Components.Web.Extensions.Tests.csproj", "{157605CB-5170-4C1A-980F-4BAE42DB60DE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testassets", "testassets", "{758F015E-324A-4414-B9A5-327380BD56F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.Tests.Utils", "src\SignalR\common\testassets\Tests.Utils\Microsoft.AspNetCore.SignalR.Tests.Utils.csproj", "{FE250007-A20A-4E32-A4AD-13DF08BBE132}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -6729,6 +6733,18 @@ Global
 		{157605CB-5170-4C1A-980F-4BAE42DB60DE}.Release|x64.Build.0 = Release|Any CPU
 		{157605CB-5170-4C1A-980F-4BAE42DB60DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{157605CB-5170-4C1A-980F-4BAE42DB60DE}.Release|x86.Build.0 = Release|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Debug|x64.Build.0 = Debug|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Debug|x86.Build.0 = Debug|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Release|x64.ActiveCfg = Release|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Release|x64.Build.0 = Release|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Release|x86.ActiveCfg = Release|Any CPU
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -7444,6 +7460,8 @@ Global
 		{F71FE795-9923-461B-9809-BB1821A276D0} = {60D51C98-2CC0-40DF-B338-44154EFEE2FF}
 		{8294A74F-7DAA-4B69-BC56-7634D93C9693} = {F71FE795-9923-461B-9809-BB1821A276D0}
 		{157605CB-5170-4C1A-980F-4BAE42DB60DE} = {F71FE795-9923-461B-9809-BB1821A276D0}
+		{758F015E-324A-4414-B9A5-327380BD56F6} = {1A304CA0-7795-4684-88E5-E66402966927}
+		{FE250007-A20A-4E32-A4AD-13DF08BBE132} = {758F015E-324A-4414-B9A5-327380BD56F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3E8720B3-DBDD-498C-B383-2CC32A054E8F}

--- a/src/SignalR/common/testassets/Tests.Utils/InProcessTestServer.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/InProcessTestServer.cs
@@ -92,6 +92,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var url = "http://127.0.0.1:0";
 
             _host = new HostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30));
+                })
                 .ConfigureWebHost(webHostBuilder =>
                 {
                     webHostBuilder


### PR DESCRIPTION
Default timeout is 5 seconds which we've generally decided is too short during tests.