### PR TITLE
Use Azure Artifacts instead of MyGet

### DIFF
--- a/build/sources.props
+++ b/build/sources.props
@@ -14,9 +14,7 @@
     </RestoreSources>
     <RestoreSources Condition=" '$(DotNetBuildOffline)' != 'true' AND '$(DisableMyGetRestoreSources)' != 'true' ">
       $(RestoreSources);
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
     </RestoreSources>

--- a/src/AzureIntegration/build/repo.targets
+++ b/src/AzureIntegration/build/repo.targets
@@ -12,7 +12,7 @@
       <SiteExtensionWorkingDirectory>$(TestDotNetPath)extension\$(SiteExtensionArch)\</SiteExtensionWorkingDirectory>
       <SiteExtensionOutputDirectory>$(RepositoryRoot)artifacts\build</SiteExtensionOutputDirectory>
       <TestProjectDirectory>$(RepositoryRoot)\test\Microsoft.AspNetCore.AzureAppServices.FunctionalTests\</TestProjectDirectory>
-      <SiteExtensionFeed Condition="$(SiteExtensionFeed) == ''">https://dotnet.myget.org/F/aspnetcore-dev/</SiteExtensionFeed>
+      <SiteExtensionFeed Condition="$(SiteExtensionFeed) == ''">https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json</SiteExtensionFeed>
   </PropertyGroup>
 
   <Target Name="_AddTestRuntimes">

--- a/src/AzureIntegration/build/sources.props
+++ b/src/AzureIntegration/build/sources.props
@@ -5,9 +5,8 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
       $(RestoreSources);
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+      https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);

--- a/src/AzureIntegration/test/Microsoft.AspNetCore.AzureAppServices.FunctionalTests/Assets/NuGet.latest.config
+++ b/src/AzureIntegration/test/Microsoft.AspNetCore.AzureAppServices.FunctionalTests/Assets/NuGet.latest.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
+    <add key="AspNetCore" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMPackageResolver/ANCMPackageResolver.csproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMPackageResolver/ANCMPackageResolver.csproj
@@ -19,7 +19,7 @@
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://api.nuget.org/v3/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
+      https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json;
     </RestoreSources>
   </PropertyGroup>
 

--- a/src/Templating/build/sources.props
+++ b/src/Templating/build/sources.props
@@ -5,9 +5,8 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
       $(RestoreSources);
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+      https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);

--- a/test/Cli.FunctionalTests/NuGetPackageSource.cs
+++ b/test/Cli.FunctionalTests/NuGetPackageSource.cs
@@ -23,7 +23,7 @@ namespace Cli.FunctionalTests
         public static NuGetPackageSource DotNetCore { get; } = new NuGetPackageSource
         {
             Name = nameof(DotNetCore),
-            SourceArgumentLazy = new Lazy<string>("--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"),
+            SourceArgumentLazy = new Lazy<string>("--source https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json"),
         };
 
         public static NuGetPackageSource EnvironmentVariable { get; } = new NuGetPackageSource


### PR DESCRIPTION
As part of [moving to Azure Artifacts from MyGet](https://github.com/dotnet/arcade/blob/master/Documentation/MigrationPlan/MyGetFeeds.md), point all MyGet feed sources to new Azure Artifacts feed.

@dougbu FYI, from email.