### PR TITLE
Implement support for multiple sockets for systemd activation

### DIFF
--- a/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
@@ -42,9 +42,7 @@ namespace Microsoft.AspNetCore.Hosting
                     listenFds = 1;
                 }
 
-                for (ulong handle = SdListenFdsStart, lastHandle = SdListenFdsStart + listenFds;
-                    handle <= lastHandle;
-                    ++handle)
+                for (ulong handle = SdListenFdsStart; handle < SdListenFdsStart + listenFds; ++handle)
                 {
                     options.ListenHandle(handle, configure);
                 }

--- a/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Hosting
     public static class KestrelServerOptionsSystemdExtensions
     {
         // SD_LISTEN_FDS_START https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
-        private const ulong SdListenFdsStart = 3;
+        private const int SdListenFdsStart = 3;
         private const string ListenPidEnvVar = "LISTEN_PID";
         private const string ListenFdsEnvVar = "LISTEN_FDS";
 
@@ -37,14 +37,15 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (string.Equals(Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture), Environment.GetEnvironmentVariable(ListenPidEnvVar), StringComparison.Ordinal))
             {
-                if (!byte.TryParse(Environment.GetEnvironmentVariable(ListenFdsEnvVar), NumberStyles.None, NumberFormatInfo.InvariantInfo, out var listenFds))
+                // This matches sd_listen_fds behavior that requires %LISTEN_FDS% to be present and in range [1;INT_MAX-SD_LISTEN_FDS_START]
+                if (int.TryParse(Environment.GetEnvironmentVariable(ListenFdsEnvVar), NumberStyles.None, NumberFormatInfo.InvariantInfo, out var listenFds)
+                    && listenFds > 0
+                    && listenFds <= int.MaxValue - SdListenFdsStart)
                 {
-                    listenFds = 1;
-                }
-
-                for (ulong handle = SdListenFdsStart; handle < SdListenFdsStart + listenFds; ++handle)
-                {
-                    options.ListenHandle(handle, configure);
+                    for (var handle = SdListenFdsStart; handle < SdListenFdsStart + listenFds; ++handle)
+                    {
+                        options.ListenHandle((ulong)handle, configure);
+                    }
                 }
             }
 

--- a/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
@@ -13,9 +13,10 @@ namespace Microsoft.AspNetCore.Hosting
         // SD_LISTEN_FDS_START https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
         private const ulong SdListenFdsStart = 3;
         private const string ListenPidEnvVar = "LISTEN_PID";
+        private const string ListenFdsEnvVar = "LISTEN_FDS";
 
         /// <summary>
-        /// Open file descriptor (SD_LISTEN_FDS_START) initialized by systemd socket-based activation logic if available.
+        /// Open file descriptors (starting from SD_LISTEN_FDS_START) initialized by systemd socket-based activation logic if available.
         /// </summary>
         /// <returns>
         /// The <see cref="KestrelServerOptions"/>.
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Open file descriptor (SD_LISTEN_FDS_START) initialized by systemd socket-based activation logic if available.
+        /// Open file descriptors (starting from SD_LISTEN_FDS_START) initialized by systemd socket-based activation logic if available.
         /// Specify callback to configure endpoint-specific settings.
         /// </summary>
         /// <returns>
@@ -36,7 +37,17 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (string.Equals(Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture), Environment.GetEnvironmentVariable(ListenPidEnvVar), StringComparison.Ordinal))
             {
-                options.ListenHandle(SdListenFdsStart, configure);
+                if (!byte.TryParse(Environment.GetEnvironmentVariable(ListenFdsEnvVar), NumberStyles.None, NumberFormatInfo.InvariantInfo, out var listenFds))
+                {
+                    listenFds = 1;
+                }
+
+                for (ulong handle = SdListenFdsStart, lastHandle = SdListenFdsStart + listenFds;
+                    handle <= lastHandle;
+                    ++handle)
+                {
+                    options.ListenHandle(handle, configure);
+                }
             }
 
             return options;


### PR DESCRIPTION
Implements support for multiple sockets when using systemd socket activation by taking into account the `%LISTEN_FDS%`. Attempts to preserve backward feature compatibility, falling back to default number of sockets to be 1.

Addresses #24067
