### PR TITLE
Updated XML docs to clarify base virtual method is noop

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -377,6 +377,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
 
         /// <summary>
         /// Gives a fixture an opportunity to configure the application before it gets built.
+        /// The default implementation does nothing.
         /// </summary>
         /// <param name="builder">The <see cref="IWebHostBuilder"/> for the application.</param>
         protected virtual void ConfigureWebHost(IWebHostBuilder builder)


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

This PR merely expands the XML docs to clarify that the base methods does nothing, to tell subclass implementors that it doesn't have to be called.
