### PR TITLE
Add DisplayName to inputs

### DIFF
--- a/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.netcoreapp.cs
+++ b/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.netcoreapp.cs
@@ -60,6 +60,8 @@ namespace Microsoft.AspNetCore.Components.Forms
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         protected TValue CurrentValue { get { throw null; } set { } }
         protected string? CurrentValueAsString { get { throw null; } set { } }
+        [Microsoft.AspNetCore.Components.ParameterAttribute]
+        public string? DisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         protected Microsoft.AspNetCore.Components.Forms.EditContext EditContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         protected internal Microsoft.AspNetCore.Components.Forms.FieldIdentifier FieldIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         [Microsoft.AspNetCore.Components.ParameterAttribute]

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -52,6 +52,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
         /// <summary>
         /// Gets or sets the display name for this field.
+        /// <para>This value is used when generating error messages when the input value fails to parse correctly.</para>
         /// </summary>
         [Parameter] public string? DisplayName { get; set; }
 

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -51,6 +51,11 @@ namespace Microsoft.AspNetCore.Components.Forms
         [Parameter] public Expression<Func<TValue>>? ValueExpression { get; set; }
 
         /// <summary>
+        /// Gets or sets the display name for this field.
+        /// </summary>
+        [Parameter] public string? DisplayName { get; set; }
+
+        /// <summary>
         /// Gets the associated <see cref="Forms.EditContext"/>.
         /// </summary>
         protected EditContext EditContext { get; set; } = default!;

--- a/src/Components/Web/src/Forms/InputDate.cs
+++ b/src/Components/Web/src/Forms/InputDate.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
             else
             {
-                validationErrorMessage = string.Format(ParsingErrorMessage, FieldIdentifier.FieldName);
+                validationErrorMessage = string.Format(ParsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
                 return false;
             }
         }

--- a/src/Components/Web/src/Forms/InputExtensions.cs
+++ b/src/Components/Web/src/Forms/InputExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 else
                 {
                     result = default;
-                    validationErrorMessage = $"The {input.FieldIdentifier.FieldName} field is not valid.";
+                    validationErrorMessage = $"The {input.DisplayName ?? input.FieldIdentifier.FieldName} field is not valid.";
                     return false;
                 }
             }

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
             else
             {
-                validationErrorMessage = string.Format(ParsingErrorMessage, FieldIdentifier.FieldName);
+                validationErrorMessage = string.Format(ParsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
                 return false;
             }
         }

--- a/src/Components/Web/test/Forms/InputDateTest.cs
+++ b/src/Components/Web/test/Forms/InputDateTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Components/Web/test/Forms/InputDateTest.cs
+++ b/src/Components/Web/test/Forms/InputDateTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    public class InputDateTest
+    {
+        [Fact]
+        public async Task ValidationErrorUsesDisplayAttributeName()
+        {
+            // Arrange
+            var model = new TestModel();
+            var rootComponent = new TestInputHostComponent<DateTime, TestInputDateComponent>
+            {
+                EditContext = new EditContext(model),
+                ValueExpression = () => model.DateProperty,
+                AdditionalAttributes = new Dictionary<string, object>
+                {
+                    { "DisplayName", "Date property" }
+                }
+            };
+            var fieldIdentifier = FieldIdentifier.Create(() => model.DateProperty);
+            var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+            // Act
+            await inputComponent.SetCurrentValueAsStringAsync("invalidDate");
+
+            // Assert
+            var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+            Assert.NotEmpty(validationMessages);
+            Assert.Contains("The Date property field must be a date.", validationMessages);
+        }
+
+        private class TestModel
+        {
+            public DateTime DateProperty { get; set; }
+        }
+
+        private class TestInputDateComponent : InputDate<DateTime>
+        {
+            public async Task SetCurrentValueAsStringAsync(string value)
+            {
+                // This is equivalent to the subclass writing to CurrentValueAsString
+                // (e.g., from @bind), except to simplify the test code there's an InvokeAsync
+                // here. In production code it wouldn't normally be required because @bind
+                // calls run on the sync context anyway.
+                await InvokeAsync(() => { base.CurrentValueAsString = value; });
+            }
+        }
+    }
+}

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    public class InputNumberTest
+    {
+        [Fact]
+        public async Task ValidationErrorUsesDisplayAttributeName()
+        {
+            // Arrange
+            var model = new TestModel();
+            var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent>
+            {
+                EditContext = new EditContext(model),
+                ValueExpression = () => model.SomeNumber,
+                AdditionalAttributes = new Dictionary<string, object>
+                {
+                    { "DisplayName", "Some number" }
+                }
+            };
+            var fieldIdentifier = FieldIdentifier.Create(() => model.SomeNumber);
+            var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+            // Act
+            await inputComponent.SetCurrentValueAsStringAsync("notANumber");
+
+            // Assert
+            var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+            Assert.NotEmpty(validationMessages);
+            Assert.Contains("The Some number field must be a number.", validationMessages);
+        }
+
+        private class TestModel
+        {
+            public int SomeNumber { get; set; }
+        }
+
+        private class TestInputNumberComponent : InputNumber<int>
+        {
+            public async Task SetCurrentValueAsStringAsync(string value)
+            {
+                // This is equivalent to the subclass writing to CurrentValueAsString
+                // (e.g., from @bind), except to simplify the test code there's an InvokeAsync
+                // here. In production code it wouldn't normally be required because @bind
+                // calls run on the sync context anyway.
+                await InvokeAsync(() => { base.CurrentValueAsString = value; });
+            }
+        }
+    }
+}

