### PR TITLE
CSS scoping deep combinators

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Xunit;
@@ -72,6 +72,54 @@ namespace Microsoft.AspNetCore.Razor.Tools
             // Assert
             Assert.Equal(@"
     .first /* space at end {} */ div[TestScope] , .myclass[TestScope] /* comment at end */ { color: red; }
+", result);
+        }
+
+        [Fact]
+        public void RespectsDeepCombinator()
+        {
+            // Arrange/act
+            var result = RewriteCssCommand.AddScopeToSelectors(@"
+    .first ::deep .second { color: red; }
+    a ::deep b, c ::deep d { color: blue; }
+", "TestScope");
+
+            // Assert
+            Assert.Equal(@"
+    .first[TestScope]  .second { color: red; }
+    a[TestScope]  b, c[TestScope]  d { color: blue; }
+", result);
+        }
+
+        [Fact]
+        public void IgnoresMultipleDeepCombinators()
+        {
+            // Arrange/act
+            var result = RewriteCssCommand.AddScopeToSelectors(@"
+    .first ::deep .second ::deep .third { color:red; }
+", "TestScope");
+
+            // Assert
+            Assert.Equal(@"
+    .first[TestScope]  .second ::deep .third { color:red; }
+", result);
+        }
+
+        [Fact]
+        public void RespectsDeepCombinatorWithSpacesAndComments()
+        {
+            // Arrange/act
+            var result = RewriteCssCommand.AddScopeToSelectors(@"
+    .a .b /* comment ::deep 1 */  ::deep  /* comment ::deep 2 */  .c /* ::deep */ .d { color: red; }
+    ::deep * { color: blue; } /* Leading deep combinator */
+    another ::deep { color: green }  /* Trailing deep combinator */
+", "TestScope");
+
+            // Assert
+            Assert.Equal(@"
+    .a .b[TestScope] /* comment ::deep 1 */    /* comment ::deep 2 */  .c /* ::deep */ .d { color: red; }
+    [TestScope] * { color: blue; } /* Leading deep combinator */
+    another[TestScope]  { color: green }  /* Trailing deep combinator */
 ", result);
         }
 

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/ComputeCssScope.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/ComputeCssScope.cs
@@ -55,17 +55,19 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             return builder.ToString();
         }
 
-        private  string ToBase36(byte[] hash)
+        private static string ToBase36(byte[] hash)
         {
-            var builder = new StringBuilder();
-            const string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-            var dividend = new BigInteger(hash.AsSpan().Slice(0,8).ToArray());
-            while (dividend > 36)
+            const string chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+            var result = new char[10];
+            var dividend = BigInteger.Abs(new BigInteger(hash.AsSpan().Slice(0, 9).ToArray()));
+            for (var i = 0; i < 10; i++)
             {
                 dividend = BigInteger.DivRem(dividend, 36, out var remainder);
-                builder.Insert(0, chars[Math.Abs(((int)remainder))]);
+                result[i] = chars[(int)remainder];
             }
-            return builder.ToString();
+
+            return new string(result);
         }
     }
 }


### PR DESCRIPTION
This is needed to make CSS scoping useful when you're trying to style elements produced by descendants. It's equivalent to [deep selectors in Vue](https://vue-loader.vuejs.org/guide/scoped-css.html#deep-selectors).

For example, we want to use this in the template to style the `<a>` tags emitted by `NavLink`.

cc @javiercn who has context on this