### PR TITLE
Update setup instructions in BuildFromSource

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -4,6 +4,22 @@ Building ASP.NET Core from source allows you to tweak and customize ASP.NET Core
 
 See <https://github.com/dotnet/aspnetcore/labels/area-infrastructure> for known issues and to track ongoing work.
 
+## Clone the source code
+
+ASP.NET Core uses git submodules to include the source from a few other projects.
+
+For a new copy of the project, run:
+
+```ps1
+git clone --recursive https://github.com/dotnet/aspnetcore
+```
+
+To update an existing copy, run:
+
+```ps1
+git submodule update --init --recursive
+```
+
 ## Install pre-requisites
 
 ### Windows
@@ -52,22 +68,6 @@ Building ASP.NET Core on macOS or Linux requires:
   * OpenJDK <https://jdk.java.net/>
   * Oracle's JDK <https://www.oracle.com/technetwork/java/javase/downloads/index.html>
 
-## Clone the source code
-
-ASP.NET Core uses git submodules to include the source from a few other projects.
-
-For a new copy of the project, run:
-
-```ps1
-git clone --recursive https://github.com/dotnet/aspnetcore
-```
-
-To update an existing copy, run:
-
-```ps1
-git submodule update --init --recursive
-```
-
 **NOTE** some ISPs have been know to use web filtering software that has caused issues with git repository cloning, if you experience issues cloning this repo please review <https://help.github.com/en/github/authenticating-to-github/using-ssh-over-the-https-port>
 
 ## Building in Visual Studio
@@ -86,6 +86,9 @@ Before opening our .sln/.slnf files in Visual Studio or VS Code, you need to per
    > :bulb: Pro tip: you will also want to run this command after pulling large sets of changes. On the master
    > branch, we regularly update the versions of .NET Core SDK required to build the repo.
    > You will need to restart Visual Studio every time we update the .NET Core SDK.
+   > To allow executing the setup script, you may need to update the execution policy on your machine.
+   You can do so by running the `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser` command
+   in PowerShell. For more information on execution policies, you can read the [execution policy docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy).
 
 2. Use the `startvs.cmd` script to open Visual Studio .sln/.slnf files. This script first sets the required
 environment variables.


### PR DESCRIPTION
- Add instructions about updating execution policy
- Move clone instructions to before install requisites so users already have the eng scripts we mention in that section
