### PR TITLE
Changed _LoginPartial wording for consistency

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Areas/Identity/Pages/Shared/_LoginPartial.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Areas/Identity/Pages/Shared/_LoginPartial.cshtml
@@ -19,7 +19,7 @@
     </li>
     <li class="nav-item">
         <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="/" method="post">
-            <button  type="submit" class="nav-link btn btn-link text-dark">Logout</button>
+            <button  type="submit" class="nav-link btn btn-link text-dark">Log Out</button>
         </form>
     </li>
 }
@@ -29,7 +29,7 @@ else
         <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Register" asp-route-returnUrl="@returnUrl">Register</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Login" asp-route-returnUrl="@returnUrl">Login</a>
+        <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Login" asp-route-returnUrl="@returnUrl">Log In</a>
     </li>
 }
 </ul>


### PR DESCRIPTION
Changed "Login" to "Log In" which matches the log in page. Capital "I" because its on the NavBar.
![image](https://user-images.githubusercontent.com/31081102/87609694-88130a80-c703-11ea-8aac-054540ffc273.png)

Changed "Logout" to "Log Out" to match  "Areas\Identity\Pages\Account\Logout.cshtml"