### PR TITLE
H/QPackEncoder overloads accepting Encoding

### DIFF
--- a/src/Shared/runtime/Http2/Hpack/HPackEncoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackEncoder.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 
 namespace System.Net.Http.HPack
 {
@@ -96,7 +97,7 @@ namespace System.Net.Http.HPack
                 if (IntegerEncoder.Encode(index, 4, destination, out int indexLength))
                 {
                     Debug.Assert(indexLength >= 1);
-                    if (EncodeStringLiteral(value, destination.Slice(indexLength), out int nameLength))
+                    if (EncodeStringLiteral(value, valueEncoding: null, destination.Slice(indexLength), out int nameLength))
                     {
                         bytesWritten = indexLength + nameLength;
                         return true;
@@ -128,7 +129,7 @@ namespace System.Net.Http.HPack
                 if (IntegerEncoder.Encode(index, 4, destination, out int indexLength))
                 {
                     Debug.Assert(indexLength >= 1);
-                    if (EncodeStringLiteral(value, destination.Slice(indexLength), out int nameLength))
+                    if (EncodeStringLiteral(value, valueEncoding: null, destination.Slice(indexLength), out int nameLength))
                     {
                         bytesWritten = indexLength + nameLength;
                         return true;
@@ -160,7 +161,7 @@ namespace System.Net.Http.HPack
                 if (IntegerEncoder.Encode(index, 6, destination, out int indexLength))
                 {
                     Debug.Assert(indexLength >= 1);
-                    if (EncodeStringLiteral(value, destination.Slice(indexLength), out int nameLength))
+                    if (EncodeStringLiteral(value, valueEncoding: null, destination.Slice(indexLength), out int nameLength))
                     {
                         bytesWritten = indexLength + nameLength;
                         return true;
@@ -276,7 +277,7 @@ namespace System.Net.Http.HPack
             {
                 destination[0] = mask;
                 if (EncodeLiteralHeaderName(name, destination.Slice(1), out int nameLength) &&
-                    EncodeStringLiteral(value, destination.Slice(1 + nameLength), out int valueLength))
+                    EncodeStringLiteral(value, valueEncoding: null, destination.Slice(1 + nameLength), out int valueLength))
                 {
                     bytesWritten = 1 + nameLength + valueLength;
                     return true;
@@ -289,6 +290,11 @@ namespace System.Net.Http.HPack
 
         /// <summary>Encodes a "Literal Header Field without Indexing - New Name".</summary>
         public static bool EncodeLiteralHeaderFieldWithoutIndexingNewName(string name, ReadOnlySpan<string> values, string separator, Span<byte> destination, out int bytesWritten)
+        {
+            return EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, separator, valueEncoding: null, destination, out bytesWritten);
+        }
+
+        public static bool EncodeLiteralHeaderFieldWithoutIndexingNewName(string name, ReadOnlySpan<string> values, string separator, Encoding? valueEncoding, Span<byte> destination, out int bytesWritten)
         {
             // From https://tools.ietf.org/html/rfc7541#section-6.2.2
             // ------------------------------------------------------
@@ -309,7 +315,7 @@ namespace System.Net.Http.HPack
             {
                 destination[0] = 0;
                 if (EncodeLiteralHeaderName(name, destination.Slice(1), out int nameLength) &&
-                    EncodeStringLiterals(values, separator, destination.Slice(1 + nameLength), out int valueLength))
+                    EncodeStringLiterals(values, separator, valueEncoding, destination.Slice(1 + nameLength), out int valueLength))
                 {
                     bytesWritten = 1 + nameLength + valueLength;
                     return true;
@@ -395,27 +401,20 @@ namespace System.Net.Http.HPack
             return false;
         }
 
-        private static bool EncodeStringLiteralValue(string value, Span<byte> destination, out int bytesWritten)
+        private static void EncodeValueStringPart(string value, Span<byte> destination)
         {
-            if (value.Length <= destination.Length)
-            {
-                for (int i = 0; i < value.Length; i++)
-                {
-                    char c = value[i];
-                    if ((c & 0xFF80) != 0)
-                    {
-                        throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
-                    }
+            Debug.Assert(destination.Length >= value.Length);
 
-                    destination[i] = (byte)c;
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                if ((c & 0xFF80) != 0)
+                {
+                    throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
                 }
 
-                bytesWritten = value.Length;
-                return true;
+                destination[i] = (byte)c;
             }
-
-            bytesWritten = 0;
-            return false;
         }
 
         public static bool EncodeStringLiteral(ReadOnlySpan<byte> value, Span<byte> destination, out int bytesWritten)
@@ -454,6 +453,11 @@ namespace System.Net.Http.HPack
 
         public static bool EncodeStringLiteral(string value, Span<byte> destination, out int bytesWritten)
         {
+            return EncodeStringLiteral(value, valueEncoding: null, destination, out bytesWritten);
+        }
+
+        public static bool EncodeStringLiteral(string value, Encoding? valueEncoding, Span<byte> destination, out int bytesWritten)
+        {
             // From https://tools.ietf.org/html/rfc7541#section-5.2
             // ------------------------------------------------------
             //   0   1   2   3   4   5   6   7
@@ -466,13 +470,28 @@ namespace System.Net.Http.HPack
             if (destination.Length != 0)
             {
                 destination[0] = 0; // TODO: Use Huffman encoding
-                if (IntegerEncoder.Encode(value.Length, 7, destination, out int integerLength))
+
+                int encodedStringLength = valueEncoding is null || ReferenceEquals(valueEncoding, Encoding.Latin1)
+                    ? value.Length
+                    : valueEncoding.GetByteCount(value);
+
+                if (IntegerEncoder.Encode(encodedStringLength, 7, destination, out int integerLength))
                 {
                     Debug.Assert(integerLength >= 1);
-
-                    if (EncodeStringLiteralValue(value, destination.Slice(integerLength), out int valueLength))
+                    destination = destination.Slice(integerLength);
+                    if (encodedStringLength <= destination.Length)
                     {
-                        bytesWritten = integerLength + valueLength;
+                        if (valueEncoding is null)
+                        {
+                            EncodeValueStringPart(value, destination);
+                        }
+                        else
+                        {
+                            int written = valueEncoding.GetBytes(value, destination);
+                            Debug.Assert(written == encodedStringLength);
+                        }
+
+                        bytesWritten = integerLength + encodedStringLength;
                         return true;
                     }
                 }
@@ -503,55 +522,86 @@ namespace System.Net.Http.HPack
 
         public static bool EncodeStringLiterals(ReadOnlySpan<string> values, string? separator, Span<byte> destination, out int bytesWritten)
         {
+            return EncodeStringLiterals(values, separator, valueEncoding: null, destination, out bytesWritten);
+        }
+
+        public static bool EncodeStringLiterals(ReadOnlySpan<string> values, string? separator, Encoding? valueEncoding, Span<byte> destination, out int bytesWritten)
+        {
             bytesWritten = 0;
 
             if (values.Length == 0)
             {
-                return EncodeStringLiteral("", destination, out bytesWritten);
+                return EncodeStringLiteral("", valueEncoding: null, destination, out bytesWritten);
             }
             else if (values.Length == 1)
             {
-                return EncodeStringLiteral(values[0], destination, out bytesWritten);
+                return EncodeStringLiteral(values[0], valueEncoding, destination, out bytesWritten);
             }
 
             if (destination.Length != 0)
             {
-                int valueLength = 0;
+                Debug.Assert(separator != null);
+                int valueLength;
 
                 // Calculate length of all parts and separators.
-                foreach (string part in values)
+                if (valueEncoding is null || ReferenceEquals(valueEncoding, Encoding.Latin1))
                 {
-                    valueLength = checked((int)(valueLength + part.Length));
+                    valueLength = checked((int)(values.Length - 1) * separator.Length);
+                    foreach (string part in values)
+                    {
+                        valueLength = checked((int)(valueLength + part.Length));
+                    }
                 }
-
-                Debug.Assert(separator != null);
-                valueLength = checked((int)(valueLength + (values.Length - 1) * separator.Length));
+                else
+                {
+                    valueLength = checked((int)(values.Length - 1) * valueEncoding.GetByteCount(separator));
+                    foreach (string part in values)
+                    {
+                        valueLength = checked((int)(valueLength + valueEncoding.GetByteCount(part)));
+                    }
+                }
 
                 destination[0] = 0;
                 if (IntegerEncoder.Encode(valueLength, 7, destination, out int integerLength))
                 {
                     Debug.Assert(integerLength >= 1);
-
-                    int encodedLength = 0;
-                    for (int j = 0; j < values.Length; j++)
+                    destination = destination.Slice(integerLength);
+                    if (destination.Length >= valueLength)
                     {
-                        if (j != 0 && !EncodeStringLiteralValue(separator, destination.Slice(integerLength), out encodedLength))
+                        if (valueEncoding is null)
                         {
-                            return false;
+                            string value = values[0];
+                            EncodeValueStringPart(value, destination);
+                            destination = destination.Slice(value.Length);
+
+                            for (int i = 1; i < values.Length; i++)
+                            {
+                                EncodeValueStringPart(separator, destination);
+                                destination = destination.Slice(separator.Length);
+
+                                value = values[i];
+                                EncodeValueStringPart(value, destination);
+                                destination = destination.Slice(value.Length);
+                            }
+                        }
+                        else
+                        {
+                            int written = valueEncoding.GetBytes(values[0], destination);
+                            destination = destination.Slice(written);
+
+                            for (int i = 1; i < values.Length; i++)
+                            {
+                                written = valueEncoding.GetBytes(separator, destination);
+                                destination = destination.Slice(written);
+
+                                written = valueEncoding.GetBytes(values[i], destination);
+                                destination = destination.Slice(written);
+                            }
                         }
 
-                        integerLength += encodedLength;
-
-                        if (!EncodeStringLiteralValue(values[j], destination.Slice(integerLength), out encodedLength))
-                        {
-                            return false;
-                        }
-
-                        integerLength += encodedLength;
+                        bytesWritten = integerLength + valueLength;
+                        return true;
                     }
-
-                    bytesWritten = integerLength;
-                    return true;
                 }
             }
 


### PR DESCRIPTION
Adds overloads accepting an Encoding for header values to H/QPackEncoders.

**This is a mirror of changes to H/QPackEncoder merged into runtime in dotnet/runtime#39468.**

This is following the [Shared code readme](https://github.com/dotnet/runtime/blob/43b8caf5d455d7a2e32de13f813f4caf66d53340/src/libraries/Common/src/System/Net/Http/aspnetcore/ReadMe.SharedCode.md) - if such changes are mirrored automagically, please close this PR.

Fixes #18943