### PR TITLE
Blazor: Add empty InvokeAsync() overload for EventCallback

### DIFF
--- a/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp.cs
+++ b/src/Components/Components/ref/Microsoft.AspNetCore.Components.netcoreapp.cs
@@ -142,6 +142,7 @@ namespace Microsoft.AspNetCore.Components
         public static readonly Microsoft.AspNetCore.Components.EventCallbackFactory Factory;
         public EventCallback(Microsoft.AspNetCore.Components.IHandleEvent? receiver, System.MulticastDelegate? @delegate) { throw null; }
         public bool HasDelegate { get { throw null; } }
+        public System.Threading.Tasks.Task InvokeAsync() { throw null; }
         public System.Threading.Tasks.Task InvokeAsync(object arg) { throw null; }
     }
     public sealed partial class EventCallbackFactory
@@ -217,6 +218,7 @@ namespace Microsoft.AspNetCore.Components
         public static readonly Microsoft.AspNetCore.Components.EventCallback<TValue> Empty;
         public EventCallback(Microsoft.AspNetCore.Components.IHandleEvent? receiver, System.MulticastDelegate? @delegate) { throw null; }
         public bool HasDelegate { get { throw null; } }
+        public System.Threading.Tasks.Task InvokeAsync() { throw null; }
         public System.Threading.Tasks.Task InvokeAsync(TValue arg) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]

--- a/src/Components/Components/src/EventCallback.cs
+++ b/src/Components/Components/src/EventCallback.cs
@@ -61,6 +61,13 @@ namespace Microsoft.AspNetCore.Components
             return Receiver.HandleEventAsync(new EventCallbackWorkItem(Delegate), arg);
         }
 
+        /// <summary>
+        /// Invokes the delegate associated with this binding and dispatches an event notification to the
+        /// appropriate component.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which completes asynchronously once event processing has completed.</returns>
+        public Task InvokeAsync() => InvokeAsync(null!);
+
         object? IEventCallback.UnpackForRenderTree()
         {
             return RequiresExplicitReceiver ? (object)this : Delegate;

--- a/src/Components/Components/src/EventCallbackOfT.cs
+++ b/src/Components/Components/src/EventCallbackOfT.cs
@@ -56,6 +56,13 @@ namespace Microsoft.AspNetCore.Components
             return Receiver.HandleEventAsync(new EventCallbackWorkItem(Delegate), arg);
         }
 
+        /// <summary>
+        /// Invokes the delegate associated with this binding and dispatches an event notification to the
+        /// appropriate component.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> which completes asynchronously once event processing has completed.</returns>
+        public Task InvokeAsync() => InvokeAsync(default!);
+
         internal EventCallback AsUntyped()
         {
             return new EventCallback(Receiver ?? Delegate?.Target as IHandleEvent, Delegate);

--- a/src/Components/Components/test/EventCallbackTest.cs
+++ b/src/Components/Components/test/EventCallbackTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = default(EventCallback);
 
             // Act & Assert (Does not throw)
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = default(EventCallback<EventArgs>);
 
             // Act & Assert (Does not throw)
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
         }
 
 
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback(null, (Action)(() => runCount++));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback<EventArgs>(null, (Action)(() => runCount++));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback(component, (Action)(() => runCount++));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback(component, (Action<EventArgs>)((e) => { arg = e; runCount++; }));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback(component, (Func<Task>)(() => { runCount++; return Task.CompletedTask; }));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback(component, (Func<EventArgs, Task>)((e) => { arg = e; runCount++; return Task.CompletedTask; }));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback<EventArgs>(component, (Action)(() => runCount++));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback<EventArgs>(component, (Action<EventArgs>)((e) => { arg = e; runCount++; }));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -373,7 +373,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback<EventArgs>(component, (Func<Task>)(() => { runCount++; return Task.CompletedTask; }));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert
@@ -410,7 +410,7 @@ namespace Microsoft.AspNetCore.Components
             var callback = new EventCallback<EventArgs>(component, (Func<EventArgs, Task>)((e) => { arg = e; runCount++; return Task.CompletedTask; }));
 
             // Act
-            await callback.InvokeAsync(null);
+            await callback.InvokeAsync();
 
 
             // Assert


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
- Adds an empty `InvokeAsync()` overload for both `EventCallback` and `EventCallbackOfT`.
- Updated tests to simply use this new overload instead of `InvokeAsync(null)`.

Addresses #23603.

I questioned whether to add the empty overload for `EventCallbackOfT`, but it is easy enough to take it out should I need to.
