### PR TITLE
[Backport] StopAsync resets state on inactive connection (#20083)

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -501,6 +501,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 {
                     connectionState.Stopping = true;
                 }
+                else
+                {
+                    // Reset StopCts if there isn't an active connection so that the next StartAsync wont immediately fail due to the token being canceled
+                    _state.StopCts = new CancellationTokenSource();
+                }
 
                 if (disposing)
                 {

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.ConnectionLifecycle.cs
@@ -335,6 +335,26 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
+            public async Task StopAsyncOnInactiveConnectionDoesNotAffectNextStartAsync()
+            {
+                // Regression test:
+                // If there wasn't an active underlying connection, StopAsync would leave a CTS canceled which would cause the next StartAsync to fail
+                var testConnection = new TestConnection();
+                await AsyncUsing(CreateHubConnection(testConnection), async connection =>
+                {
+                    Assert.Equal(HubConnectionState.Disconnected, connection.State);
+
+                    await connection.StopAsync().OrTimeout();
+                    Assert.False(testConnection.Disposed.IsCompleted);
+                    Assert.Equal(HubConnectionState.Disconnected, connection.State);
+
+                    await connection.StartAsync().OrTimeout();
+                    Assert.True(testConnection.Started.IsCompleted);
+                    Assert.Equal(HubConnectionState.Connected, connection.State);
+                });
+            }
+
+            [Fact]
             public async Task CompletingTheTransportSideMarksConnectionAsClosed()
             {
                 var testConnection = new TestConnection();


### PR DESCRIPTION
#### Description

`HubConnection` could get into a permanently broken state if `StopAsync` was called when the connection was already stopped in some cases. The fix is managing the state correctly so `StopAsync` doesn't break the connection.

#### Customer Impact

Bug was reported by a customer in https://github.com/dotnet/aspnetcore/issues/18028.
Customers can run into difficulties when trying to write a reliable service that can restart the hub connection correctly.
The most reliable workaround is to entirely recreate the `HubConnection` instead of reusing it. This can be difficult because of how customers' code is organized.

Internal partner is also asking us to backport to fix issues they're seeing.

#### Regression?

Yes, new bug in 3.0+

#### Risk

Very low, simple fix with well understood problem and easily testable.