### PR TITLE
Make ComponentBase.StateHasChanged public

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Components
         /// Notifies the component that its state has changed. When applicable, this will
         /// cause the component to be re-rendered.
         /// </summary>
-        protected void StateHasChanged()
+        public void StateHasChanged()
         {
             if (_hasPendingQueuedRender)
             {


### PR DESCRIPTION
So when people are testing they can avoid this https://github.com/VerifyTests/Verify.Blazor/blob/master/src/Verify.Blazor/VerifyBlazor.cs#L13