--- a/src/Components/Web/test/Forms/InputRenderer.cs
+++ b/src/Components/Web/test/Forms/InputRenderer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.RenderTree;
@@ -7,7 +10,8 @@ namespace Microsoft.AspNetCore.Components.Forms
 {
     internal static class InputRenderer
     {
-        public static async Task<TComponent> RenderAndGetComponent<TValue, TComponent>(TestInputHostComponent<TValue, TComponent> hostComponent) where TComponent : InputBase<TValue>
+        public static async Task<TComponent> RenderAndGetComponent<TValue, TComponent>(TestInputHostComponent<TValue, TComponent> hostComponent) 
+        where TComponent : InputBase<TValue>
         {
             var testRenderer = new TestRenderer();
             var componentId = testRenderer.AssignRootComponentId(hostComponent);

--- a/src/Components/Web/test/Forms/InputRenderer.cs
+++ b/src/Components/Web/test/Forms/InputRenderer.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    internal static class InputRenderer
+    {
+        public static async Task<TComponent> RenderAndGetComponent<TValue, TComponent>(TestInputHostComponent<TValue, TComponent> hostComponent) where TComponent : InputBase<TValue>
+        {
+            var testRenderer = new TestRenderer();
+            var componentId = testRenderer.AssignRootComponentId(hostComponent);
+            await testRenderer.RenderRootComponentAsync(componentId);
+            return FindComponent<TComponent>(testRenderer.Batches.Single());
+        }
+
+        private static TComponent FindComponent<TComponent>(CapturedBatch batch)
+            => batch.ReferenceFrames
+                    .Where(f => f.FrameType == RenderTreeFrameType.Component)
+                    .Select(f => f.Component)
+                    .OfType<TComponent>()
+                    .Single();
+    }
+}

--- a/src/Components/Web/test/Forms/InputSelectTest.cs
+++ b/src/Components/Web/test/Forms/InputSelectTest.cs
@@ -3,12 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Components.RenderTree;
-using Microsoft.AspNetCore.Components.Test.Helpers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Components.Forms
@@ -20,12 +15,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<TestEnum>
+            var rootComponent = new TestInputHostComponent<TestEnum, TestInputSelect<TestEnum>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NotNullableEnum
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             inputSelectComponent.CurrentValueAsString = "Two";
@@ -39,12 +34,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<TestEnum>
+            var rootComponent = new TestInputHostComponent<TestEnum, TestInputSelect<TestEnum>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NotNullableEnum
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             inputSelectComponent.CurrentValueAsString = "";
@@ -58,12 +53,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<TestEnum?>
+            var rootComponent = new TestInputHostComponent<TestEnum?, TestInputSelect<TestEnum?>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NullableEnum
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             inputSelectComponent.CurrentValueAsString = "Two";
@@ -77,12 +72,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<TestEnum?>
+            var rootComponent = new TestInputHostComponent<TestEnum?, TestInputSelect<TestEnum?>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NullableEnum
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             inputSelectComponent.CurrentValueAsString = "";
@@ -97,12 +92,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<Guid>
+            var rootComponent = new TestInputHostComponent<Guid, TestInputSelect<Guid>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NotNullableGuid
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             var guid = Guid.NewGuid();
@@ -118,12 +113,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<Guid?>
+            var rootComponent = new TestInputHostComponent<Guid?, TestInputSelect<Guid?>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NullableGuid
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             var guid = Guid.NewGuid();
@@ -139,12 +134,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<int>
+            var rootComponent = new TestInputHostComponent<int, TestInputSelect<int>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NotNullableInt
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             inputSelectComponent.CurrentValueAsString = "42";
@@ -159,12 +154,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         {
             // Arrange
             var model = new TestModel();
-            var rootComponent = new TestInputSelectHostComponent<int?>
+            var rootComponent = new TestInputHostComponent<int?, TestInputSelect<int?>>
             {
                 EditContext = new EditContext(model),
                 ValueExpression = () => model.NullableInt
             };
-            var inputSelectComponent = await RenderAndGetTestInputComponentAsync(rootComponent);
+            var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
             // Act
             inputSelectComponent.CurrentValueAsString = "42";
@@ -197,21 +192,6 @@ namespace Microsoft.AspNetCore.Components.Forms
             var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
             Assert.NotEmpty(validationMessages);
             Assert.Contains("The Some number field is not valid.", validationMessages);
-        }
-
-        private static TestInputSelect<TValue> FindInputSelectComponent<TValue>(CapturedBatch batch)
-            => batch.ReferenceFrames
-                    .Where(f => f.FrameType == RenderTreeFrameType.Component)
-                    .Select(f => f.Component)
-                    .OfType<TestInputSelect<TValue>>()
-                    .Single();
-
-        private static async Task<TestInputSelect<TValue>> RenderAndGetTestInputComponentAsync<TValue>(TestInputSelectHostComponent<TValue> hostComponent)
-        {
-            var testRenderer = new TestRenderer();
-            var componentId = testRenderer.AssignRootComponentId(hostComponent);
-            await testRenderer.RenderRootComponentAsync(componentId);
-            return FindInputSelectComponent<TValue>(testRenderer.Batches.Single());
         }
 
         enum TestEnum
@@ -252,26 +232,6 @@ namespace Microsoft.AspNetCore.Components.Forms
                 // here. In production code it wouldn't normally be required because @bind
                 // calls run on the sync context anyway.
                 await InvokeAsync(() => { base.CurrentValueAsString = value; });
-            }
-        }
-
-        class TestInputSelectHostComponent<TValue> : AutoRenderComponent
-        {
-            public EditContext EditContext { get; set; }
-
-            public Expression<Func<TValue>> ValueExpression { get; set; }
-
-            protected override void BuildRenderTree(RenderTreeBuilder builder)
-            {
-                builder.OpenComponent<CascadingValue<EditContext>>(0);
-                builder.AddAttribute(1, "Value", EditContext);
-                builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
-                {
-                    childBuilder.OpenComponent<TestInputSelect<TValue>>(0);
-                    childBuilder.AddAttribute(0, "ValueExpression", ValueExpression);
-                    childBuilder.CloseComponent();
-                }));
-                builder.CloseComponent();
             }
         }
     }

