### PR TITLE
In CSS scoping, support ::deep alongside other combinators

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
@@ -185,18 +185,15 @@ namespace Microsoft.AspNetCore.Razor.Tools
                     case '+':
                     case '~':
                         var trailingCombinatorMatch = _trailingCombinatorRegex.Match(text);
-                        if (!trailingCombinatorMatch.Success)
+                        if (trailingCombinatorMatch.Success)
                         {
-                            // This should never be possible given the shape of the regex. The exception is only
-                            // in case we introduce a new bug in the future.
-                            throw new InvalidOperationException($"Trailing combinator regex should have matched but didn't for value '{text}'");
+                            var trailingCombinatorLength = trailingCombinatorMatch.Length;
+                            return lastSimpleSelector.AfterEnd - trailingCombinatorLength;
                         }
-
-                        var trailingCombinatorLength = trailingCombinatorMatch.Length;
-                        return lastSimpleSelector.AfterEnd - trailingCombinatorLength;
-                    default:
-                        return lastSimpleSelector.AfterEnd;
+                        break;
                 }
+
+                return lastSimpleSelector.AfterEnd;
             }
 
             protected override void VisitAtDirective(AtDirective item)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
@@ -92,6 +92,54 @@ namespace Microsoft.AspNetCore.Razor.Tools
         }
 
         [Fact]
+        public void RespectsDeepCombinatorWithDirectDescendant()
+        {
+            // Arrange/act
+            var result = RewriteCssCommand.AddScopeToSelectors(@"
+    a  >  ::deep b { color: red; }
+    c ::deep  >  d { color: blue; }
+", "TestScope");
+
+            // Assert
+            Assert.Equal(@"
+    a[TestScope]  >   b { color: red; }
+    c[TestScope]   >  d { color: blue; }
+", result);
+        }
+
+        [Fact]
+        public void RespectsDeepCombinatorWithAdjacentSibling()
+        {
+            // Arrange/act
+            var result = RewriteCssCommand.AddScopeToSelectors(@"
+    a + ::deep b { color: red; }
+    c ::deep + d { color: blue; }
+", "TestScope");
+
+            // Assert
+            Assert.Equal(@"
+    a[TestScope] +  b { color: red; }
+    c[TestScope]  + d { color: blue; }
+", result);
+        }
+
+        [Fact]
+        public void RespectsDeepCombinatorWithGeneralSibling()
+        {
+            // Arrange/act
+            var result = RewriteCssCommand.AddScopeToSelectors(@"
+    a ~ ::deep b { color: red; }
+    c ::deep ~ d { color: blue; }
+", "TestScope");
+
+            // Assert
+            Assert.Equal(@"
+    a[TestScope] ~  b { color: red; }
+    c[TestScope]  ~ d { color: blue; }
+", result);
+        }
+
+        [Fact]
         public void IgnoresMultipleDeepCombinators()
         {
             // Arrange/act


### PR DESCRIPTION
Fixes a limitation found by @javiercn.