### PR TITLE
Default new runtime feature switches (#23932)

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Components.Wasm.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Components.Wasm.targets
@@ -25,6 +25,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Trimmer defaults -->
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
     <TrimMode Condition="'$(TrimMode)' == ''">link</TrimMode>
+    <TrimmerRemoveSymbols Condition="'$(TrimmerRemoveSymbols)' == ''">false</TrimmerRemoveSymbols>
+
+    <!-- Runtime feature defaults to trim unnecessary code -->
+    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
+    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' == 'Release'">false</DebuggerSupport>
 
     <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">/</StaticWebAssetBasePath>
     <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
@@ -414,7 +422,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'%(ResolvedFileToPublish.RelativePath)' != 'web.config' AND !$([System.String]::Copy('%(ResolvedFileToPublish.RelativePath)').Replace('\','/').StartsWith('wwwroot/'))" />
 
       <!-- Remove pdbs from the publish output -->
-      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'$(BlazorWebAssemblyEnableDebugging)' != 'true' AND '%(Extension)' == '.pdb'" />
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'$(DebuggerSupport)' == 'false' AND '%(Extension)' == '.pdb'" />
     </ItemGroup>
 
     <ItemGroup Condition="'@(ResolvedFileToPublish->AnyHaveMetadataValue('RelativePath', 'web.config'))' != 'true'">


### PR DESCRIPTION
Porting #23932 to release/5.0-preview8.

* Default new runtime feature switches

These new feature switches have been added to the runtime to make applications smaller. Setting reasonable defaults to Blazor wasm projects.

Fix #23716

For the default Blazor WASM template app, with these settings the uncompressed IL size drops:

| Build          | Size     |
|----------------|----------|
| Before change         | 3,007,488 bytes |
| With change   | 2,412,544 bytes |

cc @SteveSandersonMS @mkArtakMSFT 

If there is an ask mode template to fill out, let me know and I can do it.