### PR TITLE
Tests, tweaks, and other follow-ups to lazy-loading

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -70,6 +70,12 @@ namespace Microsoft.AspNetCore.Components.Routing
         [Parameter] public RenderFragment Navigating { get; set; }
 
         /// <summary>
+        /// Gets or sets the content to display with an asynchronous navigation task
+        /// throws an unhandled exception.
+        /// </summary>
+        [Parameter] public RenderFragment<Exception> OnNavigateError { get; set; }
+
+        /// <summary>
         /// Gets or sets a handler that should be called before navigating to a new page.
         /// </summary>
         [Parameter] public EventCallback<NavigationContext> OnNavigateAsync { get; set; }
@@ -227,6 +233,13 @@ namespace Microsoft.AspNetCore.Components.Routing
             }
 
             var completedTask = await Task.WhenAny(task, cancellationTcs.Task);
+
+            if (OnNavigateError != null && completedTask.IsFaulted)
+            {
+                _renderHandle.Render(OnNavigateError(completedTask.Exception.InnerException));
+                return false;
+            }
+
             return task == completedTask;
         }
 

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -224,9 +224,9 @@ namespace Microsoft.AspNetCore.Components.Routing
             }
             catch (OperationCanceledException e)
             {
-                if (!navigateContext.CancellationToken.IsCancellationRequested)
+                if (e.CancellationToken != navigateContext.CancellationToken)
                 {
-                    var rethrownException =  new InvalidOperationException("OnNavigateAsync can only be cancelled via he NavigateContext.CancellationToken.", e);
+                    var rethrownException = new InvalidOperationException("OnNavigateAsync can only be cancelled via NavigateContext.CancellationToken.", e);
                     _renderHandle.Render(builder => ExceptionDispatchInfo.Capture(rethrownException).Throw());
                     return false;
                 }

--- a/src/Components/Components/test/Routing/RouterTest.cs
+++ b/src/Components/Components/test/Routing/RouterTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
             var janTaskException = await Assert.ThrowsAsync<InvalidOperationException>(() => janTask);
 
             // Assert
-            Assert.Equal("OnNavigateAsync callback cannot be canceled.", janTaskException.Message);
+            Assert.Equal("OnNavigateAsync can only be cancelled via he NavigateContext.CancellationToken.", janTaskException.Message);
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
             {
                 if (args.Path.EndsWith("jan"))
                 {
-                    await Task.Delay(Timeout.Infinite);
+                    await Task.Delay(Timeout.Infinite, args.CancellationToken);
                 }
             };
             var refreshCalled = false;

--- a/src/Components/Components/test/Routing/RouterTest.cs
+++ b/src/Components/Components/test/Routing/RouterTest.cs
@@ -2,69 +2,198 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Test.Helpers;
-using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
+using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.AspNetCore.Components.Test.Routing
 {
     public class RouterTest
     {
+        private readonly Router _router;
+        private readonly TestRenderer _renderer;
+
+        public RouterTest()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            services.AddSingleton<NavigationManager, TestNavigationManager>();
+            services.AddSingleton<INavigationInterception, TestNavigationInterception>();
+            var serviceProvider = services.BuildServiceProvider();
+
+            _renderer = new TestRenderer(serviceProvider);
+            _renderer.ShouldHandleExceptions = true;
+            _router = (Router)_renderer.InstantiateComponent<Router>();
+            _router.AppAssembly = Assembly.GetExecutingAssembly();
+            _router.Found = routeData => (builder) => builder.AddContent(0, "Rendering route...");
+            _renderer.AssignRootComponentId(_router);
+        }
+
         [Fact]
         public async Task CanRunOnNavigateAsync()
         {
             // Arrange
-            var router = CreateMockRouter();
             var called = false;
             async Task OnNavigateAsync(NavigationContext args)
             {
                 await Task.CompletedTask;
                 called = true;
             }
-            router.Object.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(router, OnNavigateAsync);
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
 
             // Act
-            await router.Object.RunOnNavigateWithRefreshAsync("http://example.com/jan", false);
+            await _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
 
             // Assert
             Assert.True(called);
         }
 
         [Fact]
-        public async Task CanCancelPreviousOnNavigateAsync()
+        public async Task CanHandleSingleFailedOnNavigateAsync()
         {
             // Arrange
-            var router = CreateMockRouter();
+            var called = false;
+            async Task OnNavigateAsync(NavigationContext args)
+            {
+                called = true;
+                await Task.CompletedTask;
+                throw new Exception("This is an uncaught exception.");
+            }
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+
+            // Act
+            await _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
+
+            // Assert
+            Assert.True(called);
+            Assert.Single(_renderer.HandledExceptions);
+            var unhandledException = _renderer.HandledExceptions[0];
+            Assert.Equal("This is an uncaught exception.", unhandledException.Message);
+        }
+
+        [Fact]
+        public void CanceledFailedOnNavigateAsyncDoesNothing()
+        {
+            // Arrange
+            async Task OnNavigateAsync(NavigationContext args)
+            {
+                if (args.Path.EndsWith("jan"))
+                {
+                    await Task.Delay(Timeout.Infinite);
+                    throw new Exception("This is an uncaught exception.");
+                }
+            }
+            var refreshCalled = false;
+            _renderer.OnUpdateDisplay = (renderBatch) =>
+            {
+                if (!refreshCalled)
+                {
+                    Assert.True(true);
+                    return;
+                }
+                Assert.True(false, "OnUpdateDisplay called more than once.");
+            };
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+
+            // Act
+            _ = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
+            _ = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/feb", false));
+
+            // Assert that we render the second route component and don't throw an exception
+            Assert.Empty(_renderer.HandledExceptions);
+        }
+
+        [Fact]
+        public async Task CanHandleSingleCancelledOnNavigateAsync()
+        {
+            // Arrange
+            async Task OnNavigateAsync(NavigationContext args)
+            {
+                var tcs = new TaskCompletionSource<int>();
+                tcs.TrySetCanceled();
+                await tcs.Task;
+            }
+            _renderer.OnUpdateDisplay = (renderBatch) => Assert.True(false, "OnUpdateDisplay called more than once.");
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+
+            // Act
+            var janTask = _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false);
+
+            var janTaskException = await Assert.ThrowsAsync<InvalidOperationException>(() => janTask);
+
+            // Assert
+            Assert.Equal("OnNavigateAsync callback cannot be canceled.", janTaskException.Message);
+        }
+
+        [Fact]
+        public async Task AlreadyCanceledOnNavigateAsyncDoesNothing()
+        {
+            // Arrange
+            var triggerCancel = new TaskCompletionSource();
+            async Task OnNavigateAsync(NavigationContext args)
+            {
+                if (args.Path.EndsWith("jan"))
+                {
+                    var tcs = new TaskCompletionSource();
+                    await triggerCancel.Task;
+                    tcs.TrySetCanceled();
+                    await tcs.Task;
+                }
+            }
+            var refreshCalled = false;
+            _renderer.OnUpdateDisplay = (renderBatch) =>
+            {
+                if (!refreshCalled)
+                {
+                    Assert.True(true);
+                    return;
+                }
+                Assert.True(false, "OnUpdateDisplay called more than once.");
+            };
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+
+            // Act (start the operations then await them)
+            var jan = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
+            var feb = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/feb", false));
+            triggerCancel.TrySetResult();
+
+            await jan;
+            await feb;
+        }
+
+        [Fact]
+        public void CanCancelPreviousOnNavigateAsync()
+        {
+            // Arrange
             var cancelled = "";
             async Task OnNavigateAsync(NavigationContext args)
             {
                 await Task.CompletedTask;
                 args.CancellationToken.Register(() => cancelled = args.Path);
             };
-            router.Object.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(router, OnNavigateAsync);
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
 
             // Act
-            await router.Object.RunOnNavigateWithRefreshAsync("jan", false);
-            await router.Object.RunOnNavigateWithRefreshAsync("feb", false);
+            _ = _router.RunOnNavigateWithRefreshAsync("jan", false);
+            _ = _router.RunOnNavigateWithRefreshAsync("feb", false);
 
             // Assert
             var expected = "jan";
-            Assert.Equal(cancelled, expected);
+            Assert.Equal(expected, cancelled);
         }
 
         [Fact]
         public async Task RefreshesOnceOnCancelledOnNavigateAsync()
         {
             // Arrange
-            var router = CreateMockRouter();
             async Task OnNavigateAsync(NavigationContext args)
             {
                 if (args.Path.EndsWith("jan"))
@@ -72,33 +201,48 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                     await Task.Delay(Timeout.Infinite);
                 }
             };
-            router.Object.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(router, OnNavigateAsync);
+            var refreshCalled = false;
+            _renderer.OnUpdateDisplay = (renderBatch) =>
+            {
+                if (!refreshCalled)
+                {
+                    Assert.True(true);
+                    return;
+                }
+                Assert.True(false, "OnUpdateDisplay called more than once.");
+            };
+            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
 
             // Act
-            var janTask = router.Object.RunOnNavigateWithRefreshAsync("jan", false);
-            var febTask = router.Object.RunOnNavigateWithRefreshAsync("feb", false);
+            var jan = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
+            var feb = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/feb", false));
 
-            var janTaskException = await Record.ExceptionAsync(() => janTask);
-            var febTaskException = await Record.ExceptionAsync(() => febTask);
-
-            // Assert neither exceution threw an exception
-            Assert.Null(janTaskException);
-            Assert.Null(febTaskException);
-            // Assert refresh should've only been called once for the second route
-            router.Verify(x => x.Refresh(false), Times.Once());
+            await jan;
+            await feb;
         }
 
