### PR TITLE
Modified EditForm to return _fixedEditContext via the EditContext parameter

### DIFF
--- a/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.netcoreapp.cs
+++ b/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.netcoreapp.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>? ChildContent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
-        public Microsoft.AspNetCore.Components.Forms.EditContext? EditContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public Microsoft.AspNetCore.Components.Forms.EditContext? EditContext { get { throw null; } set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]
         public object? Model { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]

--- a/src/Components/Web/src/Forms/EditForm.cs
+++ b/src/Components/Web/src/Forms/EditForm.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 throw new InvalidOperationException($"{nameof(EditForm)} requires a {nameof(Model)} " +
                     $"parameter, or an {nameof(EditContext)} parameter, but not both.");
             }
-            else if (EditContext == null && Model == null)
+            else if (!_hasSetEditContextExplicitly && Model == null)
             {
                 throw new InvalidOperationException($"{nameof(EditForm)} requires either a {nameof(Model)} " +
                     $"parameter, or an {nameof(EditContext)} parameter, please provide one of these.");

--- a/src/Components/Web/src/Forms/EditForm.cs
+++ b/src/Components/Web/src/Forms/EditForm.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
             // Update _editContext if we don't have one yet, or if they are supplying a
             // potentially new EditContext, or if they are supplying a different Model
-            if (_editContext == null || (!_hasSetEditContextExplicitly && Model != _editContext.Model))
+            if (Model != null && Model != _editContext?.Model)
             {
                 _editContext = new EditContext(Model!);
             }

--- a/src/Components/Web/src/Forms/EditForm.cs
+++ b/src/Components/Web/src/Forms/EditForm.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         private readonly Func<Task> _handleSubmitDelegate; // Cache to avoid per-render allocations
 
         private EditContext? _fixedEditContext;
+        private EditContext? _providedEditContext;
 
         /// <summary>
         /// Constructs an instance of <see cref="EditForm"/>.
@@ -36,7 +37,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// also supply <see cref="Model"/>, since the model value will be taken
         /// from the <see cref="EditContext.Model"/> property.
         /// </summary>
-        [Parameter] public EditContext? EditContext { get; set; }
+        [Parameter]
+        public EditContext? EditContext
+        {
+            get => _fixedEditContext;
+            set => _providedEditContext = value;
+        }
 
         /// <summary>
         /// Specifies the top-level model object for the form. An edit context will
@@ -73,7 +79,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void OnParametersSet()
         {
-            if ((EditContext == null) == (Model == null))
+            if ((_providedEditContext == null) == (Model == null))
             {
                 throw new InvalidOperationException($"{nameof(EditForm)} requires a {nameof(Model)} " +
                     $"parameter, or an {nameof(EditContext)} parameter, but not both.");
@@ -91,9 +97,9 @@ namespace Microsoft.AspNetCore.Components.Forms
 
             // Update _fixedEditContext if we don't have one yet, or if they are supplying a
             // potentially new EditContext, or if they are supplying a different Model
-            if (_fixedEditContext == null || EditContext != null || Model != _fixedEditContext.Model)
+            if (_fixedEditContext == null || _providedEditContext != null || Model != _fixedEditContext.Model)
             {
-                _fixedEditContext = EditContext ?? new EditContext(Model!);
+                _fixedEditContext = _providedEditContext ?? new EditContext(Model!);
             }
         }
 

--- a/src/Components/Web/src/Forms/EditForm.cs
+++ b/src/Components/Web/src/Forms/EditForm.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         private readonly Func<Task> _handleSubmitDelegate; // Cache to avoid per-render allocations
 
         private EditContext? _fixedEditContext;
-        private bool _hasSetEditContextExplicity;
+        private bool _hasSetEditContextExplicitly;
 
         /// <summary>
         /// Constructs an instance of <see cref="EditForm"/>.
@@ -43,11 +43,8 @@ namespace Microsoft.AspNetCore.Components.Forms
             get => _fixedEditContext;
             set
             {
-                if (value != null)
-                {
-                    _fixedEditContext = value;
-                    _hasSetEditContextExplicity = true;
-                }
+                _fixedEditContext = value;
+                _hasSetEditContextExplicitly = value != null;
             }
         }
 
@@ -86,7 +83,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <inheritdoc />
         protected override void OnParametersSet()
         {
-            if (_hasSetEditContextExplicity && Model != null)
+            if (_hasSetEditContextExplicitly && Model != null)
             {
                 throw new InvalidOperationException($"{nameof(EditForm)} requires a {nameof(Model)} " +
                     $"parameter, or an {nameof(EditContext)} parameter, but not both.");
@@ -109,7 +106,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
             // Update _fixedEditContext if we don't have one yet, or if they are supplying a
             // potentially new EditContext, or if they are supplying a different Model
-            if (_fixedEditContext == null || (!_hasSetEditContextExplicity && Model != _fixedEditContext.Model))
+            if (_fixedEditContext == null || (!_hasSetEditContextExplicitly && Model != _fixedEditContext.Model))
             {
                 _fixedEditContext = new EditContext(Model!);
             }

--- a/src/Components/Web/test/Forms/EditFormTest.cs
+++ b/src/Components/Web/test/Forms/EditFormTest.cs
@@ -33,6 +33,20 @@ namespace Microsoft.AspNetCore.Components.Forms
         }
 
         [Fact]
+        public async Task ThrowsIfBothEditContextAndModelAreNull()
+        {
+            // Arrange
+            var editForm = new EditForm();
+            var testRenderer = new TestRenderer();
+            var componentId = testRenderer.AssignRootComponentId(editForm);
+
+            // Act/Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => testRenderer.RenderRootComponentAsync(componentId));
+            Assert.StartsWith($"{nameof(EditForm)} requires either a {nameof(EditForm.Model)} parameter, or an {nameof(EditContext)} parameter, please provide one of these.", ex.Message);
+        }
+
+        [Fact]
         public async Task ReturnsEditContextWhenModelParameterUsed()
         {
             // Arrange
@@ -48,6 +62,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
             // Assert
             Assert.NotNull(returnedEditContext);
+            Assert.Same(model, returnedEditContext.Model);
         }
 
         [Fact]
@@ -65,7 +80,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             var returnedEditContext = editFormComponent.EditContext;
 
             // Assert
-            Assert.NotNull(returnedEditContext);
+            Assert.Same(editContext, returnedEditContext);
         }
 
         private static EditForm FindEditFormComponent(CapturedBatch batch)
@@ -97,7 +112,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             {
                 builder.OpenComponent<EditForm>(0);
                 builder.AddAttribute(1, "Model", Model);
-                builder.AddAttribute(1, "EditContext", EditContext);
+                builder.AddAttribute(2, "EditContext", EditContext);
                 builder.CloseComponent();
             }
         }

