### PR TITLE
Handle exception thrown by ProcessName during ProcessEx timeout

### DIFF
--- a/src/Shared/Process/ProcessEx.cs
+++ b/src/Shared/Process/ProcessEx.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Internal
                 }
                 catch (Exception ex)
                 {
-                    exMessage = $"Process timed out after {DefaultProcessTimeout}. Deails about the process could not be provided because: {ex}";
+                    exMessage = $"Process timed out after {DefaultProcessTimeout}. Details about the process could not be provided because: {ex}";
                 }
 
                 _exited.TrySetException(new TimeoutException(exMessage));

--- a/src/Shared/Process/ProcessEx.cs
+++ b/src/Shared/Process/ProcessEx.cs
@@ -52,7 +52,18 @@ namespace Microsoft.AspNetCore.Internal
             _processTimeoutCts = new CancellationTokenSource(timeout);
             _processTimeoutCts.Token.Register(() =>
             {
-                _exited.TrySetException(new TimeoutException($"Process proc {proc.ProcessName} {proc.StartInfo.Arguments} timed out after {DefaultProcessTimeout}."));
+                string exMessage;
+
+                try
+                {
+                    exMessage = $"Process proc {proc.ProcessName} {proc.StartInfo.Arguments} timed out after {DefaultProcessTimeout}.";
+                }
+                catch (Exception ex)
+                {
+                    exMessage = $"Process timed out after {DefaultProcessTimeout}. Deails about the process could not be provided because: {ex}";
+                }
+
+                _exited.TrySetException(new TimeoutException(exMessage));
             });
         }
 


### PR DESCRIPTION
```
Unhandled exception. System.AggregateException: One or more errors occurred. (Process has exited, so the requested information is not available.)
 ---> System.InvalidOperationException: Process has exited, so the requested information is not available.
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_ProcessName()
   at Microsoft.AspNetCore.Internal.ProcessEx.<>c__DisplayClass13_0.<.ctor>b__0() in /_/src/Shared/Process/ProcessEx.cs:line 55
   at System.Threading.CancellationToken.<>c.<.cctor>b__26_0(Object obj)
   at System.Threading.CancellationTokenSource.CallbackNode.<>c.<ExecuteCallback>b__9_0(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.CancellationTokenSource.CallbackNode.ExecuteCallback()
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
   --- End of inner exception stack trace ---
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
   at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.TimerQueue.FireNextTimers()
```

Process.ProcessName throwing in your CT callback caused BlazorTemplates.Tests to hang on our CI server.

https://dev.azure.com/dnceng/public/_build/results?buildId=731663&view=results