### PR TITLE
Making ViewLookupCache settable by derived classes.

### DIFF
--- a/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <summary>
         /// A cache for results of view lookups.
         /// </summary>
-        protected IMemoryCache ViewLookupCache { get; protected set; }
+        protected IMemoryCache ViewLookupCache { get; set; }
 
         /// <summary>
         /// Gets the case-normalized route value for the specified route <paramref name="key"/>.

--- a/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
@@ -77,10 +77,21 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             ViewLookupCache = new MemoryCache(new MemoryCacheOptions());
         }
 
+        protected RazorViewEngine(
+            IRazorPageFactoryProvider pageFactory,
+            IRazorPageActivator pageActivator,
+            HtmlEncoder htmlEncoder,
+            IOptions<RazorViewEngineOptions> optionsAccessor,
+            ILoggerFactory loggerFactory,
+            DiagnosticListener diagnosticListener,
+            IMemoryCache memoryCache) : self(pageFactory, pageActivator, htmlEncoder, optionsAccessor, loggerFactory, diagnosticListener) {
+                this.ViewLookupCache = memoryCache;
+        }
+
         /// <summary>
         /// A cache for results of view lookups.
         /// </summary>
-        protected IMemoryCache ViewLookupCache { get; set; }
+        protected IMemoryCache ViewLookupCache { get; }
 
         /// <summary>
         /// Gets the case-normalized route value for the specified route <paramref name="key"/>.

--- a/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <summary>
         /// A cache for results of view lookups.
         /// </summary>
-        protected IMemoryCache ViewLookupCache { get; }
+        protected IMemoryCache ViewLookupCache { get; protected set; }
 
         /// <summary>
         /// Gets the case-normalized route value for the specified route <paramref name="key"/>.


### PR DESCRIPTION
This is necessary to allow derived classes to source the cache via dependency injection.
Injecting the cache has the desirable feature of potentially permitting the RazorViewEngine to be injected as scoped rather than as a singleton, while still retaining the performance of caching the output of the heavier-weight initialization.
Injecting as scoped is preferable to a singleton, as it allows for greater dynamism - e.g. in a multi-tenant application, there are instances where having different ViewLocationFormats for each tenant is useful.

Summary of the changes (Less than 80 chars)
 - Allow derived classes to source the cache via dependency injection.