-        private Mock<Router> CreateMockRouter()
+        internal class TestNavigationManager : NavigationManager
         {
-            var router = new Mock<Router>() { CallBase = true };
-            router.Setup(x => x.Refresh(It.IsAny<bool>())).Verifiable();
-            return router;
+            public TestNavigationManager() =>
+                Initialize("https://www.example.com/subdir/", "https://www.example.com/subdir/jan");
+
+            protected override void NavigateToCore(string uri, bool forceLoad) => throw new NotImplementedException();
         }
 
-        [Route("jan")]
-        private class JanComponent : ComponentBase { }
+        internal sealed class TestNavigationInterception : INavigationInterception
+        {
+            public static readonly TestNavigationInterception Instance = new TestNavigationInterception();
+
+            public Task EnableNavigationInterceptionAsync()
+            {
+                return Task.CompletedTask;
+            }
+        }
 
         [Route("feb")]
-        private class FebComponent : ComponentBase { }
+        public class FebComponent : ComponentBase { }
+
+        [Route("jan")]
+        public class JanComponent : ComponentBase { }
     }
 }

--- a/src/Components/Components/test/Routing/RouterTest.cs
+++ b/src/Components/Components/test/Routing/RouterTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 await Task.CompletedTask;
                 called = true;
             }
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act
             await _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 await Task.CompletedTask;
                 throw new Exception("This is an uncaught exception.");
             }
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act
             await _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 }
                 Assert.True(false, "OnUpdateDisplay called more than once.");
             };
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act
             _ = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
