### PR TITLE
Quarantine flaky tests

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
@@ -132,6 +132,7 @@ namespace Templates.Test
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23992")]
         public async Task BlazorWasmStandalonePwaTemplate_Works()
         {
             var project = await ProjectFactory.GetOrCreateProject("blazorstandalonepwa", Output);
@@ -251,6 +252,7 @@ namespace Templates.Test
         }
 
         [ConditionalFact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23992")]
         // LocalDB doesn't work on non Windows platforms
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithLocalDB()
@@ -259,6 +261,7 @@ namespace Templates.Test
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23992")]
         public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithOutLocalDB()
         {
             return BlazorWasmHostedTemplate_IndividualAuth_Works(false);

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -71,6 +71,7 @@ namespace Templates.Test
 
         [Theory]
         [MemberData(nameof(TemplateBaselines))]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23993")]
         public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)
         {
             Project = await ProjectFactory.GetOrCreateProject("baseline" + SanitizeArgs(arguments), Output);

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -223,6 +223,7 @@ namespace Templates.Test
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23993")]
         public async Task MvcTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
         {
             Project = await ProjectFactory.GetOrCreateProject("mvc_rc", Output);

--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/StaticWebAssetsIntegrationTest.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         }
 
         [ConditionalFact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/18543")]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         [InitializeTestProject("AppWithPackageAndP2PReferenceAndRID", additionalProjects: new[] { "ClassLibrary", "ClassLibrary2" })]
         public async Task Publish_CopiesStaticWebAssetsToDestinationFolder_PublishSingleFile()

--- a/src/Tools/dotnet-watch/test/AppWithDepsTests.cs
+++ b/src/Tools/dotnet-watch/test/AppWithDepsTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23994")]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/23360", Queues = "Windows.10.Arm64;Windows.10.Arm64.Open;Debian.9.Arm64;Debian.9.Arm64.Open;(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036;(Debian.9.Arm64)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036")]
         public async Task ChangeFileInDependency()
         {


### PR DESCRIPTION
I'm not super confident we should be quarantining the ProjectTemplates. It might be better to wait and see what happens after https://github.com/dotnet/aspnetcore/pull/23990 is merged. I'm quarantining for now since that's what the guidelines suggest, and I want to open it up for discussion.