### PR TITLE
Use ordinal comparison when detecting event handler attributes. Fixes #24465

### DIFF
--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -954,7 +954,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             // based on the common usage of attributes for DOM events.
             if ((newFrame.AttributeValue is MulticastDelegate || newFrame.AttributeValue is EventCallback) &&
                 newFrame.AttributeName.Length >= 3 &&
-                newFrame.AttributeName.StartsWith("on"))
+                newFrame.AttributeName.StartsWith("on", StringComparison.Ordinal))
             {
                 diffContext.Renderer.AssignEventHandlerId(ref newFrame);
             }


### PR DESCRIPTION
Details are in https://github.com/dotnet/aspnetcore/issues/24465

It's actually giving a 4% gain on the PlainTable benchmark now, perhaps because there are fewer other instructions overall.

To avoid any confusion, this shouldn't break anyone's scenarios. The `on` detection was never meant to be culture-sensitive, and there's no scenario I know of where you would have an attribute name that matches `on...` only due to culture sensitivity.