@@ -122,15 +122,15 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 await tcs.Task;
             }
             _renderer.OnUpdateDisplay = (renderBatch) => Assert.True(false, "OnUpdateDisplay called more than once.");
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act
-            var janTask = _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false);
-
-            var janTaskException = await Assert.ThrowsAsync<InvalidOperationException>(() => janTask);
+            await _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
 
             // Assert
-            Assert.Equal("OnNavigateAsync can only be cancelled via he NavigateContext.CancellationToken.", janTaskException.Message);
+            Assert.Single(_renderer.HandledExceptions);
+            var unhandledException = _renderer.HandledExceptions[0];
+            Assert.Equal("OnNavigateAsync can only be cancelled via he NavigateContext.CancellationToken.", unhandledException.Message);
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 }
                 Assert.True(false, "OnUpdateDisplay called more than once.");
             };
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act (start the operations then await them)
             var jan = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 await Task.CompletedTask;
                 args.CancellationToken.Register(() => cancelled = args.Path);
             };
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act
             _ = _router.RunOnNavigateWithRefreshAsync("jan", false);
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                 }
                 Assert.True(false, "OnUpdateDisplay called more than once.");
             };
-            _router.OnNavigateAsync = new EventCallbackFactory().Create<NavigationContext>(_router, OnNavigateAsync);
+            _router.OnNavigateAsync = OnNavigateAsync;
 
             // Act
             var jan = _renderer.Dispatcher.InvokeAsync(() => _router.RunOnNavigateWithRefreshAsync("http://example.com/jan", false));

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -551,6 +551,18 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             SetUrlViaPushState("/LongPage2");
             SetUrlViaPushState("/LongPage1");
 
