### PR TITLE
Don't render route component if OnNavigateAsync task in-progress

### DIFF
--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -567,6 +567,29 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.NotNull(errorUiElem);
         }
 
+        [Fact]
+        public void OnNavigate_DoesNotRenderWhileOnNavigateExecuting()
+        {
+            var app = Browser.MountTestComponent<TestRouterWithOnNavigate>();
+
+            // Navigate to a route
+            SetUrlViaPushState("/WithParameters/name/Abc");
+
+            // Click the button to trigger a re-render
+            var button = app.FindElement(By.Id("trigger-rerender"));
+            button.Click();
+
+            // Assert that the parameter route didn't render
+            Browser.DoesNotExist(By.Id("test-info"));
+
+            // Navigate to another page to cancel the previous `OnNavigateAsync`
+            // task and trigger a re-render on its completion
+            SetUrlViaPushState("/LongPage1");
+
+            // Confirm that the route was rendered
+            Browser.Equal("This is a long page you can scroll.", () => app.FindElement(By.Id("test-info")).Text);
+        }
+
         private long BrowserScrollY
         {
             get => (long)((IJavaScriptExecutor)Browser).ExecuteScript("return window.scrollY");

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
@@ -1,5 +1,9 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 
+@using System.Threading
+
+<button @onclick="TriggerRerender" id="trigger-rerender">Trigger Rerender</button>
+
 <Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" OnNavigateAsync="@OnNavigateAsync">
     <Navigating>
         <div style="padding: 20px;background-color:blue;color:white;" id="loading-banner">
@@ -21,7 +25,8 @@
     {
         { "LongPage1", new Func<NavigationContext, Task>(TestLoadingPageShows) },
         { "LongPage2", new Func<NavigationContext, Task>(TestOnNavCancel) },
-        { "Other", new Func<NavigationContext, Task>(TestOnNavException) }
+        { "Other", new Func<NavigationContext, Task>(TestOnNavException) },
+        {"WithParameters/name/Abc", new Func<NavigationContext, Task>(TestRefreshHandling)}
     };
 
     private async Task OnNavigateAsync(NavigationContext args)
@@ -49,5 +54,15 @@
     {
         await Task.CompletedTask;
         throw new Exception("This is an uncaught exception.");
+    }
+
+    public static async Task TestRefreshHandling(NavigationContext args)
+    {
+        await Task.Delay(Timeout.Infinite, args.CancellationToken);
+    }
+
+    private void TriggerRerender()
+    {
+        Console.WriteLine("Nothing to see here, just an even to trigger a re-render...");
     }
 }


### PR DESCRIPTION
This PR adds a check to the `Refresh` method in the Router class to ensure that a route's component isn't rendered while an OnNavigateAsync method is running.

We check the state of the `_previousOnNavigateTask` global which stores a references to the currently running navigation task and only render if it ran to completion.

Addresses https://github.com/dotnet/aspnetcore/issues/24211