### PR TITLE
Components with modificators - internal, public, private using Razor syntax 2

### DIFF
--- a/src/Components/test/testassets/BasicTestApp/AccessibilityModificatorComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/AccessibilityModificatorComponent.razor
@@ -1,0 +1,23 @@
+﻿@using TestContentPackage
+
+<div>
+    <p>Public container can be used here</p>
+    <p>
+        <ContainerForInternalComponentFromPackage></ContainerForInternalComponentFromPackage>
+    </p>
+</div>
+
+
+<div>
+    <p>Internal component can not be used here</p>
+    <p>
+        @*
+            <InternalComponentFromPackage></InternalComponentFromPackage>
+        *@
+    </p>
+</div>
+
+
+@code {
+
+}

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -84,6 +84,7 @@
         <option value="BasicTestApp.TouchEventComponent">Touch events</option>
         <option value="BasicTestApp.SelectVariantsComponent">Select with component options</option>
         <option value="BasicTestApp.ToggleEventComponent">Toggle Event</option>
+        <option value="BasicTestApp.AccessibilityModificatorComponent">Accessibility modificator</option>        
     </select>
 
     <span id="runtime-info"><code><tt>@System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription</tt></code></span>

--- a/src/Components/test/testassets/TestContentPackage/ContainerForInternalComponentFromPackage.razor
+++ b/src/Components/test/testassets/TestContentPackage/ContainerForInternalComponentFromPackage.razor
@@ -1,0 +1,8 @@
+﻿<div id="container-internal-component">
+    <p>Public container for Internal component</p>
+    <InternalComponentFromPackage></InternalComponentFromPackage>
+</div>
+
+@code {
+ 
+}

--- a/src/Components/test/testassets/TestContentPackage/InternalComponentFromPackage.razor
+++ b/src/Components/test/testassets/TestContentPackage/InternalComponentFromPackage.razor
@@ -1,0 +1,9 @@
+﻿@internal
+
+<div id="internal-component">
+    <p>Internal component content</p>
+</div>
+
+@code {
+ 
+}

--- a/src/Components/test/testassets/TestContentPackage/_Imports.razor
+++ b/src/Components/test/testassets/TestContentPackage/_Imports.razor
@@ -1,1 +1,2 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
+@using TestContentPackage

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewComponents/ViewComponentConventions.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewComponents/ViewComponentConventions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             }
 
             if (!typeInfo.IsClass ||
-                !typeInfo.IsPublic ||
+                // !typeInfo.IsPublic // we do not need check accessibility anymore
                 typeInfo.IsAbstract ||
                 typeInfo.ContainsGenericParameters ||
                 typeInfo.IsDefined(typeof(NonViewComponentAttribute)))

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/AccessibilityModificatorDirectives.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/AccessibilityModificatorDirectives.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
+{
+    internal static class AccessibilityModificatorDirectives
+    {
+        public static readonly DirectiveDescriptor InternalDirective = DirectiveDescriptor.CreateDirective(
+            "internal",
+            DirectiveKind.SingleLine,
+            builder =>
+            {
+                builder.Usage = DirectiveUsage.FileScopedMultipleOccurring;
+                builder.Description = "Add internal access modifier for component type";
+            });
+
+        public static readonly DirectiveDescriptor PublicDirective = DirectiveDescriptor.CreateDirective(
+            "public",
+            DirectiveKind.SingleLine,
+            builder =>
+            {
+                builder.Usage = DirectiveUsage.FileScopedMultipleOccurring;
+                builder.Description = "Add public access modifier for component type";
+            });
+
+        public static readonly DirectiveDescriptor PrivateDirective = DirectiveDescriptor.CreateDirective(
+            "private",
+            DirectiveKind.SingleLine,
+            builder =>
+            {
+                builder.Usage = DirectiveUsage.FileScopedMultipleOccurring;
+                builder.Description = "Add private access modifier for component type";
+            });
+
+        public static void Register(RazorProjectEngineBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.AddDirective(InternalDirective, FileKinds.Legacy, FileKinds.Component, FileKinds.ComponentImport);
+            builder.AddDirective(PrivateDirective, FileKinds.Legacy, FileKinds.Component, FileKinds.ComponentImport);
+            builder.AddDirective(PublicDirective, FileKinds.Legacy, FileKinds.Component, FileKinds.ComponentImport);
+            builder.Features.Add(new AccessibilityModificatorDirectivesPass());
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/AccessibilityModificatorDirectivesPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/AccessibilityModificatorDirectivesPass.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
+{
+    public class AccessibilityModificatorDirectivesPass: IntermediateNodePassBase, IRazorDirectiveClassifierPass
+    {
+        protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
+        {
+            var @class = documentNode.FindPrimaryClass();
+            if (@class == null)
+            {
+                return;
+            }
+
+            string modificator = null;
+
+            // find accessibility modificator directives in documentNode
+            if (documentNode.FindDirectiveReferences(AccessibilityModificatorDirectives.PublicDirective).Count > 0)
+            {
+                modificator = "public";
+            }
+
+            if (documentNode.FindDirectiveReferences(AccessibilityModificatorDirectives.InternalDirective).Count > 0)
+            {
+                modificator = "internal";
+            }
+
+            if (documentNode.FindDirectiveReferences(AccessibilityModificatorDirectives.PrivateDirective).Count > 0)
+            {
+                modificator = "private";
+            }
+
+            // if of the accessibility modificator directives founded remove previous (usually public) and add new
+            if (modificator != null)
+            {
+                @class.Modifiers.Remove("public");
+                @class.Modifiers.Remove("private");
+                @class.Modifiers.Remove("internal");
+                @class.Modifiers.Insert(0, modificator);
+            }
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
@@ -119,6 +119,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 InheritsDirective.Register(builder);
                 NamespaceDirective.Register(builder);
                 AttributeDirective.Register(builder);
+                AccessibilityModificatorDirectives.Register(builder);
 
                 AddComponentFeatures(builder, configuration.LanguageVersion);
             }

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Razor
             }
 
             return
-                symbol.DeclaredAccessibility == Accessibility.Public &&
+                //symbol.DeclaredAccessibility == Accessibility.Public && // we do not need check accessibility anymore
                 !symbol.IsAbstract &&
                 symbol.AllInterfaces.Contains(icomponentSymbol);
         }


### PR DESCRIPTION
Summary of the changes
- Implementing possibility to use directives like `@public`, `@internal`, `@private`
- Removed checking of accessibility of component type in checking type is Component
- Added example how use `@internal` component

Issue: Provide a way to create private Components using Razor syntax dotnet/razor-tooling#7051 

This is first inital solution, just want to know, @SteveSandersonMS is this a right way to solve this problem.