+            Assert.True(app.FindElement(By.Id("error-banner")) != null);
+        }
+
+        [Fact]
+        public void OnNavigate_CanRenderUIForExceptions()
+        {
+            var app = Browser.MountTestComponent<TestRouterWithOnNavigate>();
+
+            // Navigating from one page to another should
+            // cancel the previous OnNavigate Task
+            SetUrlViaPushState("/Other");
+
             AssertDidNotLog("I'm not happening...");
         }
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -551,7 +551,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             SetUrlViaPushState("/LongPage2");
             SetUrlViaPushState("/LongPage1");
 
-            Assert.True(app.FindElement(By.Id("error-banner")) != null);
+            AssertDidNotLog("I'm not happening...");
         }
 
         [Fact]
@@ -563,7 +563,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // cancel the previous OnNavigate Task
             SetUrlViaPushState("/Other");
 
-            AssertDidNotLog("I'm not happening...");
+            new WebDriverWait(Browser, TimeSpan.FromSeconds(2)).Until(
+                driver => driver.FindElement(By.Id("blazor-error-ui")) != null);
+
+            Assert.True(app.FindElement(By.Id("blazor-error-ui")) != null);
         }
 
         private long BrowserScrollY

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -563,10 +563,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // cancel the previous OnNavigate Task
             SetUrlViaPushState("/Other");
 
-            new WebDriverWait(Browser, TimeSpan.FromSeconds(2)).Until(
-                driver => driver.FindElement(By.Id("blazor-error-ui")) != null);
-
-            Assert.True(app.FindElement(By.Id("blazor-error-ui")) != null);
+            var errorUiElem = Browser.Exists(By.Id("blazor-error-ui"), TimeSpan.FromSeconds(10));
+            Assert.NotNull(errorUiElem);
         }
 
         private long BrowserScrollY

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
@@ -1,6 +1,11 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 
 <Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" OnNavigateAsync="@OnNavigateAsync">
+    <OnNavigateError>
+        <div style="padding: 20px;background-color:red;color:white;" id="loading-banner">
+            <p>Woops!</p>
+        </div>
+    </OnNavigateError>
     <Navigating>
         <div style="padding: 20px;background-color:blue;color:white;" id="loading-banner">
             <p>Loading the requested page...</p>
