### PR TITLE
Update default Razor Layout to use RenderSectionAsync method.

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/_Layout.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/_Layout.cshtml
@@ -89,6 +89,6 @@
         <script src="~/Identity/js/site.js" asp-append-version="true"></script>
     </environment>
 
-    @RenderSection("Scripts", required: false)
+    @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
The default razor Layout page uses the RenderSection method. This updates the default Layout to use the RenderSectionAsync method instead.