### PR TITLE
Add additional environment variables to dockerbuild

### DIFF
--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -133,10 +133,14 @@ docker run \
     -t \
     -e TF_BUILD \
     -e BUILD_NUMBER \
+    -e BUILD_BUILDID \
+    -e SYSTEM_TEAMPROJECT \
     -e BUILD_BUILDNUMBER \
     -e BUILD_REPOSITORY_URI \
     -e BUILD_SOURCEVERSION \
     -e BUILD_SOURCEBRANCH \
+    -e SYSTEM_DEFINITIONID \
+    -e SYSTEM_TEAMFOUNDATIONCOLLECTIONURI \
     -e DOTNET_CLI_TELEMETRY_OPTOUT \
     -e Configuration \
     -v "$DIR:$DIR" \


### PR DESCRIPTION
These are used by the publish/asset manifest creation tasks to fill out
some attributes. Without these in the docker environment, manifests will
be inconsistent between those produced on plain machines and ones produced
in docker files.