### PR TITLE
Add Razor Tooling Bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/razor_tooling.md
+++ b/.github/ISSUE_TEMPLATE/razor_tooling.md
@@ -1,0 +1,63 @@
+---
+name: 🐞 Razor Tooling Bug report
+about: Create a report about something that is not working in the new Razor tooling
+---
+
+<!--
+
+More information on our issue management policies can be found here: https://aka.ms/aspnet/issue-policies
+
+Please keep in mind that the GitHub issue tracker is not intended as a general support forum, but for reporting **non-security** bugs and feature requests.
+
+If you believe you have an issue that affects the SECURITY of the platform, please do NOT create an issue and instead email your issue details to secure@microsoft.com. Your report may be eligible for our [bug bounty](https://www.microsoft.com/en-us/msrc/bounty-dot-net-core) but ONLY if it is reported through email.
+For other types of questions, consider using [StackOverflow](https://stackoverflow.com).
+
+-->
+
+<!-- NOTE: This issue template is meant specifically to be used for issues with the new experimental Razor tooling experience provided in Visual Studio's Preview Feature pane -->
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+<!--
+We ❤ code! Point us to a minimalistic repro project hosted in a GitHub repo.
+For a repro project, create a new ASP.NET Core project using the template of your your choice, apply the minimum required code to result in the issue you're observing.
+
+We will close this issue if:
+- the repro project you share with us is complex. We can't investigate custom projects, so don't point us to such, please.
+- if we will not be able to repro the behavior you're reporting
+-->
+
+### Logs & Exceptions
+
+#### Activity log
+[Here](https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-use-the-activity-log?view=vs-2019#to-examine-the-activity-log) are the instructions on how to generate/acquire one.
+
+#### Razor Language Server Client log
+<!-- In Visual Studio's `Output` window, the drop-down contains a `Razor Language Server Client` item. Include that below. -->
+<details>
+<summary>Razor Language Server Client Log Output</summary>
+
+Paste log output here
+
+</details>
+
+#### HTML Language Server Client log
+<!-- In Visual Studio's `Output` window, the drop-down contains a `HtmlyLanguageClient` item. Include that below. -->
+<details>
+<summary>HTML Language Server Client Log Output</summary>
+
+Paste log output here
+
+</details>
+
+### Further technical details
+- VS version (Help => About Microsoft Visual Studio, i.e. 16.8.0 Preview 1 30313.27...). If in Codespaces there will be
+- Scenario (Local, LiveShare, Codespaces)
+
+### Pre-requisite checklist
+- [ ] Steps to reproduce the issue
+- [ ] Visual Studio Activity Log attached.
+- [ ] Razor Language Server client logs included.
+- [ ] HTML Language Server client logs included

--- a/.github/ISSUE_TEMPLATE/razor_tooling.md
+++ b/.github/ISSUE_TEMPLATE/razor_tooling.md
@@ -32,6 +32,8 @@ We will close this issue if:
 
 ### Logs & Exceptions
 
+Please collect the data below before reporting your issue to aid us in diagnosing the root cause.
+
 #### Activity log
 [Here](https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-use-the-activity-log?view=vs-2019#to-examine-the-activity-log) are the instructions on how to generate/acquire one.
 

--- a/.github/ISSUE_TEMPLATE/razor_tooling.md
+++ b/.github/ISSUE_TEMPLATE/razor_tooling.md
@@ -1,6 +1,7 @@
 ---
 name: 🐞 Razor Tooling Bug report
-about: Create a report about something that is not working in the new Razor tooling
+about: Report an issue about something that is not working in the new Razor tooling
+labels: area-razor.tooling, feature-razor.vs
 ---
 
 <!--
@@ -53,7 +54,7 @@ Paste log output here
 </details>
 
 ### Further technical details
-- VS version (Help => About Microsoft Visual Studio, i.e. 16.8.0 Preview 1 30313.27...). If in Codespaces there will be
+- VS version (Help => About Microsoft Visual Studio, i.e. 16.8.0 Preview 1 30313.27...). If in Codespaces there will be two versions (server and client), please provide both.
 - Scenario (Local, LiveShare, Codespaces)
 
 ### Pre-requisite checklist


### PR DESCRIPTION
- Given we're going to start providing a new Razor tooling editor experience we expect our users to hit a number of issues. To optimize their path of filing an issue we're creating a bug template for them to use. In parallel we're also working with the VS report an issue tool to gather additioanl data so we can encourage users to go the typical "report a bug" route for VS scenarios.

Fixes dotnet/aspnetcore#23551
