### PR TITLE
Provide default implementation for IHubFilter.InvokeMethodAsync

### DIFF
--- a/src/SignalR/server/Core/src/IHubFilter.cs
+++ b/src/SignalR/server/Core/src/IHubFilter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="invocationContext">The context for the method invocation that holds all the important information about the invoke.</param>
         /// <param name="next">The next filter to run, and for the final one, the Hub invocation.</param>
         /// <returns>Returns the result of the Hub method invoke.</returns>
-        ValueTask<object> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object>> next);
+        ValueTask<object> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object>> next) => next(invocationContext);
 
         /// <summary>
         /// Allows handling of the <see cref="Hub.OnConnectedAsync"/> method.

--- a/src/SignalR/server/SignalR/test/TestFilters.cs
+++ b/src/SignalR/server/SignalR/test/TestFilters.cs
@@ -233,4 +233,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return next(context);
         }
     }
+
+    public class EmptyFilter : IHubFilter
+    {
+        // Purposefully not implementing any methods
+    }
 }


### PR DESCRIPTION
@halter73 mentioned we should probably add a default for this as well. It's not too hard to imagine filters being written that don't want to implement `InvokeMethodAsync`.