### PR TITLE
Add support for instantiating the startup class

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Hosting
                 if (object.ReferenceEquals(_startupObject, startupFactory))
                 {
                     var webHostBuilderContext = GetWebHostBuilderContext(context);
-                    var instance = startupFactory(webHostBuilderContext) ?? new InvalidOperationException("The specified factory returned null startup instance");
+                    var instance = startupFactory(webHostBuilderContext) ?? throw new InvalidOperationException("The specified factory returned null startup instance.");
                     UseStartup(instance.GetType(), context, services, instance);
                 }
             });

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Hosting
     {
         private readonly IHostBuilder _builder;
         private readonly IConfiguration _config;
+        private object _startupObject;
         private readonly object _startupKey = new object();
 
         private AggregateException _hostingStartupErrors;
@@ -198,10 +199,12 @@ namespace Microsoft.AspNetCore.Hosting
         public IWebHostBuilder UseStartup(Type startupType)
         {
             // UseStartup can be called multiple times. Only run the last one.
-            _builder.Properties["UseStartup.StartupType"] = startupType;
+            _startupObject = startupType;
+
             _builder.ConfigureServices((context, services) =>
             {
-                if (_builder.Properties.TryGetValue("UseStartup.StartupType", out var cachedType) && (Type)cachedType == startupType)
+                // Run this delegate if the startup type matches
+                if (object.ReferenceEquals(_startupObject, startupType))
                 {
                     UseStartup(startupType, context, services);
                 }
@@ -210,13 +213,30 @@ namespace Microsoft.AspNetCore.Hosting
             return this;
         }
 
-        private void UseStartup(Type startupType, HostBuilderContext context, IServiceCollection services)
+        public IWebHostBuilder UseStartup(Func<WebHostBuilderContext, object> startupFactory)
+        {
+            // Clear the startup type
+            _startupObject = startupFactory;
+
+            _builder.ConfigureServices((context, services) =>
+            {
+                if (object.ReferenceEquals(_startupObject, startupFactory))
+                {
+                    var webHostBuilderContext = GetWebHostBuilderContext(context);
+                    var instance = startupFactory(webHostBuilderContext) ?? new InvalidOperationException("The specified factory returned null startup instance");
+                    UseStartup(instance.GetType(), context, services, instance);
+                }
+            });
+
+            return this;
+        }
+
+        private void UseStartup(Type startupType, HostBuilderContext context, IServiceCollection services, object instance = null)
         {
             var webHostBuilderContext = GetWebHostBuilderContext(context);
             var webHostOptions = (WebHostOptions)context.Properties[typeof(WebHostOptions)];
 
             ExceptionDispatchInfo startupError = null;
-            object instance = null;
             ConfigureBuilder configureBuilder = null;
 
             try
@@ -231,7 +251,7 @@ namespace Microsoft.AspNetCore.Hosting
                     throw new NotSupportedException($"ConfigureServices returning an {typeof(IServiceProvider)} isn't supported.");
                 }
 
-                instance = ActivatorUtilities.CreateInstance(new HostServiceProvider(webHostBuilderContext), startupType);
+                instance ??= ActivatorUtilities.CreateInstance(new HostServiceProvider(webHostBuilderContext), startupType);
                 context.Properties[_startupKey] = instance;
 
                 // Startup.ConfigureServices
@@ -296,13 +316,19 @@ namespace Microsoft.AspNetCore.Hosting
 
         public IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
+            // Clear the startup type
+            _startupObject = configure;
+
             _builder.ConfigureServices((context, services) =>
             {
-                services.Configure<GenericWebHostServiceOptions>(options =>
+                if (object.ReferenceEquals(_startupObject, configure))
                 {
-                    var webhostBuilderContext = GetWebHostBuilderContext(context);
-                    options.ConfigureApplication = app => configure(webhostBuilderContext, app);
-                });
+                    services.Configure<GenericWebHostServiceOptions>(options =>
+                    {
+                        var webhostBuilderContext = GetWebHostBuilderContext(context);
+                        options.ConfigureApplication = app => configure(webhostBuilderContext, app);
+                    });
+                }
             });
 
             return this;

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -220,6 +220,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             _builder.ConfigureServices((context, services) =>
             {
+                // UseStartup can be called multiple times. Only run the last one.
                 if (object.ReferenceEquals(_startupObject, startupFactory))
                 {
                     var webHostBuilderContext = GetWebHostBuilderContext(context);

--- a/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
@@ -75,5 +75,10 @@ namespace Microsoft.AspNetCore.Hosting
         {
             return _builder.UseStartup(startupType);
         }
+
+        public IWebHostBuilder UseStartup(Func<WebHostBuilderContext, object> startupFactory)
+        {
+            return _builder.UseStartup(startupFactory);
+        }
     }
 }

--- a/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
@@ -10,5 +10,6 @@ namespace Microsoft.AspNetCore.Hosting
     {
         IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure);
         IWebHostBuilder UseStartup(Type startupType);
+        IWebHostBuilder UseStartup(Func<WebHostBuilderContext, object> startupFactory);
     }
 }

--- a/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
+++ b/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
@@ -73,5 +73,11 @@ namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
             _builder.UseStartup(startupType);
             return this;
         }