--- a/src/Components/Web/test/Forms/EditFormTest.cs
+++ b/src/Components/Web/test/Forms/EditFormTest.cs
@@ -1,0 +1,105 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    public class EditFormTest
+    {
+
+        [Fact]
+        public async Task ThrowsIfBothEditContextAndModelAreSupplied()
+        {
+            // Arrange
+            var editForm = new EditForm
+            {
+                EditContext = new EditContext(new TestModel()),
+                Model = new TestModel()
+            };
+            var testRenderer = new TestRenderer();
+            var componentId = testRenderer.AssignRootComponentId(editForm);
+
+            // Act/Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => testRenderer.RenderRootComponentAsync(componentId));
+            Assert.StartsWith($"{nameof(EditForm)} requires a {nameof(EditForm.Model)} parameter, or an {nameof(EditContext)} parameter, but not both.", ex.Message);
+        }
+
+        [Fact]
+        public async Task ReturnsEditContextWhenModelParameterUsed()
+        {
+            // Arrange
+            var model = new TestModel();
+            var rootComponent = new TestEditFormHostComponent
+            {
+                Model = model
+            };
+            var editFormComponent = await RenderAndGetTestEditFormComponentAsync(rootComponent);
+
+            // Act
+            var returnedEditContext = editFormComponent.EditContext;
+
+            // Assert
+            Assert.NotNull(returnedEditContext);
+        }
+
+        [Fact]
+        public async Task ReturnsEditContextWhenEditContextParameterUsed()
+        {
+            // Arrange
+            var editContext = new EditContext(new TestModel());
+            var rootComponent = new TestEditFormHostComponent
+            {
+                EditContext = editContext
+            };
+            var editFormComponent = await RenderAndGetTestEditFormComponentAsync(rootComponent);
+
+            // Act
+            var returnedEditContext = editFormComponent.EditContext;
+
+            // Assert
+            Assert.NotNull(returnedEditContext);
+        }
+
+        private static EditForm FindEditFormComponent(CapturedBatch batch)
+            => batch.ReferenceFrames
+                    .Where(f => f.FrameType == RenderTreeFrameType.Component)
+                    .Select(f => f.Component)
+                    .OfType<EditForm>()
+                    .Single();
+
+        private static async Task<EditForm> RenderAndGetTestEditFormComponentAsync(TestEditFormHostComponent hostComponent)
+        {
+            var testRenderer = new TestRenderer();
+            var componentId = testRenderer.AssignRootComponentId(hostComponent);
+            await testRenderer.RenderRootComponentAsync(componentId);
+            return FindEditFormComponent(testRenderer.Batches.Single());
+        }
+
+        class TestModel
+        {
+            public string StringProperty { get; set; }
+        }
+
+        class TestEditFormHostComponent : AutoRenderComponent
+        {
+            public EditContext EditContext { get; set; }
+            public TestModel Model { get; set; }
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<EditForm>(0);
+                builder.AddAttribute(1, "Model", Model);
+                builder.AddAttribute(1, "EditContext", EditContext);
+                builder.CloseComponent();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Modified the `EditContext` parameter to return `_fixedEditContext`
- Introduced a new field, `_providedEditContext` which stores any `EditContext` provided by the developer. This means we don't break existing functionality.
- Updates to `OnParametersSet` to use the new `_providedEditContext` field instead of the `EditContext` property
- Unit tests to cover new `EditForm` functionality

@SteveSandersonMS tagged for review 

Addresses #12238
Addresses https://github.com/dotnet/aspnetcore/issues/23354
