### PR TITLE
Blazor: Add element/component name for duplicate key

### DIFF
--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             return result;
         }
 
-        private static void ThrowExceptionForDuplicateKey(object key, RenderTreeFrame frame)
+        private static void ThrowExceptionForDuplicateKey(object key, in RenderTreeFrame frame)
         {
             switch (frame.FrameType)
             {

--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
                 {
                     if (result.ContainsKey(key))
                     {
-                        ThrowExceptionForDuplicateKey(key);
+                        ThrowExceptionForDuplicateKey(key, frame);
                     }
 
                     result[key] = new KeyedItemInfo(oldStartIndex, -1);
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
                     {
                         if (existingEntry.NewIndex >= 0)
                         {
-                            ThrowExceptionForDuplicateKey(key);
+                            ThrowExceptionForDuplicateKey(key, frame);
                         }
 
                         result[key] = new KeyedItemInfo(existingEntry.OldIndex, newStartIndex);
@@ -355,9 +355,19 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             return result;
         }
 
-        private static void ThrowExceptionForDuplicateKey(object key)
+        private static void ThrowExceptionForDuplicateKey(object key, RenderTreeFrame frame)
         {
-            throw new InvalidOperationException($"More than one sibling has the same key value, '{key}'. Key values must be unique.");
+            switch (frame.FrameType)
+            {
+                case RenderTreeFrameType.Component:
+                    throw new InvalidOperationException($"More than one sibling of component '{frame.ComponentType}' has the same key value, '{key}'. Key values must be unique.");
+
+                case RenderTreeFrameType.Element:
+                    throw new InvalidOperationException($"More than one sibling of element '{frame.ElementName}' has the same key value, '{key}'. Key values must be unique.");
+
+                default:
+                    throw new InvalidOperationException($"More than one sibling has the same key value, '{key}'. Key values must be unique.");
+            }
         }
 
         private static object KeyValue(ref RenderTreeFrame frame)

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert
             var ex = Assert.Throws<InvalidOperationException>(() => GetSingleUpdatedComponent());
-            Assert.Equal("More than one sibling has the same key value, 'key1'. Key values must be unique.", ex.Message);
+            Assert.Equal("More than one sibling of element 'el' has the same key value, 'key1'. Key values must be unique.", ex.Message);
         }
 
         [Fact]
@@ -357,7 +357,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert
             var ex = Assert.Throws<InvalidOperationException>(() => GetSingleUpdatedComponent());
-            Assert.Equal("More than one sibling has the same key value, 'key1'. Key values must be unique.", ex.Message);
+            Assert.Equal("More than one sibling of element 'el' has the same key value, 'key1'. Key values must be unique.", ex.Message);
         }
 
         [Fact]
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.Components.Test
 
             // Act/Assert
             var ex = Assert.Throws<InvalidOperationException>(() => GetSingleUpdatedComponent());
-            Assert.Equal("More than one sibling has the same key value, 'key1'. Key values must be unique.", ex.Message);
+            Assert.Equal("More than one sibling of element 'el' has the same key value, 'key1'. Key values must be unique.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Summary of the changes
 - Duplicate key rendering error now will display the frame type and name to give more context when this error occurs.

Addresses #24152.
