### PR TITLE
Changed "log in" to "login" for wording consistency

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml
@@ -2,7 +2,7 @@
 @model LoginModel
 
 @{
-    ViewData["Title"] = "Log in";
+    ViewData["Title"] = "Login";
 }
 
 <h1>@ViewData["Title"]</h1>
@@ -10,7 +10,7 @@
     <div class="col-md-4">
         <section>
             <form id="account" method="post">
-                <h4>Use a local account to log in.</h4>
+                <h4>Use a local account to login.</h4>
                 <hr />
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-group">
@@ -32,7 +32,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <button id="login-submit" type="submit" class="btn btn-primary">Log in</button>
+                    <button id="login-submit" type="submit" class="btn btn-primary">Login</button>
                 </div>
                 <div class="form-group">
                     <p>
@@ -50,7 +50,7 @@
     </div>
     <div class="col-md-6 col-md-offset-2">
         <section>
-            <h4>Use another service to log in.</h4>
+            <h4>Use another service to login.</h4>
             <hr />
             @{
                 if ((Model.ExternalLogins?.Count ?? 0) == 0)
@@ -69,7 +69,7 @@
                             <p>
                                 @foreach (var provider in Model.ExternalLogins)
                                 {
-                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
+                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Login using your @provider.DisplayName account">@provider.DisplayName</button>
                                 }
                             </p>
                         </div>


### PR DESCRIPTION
The _LoginPartial refers to the page as "Login" so it should be consistent throughout and be called "Login".
![image](https://user-images.githubusercontent.com/31081102/87469415-8a9a3500-c61b-11ea-8d10-817c973b90a8.png)
