### PR TITLE
Add missing .ConfigureAwait(false) to WebHost

### DIFF
--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.Hosting
             switch (serviceProvider)
             {
                 case IAsyncDisposable asyncDisposable:
-                    await asyncDisposable.DisposeAsync();
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
                     break;
                 case IDisposable disposable:
                     disposable.Dispose();


### PR DESCRIPTION
We talked about this before transferring https://github.com/dotnet/runtime/issues/39911 to the runtime repo. I'm submitting this one line change now before I forget.

This probably won't fix things if there's a singleton-scoped service that awaits without ConfigureAwait(false) in its DisposeAsync implementation, but this is the only await in WebHost.cs without ConfigureAwait(false), so it still seems like a good thing to add.
