### PR TITLE
Remove extra abstract keyword

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ResendEmailConfirmation.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ResendEmailConfirmation.cshtml.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
     /// </summary>
     [AllowAnonymous]
     [IdentityDefaultUI(typeof(ResendEmailConfirmationModel<>))]
-    public abstract class ResendEmailConfirmationModel : PageModel
+    public class ResendEmailConfirmationModel : PageModel
     {
         /// <summary>
         ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used


### PR DESCRIPTION
It was removed in https://github.com/dotnet/Scaffolding/pull/1339/
Shouldn't it be removed here too? or I'm missing something?

Not sure if this fixes issue #24273 or not