### PR TITLE
Rename KeepAlivePingInterval to KeepAlivePingDelay

### DIFF
--- a/src/Servers/Kestrel/Core/src/Http2Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http2Limits.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         private int _maxRequestHeaderFieldSize = (int)Http2PeerSettings.DefaultMaxFrameSize;
         private int _initialConnectionWindowSize = 1024 * 128; // Larger than the default 64kb, and larger than any one single stream.
         private int _initialStreamWindowSize = 1024 * 96; // Larger than the default 64kb
-        private TimeSpan _keepAlivePingInterval = TimeSpan.MaxValue;
+        private TimeSpan _keepAlivePingDelay = TimeSpan.MaxValue;
         private TimeSpan _keepAlivePingTimeout = TimeSpan.FromSeconds(20);
 
         /// <summary>
@@ -147,18 +147,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         /// <summary>
-        /// Gets or sets the keep alive ping interval. The server will send a keep alive ping to the client if it
-        /// doesn't receive any frames for this period of time. This property is used together with
+        /// Gets or sets the keep alive ping delay. The server will send a keep alive ping to the client if it
+        /// doesn't receive any frames on a connection for this period of time. This property is used together with
         /// <see cref="KeepAlivePingTimeout"/> to close broken connections.
         /// <para>
-        /// Interval must be greater than or equal to 1 second. Set to <see cref="TimeSpan.MaxValue"/> to
-        /// disable the keep alive ping interval.
+        /// Delay value must be greater than or equal to 1 second. Set to <see cref="TimeSpan.MaxValue"/> to
+        /// disable the keep alive ping.
         /// Defaults to <see cref="TimeSpan.MaxValue"/>.
         /// </para>
         /// </summary>
-        public TimeSpan KeepAlivePingInterval
+        public TimeSpan KeepAlivePingDelay
         {
-            get => _keepAlivePingInterval;
+            get => _keepAlivePingDelay;
             set
             {
                 // Keep alive uses Kestrel's system clock which has a 1 second resolution. Time is greater or equal to clock resolution.
@@ -167,13 +167,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                     throw new ArgumentOutOfRangeException(nameof(value), CoreStrings.FormatArgumentTimeSpanGreaterOrEqual(Heartbeat.Interval));
                 }
 
-                _keepAlivePingInterval = value != Timeout.InfiniteTimeSpan ? value : TimeSpan.MaxValue;
+                _keepAlivePingDelay = value != Timeout.InfiniteTimeSpan ? value : TimeSpan.MaxValue;
             }
         }
 
         /// <summary>
         /// Gets or sets the keep alive ping timeout. Keep alive pings are sent when a period of inactivity exceeds
-        /// the configured <see cref="KeepAlivePingInterval"/> value. The server will close the connection if it
+        /// the configured <see cref="KeepAlivePingDelay"/> value. The server will close the connection if it
         /// doesn't receive any frames within the timeout.
         /// <para>
         /// Timeout must be greater than or equal to 1 second. Set to <see cref="TimeSpan.MaxValue"/> to

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -107,10 +107,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             var connectionWindow = (uint)http2Limits.InitialConnectionWindowSize;
             _inputFlowControl = new InputFlowControl(connectionWindow, connectionWindow / 2);
 
-            if (http2Limits.KeepAlivePingInterval != TimeSpan.MaxValue)
+            if (http2Limits.KeepAlivePingDelay != TimeSpan.MaxValue)
             {
                 _keepAlive = new Http2KeepAlive(
-                    http2Limits.KeepAlivePingInterval,
+                    http2Limits.KeepAlivePingDelay,
                     http2Limits.KeepAlivePingTimeout,
                     context.ServiceContext.SystemClock);
             }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2KeepAliveTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2KeepAliveTests.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
     public class Http2KeepAliveTests : Http2TestBase
     {
         [Fact]
-        public async Task KeepAlivePingInterval_InfiniteTimeSpan_KeepAliveNotEnabled()
+        public async Task KeepAlivePingDelay_InfiniteTimeSpan_KeepAliveNotEnabled()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = Timeout.InfiniteTimeSpan;
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = Timeout.InfiniteTimeSpan;
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task KeepAlivePingTimeout_InfiniteTimeSpan_NoGoAway()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
             _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingTimeout = Timeout.InfiniteTimeSpan;
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalExceeded_WithoutActivity_PingSent()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalExceeded_WithActivity_NoPingSent()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalNotExceeded_NoPingSent()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(5);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(5);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalExceeded_MultipleTimes_PingsNotSentWhileAwaitingOnAck()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalExceeded_MultipleTimes_PingSentAfterAck()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task TimeoutExceeded_NoAck_GoAway()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
             _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingTimeout = TimeSpan.FromSeconds(3);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task TimeoutExceeded_NonPingActivity_NoGoAway()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
             _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingTimeout = TimeSpan.FromSeconds(3);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalExceeded_StreamStarted_NoPingSent()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
 
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task IntervalExceeded_ConnectionFlowControlUsedUpThenPings_NoPingSent()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             // Reduce connection window size so that one stream can fill it
             _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize = 65535;
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task TimeoutExceeded_ConnectionFlowControlUsedUpThenPings_NoGoAway()
         {
-            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingInterval = TimeSpan.FromSeconds(1);
+            _serviceContext.ServerOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(1);
 
             // Reduce connection window size so that one stream can fill it
             _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize = 65535;


### PR DESCRIPTION
`SocketsHttpHandler` is adding `KeepAlivePingDelay` property. Our setting is called `KeepAlivePingInterval`.

https://github.com/dotnet/runtime/issues/31198#issuecomment-663134549

I think both names are fine. For consistency let rename Kestrel's property to match.