### PR TITLE
Add a readonly modifier to a missing readonly field

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private long _highestOpenedStreamId; // TODO lock to access
         private volatile bool _haveSentGoAway;
         private readonly object _sync = new object();
-        private MultiplexedConnectionContext _multiplexedContext;
+        private readonly MultiplexedConnectionContext _multiplexedContext;
         private readonly Http3ConnectionContext _context;
         private readonly ISystemClock _systemClock;
         private readonly TimeoutControl _timeoutControl;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -20,9 +20,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private const int EncoderStream = 2;
         private const int DecoderStream = 3;
 
-        private Http3FrameWriter _frameWriter;
+        private readonly Http3FrameWriter _frameWriter;
         private readonly Http3Connection _http3Connection;
-        private HttpConnectionContext _context;
+        private readonly HttpConnectionContext _context;
         private readonly Http3RawFrame _incomingFrame = new Http3RawFrame();
         private volatile int _isClosed;
         private int _gracefulCloseInitiator;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private static ReadOnlySpan<byte> TrailersBytes => new byte[8] { (byte)'t', (byte)'r', (byte)'a', (byte)'i', (byte)'l', (byte)'e', (byte)'r', (byte)'s' };
         private static ReadOnlySpan<byte> ConnectBytes => new byte[7] { (byte)'C', (byte)'O', (byte)'N', (byte)'N', (byte)'E', (byte)'C', (byte)'T' };
 
-        private Http3FrameWriter _frameWriter;
-        private Http3OutputProducer _http3Output;
+        private readonly Http3FrameWriter _frameWriter;
+        private readonly Http3OutputProducer _http3Output;
         private int _isClosed;
         private int _gracefulCloseInitiator;
         private readonly Http3StreamContext _context;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/QPack/DecoderStreamReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/QPack/DecoderStreamReader.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3.QPack
         private const byte InsertCountIncrementPrefixMask = 0x3F;
         private const int InsertCountIncrementPrefix = 6;
 
-        private IntegerDecoder _integerDecoder = new IntegerDecoder();
+        private readonly IntegerDecoder _integerDecoder = new IntegerDecoder();
         private State _state;
 
         public DecoderStreamReader()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/QPack/EncoderStreamReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/QPack/EncoderStreamReader.cs
@@ -76,15 +76,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3.QPack
         private const byte HuffmanMask = 0x80;
 
         private bool _s;
-        private byte[] _stringOctets;
-        private byte[] _headerNameOctets;
-        private byte[] _headerValueOctets;
+        private readonly byte[] _stringOctets;
+        private readonly byte[] _headerNameOctets;
+        private readonly byte[] _headerValueOctets;
         private byte[] _headerName;
         private int _headerNameLength;
         private int _headerValueLength;
         private int _stringLength;
         private int _stringIndex;
-        private DynamicTable _dynamicTable = new DynamicTable(1000); // TODO figure out architecture.
+        private readonly DynamicTable _dynamicTable = new DynamicTable(1000); // TODO figure out architecture.
 
         private readonly IntegerDecoder _integerDecoder = new IntegerDecoder();
         private State _state = State.Ready;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Heartbeat.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Heartbeat.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private readonly IDebugger _debugger;
         private readonly IKestrelTrace _trace;
         private readonly TimeSpan _interval;
-        private Thread _timerThread;
+        private readonly Thread _timerThread;
         private volatile bool _stopped;
 
         public Heartbeat(IHeartbeatHandler[] callbacks, ISystemClock systemClock, IDebugger debugger, IKestrelTrace trace)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ThreadPoolAwaitable.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ThreadPoolAwaitable.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     internal class ThreadPoolAwaitable : ICriticalNotifyCompletion
     {
-        public static ThreadPoolAwaitable Instance = new ThreadPoolAwaitable();
+        public static readonly ThreadPoolAwaitable Instance = new ThreadPoolAwaitable();
 
         private ThreadPoolAwaitable()
         {

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerOptionsSetup.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerOptionsSetup.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
     internal class KestrelServerOptionsSetup : IConfigureOptions<KestrelServerOptions>
     {
-        private IServiceProvider _services;
+        private readonly IServiceProvider _services;
 
         public KestrelServerOptionsSetup(IServiceProvider services)
         {


### PR DESCRIPTION
Add a readonly modifier to a missing readonly field. The readonly modifier ensures the field can only be given a value during its initialization or in its class constructor.