@@ -19,8 +24,9 @@
 @code {
     private Dictionary<string, Func<NavigationContext, Task>> preNavigateTasks = new Dictionary<string, Func<NavigationContext, Task>>()
     {
-        { "LongPage1", new Func<NavigationContext, Task>(TestLoadingPageShows) },
-        { "LongPage2", new Func<NavigationContext, Task>(TestOnNavCancel) }
+    { "LongPage1", new Func<NavigationContext, Task>(TestLoadingPageShows) },
+    { "LongPage2", new Func<NavigationContext, Task>(TestOnNavCancel) },
+    { "Other", new Func<NavigationContext, Task>(TestOnNavException) }
     };
 
     private async Task OnNavigateAsync(NavigationContext args)
@@ -42,5 +48,10 @@
     {
         await Task.Delay(2000, args.CancellationToken);
         Console.WriteLine("I'm not happening...");
+    }
+    public static async Task TestOnNavException(NavigationContext args)
+    {
+        await Task.Delay(2000);
+        throw new Exception("This is an uncaught exception.");
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
@@ -19,9 +19,9 @@
 @code {
     private Dictionary<string, Func<NavigationContext, Task>> preNavigateTasks = new Dictionary<string, Func<NavigationContext, Task>>()
     {
-    { "LongPage1", new Func<NavigationContext, Task>(TestLoadingPageShows) },
-    { "LongPage2", new Func<NavigationContext, Task>(TestOnNavCancel) },
-    { "Other", new Func<NavigationContext, Task>(TestOnNavException) }
+        { "LongPage1", new Func<NavigationContext, Task>(TestLoadingPageShows) },
+        { "LongPage2", new Func<NavigationContext, Task>(TestOnNavCancel) },
+        { "Other", new Func<NavigationContext, Task>(TestOnNavException) }
     };
 
     private async Task OnNavigateAsync(NavigationContext args)

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
@@ -1,11 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 
 <Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" OnNavigateAsync="@OnNavigateAsync">
-    <OnNavigateError>
-        <div style="padding: 20px;background-color:red;color:white;" id="loading-banner">
-            <p>Woops!</p>
-        </div>
-    </OnNavigateError>
     <Navigating>
         <div style="padding: 20px;background-color:blue;color:white;" id="loading-banner">
             <p>Loading the requested page...</p>
@@ -49,9 +44,10 @@
         await Task.Delay(2000, args.CancellationToken);
         Console.WriteLine("I'm not happening...");
     }
+
     public static async Task TestOnNavException(NavigationContext args)
     {
-        await Task.Delay(2000);
+        await Task.CompletedTask;
         throw new Exception("This is an uncaught exception.");
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Components
         public static bool TryConvertToString(object obj, System.Globalization.CultureInfo culture, out string value) { throw null; }
         public static bool TryConvertTo<T>(object obj, System.Globalization.CultureInfo culture, out T value) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
     public sealed partial class BindElementAttribute : System.Attribute
     {
         public BindElementAttribute(string element, string suffix, string valueAttribute, string changeAttribute) { }
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Components
         public string Suffix { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ValueAttribute { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public sealed partial class CascadingParameterAttribute : System.Attribute
     {
         public CascadingParameterAttribute() { }
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Components
         public bool HasDelegate { get { throw null; } }
         public System.Threading.Tasks.Task InvokeAsync(TValue arg) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
     public sealed partial class EventHandlerAttribute : System.Attribute
     {
         public EventHandlerAttribute(string attributeName, System.Type eventArgsType) { }
@@ -226,12 +226,12 @@ namespace Microsoft.AspNetCore.Components
     {
         System.Threading.Tasks.Task HandleEventAsync(Microsoft.AspNetCore.Components.EventCallbackWorkItem item, object arg);
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public sealed partial class InjectAttribute : System.Attribute
     {
         public InjectAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
     public sealed partial class LayoutAttribute : System.Attribute
     {
         public LayoutAttribute(System.Type layoutType) { }
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Components
         private readonly object _dummy;
         public MarkupString(string value) { throw null; }
         public string Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public static explicit operator Microsoft.AspNetCore.Components.MarkupString(string value) { throw null; }
+        public static explicit operator Microsoft.AspNetCore.Components.MarkupString (string value) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class NavigationException : System.Exception
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Components
         protected OwningComponentBase() { }
         protected TService Service { get { throw null; } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public sealed partial class ParameterAttribute : System.Attribute
     {
         public ParameterAttribute() { }
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Components
         public bool IsInitialized { get { throw null; } }
         public void Render(Microsoft.AspNetCore.Components.RenderFragment renderFragment) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
     public sealed partial class RouteAttribute : System.Attribute
     {
         public RouteAttribute(string template) { }
@@ -525,7 +525,6 @@ namespace Microsoft.AspNetCore.Components.Routing
         public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Found { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public Microsoft.AspNetCore.Components.RenderFragment NotFound { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext> OnNavigateAsync { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public void Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
         public void Dispose() { }
         System.Threading.Tasks.Task Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync() { throw null; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Components
         public static bool TryConvertToString(object obj, System.Globalization.CultureInfo culture, out string value) { throw null; }
         public static bool TryConvertTo<T>(object obj, System.Globalization.CultureInfo culture, out T value) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public sealed partial class BindElementAttribute : System.Attribute
     {
         public BindElementAttribute(string element, string suffix, string valueAttribute, string changeAttribute) { }
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Components
         public string Suffix { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ValueAttribute { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed partial class CascadingParameterAttribute : System.Attribute
     {
         public CascadingParameterAttribute() { }
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Components
         public bool HasDelegate { get { throw null; } }
         public System.Threading.Tasks.Task InvokeAsync(TValue arg) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public sealed partial class EventHandlerAttribute : System.Attribute
     {
         public EventHandlerAttribute(string attributeName, System.Type eventArgsType) { }
@@ -226,12 +226,12 @@ namespace Microsoft.AspNetCore.Components
     {
         System.Threading.Tasks.Task HandleEventAsync(Microsoft.AspNetCore.Components.EventCallbackWorkItem item, object arg);
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed partial class InjectAttribute : System.Attribute
     {
         public InjectAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed partial class LayoutAttribute : System.Attribute
     {
         public LayoutAttribute(System.Type layoutType) { }
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Components
         private readonly object _dummy;
         public MarkupString(string value) { throw null; }
         public string Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public static explicit operator Microsoft.AspNetCore.Components.MarkupString (string value) { throw null; }
+        public static explicit operator Microsoft.AspNetCore.Components.MarkupString(string value) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class NavigationException : System.Exception
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Components
         protected OwningComponentBase() { }
         protected TService Service { get { throw null; } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed partial class ParameterAttribute : System.Attribute
     {
         public ParameterAttribute() { }
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Components
         public bool IsInitialized { get { throw null; } }
         public void Render(Microsoft.AspNetCore.Components.RenderFragment renderFragment) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public sealed partial class RouteAttribute : System.Attribute
     {
         public RouteAttribute(string template) { }
@@ -525,6 +525,9 @@ namespace Microsoft.AspNetCore.Components.Routing
         public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Found { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public Microsoft.AspNetCore.Components.RenderFragment NotFound { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext> OnNavigateAsync { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public Microsoft.AspNetCore.Components.RenderFragment<System.Exception> OnNavigateError { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public void Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
         public void Dispose() { }
         System.Threading.Tasks.Task Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync() { throw null; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -526,8 +526,6 @@ namespace Microsoft.AspNetCore.Components.Routing
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public Microsoft.AspNetCore.Components.RenderFragment NotFound { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext> OnNavigateAsync { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.RenderFragment<System.Exception> OnNavigateError { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public void Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) { }
         public void Dispose() { }
         System.Threading.Tasks.Task Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync() { throw null; }


### PR DESCRIPTION
* Re-throws uncaught exceptions in the renderer
* Add tests for more cancellation and failure scenarios
* Clean-up code comments
* Throw error if user attempts to cancel `OnNavigateAsync`

Addresses #23763