--- a/src/Components/Web/test/Forms/TestInputHostComponent.cs
+++ b/src/Components/Web/test/Forms/TestInputHostComponent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Components/Web/test/Forms/TestInputHostComponent.cs
+++ b/src/Components/Web/test/Forms/TestInputHostComponent.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    internal class TestInputHostComponent<TValue, TComponent> : AutoRenderComponent where TComponent : InputBase<TValue>
+    {
+        public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+        public EditContext EditContext { get; set; }
+
+        public TValue Value { get; set; }
+
+        public Action<TValue> ValueChanged { get; set; }
+
+        public Expression<Func<TValue>> ValueExpression { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<CascadingValue<EditContext>>(0);
+            builder.AddAttribute(1, "Value", EditContext);
+            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            {
+                childBuilder.OpenComponent<TComponent>(0);
+                childBuilder.AddAttribute(0, "Value", Value);
+                childBuilder.AddAttribute(1, "ValueChanged",
+                    EventCallback.Factory.Create(this, ValueChanged));
+                childBuilder.AddAttribute(2, "ValueExpression", ValueExpression);
+                childBuilder.AddMultipleAttributes(3, AdditionalAttributes);
+                childBuilder.CloseComponent();
+            }));
+            builder.CloseComponent();
+        }
+    }
+}


### PR DESCRIPTION
Add a `DisplayName` parameter to `InputBase`, which is used in validation messages instead of `FieldIdentifier.FieldName`.
- This works for `InputDate`, `InputNumber` and `InputSelect`.
- Extracted some shared code, just like what @StephanZahariev did in his PR.

Addresses #11414