+
+        public IWebHostBuilder UseStartup(Func<WebHostBuilderContext, object> startupFactory)
+        {
+            _builder.UseStartup(startupFactory);
+            return this;
+        }
     }
 }

--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -6,15 +6,19 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Fakes;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Tests.Fakes;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -65,6 +69,54 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 await host.StartAsync();
                 await AssertResponseContains(server.RequestDelegate, "Exception from static constructor");
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultWebHostBuildersWithConfig))]
+        public async Task MultipleUseStartupCallsLastWins(IWebHostBuilder builder)
+        {
+            var server = new TestServer();
+            var host = builder.UseServer(server)
+                              .UseStartup<StartupCtorThrows>()
+                              .UseStartup(context => throw new InvalidOperationException("This doesn't run"))
+                              .Configure(app =>
+                              {
+                                  throw new InvalidOperationException("This doesn't run");
+                              })
+                              .Configure(app =>
+                              {
+                                  app.Run(context =>
+                                  {
+                                      return context.Response.WriteAsync("This wins");
+                                  });
+                              })
+                              .Build();
+            using (host)
+            {
+                await host.StartAsync();
+                await AssertResponseContains(server.RequestDelegate, "This wins");
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultWebHostBuildersWithConfig))]
+        public async Task UseStartupFactoryWorks(IWebHostBuilder builder)
+        {
+            void ConfigureServices(IServiceCollection services) { }
+            void Configure(IApplicationBuilder app)
+            {
+                app.Run(context => context.Response.WriteAsync("UseStartupFactoryWorks"));
+            }
+
+            var server = new TestServer();
+            var host = builder.UseServer(server)
+                              .UseStartup(context => new DelegatingStartup(ConfigureServices, Configure))
+                              .Build();
+            using (host)
+            {
+                await host.StartAsync();
+                await AssertResponseContains(server.RequestDelegate, "UseStartupFactoryWorks");
             }
         }
 
@@ -199,7 +251,7 @@ namespace Microsoft.AspNetCore.Hosting
                     options.ValidateScopes = true;
                 });
 
-            using  var host = hostBuilder.Build();
+            using var host = hostBuilder.Build();
             Assert.Throws<InvalidOperationException>(() => host.Start());
             Assert.True(configurationCallbackCalled);
         }
@@ -730,6 +782,22 @@ namespace Microsoft.AspNetCore.Hosting
 
         [Theory]
         [MemberData(nameof(DefaultWebHostBuilders))]
+        public void DefaultApplicationNameWithUseStartupFactory(IWebHostBuilder builder)
+        {
+            using (var host = builder
+                .UseServer(new TestServer())
+                .UseStartup(context => new DelegatingStartup(s => { }, app => { }))
+                .Build())
+            {
+                var hostingEnv = host.Services.GetService<IHostEnvironment>();
+
+                // Should be the assembly containing this test, because that's where the delegate comes from
+                Assert.Equal(typeof(WebHostBuilderTests).Assembly.GetName().Name, hostingEnv.ApplicationName);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultWebHostBuilders))]
         public void Configure_SupportsNonStaticMethodDelegate(IWebHostBuilder builder)
         {
             using (var host = builder
@@ -1218,7 +1286,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             Assert.Equal("nestedvalue", builder.GetSetting("key"));
 
-            using  var host = builder.Build();
+            using var host = builder.Build();
             var appConfig = host.Services.GetRequiredService<IConfiguration>();
             Assert.Equal("nestedvalue", appConfig["key"]);
         }
@@ -1572,6 +1640,21 @@ namespace Microsoft.AspNetCore.Hosting
                                new KeyValuePair<string,string>("testhostingstartup:config", "value")
                            }));
             }
+        }
+
+        public class DelegatingStartup
+        {
+            private readonly Action<IServiceCollection> _configureServices;
+            private readonly Action<IApplicationBuilder> _configure;
+
+            public DelegatingStartup(Action<IServiceCollection> configureServices, Action<IApplicationBuilder> configure)
+            {
+                _configureServices = configureServices;
+                _configure = configure;
+            }
+
+            public void ConfigureServices(IServiceCollection services) => _configureServices(services);
+            public void Configure(IApplicationBuilder app) => _configure(app);
         }
 
         public class StartupWithResolvedDisposableThatThrows


### PR DESCRIPTION
- Adds an overload of UseStartup that takes a factory so users can control the instance creation. The factory is given the WebHostBuilderContext to expose access to configuration and IWebHostEnvironment.
- Make sure only one startup delegate runs, the last one registered.

Fixes #19809