### PR TITLE
Improve detection of Record types

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultBindingMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultBindingMetadataProvider.cs
@@ -143,7 +143,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             static bool IsRecordType(Type type)
             {
                 // Based on the state of the art as described in https://github.com/dotnet/roslyn/issues/45777
-                var cloneMethod = type.GetMethod("<>Clone", BindingFlags.Public | BindingFlags.Instance);
+                var cloneMethod = type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance) ??
+                    type.GetMethod("<>Clone", BindingFlags.Public | BindingFlags.Instance);
                 return cloneMethod != null && cloneMethod.ReturnType == type;
             }
         }


### PR DESCRIPTION
## Description

MVC detects record types based on compiler generated methods. The name of this method changed between preview releases of the compiler. We discovered this when merging this changes to master that uses a new compiler. Pro-actively porting this to preview8 for defensive coding.

## Impact

In the absence of this change, the newly added support for record types in MVC will not function.


## Regression

No

## Risk

Minimal. This is a new feature in 5.0-preview8