### PR TITLE
Move DataProtection tests to HostBuilder

### DIFF
--- a/src/DataProtection/DataProtection.slnf
+++ b/src/DataProtection/DataProtection.slnf
@@ -1,7 +1,7 @@
-﻿{
+{
   "solution": {
     "path": "..\\..\\AspNetCore.sln",
-    "projects" : [
+    "projects": [
       "src\\DataProtection\\Abstractions\\src\\Microsoft.AspNetCore.DataProtection.Abstractions.csproj",
       "src\\DataProtection\\Abstractions\\test\\Microsoft.AspNetCore.DataProtection.Abstractions.Tests.csproj",
       "src\\DataProtection\\Cryptography.Internal\\src\\Microsoft.AspNetCore.Cryptography.Internal.csproj",
@@ -10,17 +10,28 @@
       "src\\DataProtection\\Cryptography.KeyDerivation\\test\\Microsoft.AspNetCore.Cryptography.KeyDerivation.Tests.csproj",
       "src\\DataProtection\\DataProtection\\src\\Microsoft.AspNetCore.DataProtection.csproj",
       "src\\DataProtection\\DataProtection\\test\\Microsoft.AspNetCore.DataProtection.Tests.csproj",
+      "src\\DataProtection\\EntityFrameworkCore\\src\\Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.csproj",
+      "src\\DataProtection\\EntityFrameworkCore\\test\\Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.Test.csproj",
       "src\\DataProtection\\Extensions\\src\\Microsoft.AspNetCore.DataProtection.Extensions.csproj",
       "src\\DataProtection\\Extensions\\test\\Microsoft.AspNetCore.DataProtection.Extensions.Tests.csproj",
       "src\\DataProtection\\StackExchangeRedis\\src\\Microsoft.AspNetCore.DataProtection.StackExchangeRedis.csproj",
       "src\\DataProtection\\StackExchangeRedis\\test\\Microsoft.AspNetCore.DataProtection.StackExchangeRedis.Tests.csproj",
       "src\\DataProtection\\samples\\CustomEncryptorSample\\CustomEncryptorSample.csproj",
+      "src\\DataProtection\\samples\\EntityFrameworkCoreSample\\EntityFrameworkCoreSample.csproj",
       "src\\DataProtection\\samples\\KeyManagementSample\\KeyManagementSample.csproj",
       "src\\DataProtection\\samples\\NonDISample\\NonDISample.csproj",
       "src\\DataProtection\\samples\\Redis\\Redis.csproj",
-      "src\\DataProtection\\EntityFrameworkCore\\src\\Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.csproj",
-      "src\\DataProtection\\EntityFrameworkCore\\test\\Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.Test.csproj",
-      "src\\DataProtection\\samples\\EntityFrameworkCoreSample\\EntityFrameworkCoreSample.csproj"
+      "src\\Hosting\\Abstractions\\src\\Microsoft.AspNetCore.Hosting.Abstractions.csproj",
+      "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
+      "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
+      "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
+      "src\\Http\\Http.Abstractions\\src\\Microsoft.AspNetCore.Http.Abstractions.csproj",
+      "src\\Http\\Http.Extensions\\src\\Microsoft.AspNetCore.Http.Extensions.csproj",
+      "src\\Http\\Http.Features\\src\\Microsoft.AspNetCore.Http.Features.csproj",
+      "src\\Http\\Http\\src\\Microsoft.AspNetCore.Http.csproj",
+      "src\\Http\\WebUtilities\\src\\Microsoft.AspNetCore.WebUtilities.csproj",
+      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
+      "src\\Testing\\src\\Microsoft.AspNetCore.Testing.csproj"
     ]
   }
 }

--- a/src/DataProtection/DataProtection/test/HostingTests.cs
+++ b/src/DataProtection/DataProtection/test/HostingTests.cs
@@ -82,13 +82,13 @@ namespace Microsoft.AspNetCore.DataProtection.Test
                 .Throws(new NotSupportedException("This mock doesn't actually work, but shouldn't kill the server"))
                 .Verifiable();
 
-            var builder = new WebHostBuilder()
-                .UseStartup<TestStartup>()
+            var builder = new HostBuilder()
                 .ConfigureServices(s =>
                     s.AddDataProtection()
                     .Services
                     .Replace(ServiceDescriptor.Singleton(mockKeyRing.Object))
-                    .AddSingleton(Mock.Of<IServer>()));
+                    .AddSingleton(Mock.Of<IServer>()))
+                    .ConfigureWebHost(b => b.UseStartup<TestStartup>());
 
             using (var host = builder.Build())
             {


### PR DESCRIPTION
Contributes to #20964

HostingTests were the only place that used WebHostBuilder. One of the tests is explicitly for WebHostBuilder behavior and should remain.